### PR TITLE
docs(vision): lead with ergonomics; fix 'no symbol resolver' claim

### DIFF
--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -67,12 +67,11 @@ context-aware escaping, and props checked against real Go types. The question wa
 never whether to resolve symbols, but how to keep that resolution from becoming a
 tar pit.
 
-That lesson comes first-hand. In an early experiment to bring JSX-style inline
-components to templ, the approach tried to map markup attributes onto *positional*
-function parameters and to infer whether a lowercase tag was a component. Doing that
-across packages spiralled into a large, fragile resolver on `go/packages` and
-overlays — hitting overlay module-boundary bugs and performance cliffs. The cost
-wasn't symbol resolution itself; it was the open-ended *inference* layered on top.
+The trap is the open-ended *inference*, not the resolution itself. Try to map markup
+attributes onto *positional* function parameters, or to infer whether a lowercase
+tag is a component, and the resolver has to chase those guesses across packages —
+straight into overlay module-boundary bugs and performance cliffs. gsx never takes
+that on.
 
 gsx makes design choices that keep its resolution bounded — it asks the type checker
 for facts instead of guessing:

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -105,10 +105,18 @@ ordinary Go, and the runtime package imports nothing outside the standard librar
 
 ---
 
-> **Status — alpha.** gsx is runnable end-to-end. `gsx generate` compiles
-> `.gsx` → `.x.go`, with `gsx fmt`, `gsx info`, `gsx init`, and an `gsx lsp`
-> language server (Go ↔ `.gsx` navigation, formatting, diagnostics). Codegen
-> covers interpolation, control flow, attributes with contextual escaping, the
-> `|>` pipeline + filters, components/props/`{children}`, method components, named
-> slots, attribute fallthrough, and `style` composition. See the
+> **Status — alpha.** gsx is runnable end-to-end, and it's a toolchain, not just a
+> compiler:
+>
+> - **CLI** — `gsx generate` compiles `.gsx` → `.x.go`; plus `gsx fmt`, `gsx info`,
+>   and `gsx init` to scaffold a ready-to-run project.
+> - **Editor** — `gsx lsp` language server: Go ↔ `.gsx` navigation, formatting, and
+>   diagnostics.
+> - **Dev loop** — a Vite plugin (`@gsxhq/vite-plugin-gsx`) regenerates and
+>   live-reloads on save, paired with the `github.com/gsxhq/vite` Go helper for
+>   asset manifests; `gsx init` wires both together.
+>
+> Codegen covers interpolation, control flow, attributes with contextual escaping,
+> the `|>` pipeline + filters, components/props/`{children}`, method components,
+> named slots, attribute fallthrough, and `style` composition. See the
 > [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -1,50 +1,93 @@
 # Why gsx
 
-Generating HTML from Go has always meant a trade-off. `html/template` ships in the
-standard library and auto-escapes, but it is stringly-typed: templates parse at
+Generating HTML from Go has always meant giving something up.
+
+`html/template` ships in the standard library, auto-escapes, and has the
+ergonomic everyone quietly loves — the **pipe**: `{{ .Name | upper }}` reads
+left-to-right and composes cleanly. But it is stringly-typed. Templates parse at
 runtime, errors surface late, and refactoring across templates is unsafe.
-[templ](https://templ.guide) solved the type-safety problem by compiling templates
-to Go — but its component syntax is its own, and an experimental branch that tried
-to bring JSX-style inline components to templ ran into a wall.
 
-gsx is a fresh take on that JSX-for-Go idea, designed around the lesson that broke
-the first attempt.
+[JSX](https://react.dev/learn/writing-markup-with-jsx) went the other way on
+ergonomics: markup that *reads like HTML*, with components that nest and compose
+exactly like elements. It made writing UI feel like writing HTML again — but it
+lives in JavaScript/TypeScript, with none of Go's guarantees.
 
-## The bet: no symbol resolver
+[templ](https://templ.guide) brought type-safety to Go templating by compiling
+templates to Go. It solved the late-errors problem — but its component syntax is
+its own dialect, and writing markup in it never quite feels like writing HTML.
 
-The experimental templ branch tried to map markup attributes onto *positional*
-function parameters and to infer whether a lowercase tag was a component. Doing
-that across packages drove it to a ~5,000-line symbol resolver on `go/packages`
-and overlays — hitting overlay module-boundary bugs and performance cliffs.
+gsx takes the ergonomics people already reach for — **JSX's markup and
+html/template's pipe** — and compiles them to type-safe, auto-escaping Go.
 
-gsx designs that whole class of work away:
+## Ergonomics first: markup that reads like HTML
 
-- the **`component` keyword** identifies templates — no inference about what is a
-  template;
-- **capitalization** decides component-vs-element: `<div>` is HTML, `<Card>` is a
-  component;
-- gsx **generates every component's props struct**, so it always owns the field
-  names.
+This is the whole point. You write markup, not a bespoke template dialect:
 
-What's left is plain Go the compiler type-checks. There is no symbol resolver to go
-wrong.
+```gsx
+component Card(title string, featured bool) {
+  <section class={ "card", "card-featured": featured }>
+    <h2>{ title }</h2>
+    <div class="body">{ children }</div>
+  </section>
+}
+```
 
-## Lessons borrowed from templ
-
-1. **Symbol resolution is the tar pit** — so gsx designs it away (above).
-2. **Find Go boundaries; don't re-parse Go.** templ locates where a Go expression
-   ends instead of reimplementing a Go parser. gsx does the same for embedded
-   expressions and hands the rest to the real `go/parser`.
-3. **Markup-vs-Go detection is subtle.** `{ <div/> }` (markup) versus `{ a < b }`
-   (Go) is resolved positionally — the same rule Babel uses for JSX.
+- **JSX-style inline components.** `<Card>` nests and composes exactly like
+  `<div>`. **Capitalization** decides the meaning — `<div>` is an HTML element,
+  `<Card>` is a component — so there is no inference about what a lowercase tag is.
+- **The pipe, kept.** html/template's `{{ . | f }}` is the transform ergonomic gsx
+  preserves as a `|>` filter pipeline — `{ name |> trim |> upper }` — except the
+  filters are real, type-checked Go functions resolved at codegen, not stringly
+  dispatched at runtime.
+- **Everything else is ordinary Go.** Helpers, variant logic, anything that isn't
+  a template is plain Go. The only seam is the `component` keyword and `{ }`
+  interpolation — there is no third language in between.
 
 ## Type-safe by construction
 
-Because components lower to plain Go and props are generated structs, a wrong prop
-name or type is a **compile error with a real source location** — gsx emits
-`//line` directives back to the `.gsx` — not a runtime surprise. Interpolation is
-auto-escaped, and the design treats escaping as context-aware (text, attribute,
-URL, script/style). This compile-time safety is gsx's core differentiator.
+Components compile to plain Go, and a component's props are a Go struct — either one
+**you define and own** (pass a single struct param and gsx uses your type verbatim)
+or one **gsx generates** from inline params. Either way, attributes map onto *named
+struct fields* that the Go compiler checks. A wrong prop name or type is a **compile
+error with a real source location** — gsx emits `//line` directives back to the
+`.gsx` — not a runtime surprise.
+
+Interpolation is auto-escaped, and escaping is **context-aware**: text, attribute,
+URL, and CSS contexts each get the right treatment, determined at codegen from where
+the value sits. JS contexts with no safe encoding are compile errors rather than
+silent holes. The opt-outs (`gsx.Raw`, `gsx.RawURL`, `gsx.RawCSS`) are explicit and
+grep-able. This compile-time safety is gsx's core differentiator. See
+[Principles](./principles) for the full model.
+
+## The design lesson: bounded symbol resolution
+
+To deliver those ergonomics, gsx *does* resolve symbols — it loads packages with
+`go/packages` and type-checks with `go/types` so it can do type-aware interpolation,
+context-aware escaping, and props checked against real Go types. The question was
+never whether to resolve symbols, but how to keep that resolution from becoming a
+tar pit.
+
+That lesson comes first-hand. In an early experiment to bring JSX-style inline
+components to templ, the approach tried to map markup attributes onto *positional*
+function parameters and to infer whether a lowercase tag was a component. Doing that
+across packages spiralled into a large, fragile resolver on `go/packages` and
+overlays — hitting overlay module-boundary bugs and performance cliffs. The cost
+wasn't symbol resolution itself; it was the open-ended *inference* layered on top.
+
+gsx makes design choices that keep its resolution bounded — it asks the type checker
+for facts instead of guessing:
+
+- the **`component` keyword** identifies templates — no inference about what is a
+  template;
+- **capitalization** decides component-vs-element at the tag, with no type lookup;
+- components take a **named props struct** — yours or generated — so attributes bind
+  to struct fields, never to reverse-engineered positional parameters.
+
+A related discipline: where markup embeds Go, gsx **finds where the Go expression
+ends and hands it to the real `go/parser`** rather than reimplementing one. And
+`{ <div/> }` (markup) versus `{ a < b }` (Go) is disambiguated positionally — the
+same rule Babel uses for JSX. What's left is plain Go that `go/types` checks
+directly.
 
 ## Relationship to templ
 
@@ -59,14 +102,14 @@ existing templ project.
 
 gsx is templating only — no router, no HTTP handlers, no framework. It is a way to
 write HTML as a first-class, composable Go value. Everything non-template is
-ordinary Go.
+ordinary Go, and the runtime package imports nothing outside the standard library.
 
 ---
 
-> **Status — alpha.** gsx is runnable end-to-end: `gsx generate` compiles
-> `.gsx` → `.x.go` (plus `gsx fmt` and `gsx info`). Codegen covers interpolation,
-> control flow, attributes with contextual escaping, the `|>` pipeline + filters,
-> components/props/`{children}`, method components, named slots, and attribute
-> fallthrough. Still in progress: some CLI commands (`vet`/`lsp`), `style`
-> composition, and structured diagnostics. See the
+> **Status — alpha.** gsx is runnable end-to-end. `gsx generate` compiles
+> `.gsx` → `.x.go`, with `gsx fmt`, `gsx info`, `gsx init`, and an `gsx lsp`
+> language server (Go ↔ `.gsx` navigation, formatting, diagnostics). Codegen
+> covers interpolation, control flow, attributes with contextual escaping, the
+> `|>` pipeline + filters, components/props/`{children}`, method components, named
+> slots, attribute fallthrough, and `style` composition. See the
 > [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).


### PR DESCRIPTION
## What

Rewrites `docs/guide/vision.md` (the source the website's `/guide` is synced from).

### Framing
- **Lead with ergonomics**, not symbol resolution: opens on the two ergonomics gsx adopts — **JSX-style markup** (reads like HTML, capitalization decides element-vs-component) and **html/template's pipe**, kept as the typed `|>` filter pipeline.
- **Less templ-centric.** Collapsed three templ sections into one design-lesson section + the interop section.
- The early "JSX-for-templ" experiment is now framed as **first-hand**, not a well-known public event.

### Correctness
- The old doc claimed gsx has **"no symbol resolver"** — this is wrong. gsx resolves symbols via `go/packages` + `go/types` (`internal/codegen/resolver.go`) for type-aware interpolation, contextual escaping, and props checks. Reframed as **bounded** symbol resolution: gsx asks `go/types` for facts instead of layering open-ended *inference* (which is what spiralled in the templ experiment).

### Stale status fixed (verified against code)
- `lsp` is **shipped** (was listed in-progress); `vet` **does not exist** (removed); `style` composition is **shipped**; added `gsx init`.
- Props: reflect the **author-owns-or-generated** two-mode model, not "gsx generates every props struct".
- Kept verified-accurate claims: `.x.go` output, `//line` directives, `gsx.Node`/`Render(ctx,w) error` with no templ import, templating-only.

## Note
The `gsxhq.github.io` repo gitignores `/guide/` and syncs it from this repo at build time, so this is the correct place to edit.