### PR TITLE
diag: exact interpolation type-error columns + dead-code cleanup

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -179,6 +179,12 @@ type Interp struct {
 	Expr   string
 	Try    bool
 	Stages []PipeStage
+	// ExprPos is the position of the first non-whitespace character of the
+	// interpolation's inner expression in the source file (i.e. where Expr
+	// starts before trimming). It is token.NoPos when unavailable. Used by
+	// codegen to emit compensated //line directives so type errors map to the
+	// exact source column of the expression rather than the '{' opener.
+	ExprPos token.Pos
 	// JSCtx is set by internal/jsx for Interps inside a <script>; JSCtxNone otherwise.
 	JSCtx JSCtx
 }

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -486,8 +486,13 @@ func emitProbes(sb *strings.Builder, nodes []gsxast.Markup, table filterTable, p
 					// "_gsxuse(expr)") will be reported at ep.Column, matching the source.
 					fmt.Fprintf(sb, "//line %s:%d:%d\n", ep.Filename, ep.Line, col)
 				} else {
-					// Expr is too near the line start for compensation; file+line are exact.
-					emitSkeletonLine(sb, fset, t.ExprPos)
+					// Expr is too near the line start for //line compensation (col < 1 is
+					// invalid). Fall back to the '{'-anchored position — identical to the
+					// pre-column-accuracy behavior — so shallow interps are never worse than
+					// the base. Making shallow interps exact would need a post-type-check
+					// column override keyed to the originating Interp — deferred.
+					// TODO(column-accuracy): exact columns for shallow interps (exprCol ≤ 8).
+					emitSkeletonLine(sb, fset, t.Pos())
 				}
 			} else {
 				// Staged pipeline or no ExprPos: keep unchanged behavior ('{' pos).

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -29,7 +29,6 @@ import (
 // propagate as fatal errors.
 var errSkipComponent = errors.New("skip")
 
-
 // resolveTypesPkg type-checks the package (real .go files + synthesized gsx
 // component skeletons via Overlay) and returns each interpolation's type.
 //
@@ -479,7 +478,21 @@ func emitProbes(sb *strings.Builder, nodes []gsxast.Markup, table filterTable, p
 			if err != nil {
 				return err
 			}
-			emitSkeletonLine(sb, fset, t.Pos())
+			const probePrefixLen = len("_gsxuse(") // 8
+			if len(t.Stages) == 0 && t.ExprPos.IsValid() {
+				ep := fset.Position(t.ExprPos)
+				if col := ep.Column - probePrefixLen; col >= 1 {
+					// Compensated //line: the probe's first token (at byte offset 8 into
+					// "_gsxuse(expr)") will be reported at ep.Column, matching the source.
+					fmt.Fprintf(sb, "//line %s:%d:%d\n", ep.Filename, ep.Line, col)
+				} else {
+					// Expr is too near the line start for compensation; file+line are exact.
+					emitSkeletonLine(sb, fset, t.ExprPos)
+				}
+			} else {
+				// Staged pipeline or no ExprPos: keep unchanged behavior ('{' pos).
+				emitSkeletonLine(sb, fset, t.Pos())
+			}
 			fmt.Fprintf(sb, "_gsxuse(%s)\n", probe)
 		case *gsxast.Element:
 			if isComponentTag(t.Tag) {
@@ -621,13 +634,11 @@ func emitProbes(sb *strings.Builder, nodes []gsxast.Markup, table filterTable, p
 // resolve to .gsx file:line:col instead of the generated overlay .x.go.
 // fset may be nil (e.g. in test-only callers); in that case no directive is emitted.
 //
-// TODO(column-accuracy): the .gsx FILE and LINE are exact, but the reported
-// COLUMN is skeleton-relative — it is offset by the probe wrapper (e.g.
-// `_gsxuse(`) and, for child-component prop errors, points inside the generated
-// props literal rather than the .gsx source. Anchoring at the user expression's
-// start (an expression-start token.Pos on ast.Interp, plus per-probe column
-// compensation `col = srcCol - skeletonCol + 1`) would make the column exact.
-// Deferred to a follow-up (Slice 2): file+line is the Slice-1 promise and is met.
+// Column accuracy: interpolation expression columns are now exact via
+// Interp.ExprPos + compensated //line (col = exprCol - len("_gsxuse(")).
+// Component-prop and pipeline-staged probes remain coarse: synthesized
+// props-literal fields and rewritten pipeline expressions have no faithful
+// source column, so they still emit //line at the node's Pos().
 func emitSkeletonLine(sb *strings.Builder, fset *token.FileSet, pos token.Pos) {
 	if fset == nil || !pos.IsValid() {
 		return

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -56,6 +56,9 @@ func GeneratePackageWithFilters(dir string, filterPkgs []string, cls *attrclass.
 		return nil, err
 	}
 	fset := token.NewFileSet()
+	// Note: this single-dir path returns a plain error on failure; it does not
+	// surface diagnostics through the bag. The batch path (GeneratePackages) is
+	// the production entry point and does surface diagnostics.
 	bag := diag.NewBag(fset)
 	files := map[string]*gsxast.File{}
 	for _, m := range matches {

--- a/internal/codegen/column_accuracy_test.go
+++ b/internal/codegen/column_accuracy_test.go
@@ -68,3 +68,71 @@ func TestInterpColumnAccuracy(t *testing.T) {
 		t.Error("no 'types' diagnostic found — undefinedX was not reported as a type error")
 	}
 }
+
+// TestInterpShallowColumnNoRegression verifies that a shallow interp
+// (identifier at source column ≤ 8, where the compensated //line col would be
+// < 1) falls back to the '{'-anchored position — the same as pre-column-accuracy
+// behavior — and does NOT report a column that is worse (i.e., column of
+// exprPos + 8).
+//
+// Source layout (1-based columns):
+//
+//	line 4: "{ undefinedA }\n"   (no leading whitespace)
+//	  col 1 = {       ← Interp.Pos()
+//	  col 2 = space
+//	  col 3 = u       ← undefinedA ExprPos; compensated col = 3−8 = −5 < 1 → fallback
+//
+// With the buggy fallback (emitSkeletonLine at ExprPos col 3), the probe at
+// byte offset 8 causes the type-checker to report col 3+8 = 11.
+// With the fix (emitSkeletonLine at Pos() col 1), the probe reports col 1+8 = 9.
+// The '{' col is 1, so base anchored col = 1+8 = 9.
+// Assertion: reported column ≤ (col of '{') + 8.
+func TestInterpShallowColumnNoRegression(t *testing.T) {
+	mod := tempModule(t, "gsxshallowtest")
+	viewsDir := filepath.Join(mod, "views")
+	if err := os.MkdirAll(viewsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Shallow interp: '{ undefinedA }' at column 1 — identifier at col 3.
+	// exprCol(3) - probePrefixLen(8) = -5 < 1 → fallback branch.
+	src := "package views\n\ncomponent A() {\n{ undefinedA }\n}\n"
+	if err := os.WriteFile(filepath.Join(viewsDir, "v.gsx"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := GeneratePackages(mod, []string{viewsDir})
+	if err != nil {
+		t.Fatalf("GeneratePackages: %v", err)
+	}
+	pr := out[mustAbs(t, viewsDir)]
+	if pr == nil {
+		t.Fatal("no PackageResult")
+	}
+
+	// col of '{' is 1; base-anchored column = 1 + 8 = 9.
+	const braceCol = 1
+	const probePrefixLen = 8
+	baseCol := braceCol + probePrefixLen // 9
+
+	var found bool
+	for _, d := range pr.Diags {
+		if d.Source != "types" {
+			continue
+		}
+		if d.Start.Line != 4 {
+			t.Errorf("type error on wrong line: got %d, want 4", d.Start.Line)
+			continue
+		}
+		found = true
+		// Must NOT be worse than base ({-anchored). With the bug the buggy fallback
+		// anchors at ExprPos (col 3), reporting col 3+8=11, which is > baseCol(9).
+		if d.Start.Column > baseCol {
+			t.Errorf("shallow interp column regression: got %d, want ≤ %d (base); buggy exprPos-anchored fallback would give %d",
+				d.Start.Column, baseCol, 3+probePrefixLen)
+		}
+	}
+	if !found {
+		t.Error("no 'types' diagnostic found — undefinedA was not reported as a type error")
+	}
+}

--- a/internal/codegen/column_accuracy_test.go
+++ b/internal/codegen/column_accuracy_test.go
@@ -1,0 +1,70 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestInterpColumnAccuracy verifies that a type error on an interpolation
+// expression is reported at the EXACT source column of the offending
+// identifier, not offset by the _gsxuse( wrapper (8 chars).
+//
+// Source layout (1-based columns as go/token counts them):
+//
+//	line 4: "\t<div>{ undefinedX }</div>\n"
+//	  col 1 = \t
+//	  col 2 = <
+//	  col 3 = d
+//	  col 4 = i
+//	  col 5 = v
+//	  col 6 = >
+//	  col 7 = {       ← Interp.Pos() (the '{')
+//	  col 8 = space
+//	  col 9 = u       ← undefinedX starts here (ExprPos after this fix)
+//
+// Before this fix: //line points to col 7 ({), so probe's first token (at
+// byte 8 = len("_gsxuse(")) reports col 7+8=15.
+// After this fix: column must be 9.
+func TestInterpColumnAccuracy(t *testing.T) {
+	mod := tempModule(t, "gsxcoltest")
+	viewsDir := filepath.Join(mod, "views")
+	if err := os.MkdirAll(viewsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Interpolation on line 4; 'undefinedX' starts at column 9 (tab + "<div>{ ").
+	src := "package views\n\ncomponent A() {\n\t<div>{ undefinedX }</div>\n}\n"
+	if err := os.WriteFile(filepath.Join(viewsDir, "v.gsx"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := GeneratePackages(mod, []string{viewsDir})
+	if err != nil {
+		t.Fatalf("GeneratePackages: %v", err)
+	}
+	pr := out[mustAbs(t, viewsDir)]
+	if pr == nil {
+		t.Fatal("no PackageResult")
+	}
+
+	var found bool
+	for _, d := range pr.Diags {
+		if d.Source != "types" {
+			continue
+		}
+		// Must be on line 4, column 9.
+		if d.Start.Line != 4 {
+			t.Errorf("type error on wrong line: got %d, want 4", d.Start.Line)
+			continue
+		}
+		found = true
+		if d.Start.Column != 9 {
+			t.Errorf("interp column inaccurate: got %d, want 9 (before fix this was 17 = 9 + 8 probe-wrapper offset)",
+				d.Start.Column)
+		}
+	}
+	if !found {
+		t.Error("no 'types' diagnostic found — undefinedX was not reported as a type error")
+	}
+}

--- a/internal/corpus/codegen.go
+++ b/internal/corpus/codegen.go
@@ -42,6 +42,7 @@ func (c *caseDoc) astAndParserDiag() (astDump []byte, parserDiag []byte, single 
 		return nil, nil, false
 	}
 	fset := token.NewFileSet()
+	// nil classifier → attrclass.Builtin(), same default as ParseFile.
 	file, errs := parser.ParseFileWithClassifier(fset, "input.gsx", src, 0, nil)
 	var dump, diag bytes.Buffer
 	if file != nil {

--- a/internal/corpus/testdata/cases/diagnostics/undefined_interp.txtar
+++ b/internal/corpus/testdata/cases/diagnostics/undefined_interp.txtar
@@ -5,4 +5,4 @@ component A() {
 	<div>{ undefinedIdent }</div>
 }
 -- diagnostics.golden --
-4:15: undefined: undefinedIdent
+4:9: undefined: undefinedIdent

--- a/internal/printer/corpus_test.go
+++ b/internal/printer/corpus_test.go
@@ -52,10 +52,15 @@ func TestCorpusIdempotence(t *testing.T) {
 
 // zeroSpans resets every node's span to zero so two ASTs parsed from different
 // text can be compared by content alone (positions necessarily differ).
+// Position fields outside the embedded span (e.g. Interp.ExprPos) are also
+// cleared so deep-equal is unaffected by source layout differences.
 func zeroSpans(n ast.Node) {
 	ast.Inspect(n, func(m ast.Node) bool {
 		if m != nil {
 			ast.SetSpan(m, 0, 0)
+			if interp, ok := m.(*ast.Interp); ok {
+				interp.ExprPos = 0
+			}
 		}
 		return true
 	})

--- a/parser/file.go
+++ b/parser/file.go
@@ -2,6 +2,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"go/scanner"
 	"go/token"
@@ -29,7 +30,7 @@ func ParseFile(fset *token.FileSet, filename string, src any, mode Mode) (*ast.F
 		if pos.IsValid() {
 			return f, fmt.Errorf("%d:%d: %s", pos.Line, pos.Column, e.Msg)
 		}
-		return f, fmt.Errorf("%s", e.Msg)
+		return f, errors.New(e.Msg)
 	}
 	return f, nil
 }

--- a/parser/markup.go
+++ b/parser/markup.go
@@ -16,13 +16,16 @@ func (p *parser) parseInterp() (*ast.Interp, error) {
 	if !ok {
 		return nil, p.errorf(startPos, "unterminated `{`")
 	}
-	inner := strings.TrimSpace(p.src[p.i+1 : end])
+	rawInner := p.src[p.i+1 : end]
+	lead := len(rawInner) - len(strings.TrimLeft(rawInner, " \t\r\n"))
+	exprPos := p.posAt(p.i + 1 + lead)
+	inner := strings.TrimSpace(rawInner)
 	seed, seedTry, stages, perr := parsePipe(inner)
 	if perr != nil {
 		return nil, p.errorf(startPos, "%v", perr)
 	}
 	p.i = end + 1
-	n := &ast.Interp{Expr: seed, Try: seedTry, Stages: stages}
+	n := &ast.Interp{Expr: seed, Try: seedTry, Stages: stages, ExprPos: exprPos}
 	ast.SetSpan(n, startPos, p.posAt(p.i))
 	return n, nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"errors"
 	"fmt"
 	"go/token"
 	"strings"
@@ -17,20 +16,6 @@ type Error struct {
 	Msg string
 }
 
-// errParse is the sentinel identity for all parser errors. errorf returns a
-// *parseErr that wraps this sentinel so errors.Is(err, errParse) is true, yet
-// err.Error() still returns the message text (needed by internal tests that
-// call parser methods directly).
-var errParse = errors.New("parse error")
-
-// parseErr is a lightweight wrapper returned by errorf. It satisfies
-// errors.Is(err, errParse) via its Unwrap method, while still exposing the
-// human-readable message through Error().
-type parseErr struct{ msg string }
-
-func (e *parseErr) Error() string  { return e.msg }
-func (e *parseErr) Unwrap() error  { return errParse }
-
 type parser struct {
 	file       *token.File
 	src        string
@@ -40,12 +25,13 @@ type parser struct {
 	errs       []Error
 }
 
-// errorf records a positioned error and returns a *parseErr whose Error()
-// returns the message text; errors.Is(err, errParse) is true via Unwrap.
+// errorf records a positioned error and returns an error whose Error() returns
+// the message text. Callers only check err != nil; the positioned errors are
+// read from p.errs by the caller.
 func (p *parser) errorf(pos token.Pos, format string, args ...any) error {
 	msg := fmt.Sprintf(format, args...)
 	p.errs = append(p.errs, Error{Pos: pos, Msg: msg})
-	return &parseErr{msg: msg}
+	return fmt.Errorf("%s", msg)
 }
 
 // newParser creates a parser for src at absolute offset 0 in file.


### PR DESCRIPTION
Finishes the recorded follow-ups ("loose ends") from the diagnostics + parser-recovery work.

## Exact interpolation type-error columns
Type errors inside an interpolation `{ expr }` previously reported a column offset by the type-check probe wrapper (`_gsxuse(` = 8 cols). Now exact:
- `ast.Interp` gains `ExprPos token.Pos` (source start of the inner expression), set in `parseInterp`.
- `emitProbes` emits a compensated `//line` so the probe maps to the exact source column (verified byte-for-byte across indentation, inner whitespace, and multi-token expressions).
- Shallow interps where the expression starts in the first 8 columns fall back to the `{`-anchored column (a `//line` column can't be < 1) — file+line exact, **never worse than before** (regression caught in review and fixed).
- Staged (`|> filter`) and component-prop probes are unchanged (rewritten/synthesized expressions have no faithful source column).

Example: `{ undefinedX }` now reports the exact column of `undefinedX` (was offset by 6).

## Cleanup (no behavior change)
- Removed the dead `errParse`/`parseErr`/`Unwrap` wiring in the parser (`errors.Is` was never consulted; `errorf` returns a plain error).
- `fmt.Errorf("%s", msg)` → `errors.New`; clarifying comments on the single-dir codegen path and the corpus nil-classifier.

Adversarially reviewed (live-probed); full suite green.

https://claude.ai/code/session_01WYfSGNoFisL8JdENKfL5CA