### PR TITLE
Parallelize CI: faster make ci, reentrant gen/codegen, cached make check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,17 @@
 name: CI
 
 # Comprehensive checks for the gsx repo. Runs on every push to main and on PRs.
+#
+# Each job invokes a Makefile target so the commands stay defined in ONE place
+# (the Makefile, which developers run locally as `make ci`); this workflow only
+# provides the runner, Go/Node toolchain, and job-level parallelism. Keep CI and
+# the Makefile in sync by editing the targets, not by duplicating commands here.
 # Jobs:
-#   build-test  — compile + vet + test BOTH Go modules (root gsx + playground/server)
-#   examples    — render-check every example AND guard against stale generated artifacts
+#   build-test  — `make ci-gomod` + `make ci-playground` (both Go modules)
+#   examples    — `make ci-examples` (regenerate artifacts, fail on drift)
 #   docs        — build the VitePress site against this checkout (catches gsx docs/guide
 #                 markdown that breaks the site — e.g. raw {{ }} / <tags> in prose)
-#   format      — gofmt + gsx fmt (advisory; see note on the job)
+#   format      — `make ci-format` (gofmt + gsx fmt)
 
 on:
   push:
@@ -29,36 +34,24 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-      - name: Build (gsx module)
-        run: go build ./...
-      - name: Vet (gsx module)
-        run: go vet ./...
-      - name: Test (gsx module)
-        run: go test ./... -count=1
-      - name: Build + test (playground/server module)
-        working-directory: playground/server
-        run: |
-          go build ./...
-          go test ./... -count=1
+      - name: gsx module (build · vet · test)
+        run: make ci-gomod
+      - name: playground/server module (build · test)
+        run: make ci-playground
 
   examples:
     name: examples render + drift
     runs-on: ubuntu-latest
+    # Render-checking every example (TestExamples) is covered by `make ci-gomod`'s
+    # `go test ./...` in the build-test job; this job guards the generated artifacts.
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-      - name: Render-check every example (compile + go run + golden)
-        run: go test ./internal/corpus/ -run TestExamples -count=1
       - name: Generated artifacts match the fixtures (no uncommitted drift)
-        run: |
-          make examples
-          if ! git diff --exit-code -- docs/guide/examples.md docs/examples.json playground/server/examples.json; then
-            echo "::error::examples artifacts are stale — run 'make examples' and commit the result"
-            exit 1
-          fi
+        run: make ci-examples
 
   docs:
     name: docs build (VitePress)
@@ -98,14 +91,5 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-      - name: gofmt
-        run: |
-          files=$(gofmt -l $(git ls-files '*.go' | grep -v /testdata/))
-          if [ -n "$files" ]; then
-            echo "::error::these Go files need gofmt:"; echo "$files"; exit 1
-          fi
-      - name: gsx fmt
-        run: |
-          if ! go run ./cmd/gsx fmt -l .; then
-            echo "::error::the listed .gsx files need 'gsx fmt -w'"; exit 1
-          fi
+      - name: gofmt + gsx fmt
+        run: make ci-format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,16 @@ Runtime (root package) is **standard-library only** — keep it dependency-free;
 
 `gsx` binary conflicts with another system tool — run `go run ./cmd/gsx …`, or `gsx version` to verify.
 
-## Before every commit to main / merge
+## Before merging to main
 
 Run `make ci` — it mirrors `.github/workflows/ci.yml` (build/vet/test both modules, examples drift, `gofmt` + `gsx fmt`).
+It is the authoritative, uncached run (`-count=1`); GitHub CI runs the same.
+
+For the **inner dev loop**, use `make check`: the same checks, but it drops `-count=1` so the Go test cache
+serves unchanged packages (a repeat run only re-tests what you edited). The cache is content-keyed over each
+test binary's import closure, so your edits always re-run the tests they affect — no stale-pass risk. You don't
+need the full uncached `make ci` after every small change; run it (or rely on GitHub CI) before merging.
+
 Pin Go to `GO_VERSION` in `ci.yml` (currently 1.26.1); a different minor re-introduces gofmt drift.
 The CI `docs` job (VitePress, clones `gsxhq/gsxhq.github.io`) isn't in `make ci` — only matters when editing `docs/guide/**`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,7 @@ Runtime (root package) is **standard-library only** — keep it dependency-free;
 ## Before merging to main
 
 Run `make ci` — it mirrors `.github/workflows/ci.yml` (build/vet/test both modules, examples drift, `gofmt` + `gsx fmt`).
-It is the authoritative, uncached run (`-count=1`); GitHub CI runs the same.
-
-For the **inner dev loop**, use `make check`: the same checks, but it drops `-count=1` so the Go test cache
-serves unchanged packages (a repeat run only re-tests what you edited). The cache is content-keyed over each
-test binary's import closure, so your edits always re-run the tests they affect — no stale-pass risk. You don't
-need the full uncached `make ci` after every small change; run it (or rely on GitHub CI) before merging.
+It is the authoritative, uncached run (`-count=1`); GitHub CI runs the same. For the **inner dev loop**, use `make check`: the same checks, but it drops `-count=1` 
 
 Pin Go to `GO_VERSION` in `ci.yml` (currently 1.26.1); a different minor re-introduces gofmt drift.
 The CI `docs` job (VitePress, clones `gsxhq/gsxhq.github.io`) isn't in `make ci` — only matters when editing `docs/guide/**`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # gsx developer tasks. Use tabs for recipe indentation.
-.PHONY: test check cover cover-html examples ci ci-gomod ci-playground ci-format
+.PHONY: test check cover cover-html examples ci ci-gomod ci-playground ci-examples ci-format
 
 # COUNT is the go-test cache control. -count=1 disables the test cache so every
 # run re-executes — the authoritative behaviour `ci` uses to mirror GitHub CI.
@@ -20,8 +20,7 @@ test:
 # — the long pole is `ci-gomod` (the gen/ e2e suite), under which the ~7s
 # playground build+test and the ~1s format check overlap for free.
 ci:
-	$(MAKE) examples
-	git diff --exit-code -- docs/guide/examples.md docs/examples.json playground/server/examples.json
+	$(MAKE) ci-examples
 	$(MAKE) -j3 ci-gomod ci-playground ci-format
 
 # Fast inner-loop check: the SAME checks as `ci`, but lets the Go test cache
@@ -44,9 +43,20 @@ ci-gomod:
 ci-playground:
 	cd playground/server && go build ./... && go test ./... $(COUNT)
 
+# Regenerate the example artifacts and fail if they drift from what's committed
+# (the generator is the source of truth). Run before the parallel lanes in `ci`:
+# the playground module embeds examples.json, so its build must not race the regen.
+ci-examples:
+	$(MAKE) examples
+	@if ! git diff --exit-code -- docs/guide/examples.md docs/examples.json playground/server/examples.json; then \
+		echo "examples artifacts are stale — run 'make examples' and commit the result"; \
+		exit 1; \
+	fi
+
 # gofmt + gsx fmt must stay clean (see the format gate note in ci.yml).
 ci-format:
-	test -z "$$(gofmt -l $$(git ls-files '*.go' | grep -v /testdata/))"
+	@files=$$(gofmt -l $$(git ls-files '*.go' | grep -v /testdata/)); \
+	if [ -n "$$files" ]; then echo "these Go files need gofmt:"; echo "$$files"; exit 1; fi
 	go run ./cmd/gsx fmt -l .
 
 # Honest cross-package coverage: -coverpkg attributes the corpus's in-process

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,36 @@
 # gsx developer tasks. Use tabs for recipe indentation.
-.PHONY: test cover cover-html examples ci
+.PHONY: test cover cover-html examples ci ci-gomod ci-playground ci-format
 
 test:
 	go test ./... -count=1
 
 # Mirrors .github/workflows/ci.yml (minus the VitePress docs build, which clones
 # the external site repo). Run before every commit to main / merge.
+#
+# Examples are regenerated FIRST, serially: the playground module embeds
+# examples.json (`//go:embed` in playground/server/presets.go), so its build
+# must not race the regeneration. The drift check reads the just-written files.
+# The three remaining lanes are independent, so `make -j3` runs them in parallel
+# — the long pole is `ci-gomod` (the gen/ e2e suite), under which the ~7s
+# playground build+test and the ~1s format check overlap for free.
 ci:
+	$(MAKE) examples
+	git diff --exit-code -- docs/guide/examples.md docs/examples.json playground/server/examples.json
+	$(MAKE) -j3 ci-gomod ci-playground ci-format
+
+# Root module: build, vet, test. The long pole (~50s of in-process e2e tests
+# in gen/, which spawn the Go toolchain per case).
+ci-gomod:
 	go build ./...
 	go vet ./...
 	go test ./... -count=1
+
+# playground/server is a separate Go module.
+ci-playground:
 	cd playground/server && go build ./... && go test ./... -count=1
-	$(MAKE) examples
-	git diff --exit-code -- docs/guide/examples.md docs/examples.json playground/server/examples.json
+
+# gofmt + gsx fmt must stay clean (see the format gate note in ci.yml).
+ci-format:
 	test -z "$$(gofmt -l $$(git ls-files '*.go' | grep -v /testdata/))"
 	go run ./cmd/gsx fmt -l .
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 # gsx developer tasks. Use tabs for recipe indentation.
-.PHONY: test cover cover-html examples ci ci-gomod ci-playground ci-format
+.PHONY: test check cover cover-html examples ci ci-gomod ci-playground ci-format
+
+# COUNT is the go-test cache control. -count=1 disables the test cache so every
+# run re-executes — the authoritative behaviour `ci` uses to mirror GitHub CI.
+# `make check` overrides it to empty, letting the cache skip unchanged packages.
+COUNT ?= -count=1
 
 test:
 	go test ./... -count=1
 
 # Mirrors .github/workflows/ci.yml (minus the VitePress docs build, which clones
-# the external site repo). Run before every commit to main / merge.
+# the external site repo). Run before merging to main; this is the authoritative,
+# uncached run (-count=1). For the inner dev loop use `make check` instead.
 #
 # Examples are regenerated FIRST, serially: the playground module embeds
 # examples.json (`//go:embed` in playground/server/presets.go), so its build
@@ -18,16 +24,25 @@ ci:
 	git diff --exit-code -- docs/guide/examples.md docs/examples.json playground/server/examples.json
 	$(MAKE) -j3 ci-gomod ci-playground ci-format
 
+# Fast inner-loop check: the SAME checks as `ci`, but lets the Go test cache
+# serve unchanged packages (drops -count=1), so a repeat run after editing one
+# package only re-tests that package and its dependents. The cache is content-
+# keyed over each test binary's import closure, so your edits always re-run the
+# tests they affect — there is no stale-pass risk for code you are changing.
+# GitHub CI's -count=1 run (and `make ci`) remain the authoritative gate.
+check:
+	$(MAKE) ci COUNT=
+
 # Root module: build, vet, test. The long pole (~50s of in-process e2e tests
 # in gen/, which spawn the Go toolchain per case).
 ci-gomod:
 	go build ./...
 	go vet ./...
-	go test ./... -count=1
+	go test ./... $(COUNT)
 
 # playground/server is a separate Go module.
 ci-playground:
-	cd playground/server && go build ./... && go test ./... -count=1
+	cd playground/server && go build ./... && go test ./... $(COUNT)
 
 # gofmt + gsx fmt must stay clean (see the format gate note in ci.yml).
 ci-format:

--- a/gen/api_nav_e2e_test.go
+++ b/gen/api_nav_e2e_test.go
@@ -52,6 +52,7 @@ func lspRequest(v any) string {
 // THE ARGUMENT LIST in card.gsx (the props ARE the params, so the props struct
 // lands on the param list rather than the component name).
 func TestAPINavCardProps(t *testing.T) {
+	t.Parallel()
 	dir, cardSrc, _, renderSrc := setupAPINavModule(t)
 	renderURI := "file://" + filepath.Join(dir, "render.go")
 
@@ -108,6 +109,7 @@ func paramListStart(t *testing.T, cardSrc string) (line, character int) {
 
 // TestAPINavTitle: gd on `Title` field in render.go → resolves to card.gsx at the `title` param.
 func TestAPINavTitle(t *testing.T) {
+	t.Parallel()
 	dir, cardSrc, _, renderSrc := setupAPINavModule(t)
 	renderURI := "file://" + filepath.Join(dir, "render.go")
 
@@ -150,6 +152,7 @@ func TestAPINavTitle(t *testing.T) {
 
 // TestAPINavComponentTag: gd on `Card` tag in page.gsx → resolves to card.gsx component declaration.
 func TestAPINavComponentTag(t *testing.T) {
+	t.Parallel()
 	dir, _, pageSrc, _ := setupAPINavModule(t)
 	pageURI := "file://" + filepath.Join(dir, "page.gsx")
 

--- a/gen/attrtypes_test.go
+++ b/gen/attrtypes_test.go
@@ -7,6 +7,7 @@ package gen
 import "testing"
 
 func TestAttrTypesPublicFacadeCompiles(t *testing.T) {
+	t.Parallel()
 	// Construct rules using only gen.Rule — no attrclass import.
 	var cfg config
 	WithJSAttrs(Rule{Prefix: "wire:"})(&cfg)

--- a/gen/cacheinval_test.go
+++ b/gen/cacheinval_test.go
@@ -18,6 +18,7 @@ import (
 // what prevents the "5aed1ba changed emit but version wasn't bumped → cache
 // served stale output" class of bug without relying on a manual constant bump.
 func TestCodegenIdentityKeySensitivity(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module ex/cid\n\ngo 1.26\n"), 0o644)
 	os.MkdirAll(filepath.Join(tmp, "a"), 0o755)
@@ -53,6 +54,7 @@ func TestCodegenIdentityKeySensitivity(t *testing.T) {
 // (so a rebuilt binary auto-invalidates the cache) and that the hash is stable
 // within a process and matches a manual hash of the executable.
 func TestSelfHashStableNonEmpty(t *testing.T) {
+	t.Parallel()
 	h1 := selfHash()
 	if h1 == "" {
 		t.Fatal("selfHash empty — gsx binary not hashed into the cache key")
@@ -78,6 +80,7 @@ func TestSelfHashStableNonEmpty(t *testing.T) {
 // on disk) is reported as up-to-date rather than vanishing into silence: the
 // second Generate writes nothing but counts the unchanged output in UpToDate.
 func TestGenerateReportsUpToDate(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -109,6 +112,7 @@ func TestGenerateReportsUpToDate(t *testing.T) {
 // writes nothing because everything is current — so -v / a bare run is never
 // silently empty.
 func TestRunGenerateUpToDateMessage(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -130,6 +134,7 @@ func TestRunGenerateUpToDateMessage(t *testing.T) {
 // codegen version (a coarse, explicit invalidation lever) and the binary hash
 // (automatic invalidation on any codegen change).
 func TestCodegenIdentityComposition(t *testing.T) {
+	t.Parallel()
 	id := codegenIdentity()
 	if !strings.Contains(id, codegen.Version()) {
 		t.Fatalf("codegenIdentity %q must include codegen.Version() %q", id, codegen.Version())

--- a/gen/cachekey_minify_test.go
+++ b/gen/cachekey_minify_test.go
@@ -18,6 +18,7 @@ func keyWith(t *testing.T, cssMinify, jsMinify bool) string {
 }
 
 func TestComputeKey_MinifyChangesKey(t *testing.T) {
+	t.Parallel()
 	on := keyWith(t, true, true)
 	offCSS := keyWith(t, false, true)
 	offJS := keyWith(t, true, false)

--- a/gen/cachekey_test.go
+++ b/gen/cachekey_test.go
@@ -10,6 +10,7 @@ import (
 // a different buildCtx string must produce a different cache key, and the same
 // buildCtx must produce the same key (stability).
 func TestBuildContextKeySensitivity(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module ex/bctx\n\ngo 1.26\n"), 0o644)
 	os.MkdirAll(filepath.Join(tmp, "a"), 0o755)
@@ -46,6 +47,7 @@ func TestBuildContextKeySensitivity(t *testing.T) {
 }
 
 func TestDirSourceHashStableAndSensitive(t *testing.T) {
+	t.Parallel()
 	d := t.TempDir()
 	os.WriteFile(filepath.Join(d, "a.gsx"), []byte("package v\ncomponent A(){<p>x</p>}\n"), 0o644)
 	h1, err := dirSourceHash(d)
@@ -80,6 +82,7 @@ func TestDirSourceHashStableAndSensitive(t *testing.T) {
 }
 
 func TestComputeKeyDepClosure(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module ex/app\n\ngo 1.26\n"), 0o644)
 	mk := func(p, content string) {
@@ -125,6 +128,7 @@ func loadGraphMust(t *testing.T, root string) map[string]pkgInfo {
 // produces a different cache key (so changing attr rules invalidates the cache),
 // and that the same fingerprint produces the same key (stability).
 func TestComputeKeyFingerprintSensitivity(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module ex/fptest\n\ngo 1.26\n"), 0o644)
 	os.MkdirAll(filepath.Join(tmp, "a"), 0o755)

--- a/gen/cachestore_test.go
+++ b/gen/cachestore_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestStoreRoundTrip(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	out := pkgOutput{"a.x.go": []byte("package a\n"), "b.x.go": []byte("package b\n")}
 	if err := storePut(dir, "deadbeefkey", out); err != nil {

--- a/gen/configfile_e2e_test.go
+++ b/gen/configfile_e2e_test.go
@@ -39,6 +39,7 @@ component C(s string) { <p>{ s |> f("k") }</p> }
 // the STOCK run path (no programmatic opts) honors a repo-root gsx.toml found by
 // walking up ACROSS a go.mod module boundary, and lowers the ctx-injecting alias.
 func TestStockGenerateHonorsConfigAcrossModuleBoundary(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-run e2e in -short mode")
 	}
@@ -105,6 +106,7 @@ func main() {
 // programmatic opt alias both apply, and an opt overrides a same-named config
 // alias (opt wins, last-wins). Driven through runConfig (Main without os.Exit).
 func TestMainMergeConfigAndOpts(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-run e2e in -short mode")
 	}
@@ -204,6 +206,7 @@ component C(s string) { <p>{ s |> shout }</p> }
 // TestInfoPrintsConfigPathAndAliases proves `gsx info` prints the discovered
 // gsx.toml path and the resolved alias (name → pkg.Func).
 func TestInfoPrintsConfigPathAndAliases(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-load info test in -short mode")
 	}
@@ -238,6 +241,7 @@ func TestInfoPrintsConfigPathAndAliases(t *testing.T) {
 
 // TestInfoNoConfig proves `gsx info` prints "config: none" when no gsx.toml.
 func TestInfoNoConfig(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-load info test in -short mode")
 	}

--- a/gen/configfile_test.go
+++ b/gen/configfile_test.go
@@ -23,6 +23,7 @@ func mkfile(t *testing.T, path, content string) {
 
 // TestLoadConfigAllKeys decodes each schema key and asserts the resolved config.
 func TestLoadConfigAllKeys(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "gsx.toml")
 	mkfile(t, path, `
@@ -70,6 +71,7 @@ name = "data-style"
 // TestSplitPkgFunc covers the shared alias-string parser, including a dotted
 // final path segment (gopkg.in/x.F) and non-exported rejection.
 func TestSplitPkgFunc(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		in      string
 		pkg     string
@@ -102,6 +104,7 @@ func TestSplitPkgFunc(t *testing.T) {
 // TestLoadConfigBadAlias proves a non-exported alias target errors clearly,
 // naming the path and the alias key.
 func TestLoadConfigBadAlias(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "gsx.toml")
 	mkfile(t, path, "[filters]\nbad = \"example.com/p.helper\"\n")
@@ -116,6 +119,7 @@ func TestLoadConfigBadAlias(t *testing.T) {
 
 // TestLoadConfigUnknownKey proves strict decoding rejects an unknown key.
 func TestLoadConfigUnknownKey(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "gsx.toml")
 	mkfile(t, path, "filteres = [\"x\"]\n") // typo
@@ -130,6 +134,7 @@ func TestLoadConfigUnknownKey(t *testing.T) {
 
 // TestLoadConfigBothNamePrefix proves a rule with both name+prefix is rejected.
 func TestLoadConfigBothNamePrefix(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "gsx.toml")
 	mkfile(t, path, "[[jsAttrs]]\nname = \"a\"\nprefix = \"b\"\n")
@@ -144,6 +149,7 @@ func TestLoadConfigBothNamePrefix(t *testing.T) {
 
 // TestDiscoverConfigMissing proves a tree with no gsx.toml yields (",false).
 func TestDiscoverConfigMissing(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	sub := filepath.Join(tmp, "a", "b")
 	if err := os.MkdirAll(sub, 0o755); err != nil {
@@ -158,6 +164,7 @@ func TestDiscoverConfigMissing(t *testing.T) {
 // boundary: a repo-root gsx.toml (bounded by .git) is found from a nested
 // sub-module dir.
 func TestDiscoverConfigAcrossModuleBoundary(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0o755); err != nil {
 		t.Fatal(err)
@@ -177,6 +184,7 @@ func TestDiscoverConfigAcrossModuleBoundary(t *testing.T) {
 
 // TestDiscoverConfigNearerWins proves a nearer gsx.toml overrides an ancestor.
 func TestDiscoverConfigNearerWins(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0o755); err != nil {
 		t.Fatal(err)
@@ -197,6 +205,7 @@ func TestDiscoverConfigNearerWins(t *testing.T) {
 // TestDiscoverConfigStopsAtGitRoot proves a gsx.toml ABOVE the .git repo root
 // is NOT used (the walk is bounded at the repo root, inclusive).
 func TestDiscoverConfigStopsAtGitRoot(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	// gsx.toml above the repo root — must NOT be used.
 	mkfile(t, filepath.Join(tmp, "gsx.toml"), "filters = []\n")
@@ -217,6 +226,7 @@ func TestDiscoverConfigStopsAtGitRoot(t *testing.T) {
 // walk falls back to the module root (go.mod) as the stop and finds a gsx.toml
 // beside go.mod.
 func TestDiscoverConfigNonRepoFallback(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	modCfg := filepath.Join(tmp, "gsx.toml")
 	mkfile(t, modCfg, "filters = []\n")
@@ -237,6 +247,7 @@ func TestDiscoverConfigNonRepoFallback(t *testing.T) {
 // the I1+I2 regression: config used to load unconditionally before dispatch, so a
 // typo'd gsx.toml broke `gsx version` etc.
 func TestConfigAgnosticCommandsSurviveMalformedConfig(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0o755); err != nil {
 		t.Fatal(err)
@@ -275,6 +286,7 @@ func TestConfigAgnosticCommandsSurviveMalformedConfig(t *testing.T) {
 // TestMergeConfigOptsOverride proves opts append after base (opts win last) and
 // func-valued opts override base.
 func TestMergeConfigOptsOverride(t *testing.T) {
+	t.Parallel()
 	base := applyOpts()
 	base.filterPkgs = []string{"a"}
 	base.aliases = []codegen.FilterAlias{{Name: "base", PkgPath: "p", FuncName: "Base"}}
@@ -293,6 +305,7 @@ func TestMergeConfigOptsOverride(t *testing.T) {
 }
 
 func TestConfigPrintWidth(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gsx.toml")
 	if err := os.WriteFile(path, []byte("printWidth = 100\n"), 0o644); err != nil {
@@ -308,6 +321,7 @@ func TestConfigPrintWidth(t *testing.T) {
 }
 
 func TestConfigPrintWidthDefault(t *testing.T) {
+	t.Parallel()
 	var c config
 	if got := c.effectivePrintWidth(); got != 80 {
 		t.Fatalf("default printWidth = %d, want 80", got)

--- a/gen/cssformatter_test.go
+++ b/gen/cssformatter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestWithCSSFormatterOption(t *testing.T) {
+	t.Parallel()
 	var cfg config
 	f := func(src []byte) ([]byte, error) { return src, nil }
 	WithCSSFormatter(rawfmt.Formatter(f))(&cfg)
@@ -16,6 +17,7 @@ func TestWithCSSFormatterOption(t *testing.T) {
 }
 
 func TestMergeConfigCSSFormatterOptsWins(t *testing.T) {
+	t.Parallel()
 	base := config{cssFmt: func(src []byte) ([]byte, error) { return []byte("base"), nil }}
 	opts := config{cssFmt: func(src []byte) ([]byte, error) { return []byte("opts"), nil }}
 	merged := mergeConfig(base, opts)
@@ -26,6 +28,7 @@ func TestMergeConfigCSSFormatterOptsWins(t *testing.T) {
 }
 
 func TestMergeConfigCSSFormatterFallsBackToBase(t *testing.T) {
+	t.Parallel()
 	base := config{cssFmt: func(src []byte) ([]byte, error) { return []byte("base"), nil }}
 	merged := mergeConfig(base, config{})
 	if merged.cssFmt == nil {

--- a/gen/definition_attr_e2e_test.go
+++ b/gen/definition_attr_e2e_test.go
@@ -13,6 +13,7 @@ import (
 // gd on the `comments` attribute name in `<CommentsList comments={nil}/>`
 // resolves to the `comments` parameter of `component CommentsList(comments []Comment)`.
 func TestDefinitionAttrParam(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/definition_crosspkg_e2e_test.go
+++ b/gen/definition_crosspkg_e2e_test.go
@@ -13,6 +13,7 @@ import (
 // gd on the cross-package tag `components.Input` in <components.Input .../>
 // resolves to `component Input(...)` in the imported package's .gsx.
 func TestDefinitionCrossPkgTag(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -81,6 +82,7 @@ func TestDefinitionCrossPkgTag(t *testing.T) {
 // gd on the `name` attribute of <components.Input name="a"/> resolves to the
 // `name` parameter of `component Input(name string)` in the imported package.
 func TestDefinitionCrossPkgAttrParam(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -158,6 +160,7 @@ func TestDefinitionCrossPkgAttrParam(t *testing.T) {
 // position against the importing package's fset returned a wrong/empty location
 // (a random spot in page.gsx, never helpers.gsx).
 func TestDefinitionCrossPkgExprCall(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -230,6 +233,7 @@ func TestDefinitionCrossPkgExprCall(t *testing.T) {
 // Bug B (cross-package): crossPkgTagDeclAt previously only checked el.Pos()
 // (opening), so a cursor on the closing tag returned null.
 func TestDefinitionCrossPkgClosingTag(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/definition_e2e_test.go
+++ b/gen/definition_e2e_test.go
@@ -15,6 +15,7 @@ import (
 // TestDefinitionD1 drives the real analyzer through lsp.Server: go-to-def on the
 // `Name` field in `{ u.Name }` resolves to its declaration in user.go.
 func TestDefinitionD1(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -75,6 +76,7 @@ func TestDefinitionD1(t *testing.T) {
 // `u` in `{ u.Name }`) resolves back to the param's declaration in card.gsx — not
 // null, and never into generated .x.go.
 func TestDefinitionParam(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -149,6 +151,7 @@ func TestDefinitionParam(t *testing.T) {
 // raw-Go body is emitted under a //line directive in the skeleton, which is what
 // makes this resolve to source.
 func TestDefinitionRawGoSymbol(t *testing.T) {
+	t.Parallel()
 	src := "package x\n\nfunc greeting() string {\n\treturn \"hi\"\n}\n\ncomponent Page() {\n\t<p>{ greeting() }</p>\n}\n"
 	loc := rawGoDefinition(t, src, "{ greeting()", 2 /* skip "{ " to the 'g' */)
 	if loc == nil {
@@ -170,6 +173,7 @@ func TestDefinitionRawGoSymbol(t *testing.T) {
 // decls) and reports the body's offset, so the //line still anchors the func to
 // its true .gsx line despite the removed import lines.
 func TestDefinitionRawGoSymbolWithImport(t *testing.T) {
+	t.Parallel()
 	src := "package x\n\nimport \"strings\"\n\nfunc shout(s string) string {\n\treturn strings.ToUpper(s)\n}\n\ncomponent Page() {\n\t<p>{ shout(\"hi\") }</p>\n}\n"
 	loc := rawGoDefinition(t, src, "{ shout(", 2 /* skip "{ " to the 's' */)
 	if loc == nil {

--- a/gen/diag_render_test.go
+++ b/gen/diag_render_test.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -23,13 +24,15 @@ component A(ctx string) {
 func runGenerateArgs(t *testing.T, args []string) (int, string, string) {
 	t.Helper()
 	var out, errb bytes.Buffer
-	code := runGenerate(args, &out, &errb, false, false, true /*noCache*/, nil, nil, attrclass.Builtin(), nil, nil, nil, true, true)
+	wd, _ := os.Getwd()
+	code := runGenerate(args, &out, &errb, false, false, true /*noCache*/, nil, nil, attrclass.Builtin(), nil, nil, nil, true, true, wd)
 	return code, out.String(), errb.String()
 }
 
 // TestGenerateDiagNonZeroExit proves that a .gsx with a codegen error (reserved-param)
 // causes runGenerate to exit with code 1.
 func TestGenerateDiagNonZeroExit(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -46,6 +49,7 @@ func TestGenerateDiagNonZeroExit(t *testing.T) {
 // runGenerate emits a compact-format diagnostic line containing "error[" and
 // the file position.
 func TestGenerateDiagCompactOutput(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -66,6 +70,7 @@ func TestGenerateDiagCompactOutput(t *testing.T) {
 // JSON array on stdout containing the diagnostic with the expected code field,
 // and the exit code is still non-zero.
 func TestGenerateDiagJSONOutput(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -100,6 +105,7 @@ func TestGenerateDiagJSONOutput(t *testing.T) {
 // TestGenerateDiagJSONNoStderr proves that --json writes nothing to stderr for
 // diagnostics (only to stdout), keeping stderr clean for scripted use.
 func TestGenerateDiagJSONNoStderr(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -117,6 +123,7 @@ func TestGenerateDiagJSONNoStderr(t *testing.T) {
 // error: the fields file, range.start/end, severity, code, and source must be
 // present and have the expected types and values. This is the JSON-shape golden.
 func TestGenerateDiagJSONShape(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -192,6 +199,7 @@ func TestGenerateDiagJSONShape(t *testing.T) {
 // file or directory". The fix pre-partitions args into flags and positionals
 // before calling gfs.Parse.
 func TestGenerateDiagJSONFlagAfterPath(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/envconfig_test.go
+++ b/gen/envconfig_test.go
@@ -50,6 +50,7 @@ func TestApplyEnvOverrides_MinifyVocabulary(t *testing.T) {
 }
 
 func TestApplyEnvOverrides_AbsentIsNoop(t *testing.T) {
+	t.Parallel()
 	// No GSX_* set: file value (none/full) is preserved untouched.
 	base := config{cssMinLevel: MinifyNone, jsMinLevel: MinifyFull}
 	cfg, err := applyEnvOverrides(base)
@@ -66,7 +67,7 @@ func TestResolveConfig_EnvWithoutFile(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 	t.Setenv("GSX_MINIFY", "none")
-	merged, path, err := resolveConfig(config{})
+	merged, path, err := resolveConfig(config{}, dir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gen/fieldmatcher_e2e_test.go
+++ b/gen/fieldmatcher_e2e_test.go
@@ -15,6 +15,7 @@ import (
 // attribute "x-title" directly to "Title" (bypassing the default "XTitle"
 // candidate) and confirms the generated output reflects that mapping.
 func TestWithFieldMatcherGoodMapper(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -77,6 +78,7 @@ component Page() {
 // instead of a raw Go compile error. This is the safety net for buggy custom
 // matchers; the default matcher is unaffected (it only ever returns known fields).
 func TestWithFieldMatcherBadMapper(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/fmt.go
+++ b/gen/fmt.go
@@ -42,7 +42,7 @@ import (
 //
 // All logic lives here (runFmt returns an int) so tests can drive it without
 // os.Exit.
-func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Formatter) int {
+func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Formatter, workDir string) int {
 	fs := flag.NewFlagSet("gsx fmt", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
@@ -62,7 +62,9 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 		return 2
 	}
 
-	paths := fs.Args()
+	// Anchor relative path arguments (and the default ".") at workDir so fmt never
+	// consults the process-global cwd.
+	paths := absPaths(workDir, fs.Args())
 	files, err := gsxFiles(paths)
 	if err != nil {
 		fmt.Fprintf(stderr, "gsx: %v\n", err)

--- a/gen/fmt_test.go
+++ b/gen/fmt_test.go
@@ -12,7 +12,8 @@ import (
 func fmtCapture(t *testing.T, args []string) (int, string, string) {
 	t.Helper()
 	var out, errb bytes.Buffer
-	code := runFmt(&out, &errb, args, nil, nil)
+	wd, _ := os.Getwd()
+	code := runFmt(&out, &errb, args, nil, nil, wd)
 	return code, out.String(), errb.String()
 }
 
@@ -30,6 +31,7 @@ component   Hi(name string) {
 // TestFmtDefaultStdout proves the default mode writes formatted output to stdout
 // and does not touch the file on disk.
 func TestFmtDefaultStdout(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "hi.gsx")
 	if err := os.WriteFile(p, []byte(unformattedGsx), 0o644); err != nil {
@@ -51,6 +53,7 @@ func TestFmtDefaultStdout(t *testing.T) {
 
 // TestFmtListUnformatted proves -l lists an unformatted file and exits 1.
 func TestFmtListUnformatted(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "hi.gsx")
 	if err := os.WriteFile(p, []byte(unformattedGsx), 0o644); err != nil {
@@ -68,6 +71,7 @@ func TestFmtListUnformatted(t *testing.T) {
 // TestFmtListFormatted proves -l on an already-canonical file exits 0 with no
 // output. The canonical form is obtained by running fmt's default mode first.
 func TestFmtListFormatted(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "hi.gsx")
 	if err := os.WriteFile(p, []byte(unformattedGsx), 0o644); err != nil {
@@ -90,6 +94,7 @@ func TestFmtListFormatted(t *testing.T) {
 // TestFmtWriteIdempotent proves -w rewrites a changed file and is a no-op on the
 // second run.
 func TestFmtWriteIdempotent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "hi.gsx")
 	if err := os.WriteFile(p, []byte(unformattedGsx), 0o644); err != nil {
@@ -123,6 +128,7 @@ func TestFmtWriteIdempotent(t *testing.T) {
 // TestFmtParseError proves a parse-error file is reported to stderr and exits 1,
 // while other files in the same invocation still format.
 func TestFmtParseError(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	bad := filepath.Join(dir, "bad.gsx")
 	if err := os.WriteFile(bad, []byte("package views\n\ncomponent Broken( {\n"), 0o644); err != nil {
@@ -148,6 +154,7 @@ func TestFmtParseError(t *testing.T) {
 // TestFmtDirRecursive proves a directory arg recurses for .gsx files and skips
 // junk dirs (here a hidden dir).
 func TestFmtDirRecursive(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.gsx"), []byte(unformattedGsx), 0o644); err != nil {
 		t.Fatal(err)
@@ -185,6 +192,7 @@ func TestFmtDirRecursive(t *testing.T) {
 // TestFmtDiff proves -d emits a unified-diff-style block for a changed file and
 // exits 1.
 func TestFmtDiff(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "hi.gsx")
 	if err := os.WriteFile(p, []byte(unformattedGsx), 0o644); err != nil {
@@ -204,6 +212,7 @@ func TestFmtDiff(t *testing.T) {
 
 // TestFmtRemovesUnusedImport: `gsx fmt -w` drops an unused import by default.
 func TestFmtRemovesUnusedImport(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -229,6 +238,7 @@ func TestFmtRemovesUnusedImport(t *testing.T) {
 
 // TestFmtNoImportsKeepsUnused: `-no-imports` skips removal (syntactic only).
 func TestFmtNoImportsKeepsUnused(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -255,6 +265,7 @@ func TestFmtNoImportsKeepsUnused(t *testing.T) {
 // TestFmtOutsideModuleFallsBack: a .gsx not in any module is still formatted
 // (syntactically); the unused import is kept and the exit code is success.
 func TestFmtOutsideModuleFallsBack(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/formatting_e2e_test.go
+++ b/gen/formatting_e2e_test.go
@@ -16,6 +16,7 @@ import (
 // a non-canonical .gsx buffer yields a single whole-document TextEdit whose text
 // is the canonical form.
 func TestFormattingReformats(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hi.gsx")
 	if err := os.WriteFile(path, []byte(unformattedGsx), 0o644); err != nil {
@@ -47,6 +48,7 @@ func TestFormattingReformats(t *testing.T) {
 
 // TestFormattingAlreadyCanonical: formatting a canonical buffer returns no edits.
 func TestFormattingAlreadyCanonical(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hi.gsx")
 	canonical, err := formatGsx(path, []byte(unformattedGsx))
@@ -64,6 +66,7 @@ func TestFormattingAlreadyCanonical(t *testing.T) {
 
 // TestFormattingAdvertised: the server advertises documentFormattingProvider.
 func TestFormattingAdvertised(t *testing.T) {
+	t.Parallel()
 	frame := func(v any) string {
 		b, _ := json.Marshal(v)
 		return "Content-Length: " + strconv.Itoa(len(b)) + "\r\n\r\n" + string(b)
@@ -82,6 +85,7 @@ func TestFormattingAdvertised(t *testing.T) {
 // TestFormattingRemovesUnusedImport: textDocument/formatting on a .gsx with an
 // unused import returns an edit whose text drops that import.
 func TestFormattingRemovesUnusedImport(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -42,6 +42,34 @@ func shouldSkipDir(name string) bool {
 // directory. Directories named .git, vendor, node_modules, testdata, or any
 // hidden (dot-prefixed) directory are skipped and not descended into. An error
 // is returned if any given path does not exist.
+// absAgainst resolves p against base when p is relative, returning a cleaned
+// absolute path; an already-absolute p is returned cleaned, unchanged. base must
+// itself be absolute. This is the reentrant replacement for filepath.Abs at the
+// CLI path-resolution boundary: resolution depends on an explicit working
+// directory (-C, else the startup cwd) instead of the process-global cwd, so the
+// command never has to os.Chdir and can run concurrently (the gen test suite
+// drives run/runConfig in-process and now runs in parallel).
+func absAgainst(base, p string) string {
+	if filepath.IsAbs(p) {
+		return filepath.Clean(p)
+	}
+	return filepath.Join(base, p)
+}
+
+// absPaths resolves each CLI path argument against base (see absAgainst). An
+// empty list defaults to base itself — the old "." default, now anchored at the
+// chosen working directory rather than the process cwd.
+func absPaths(base string, paths []string) []string {
+	if len(paths) == 0 {
+		return []string{base}
+	}
+	out := make([]string, len(paths))
+	for i, p := range paths {
+		out[i] = absAgainst(base, p)
+	}
+	return out
+}
+
 func discoverDirs(paths []string) ([]string, error) {
 	if len(paths) == 0 {
 		paths = []string{"."}

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -67,6 +67,7 @@ component Bye(name string) {
 // TestGenerateSinglePackage writes two .gsx files into one package, generates,
 // asserts the .x.go files exist on disk, and proves the result compiles.
 func TestGenerateSinglePackage(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-build test in -short mode")
 	}
@@ -97,6 +98,7 @@ func TestGenerateSinglePackage(t *testing.T) {
 // TestGenerateNestedDirs proves two package dirs each with a .gsx are both
 // generated and the whole module builds.
 func TestGenerateNestedDirs(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-build test in -short mode")
 	}
@@ -128,6 +130,7 @@ func TestGenerateNestedDirs(t *testing.T) {
 // (as an error-severity diagnostic naming the bad file) and writes nothing for
 // that dir, while a good dir in the same call IS written.
 func TestGeneratePartialFailure(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -172,6 +175,7 @@ func TestGeneratePartialFailure(t *testing.T) {
 
 // TestGenerateNoGsxDir proves a dir with no .gsx files is a clean no-op.
 func TestGenerateNoGsxDir(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	res, err := Generate([]string{tmp})
 	if err != nil {
@@ -184,6 +188,7 @@ func TestGenerateNoGsxDir(t *testing.T) {
 
 // TestGenerateMissingPath proves a non-existent path is an error.
 func TestGenerateMissingPath(t *testing.T) {
+	t.Parallel()
 	_, err := Generate([]string{"/does/not/exist/anywhere"})
 	if err == nil {
 		t.Fatal("expected error for missing path, got nil")
@@ -191,6 +196,7 @@ func TestGenerateMissingPath(t *testing.T) {
 }
 
 func TestDiscoverDirsFileArg(t *testing.T) {
+	t.Parallel()
 	mod := t.TempDir()
 	pkgDir := filepath.Join(mod, "views")
 	gsxPath := writeFile(t, pkgDir, "hi.gsx", hiComponent)
@@ -205,6 +211,7 @@ func TestDiscoverDirsFileArg(t *testing.T) {
 }
 
 func TestDiscoverDirsSkipsJunk(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	// A real package dir.
 	writeFile(t, filepath.Join(root, "pkg"), "a.gsx", hiComponent)
@@ -226,6 +233,7 @@ func TestDiscoverDirsSkipsJunk(t *testing.T) {
 }
 
 func TestDiscoverDirsDefaultsToCwd(t *testing.T) {
+	t.Parallel()
 	// Empty paths must default to ["."] and not error.
 	if _, err := discoverDirs(nil); err != nil {
 		t.Fatalf("discoverDirs(nil): %v", err)
@@ -233,6 +241,7 @@ func TestDiscoverDirsDefaultsToCwd(t *testing.T) {
 }
 
 func TestDiscoverDirsSortedUnique(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "b"), "x.gsx", hiComponent)
 	writeFile(t, filepath.Join(root, "a"), "x.gsx", hiComponent)

--- a/gen/go_definition_e2e_test.go
+++ b/gen/go_definition_e2e_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGoToGsxDefinition(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skips module resolution in -short")
 	}

--- a/gen/hover_attr_e2e_test.go
+++ b/gen/hover_attr_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 // H1 same-package: hover on the `comments` attribute → "comments []store.Comment".
 func TestHoverAttrParamSamePkg(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -36,6 +37,7 @@ func TestHoverAttrParamSamePkg(t *testing.T) {
 // H1 cross-package + H2: hover on `name` attr → "name string"; hover on the
 // `components.Input` tag → "component Input(".
 func TestHoverCrossPkgAttrAndTag(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/hover_e2e_test.go
+++ b/gen/hover_e2e_test.go
@@ -88,6 +88,7 @@ func hoverAt(t *testing.T, dir, file, text, needle string, cursorOff int) *lsp.H
 }
 
 func TestHoverField(t *testing.T) {
+	t.Parallel()
 	dir, src := hoverModule(t)
 	h := hoverAt(t, dir, "card.gsx", src, "{ u.Name }", len("{ u."))
 	if h == nil || !strings.Contains(h.Contents.Value, "field Name string") {
@@ -99,6 +100,7 @@ func TestHoverField(t *testing.T) {
 }
 
 func TestHoverVar(t *testing.T) {
+	t.Parallel()
 	dir, src := hoverModule(t)
 	h := hoverAt(t, dir, "card.gsx", src, "{ u.Name }", len("{ ")) // on 'u'
 	if h == nil || !strings.Contains(h.Contents.Value, "var u User") {
@@ -107,6 +109,7 @@ func TestHoverVar(t *testing.T) {
 }
 
 func TestHoverFunc(t *testing.T) {
+	t.Parallel()
 	dir, src := hoverModule(t)
 	h := hoverAt(t, dir, "card.gsx", src, "Greeting(u.Email)", 0) // on 'Greeting'
 	if h == nil || !strings.Contains(h.Contents.Value, "func Greeting(name string) string") {
@@ -115,6 +118,7 @@ func TestHoverFunc(t *testing.T) {
 }
 
 func TestHoverWholeExprType(t *testing.T) {
+	t.Parallel()
 	dir, src := hoverModule(t)
 	h := hoverAt(t, dir, "card.gsx", src, `{ "hi" }`, len("{ ")) // on the string literal
 	if h == nil || !strings.Contains(h.Contents.Value, "string") {
@@ -123,6 +127,7 @@ func TestHoverWholeExprType(t *testing.T) {
 }
 
 func TestHoverGoFileNull(t *testing.T) {
+	t.Parallel()
 	dir, _ := hoverModule(t)
 	goSrc, _ := os.ReadFile(filepath.Join(dir, "user.go"))
 	h := hoverAt(t, dir, "user.go", string(goSrc), "Greeting", 0)
@@ -132,6 +137,7 @@ func TestHoverGoFileNull(t *testing.T) {
 }
 
 func TestHoverNonExprNull(t *testing.T) {
+	t.Parallel()
 	dir, src := hoverModule(t)
 	h := hoverAt(t, dir, "card.gsx", src, "<div>", 1) // on the 'div' tag text, not an expr
 	if h != nil {
@@ -140,6 +146,7 @@ func TestHoverNonExprNull(t *testing.T) {
 }
 
 func TestHoverPipedNull(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -161,6 +168,7 @@ func TestHoverPipedNull(t *testing.T) {
 }
 
 func TestHoverComponentTag(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -182,6 +190,7 @@ func TestHoverComponentTag(t *testing.T) {
 }
 
 func TestHoverCapabilityAdvertised(t *testing.T) {
+	t.Parallel()
 	frame := func(v any) string {
 		b, _ := json.Marshal(v)
 		return "Content-Length: " + strconv.Itoa(len(b)) + "\r\n\r\n" + string(b)

--- a/gen/info_test.go
+++ b/gen/info_test.go
@@ -14,6 +14,7 @@ import (
 // TestRunInfoStd drives runInfo against the repo root (a module that resolves
 // std) and checks the output lists std filters and the filter-packages header.
 func TestRunInfoStd(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)
@@ -35,6 +36,7 @@ func TestRunInfoStd(t *testing.T) {
 // single "gsx " prefix (regression: version() began returning a banner that
 // itself starts with "gsx ", which doubled the prefix to "gsx gsx ...").
 func TestRunInfoVersionSingleLine(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)
@@ -51,6 +53,7 @@ func TestRunInfoVersionSingleLine(t *testing.T) {
 
 // TestRunInfoShadow proves a shadowed filter is marked with "(shadows ".
 func TestRunInfoShadow(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-load shadow test in -short mode")
 	}
@@ -81,6 +84,7 @@ func TestRunInfoShadow(t *testing.T) {
 
 // TestRunInfoBadPkg proves a non-existent filter package makes runInfo exit 1.
 func TestRunInfoBadPkg(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)
@@ -97,6 +101,7 @@ func TestRunInfoBadPkg(t *testing.T) {
 // alias still shows which config is in effect (spec §6 debugging scenario). The
 // exit stays nonzero, but the config line must already be on stdout.
 func TestRunInfoPrintsConfigBeforeFilterError(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)

--- a/gen/init.go
+++ b/gen/init.go
@@ -112,11 +112,11 @@ var setupSteps = [][]string{
 	{"npm", "install"},
 }
 
-func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	return initWith(args, stdin, stdout, stderr, isTTYReader(stdin), execStep)
+func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer, workDir string) int {
+	return initWith(args, stdin, stdout, stderr, isTTYReader(stdin), execStep, workDir)
 }
 
-func initWith(args []string, stdin io.Reader, stdout, stderr io.Writer, interactive bool, run stepRunner) int {
+func initWith(args []string, stdin io.Reader, stdout, stderr io.Writer, interactive bool, run stepRunner, workDir string) int {
 	ifs := flag.NewFlagSet("init", flag.ContinueOnError)
 	ifs.SetOutput(stderr)
 	var templateName, module string
@@ -163,11 +163,9 @@ func initWith(args []string, stdin io.Reader, stdout, stderr io.Writer, interact
 		}
 	}
 
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		fmt.Fprintf(stderr, "gsx: %v\n", err)
-		return 2
-	}
+	// Anchor a relative target dir (and the default ".") at workDir rather than the
+	// process-global cwd, so init is reentrant under -C.
+	abs := absAgainst(workDir, dir)
 	if module == "" {
 		module = filepath.Base(abs)
 	}

--- a/gen/init_test.go
+++ b/gen/init_test.go
@@ -18,7 +18,8 @@ func initNI(t *testing.T, args ...string) (int, string, string) {
 	t.Helper()
 	var out, errb bytes.Buffer
 	noop := func(_ []string, _ string, _, _ io.Writer) error { return nil }
-	code := initWith(args, strings.NewReader(""), &out, &errb, false, noop)
+	wd, _ := os.Getwd()
+	code := initWith(args, strings.NewReader(""), &out, &errb, false, noop, wd)
 	return code, out.String(), errb.String()
 }
 
@@ -37,11 +38,12 @@ func recordingRunner(failAt int, failErr error) (*[][]string, stepRunner) {
 }
 
 func TestInitInteractiveRunsAllSteps(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	calls, run := recordingRunner(-1, nil)
 	var out, errb bytes.Buffer
 	code := initWith([]string{"--module", "demo", dir},
-		strings.NewReader("y\ny\ny\n"), &out, &errb, true, run)
+		strings.NewReader("y\ny\ny\n"), &out, &errb, true, run, dir)
 	if code != 0 {
 		t.Fatalf("exit %d; stderr=%q", code, errb.String())
 	}
@@ -57,11 +59,12 @@ func TestInitInteractiveRunsAllSteps(t *testing.T) {
 }
 
 func TestInitInteractiveSkipsOnNo(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	calls, run := recordingRunner(-1, nil)
 	var out, errb bytes.Buffer
 	code := initWith([]string{"--module", "demo", dir},
-		strings.NewReader("n\ny\ny\n"), &out, &errb, true, run)
+		strings.NewReader("n\ny\ny\n"), &out, &errb, true, run, dir)
 	if code != 0 {
 		t.Fatalf("exit %d; %q", code, errb.String())
 	}
@@ -74,11 +77,12 @@ func TestInitInteractiveSkipsOnNo(t *testing.T) {
 }
 
 func TestInitInteractiveStopsOnFailure(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	calls, run := recordingRunner(1, fmt.Errorf("boom")) // 2nd step fails
 	var out, errb bytes.Buffer
 	code := initWith([]string{"--module", "demo", dir},
-		strings.NewReader("y\ny\ny\n"), &out, &errb, true, run)
+		strings.NewReader("y\ny\ny\n"), &out, &errb, true, run, dir)
 	if code != 1 {
 		t.Fatalf("expected exit 1, got %d", code)
 	}
@@ -91,12 +95,13 @@ func TestInitInteractiveStopsOnFailure(t *testing.T) {
 }
 
 func TestInitYesRunsWithoutPrompt(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	calls, run := recordingRunner(-1, nil)
 	var out, errb bytes.Buffer
 	// interactive=false but --yes ⇒ run all, no stdin consumed.
 	code := initWith([]string{"--yes", "--module", "demo", dir},
-		strings.NewReader(""), &out, &errb, false, run)
+		strings.NewReader(""), &out, &errb, false, run, dir)
 	if code != 0 {
 		t.Fatalf("exit %d; %q", code, errb.String())
 	}
@@ -106,6 +111,7 @@ func TestInitYesRunsWithoutPrompt(t *testing.T) {
 }
 
 func TestInitDefault(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	target := filepath.Join(dir, "myapp")
 	code, out, errb := initNI(t, target)
@@ -125,6 +131,7 @@ func TestInitDefault(t *testing.T) {
 }
 
 func TestInitModuleFlag(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	code, _, errb := initNI(t, "--module", "example.com/foo", dir)
 	if code != 0 {
@@ -141,6 +148,7 @@ func TestInitModuleFlag(t *testing.T) {
 }
 
 func TestInitUnknownTemplate(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	code, _, errb := initNI(t, "--template", "bogus", dir)
 	if code != 2 {
@@ -152,6 +160,7 @@ func TestInitUnknownTemplate(t *testing.T) {
 }
 
 func TestInitRefusesExistingProject(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -171,6 +180,7 @@ func TestInitRefusesExistingProject(t *testing.T) {
 }
 
 func TestInitRefusesExistingPackageJSON(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -185,6 +195,7 @@ func TestInitRefusesExistingPackageJSON(t *testing.T) {
 }
 
 func TestInitFlagsAfterDir(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	code, _, errb := initNI(t, dir, "--module", "example.com/after")
 	if code != 0 {
@@ -197,6 +208,7 @@ func TestInitFlagsAfterDir(t *testing.T) {
 }
 
 func TestScaffoldRendersAndTransforms(t *testing.T) {
+	t.Parallel()
 	src := fstest.MapFS{
 		"tpl/go.mod.tmpl":      {Data: []byte("module «.Module»\n")},
 		"tpl/app.gsx":          {Data: []byte("{{ x := 1 }}<p>«.Name»</p>")},
@@ -236,6 +248,7 @@ func TestScaffoldRendersAndTransforms(t *testing.T) {
 }
 
 func TestTransformName(t *testing.T) {
+	t.Parallel()
 	cases := map[string]string{
 		"go.mod.tmpl":      "go.mod",
 		"main.go.tmpl":     "main.go",
@@ -252,6 +265,7 @@ func TestTransformName(t *testing.T) {
 }
 
 func TestRenderCustomDelims(t *testing.T) {
+	t.Parallel()
 	// «» substituted; {{ }} and { } left alone.
 	out, err := render([]byte("«.Name»: {{ go }} and { x }"), tmplData{Name: "n"})
 	if err != nil {
@@ -263,6 +277,7 @@ func TestRenderCustomDelims(t *testing.T) {
 }
 
 func TestScaffoldSimpleTemplate(t *testing.T) {
+	t.Parallel()
 	dest := t.TempDir()
 	tpl := templates[defaultTemplate]
 	if err := scaffold(initFS, tpl.root, dest, tmplData{Module: "example.com/demo", Name: "demo"}, false); err != nil {
@@ -302,6 +317,7 @@ func TestScaffoldSimpleTemplate(t *testing.T) {
 }
 
 func TestInitTaskfileParses(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping Taskfile-parse gate in -short mode")
 	}
@@ -323,6 +339,7 @@ func TestInitTaskfileParses(t *testing.T) {
 }
 
 func TestInitScaffoldCompiles(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping scaffold-compiles integration test in -short mode")
 	}

--- a/gen/jsformatter_test.go
+++ b/gen/jsformatter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestWithJSFormatterOption(t *testing.T) {
+	t.Parallel()
 	var cfg config
 	WithJSFormatter(rawfmt.Formatter(func(src []byte) ([]byte, error) { return src, nil }))(&cfg)
 	if cfg.jsFmt == nil {
@@ -15,6 +16,7 @@ func TestWithJSFormatterOption(t *testing.T) {
 }
 
 func TestMergeConfigJSFormatterOptsWins(t *testing.T) {
+	t.Parallel()
 	base := config{jsFmt: func(src []byte) ([]byte, error) { return []byte("base"), nil }}
 	opts := config{jsFmt: func(src []byte) ([]byte, error) { return []byte("opts"), nil }}
 	got, _ := mergeConfig(base, opts).jsFmt(nil)
@@ -24,6 +26,7 @@ func TestMergeConfigJSFormatterOptsWins(t *testing.T) {
 }
 
 func TestMergeConfigJSFormatterFallsBackToBase(t *testing.T) {
+	t.Parallel()
 	base := config{jsFmt: func(src []byte) ([]byte, error) { return []byte("base"), nil }}
 	merged := mergeConfig(base, config{})
 	if merged.jsFmt == nil {

--- a/gen/lsp_config_test.go
+++ b/gen/lsp_config_test.go
@@ -48,6 +48,7 @@ func hasUnknownFilter(pkg *lsp.Package, name string) bool {
 
 // A gsx.toml alias resolves a project filter in the LSP.
 func TestLSPAnalyzeResolvesTomlAlias(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -66,6 +67,7 @@ func TestLSPAnalyzeResolvesTomlAlias(t *testing.T) {
 // A ctx-injected, variadic, (R,error) alias resolves — proving the analyzer
 // re-derives the seed-first contract from the alias's live signature.
 func TestLSPAnalyzeResolvesCtxAlias(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -84,6 +86,7 @@ func TestLSPAnalyzeResolvesCtxAlias(t *testing.T) {
 // A malformed gsx.toml is ignored: Analyze never errors, the std baseline still
 // resolves (upper), the alias does NOT (shout), and a warning is logged.
 func TestLSPAnalyzeMalformedConfigFallsBack(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -109,6 +112,7 @@ func TestLSPAnalyzeMalformedConfigFallsBack(t *testing.T) {
 
 // No gsx.toml → std baseline: upper resolves, an undeclared filter is unknown.
 func TestLSPAnalyzeNoConfigStdBaseline(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -129,6 +133,7 @@ func TestLSPAnalyzeNoConfigStdBaseline(t *testing.T) {
 // In-process opts (as a custom binary built with WithFilter would supply) feed
 // the analyzer even with no gsx.toml present.
 func TestLSPAnalyzeHonorsInProcessOpts(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -147,6 +152,7 @@ func TestLSPAnalyzeHonorsInProcessOpts(t *testing.T) {
 // resolveConfigBestEffort: no file → optCfg unchanged; valid file → merged;
 // malformed file → optCfg + a warning, no panic.
 func TestResolveConfigBestEffort(t *testing.T) {
+	t.Parallel()
 	dir, must := lspFilterModule(t)
 	opt := config{aliases: []codegen.FilterAlias{{Name: "x", PkgPath: "p", FuncName: "F"}}}
 

--- a/gen/lsp_test.go
+++ b/gen/lsp_test.go
@@ -19,6 +19,7 @@ func frameMsg(t *testing.T, v any) string {
 // TestLSPEndToEndDiagnostics drives the real analyzer through lsp.Server over an
 // in-memory stream and asserts a publishDiagnostics for a .gsx with a type error.
 func TestLSPEndToEndDiagnostics(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("..")
 	dir := t.TempDir()
 	goMod := "module example.com/x\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => " + repoRoot + "\n"

--- a/gen/lsp_warm_test.go
+++ b/gen/lsp_warm_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestLSPAnalyzeUsesWarmModule(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/main.go
+++ b/gen/main.go
@@ -159,17 +159,26 @@ func runConfig(args []string, stdout, stderr io.Writer, cfg config) int {
 		return 0
 	}
 
+	// workDir is the absolute directory that relative path arguments and gsx.toml
+	// discovery resolve against: -C selects it, otherwise it is the process cwd at
+	// startup. We deliberately do NOT os.Chdir — that mutates process-global state,
+	// making the command non-reentrant and the in-process test suite unsafe to run
+	// in parallel. Each command resolves its own paths against workDir instead.
+	workDir, err := filepath.Abs(".")
+	if err != nil {
+		fmt.Fprintf(stderr, "gsx: %v\n", err)
+		return 2
+	}
 	if chdir != "" {
-		orig, err := os.Getwd()
+		workDir, err = filepath.Abs(chdir)
 		if err != nil {
-			fmt.Fprintf(stderr, "gsx: %v\n", err)
-			return 2
-		}
-		if err := os.Chdir(chdir); err != nil {
 			fmt.Fprintf(stderr, "gsx: -C %s: %v\n", chdir, err)
 			return 2
 		}
-		defer os.Chdir(orig)
+		if fi, statErr := os.Stat(workDir); statErr != nil || !fi.IsDir() {
+			fmt.Fprintf(stderr, "gsx: -C %s: not a directory\n", chdir)
+			return 2
+		}
 	}
 
 	cmd, cmdArgs := rest[0], rest[1:]
@@ -178,32 +187,31 @@ func runConfig(args []string, stdout, stderr io.Writer, cfg config) int {
 		// Only generate and info consume gsx.toml; config-agnostic commands
 		// (version/help/clean/fmt/lsp) must not load it, so a malformed config
 		// can't break them. resolveConfig discovers+loads+merges (opts on top).
-		merged, _, err := resolveConfig(cfg)
+		merged, _, err := resolveConfig(cfg, workDir)
 		if err != nil {
 			fmt.Fprintf(stderr, "gsx: %v\n", err)
 			return 2
 		}
-		return runGenerate(cmdArgs, stdout, stderr, quiet, verbose, false, merged.filterPkgs, merged.aliases, merged.classifier(), merged.fieldMatcher, merged.effectiveCSSMin(), merged.effectiveJSMin(), merged.cssMinLevel.enabled(), merged.jsMinLevel.enabled())
+		return runGenerate(cmdArgs, stdout, stderr, quiet, verbose, false, merged.filterPkgs, merged.aliases, merged.classifier(), merged.fieldMatcher, merged.effectiveCSSMin(), merged.effectiveJSMin(), merged.cssMinLevel.enabled(), merged.jsMinLevel.enabled(), workDir)
 	case "clean":
 		return runClean(cmdArgs, stdout, stderr)
 	case "info":
-		// Resolve against cwd: -C (handled above) has already chdir'd, so "."
-		// anchors the go/packages load at the user's chosen directory.
-		merged, configPath, err := resolveConfig(cfg)
+		// Anchor the go/packages load at workDir (the -C dir, else startup cwd).
+		merged, configPath, err := resolveConfig(cfg, workDir)
 		if err != nil {
 			fmt.Fprintf(stderr, "gsx: %v\n", err)
 			return 2
 		}
-		return runInfo(stdout, stderr, ".", configPath, merged.filterPkgs, merged.aliases, merged.classifier(), merged.predLabel, merged.fieldMatcher, cmdArgs, merged.cssMinLevel, merged.jsMinLevel)
+		return runInfo(stdout, stderr, workDir, configPath, merged.filterPkgs, merged.aliases, merged.classifier(), merged.predLabel, merged.fieldMatcher, cmdArgs, merged.cssMinLevel, merged.jsMinLevel)
 	case "fmt":
 		// fmt respects gsx.toml printWidth per-dir (via printWidthFor inside
 		// runFmt) and tolerates a malformed config. The CSS/JS formatter
 		// overrides are programmatic options (no gsx.toml entry), so they come
 		// from cfg directly — not resolveConfig (which would hard-fail on a bad
 		// config).
-		return runFmt(stdout, stderr, cmdArgs, cfg.cssFmt, cfg.jsFmt)
+		return runFmt(stdout, stderr, cmdArgs, cfg.cssFmt, cfg.jsFmt, workDir)
 	case "init":
-		return runInit(cmdArgs, os.Stdin, stdout, stderr)
+		return runInit(cmdArgs, os.Stdin, stdout, stderr, workDir)
 	case "lsp":
 		// lsp resolves gsx.toml per-file (best-effort) and merges these compiled-in
 		// opts under it; cfg.errs are already surfaced at the top of runConfig.
@@ -236,10 +244,11 @@ func runConfig(args []string, stdout, stderr io.Writer, cfg config) int {
 // automatically (no separate config hash). Option-construction errs on optCfg are
 // already surfaced at the top of runConfig before dispatch, so they need no
 // recheck here.
-func resolveConfig(optCfg config) (merged config, configPath string, err error) {
+func resolveConfig(optCfg config, workDir string) (merged config, configPath string, err error) {
 	// Layer 1: file defaults (base is the zero config when no gsx.toml exists).
+	// Discovery starts at workDir (-C dir, else startup cwd) and walks up.
 	var base config
-	path, ok := discoverConfig(".")
+	path, ok := discoverConfig(workDir)
 	if ok {
 		base, err = loadConfig(path)
 		if err != nil {
@@ -303,7 +312,7 @@ func runClean(args []string, stdout, stderr io.Writer) int {
 // discovery fails → exit 2) from a codegen error (one or more error-severity
 // diagnostics → exit 1). Success returns 0.
 // noCache bypasses the content-hash cache and forces a full regeneration.
-func runGenerate(args []string, stdout, stderr io.Writer, quiet, verbose, noCache bool, filterPkgs []string, aliases []codegen.FilterAlias, cls *attrclass.Classifier, fm codegen.FieldMatcher, cssMin, jsMin func(string) (string, error), cssMinify, jsMinify bool) int {
+func runGenerate(args []string, stdout, stderr io.Writer, quiet, verbose, noCache bool, filterPkgs []string, aliases []codegen.FilterAlias, cls *attrclass.Classifier, fm codegen.FieldMatcher, cssMin, jsMin func(string) (string, error), cssMinify, jsMinify bool, workDir string) int {
 	gfs := flag.NewFlagSet("generate", flag.ContinueOnError)
 	gfs.SetOutput(stderr)
 	var nocacheFlag bool
@@ -335,9 +344,10 @@ func runGenerate(args []string, stdout, stderr io.Writer, quiet, verbose, noCach
 	if err := gfs.Parse(flagArgs); err != nil {
 		return 2
 	}
-	if len(paths) == 0 {
-		paths = []string{"."}
-	}
+	// Anchor relative path arguments (and the default ".") at workDir, then hand
+	// absolute paths to discovery/codegen — so resolution never consults the
+	// process-global cwd.
+	paths = absPaths(workDir, paths)
 	if watchFlag {
 		return runWatch(watchConfig{
 			paths: paths, format: formatFlag,

--- a/gen/main_test.go
+++ b/gen/main_test.go
@@ -20,6 +20,7 @@ func runCapture(t *testing.T, args []string) (int, string, string) {
 // TestRunGenerate proves `generate <pkgDir>` writes the .x.go, returns 0, and
 // the default summary mentions wrote/1.
 func TestRunGenerate(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -42,6 +43,7 @@ func TestRunGenerate(t *testing.T) {
 
 // TestRunGenerateVerbose proves -v lists the written file.
 func TestRunGenerateVerbose(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -61,6 +63,7 @@ func TestRunGenerateVerbose(t *testing.T) {
 
 // TestRunGenerateQuiet proves -q prints nothing on success.
 func TestRunGenerateQuiet(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -79,6 +82,7 @@ func TestRunGenerateQuiet(t *testing.T) {
 
 // TestRunGenerateMissingPath proves a non-existent path is a USAGE error (exit 2).
 func TestRunGenerateMissingPath(t *testing.T) {
+	t.Parallel()
 	code, _, errb := runCapture(t, []string{"generate", "/does/not/exist/anywhere"})
 	if code != 2 {
 		t.Fatalf("expected exit 2 for missing path, got %d; stderr=%q", code, errb)
@@ -88,6 +92,7 @@ func TestRunGenerateMissingPath(t *testing.T) {
 // TestRunGenerateCodegenError proves a .gsx that fails codegen is a CODEGEN error
 // (exit 1) and stderr names the dir.
 func TestRunGenerateCodegenError(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -106,6 +111,7 @@ func TestRunGenerateCodegenError(t *testing.T) {
 
 // TestRunVersion proves version prints something non-empty and returns 0.
 func TestRunVersion(t *testing.T) {
+	t.Parallel()
 	code, out, errb := runCapture(t, []string{"version"})
 	if code != 0 {
 		t.Fatalf("expected exit 0, got %d; stderr=%q", code, errb)
@@ -119,6 +125,7 @@ func TestRunVersion(t *testing.T) {
 // path argument (the flag-position fix): `gsx generate <dir> -v` lists the file
 // rather than erroring with exit 2.
 func TestRunGenerateVerboseAfterCommand(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -138,6 +145,7 @@ func TestRunGenerateVerboseAfterCommand(t *testing.T) {
 
 // TestRunGenerateQuietAfterCommand proves -q works AFTER the command.
 func TestRunGenerateQuietAfterCommand(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -158,6 +166,7 @@ func TestRunGenerateQuietAfterCommand(t *testing.T) {
 // a shortened VCS revision with time + dirty marker, and the Go toolchain
 // version, and that it omits the commit line when no VCS info is present.
 func TestFormatBuildVersion(t *testing.T) {
+	t.Parallel()
 	full := &debug.BuildInfo{
 		GoVersion: "go1.24.0",
 		Settings: []debug.BuildSetting{
@@ -190,6 +199,7 @@ func TestFormatBuildVersion(t *testing.T) {
 
 // TestRunHelp proves help/no-args list the generate command and return 0.
 func TestRunHelp(t *testing.T) {
+	t.Parallel()
 	for _, args := range [][]string{{"help"}, nil, {"-h"}} {
 		code, out, errb := runCapture(t, args)
 		if code != 0 {
@@ -204,6 +214,7 @@ func TestRunHelp(t *testing.T) {
 // TestRunUnknownCommand proves an unknown command is a usage error (exit 2) and
 // stderr mentions unknown.
 func TestRunUnknownCommand(t *testing.T) {
+	t.Parallel()
 	code, _, errb := runCapture(t, []string{"bogus"})
 	if code != 2 {
 		t.Fatalf("expected exit 2 for unknown command, got %d; stderr=%q", code, errb)
@@ -217,6 +228,7 @@ func TestRunUnknownCommand(t *testing.T) {
 // `fmt` over an empty directory (via -C) is a recognized command that succeeds
 // (exit 0) rather than the unknown-command exit 2.
 func TestRunFmtDispatch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	code, _, errb := runCapture(t, []string{"-C", dir, "fmt"})
 	if code != 0 {
@@ -277,6 +289,7 @@ func TestCleanCacheSentinelGuard(t *testing.T) {
 // TestCleanCacheSentinelWrittenByStorePut proves that a normal generate/storePut
 // lifecycle writes the CACHEDIR.TAG sentinel so clean --cache works afterward.
 func TestCleanCacheSentinelWrittenByStorePut(t *testing.T) {
+	t.Parallel()
 	cacheRoot := t.TempDir()
 	out := pkgOutput{"a.x.go": []byte("package a\n")}
 	if err := storePut(cacheRoot, "testkey", out); err != nil {
@@ -308,6 +321,7 @@ func TestCleanCacheDisabled(t *testing.T) {
 
 // TestCleanNoFlags proves `clean` without --cache prints usage and exits 0.
 func TestCleanNoFlags(t *testing.T) {
+	t.Parallel()
 	code, out, errb := runCapture(t, []string{"clean"})
 	if code != 0 {
 		t.Fatalf("expected exit 0, got %d; stderr=%q", code, errb)
@@ -321,6 +335,7 @@ func TestCleanNoFlags(t *testing.T) {
 // TestRunChdir proves -C runs relative to the given directory: a relative path
 // "views" resolves under the -C dir.
 func TestRunChdir(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/minify_test.go
+++ b/gen/minify_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestMinifyLevel_Basics(t *testing.T) {
+	t.Parallel()
 	if MinifyNone != 0 {
 		t.Fatalf("MinifyNone must be the zero value, got %d", MinifyNone)
 	}
@@ -23,6 +24,7 @@ func TestMinifyLevel_Basics(t *testing.T) {
 }
 
 func TestParseMinifyLevel(t *testing.T) {
+	t.Parallel()
 	for in, want := range map[string]MinifyLevel{"none": MinifyNone, "full": MinifyFull} {
 		got, err := parseMinifyLevel(in)
 		if err != nil || got != want {
@@ -48,6 +50,7 @@ func writeTOML(t *testing.T, body string) string {
 }
 
 func TestLoadConfig_Minify(t *testing.T) {
+	t.Parallel()
 	// Absent [minify] → both default to none.
 	cfg, err := loadConfig(writeTOML(t, "[filters]\nupper = \"example.com/x.Up\"\n"))
 	if err != nil {
@@ -73,6 +76,7 @@ func TestLoadConfig_Minify(t *testing.T) {
 }
 
 func TestMergeConfig_MinifyPrecedence(t *testing.T) {
+	t.Parallel()
 	// option > config: opts pin via WithMinifyLevel beats file base.
 	base := config{cssMinLevel: MinifyNone, jsMinLevel: MinifyNone}
 	var opts config
@@ -90,6 +94,7 @@ func TestMergeConfig_MinifyPrecedence(t *testing.T) {
 }
 
 func TestMinifyLevel_Full(t *testing.T) {
+	t.Parallel()
 	if !MinifyFull.enabled() {
 		t.Fatal("MinifyFull must be enabled")
 	}
@@ -107,6 +112,7 @@ func TestMinifyLevel_Full(t *testing.T) {
 }
 
 func TestEffectiveMinifier_Full(t *testing.T) {
+	t.Parallel()
 	// full with no custom minifier → built-in full installed.
 	cfg := config{cssMinLevel: MinifyFull, jsMinLevel: MinifyFull}
 	if cfg.effectiveCSSMin() == nil {
@@ -152,7 +158,7 @@ func TestGenerate_MinifyFullViaConfig(t *testing.T) {
 	}
 	chdir(t, dir)
 
-	merged, _, err := resolveConfig(config{})
+	merged, _, err := resolveConfig(config{}, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,6 +186,7 @@ func TestGenerate_MinifyFullViaConfig(t *testing.T) {
 // it is not called. effectiveCSSMin still resolves WHICH minifier runs when the
 // gate is on.
 func TestMinifyGate_LevelGoverns(t *testing.T) {
+	t.Parallel()
 	custom := func(s string) (string, error) { return s, nil }
 	// default level (none): gate off, even with a custom minifier installed.
 	if (config{}).cssMinLevel.enabled() || (config{cssMin: custom}).cssMinLevel.enabled() {
@@ -214,7 +221,7 @@ func TestGenerate_MinifyNoneViaConfig(t *testing.T) {
 	}
 	chdir(t, dir)
 
-	merged, _, err := resolveConfig(config{})
+	merged, _, err := resolveConfig(config{}, dir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gen/modroot_test.go
+++ b/gen/modroot_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestModuleRoot(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module example.com/app\n\ngo 1.26\n"), 0o644)
 	sub := filepath.Join(tmp, "a", "b")

--- a/gen/multimodule_test.go
+++ b/gen/multimodule_test.go
@@ -21,6 +21,7 @@ func writeModule(t *testing.T, dir, mod string) {
 // fix, every interpolation in both modules failed to type-check because all dirs
 // were loaded against the first module's root.
 func TestGenerateMultiModule(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}
@@ -61,6 +62,7 @@ func TestGenerateMultiModule(t *testing.T) {
 // Before the fix the session built a single resolver rooted at the first module,
 // so regenerating a dir in the second module resolved nothing.
 func TestWatchSessionMultiModule(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-resolution test in -short mode")
 	}

--- a/gen/options_e2e_test.go
+++ b/gen/options_e2e_test.go
@@ -12,6 +12,7 @@ import (
 // flows through the user filter. This is the end-to-end equivalent of
 // gen.Main(gen.WithFilters(std.Pkg, myfilters.Pkg)).
 func TestGenerateWithUserFilter(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-build/run test in -short mode")
 	}

--- a/gen/options_test.go
+++ b/gen/options_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestWithAttrOptionsBuildClassifier(t *testing.T) {
+	t.Parallel()
 	var cfg config
 	WithJSAttrs(attrclass.Rule{Prefix: "wire:"})(&cfg)
 	WithURLAttrs(attrclass.Rule{Name: "data-href"})(&cfg)
@@ -32,6 +33,7 @@ func TestWithAttrOptionsBuildClassifier(t *testing.T) {
 }
 
 func TestWithAttrsRejectsInvalidRule(t *testing.T) {
+	t.Parallel()
 	var cfg config
 	WithJSAttrs(attrclass.Rule{Name: "x", Prefix: "y"})(&cfg) // both set
 	if len(cfg.errs) == 0 {
@@ -40,6 +42,7 @@ func TestWithAttrsRejectsInvalidRule(t *testing.T) {
 }
 
 func TestWithAttrClassifierSetsPredicate(t *testing.T) {
+	t.Parallel()
 	var cfg config
 	WithAttrClassifier("fancy", func(name string) (attrclass.Context, bool) {
 		if name == "fancy-go" {
@@ -71,6 +74,7 @@ func applyOpts(opts ...Option) config {
 // TestWithFiltersStdPath proves WithFilters(std.Pkg) records the std import
 // path recovered via reflection.
 func TestWithFiltersStdPath(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilters(std.Pkg))
 	if len(cfg.errs) != 0 {
 		t.Fatalf("unexpected errs: %v", cfg.errs)
@@ -92,6 +96,7 @@ const genPath = "github.com/gsxhq/gsx/gen"
 // TestWithFiltersOrderAndDedup proves order is preserved (overrides last) and
 // duplicate package paths are collapsed to a single first-seen entry.
 func TestWithFiltersOrderAndDedup(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilters(std.Pkg, otherPkg, std.Pkg))
 	if len(cfg.errs) != 0 {
 		t.Fatalf("unexpected errs: %v", cfg.errs)
@@ -107,6 +112,7 @@ func TestWithFiltersOrderAndDedup(t *testing.T) {
 // TestWithFiltersAcrossCalls proves dedup spans multiple WithFilters options
 // applied to the same config.
 func TestWithFiltersAcrossCalls(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilters(std.Pkg), WithFilters(otherPkg), WithFilters(std.Pkg))
 	want := []string{stdPath, genPath}
 	if !reflect.DeepEqual(cfg.filterPkgs, want) {
@@ -117,6 +123,7 @@ func TestWithFiltersAcrossCalls(t *testing.T) {
 // TestWithFiltersNilMarkerRecorded proves a nil marker is recorded as an error
 // rather than silently dropped, and does not add a filter package.
 func TestWithFiltersNilMarkerRecorded(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilters(nil))
 	if len(cfg.errs) == 0 {
 		t.Fatal("expected an error for a nil marker, got none")
@@ -129,6 +136,7 @@ func TestWithFiltersNilMarkerRecorded(t *testing.T) {
 // TestWithFiltersBuiltinMarkerRecorded proves a marker whose type has no
 // package path (a builtin/unnamed type) is recorded as an error, not dropped.
 func TestWithFiltersBuiltinMarkerRecorded(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilters(42))
 	if len(cfg.errs) == 0 {
 		t.Fatal("expected an error for a builtin-typed marker, got none")
@@ -143,6 +151,7 @@ func TestWithFiltersBuiltinMarkerRecorded(t *testing.T) {
 // a temp module; the corpus covers built-in end-to-end. Here we assert the ext
 // func reaches holeless blocks only.)
 func TestWithCSSMinifierBoundary(t *testing.T) {
+	t.Parallel()
 	called := false
 	ext := func(css string) (string, error) { called = true; return "/*ext*/" + css, nil }
 
@@ -175,6 +184,7 @@ func TestWithCSSMinifierBoundary(t *testing.T) {
 }
 
 func TestWithCSSMinifierOption(t *testing.T) {
+	t.Parallel()
 	min := func(css string) (string, error) { return css, nil }
 	var cfg config
 	WithCSSMinifier(min)(&cfg)
@@ -184,6 +194,7 @@ func TestWithCSSMinifierOption(t *testing.T) {
 }
 
 func TestWithJSMinifierOption(t *testing.T) {
+	t.Parallel()
 	min := func(js string) (string, error) { return js, nil }
 	var cfg config
 	WithJSMinifier(min)(&cfg)

--- a/gen/options_withfilter_test.go
+++ b/gen/options_withfilter_test.go
@@ -19,6 +19,7 @@ func (sampleRecv) Method(s string) string { return s }
 // TestWithFilterTopLevelFunc proves a plain exported top-level function resolves
 // to its package import path + exported func name and is recorded as an alias.
 func TestWithFilterTopLevelFunc(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilter("sample", SampleFilter))
 	if len(cfg.errs) != 0 {
 		t.Fatalf("unexpected errs: %v", cfg.errs)
@@ -36,6 +37,7 @@ func TestWithFilterTopLevelFunc(t *testing.T) {
 // TestWithFilterAliasOrder proves aliases accumulate in option order (last-wins
 // is applied later at harvest, so order must be preserved here).
 func TestWithFilterAliasOrder(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilter("a", SampleFilter), WithFilter("b", SampleFilter))
 	if len(cfg.aliases) != 2 || cfg.aliases[0].Name != "a" || cfg.aliases[1].Name != "b" {
 		t.Fatalf("alias order not preserved: %+v", cfg.aliases)
@@ -45,6 +47,7 @@ func TestWithFilterAliasOrder(t *testing.T) {
 // TestWithFilterRejectsMethodValue proves a bound/unbound method value is
 // rejected with a clear config error and adds no alias.
 func TestWithFilterRejectsMethodValue(t *testing.T) {
+	t.Parallel()
 	var r sampleRecv
 	cfg := applyOpts(WithFilter("m", r.Method))
 	if len(cfg.errs) == 0 {
@@ -58,6 +61,7 @@ func TestWithFilterRejectsMethodValue(t *testing.T) {
 // TestWithFilterRejectsClosure proves a closure (anonymous function value) is
 // rejected: its runtime name carries a .funcN suffix, not an exported ident.
 func TestWithFilterRejectsClosure(t *testing.T) {
+	t.Parallel()
 	closure := func(s string) string { return s }
 	cfg := applyOpts(WithFilter("c", closure))
 	if len(cfg.errs) == 0 {
@@ -70,6 +74,7 @@ func TestWithFilterRejectsClosure(t *testing.T) {
 
 // TestWithFilterRejectsNonFunc proves a non-function value is rejected.
 func TestWithFilterRejectsNonFunc(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilter("x", 42))
 	if len(cfg.errs) == 0 {
 		t.Fatal("expected an error for a non-function, got none")
@@ -78,6 +83,7 @@ func TestWithFilterRejectsNonFunc(t *testing.T) {
 
 // TestWithFilterRejectsNil proves a nil fn is rejected.
 func TestWithFilterRejectsNil(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilter("x", nil))
 	if len(cfg.errs) == 0 {
 		t.Fatal("expected an error for nil fn, got none")
@@ -87,6 +93,7 @@ func TestWithFilterRejectsNil(t *testing.T) {
 // TestWithFilterRejectsUnexported proves an unexported top-level function is
 // rejected (the template vocabulary must point at an exported func).
 func TestWithFilterRejectsUnexported(t *testing.T) {
+	t.Parallel()
 	cfg := applyOpts(WithFilter("u", unexportedFilter))
 	if len(cfg.errs) == 0 {
 		t.Fatal("expected an error for an unexported function, got none")

--- a/gen/perf_test.go
+++ b/gen/perf_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestPerfBaseline(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("GSX_PERF") == "" {
 		t.Skip("set GSX_PERF=1 to run")
 	}

--- a/gen/pipe_nav_e2e_test.go
+++ b/gen/pipe_nav_e2e_test.go
@@ -74,6 +74,7 @@ func pipeDefAt(t *testing.T, dir, src, needle string, off int) *lsp.Location {
 }
 
 func TestPipeDefSeed(t *testing.T) {
+	t.Parallel()
 	dir, src := pipeNavModule(t)
 	loc := pipeDefAt(t, dir, src, "Greeting(name)", 0) // on `Greeting` (the seed call)
 	if loc == nil || !strings.HasSuffix(loc.URI, "u.go") {
@@ -82,6 +83,7 @@ func TestPipeDefSeed(t *testing.T) {
 }
 
 func TestPipeDefFilter(t *testing.T) {
+	t.Parallel()
 	dir, src := pipeNavModule(t)
 	loc := pipeDefAt(t, dir, src, "|> upper", len("|> ")) // on `upper`
 	if loc == nil || !strings.HasSuffix(loc.URI, "std.go") {
@@ -90,6 +92,7 @@ func TestPipeDefFilter(t *testing.T) {
 }
 
 func TestPipeDefArg(t *testing.T) {
+	t.Parallel()
 	dir, _ := pipeNavModule(t)
 	// { name |> truncate(n) } with a param n.
 	src := "package p\n\ncomponent Card(name string, n int) {\n\t<div>{ name |> truncate(n) }</div>\n}\n"
@@ -103,6 +106,7 @@ func TestPipeDefArg(t *testing.T) {
 }
 
 func TestPipeDefOnOperatorNull(t *testing.T) {
+	t.Parallel()
 	dir, src := pipeNavModule(t)
 	loc := pipeDefAt(t, dir, src, "|> upper", 0) // on the `|` of `|>`
 	if loc != nil {
@@ -165,6 +169,7 @@ func pipeHoverAt(t *testing.T, dir, src, needle string, off int) *lsp.Hover {
 }
 
 func TestPipeHoverFilter(t *testing.T) {
+	t.Parallel()
 	dir, src := pipeNavModule(t)
 	h := pipeHoverAt(t, dir, src, "|> upper", len("|> ")) // on `upper`
 	if h == nil || !strings.Contains(h.Contents.Value, "func std.Upper(") {
@@ -173,6 +178,7 @@ func TestPipeHoverFilter(t *testing.T) {
 }
 
 func TestPipeHoverSeed(t *testing.T) {
+	t.Parallel()
 	dir, src := pipeNavModule(t)
 	h := pipeHoverAt(t, dir, src, "Greeting(name)", 0) // on `Greeting`
 	if h == nil || !strings.Contains(h.Contents.Value, "func Greeting(name string) string") {
@@ -181,6 +187,7 @@ func TestPipeHoverSeed(t *testing.T) {
 }
 
 func TestPipeHoverArg(t *testing.T) {
+	t.Parallel()
 	dir, _ := pipeNavModule(t)
 	src := "package p\n\ncomponent Card(name string, n int) {\n\t<div>{ name |> truncate(n) }</div>\n}\n"
 	if err := os.WriteFile(filepath.Join(dir, "card.gsx"), []byte(src), 0o644); err != nil {

--- a/gen/references_crosspkg_e2e_test.go
+++ b/gen/references_crosspkg_e2e_test.go
@@ -46,6 +46,7 @@ func lspFrame(v any) string {
 // result includes both the cross-package .gsx tag (post.gsx) and the .go
 // direct reference (use.go).
 func TestReferencesCrossPkgFromDecl(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -95,6 +96,7 @@ func TestReferencesCrossPkgFromDecl(t *testing.T) {
 // cursor on the `Input` identifier in use.go (`components.Input`) and asserts
 // the result includes both cross-package reference sites.
 func TestReferencesCrossPkgFromGoCursor(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}

--- a/gen/references_crosspkg_test.go
+++ b/gen/references_crosspkg_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAnalyzeModuleCrossPkg(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}

--- a/gen/references_e2e_test.go
+++ b/gen/references_e2e_test.go
@@ -13,6 +13,7 @@ import (
 // TestReferences: references on Card (from its card.gsx declaration) returns the
 // main.go call site AND the page.gsx <Card/> tag.
 func TestReferences(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -91,6 +92,7 @@ func refFrame(v any) string {
 // TestReferencesFromGoCursor: references invoked from a .go call site (cursor on
 // Card in main.go) returns both the .go and .gsx use sites.
 func TestReferencesFromGoCursor(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -119,6 +121,7 @@ func TestReferencesFromGoCursor(t *testing.T) {
 // .gsx <Card/> TAG cursor returns empty (component-tag resolution is a follow-up;
 // invoke references from the declaration or a .go site instead).
 func TestReferencesTagCursorEmpty(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -145,6 +148,7 @@ func TestReferencesTagCursorEmpty(t *testing.T) {
 // TestGoScopingNonGsxPackage: a .go file in a package with NO .gsx files — gsx-LSP
 // must return null (it defers entirely to gopls).
 func TestGoScopingNonGsxPackage(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}

--- a/gen/resolver_test.go
+++ b/gen/resolver_test.go
@@ -11,6 +11,7 @@ import (
 // TestCachedResolverGenerate proves that Generate of a valid component yields
 // the expected generated Go with no diagnostics.
 func TestCachedResolverGenerate(t *testing.T) {
+	t.Parallel()
 	r, err := NewCachedResolver(repoRoot(t), DefaultPlaygroundImports)
 	if err != nil {
 		t.Fatal(err)
@@ -35,6 +36,7 @@ func TestCachedResolverGenerate(t *testing.T) {
 // ({missng}) yields a positioned diagnostic in the .gsx source, and that the
 // position matches the default path's diagnostic for the same input.
 func TestCachedResolverTypeError(t *testing.T) {
+	t.Parallel()
 	const badSrc = "package views\n\ncomponent Bad() {\n\t<p>{missng}</p>\n}\n"
 
 	// --- Cached path ---

--- a/gen/watch_integration_test.go
+++ b/gen/watch_integration_test.go
@@ -24,8 +24,12 @@ func (s *syncBuf) String() string              { s.mu.Lock(); defer s.mu.Unlock(
 
 // NOTE: the TestRunWatch_* integration tests are intentionally NOT t.Parallel():
 // they drive a real fsnotify watcher + debounce timer and assert within wall-clock
-// deadlines (waitFor, 5s), which starve and flake when competing with the rest of
-// the parallel suite for CPU. Keep them serial.
+// deadlines, which would starve competing with the parallel suite for CPU. Keep
+// them serial. The deadlines are generous (60s) because the watcher's startup
+// cycle runs a cold packages.Load + compile of the temp module — that can take
+// tens of seconds on a cold 2-core CI runner (locally it's sub-second). waitFor
+// polls and returns as soon as the condition holds, so a large deadline only
+// guards against slow CI; it never slows the happy path.
 func TestRunWatch_RegeneratesOnGsxChange(t *testing.T) {
 	root := t.TempDir()
 	writeMod(t, root)
@@ -45,13 +49,13 @@ func TestRunWatch_RegeneratesOnGsxChange(t *testing.T) {
 
 	// Wait for the watcher to announce it is ready (start event appears first,
 	// then the cold-generate startup cycle is emitted).
-	waitFor(t, 5*time.Second, func() bool { return strings.Contains(out.String(), `"event":"start"`) })
+	waitFor(t, 60*time.Second, func() bool { return strings.Contains(out.String(), `"event":"start"`) })
 	// Capture the generated count after startup so we can detect the regen.
 	priorCount := countGenerated(out.String(), true)
 
 	// Edit and expect a new generated event with the updated content.
 	writeFileT(t, gsxPath, "package views\n\ncomponent Page() {\n\t<h1>two</h1>\n}\n")
-	waitFor(t, 5*time.Second, func() bool { return countGenerated(out.String(), true) > priorCount })
+	waitFor(t, 60*time.Second, func() bool { return countGenerated(out.String(), true) > priorCount })
 
 	xgo, _ := os.ReadFile(filepath.Join(root, "views", "page.x.go"))
 	// Coalesced static writes emit `S("<h1>two</h1>")`, so assert on the content,
@@ -103,16 +107,16 @@ func TestRunWatch_DebounceCoalesces(t *testing.T) {
 	go func() {
 		done <- runWatchWithStop(watchConfig{paths: []string{filepath.Join(root, "views")}, format: "ndjson", stdout: out, stderr: &syncBuf{}}, stop)
 	}()
-	waitFor(t, 5*time.Second, func() bool { return strings.Contains(out.String(), `"event":"start"`) })
+	waitFor(t, 60*time.Second, func() bool { return strings.Contains(out.String(), `"event":"start"`) })
 	// Wait for startup cycle to settle before measuring.
-	waitFor(t, 5*time.Second, func() bool { return countGenerated(out.String(), true) >= 1 })
+	waitFor(t, 60*time.Second, func() bool { return countGenerated(out.String(), true) >= 1 })
 	priorCount := countGenerated(out.String(), true)
 
 	for i := 1; i <= 5; i++ { // 5 rapid writes
 		writeFileT(t, gsxPath, "package views\n\ncomponent Page() {\n\t<h1>"+string(rune('0'+i))+"</h1>\n}\n")
 		time.Sleep(10 * time.Millisecond) // all within the 100ms window
 	}
-	waitFor(t, 5*time.Second, func() bool { return countGenerated(out.String(), true) > priorCount })
+	waitFor(t, 60*time.Second, func() bool { return countGenerated(out.String(), true) > priorCount })
 	time.Sleep(300 * time.Millisecond) // let any extra cycles flush
 	if n := countGenerated(out.String(), true) - priorCount; n > 2 {
 		t.Fatalf("debounce failed: %d generated cycles for a 5-write burst (want 1, ≤2 tolerated)", n)

--- a/gen/watch_integration_test.go
+++ b/gen/watch_integration_test.go
@@ -22,6 +22,10 @@ type syncBuf struct {
 func (s *syncBuf) Write(p []byte) (int, error) { s.mu.Lock(); defer s.mu.Unlock(); return s.b.Write(p) }
 func (s *syncBuf) String() string              { s.mu.Lock(); defer s.mu.Unlock(); return s.b.String() }
 
+// NOTE: the TestRunWatch_* integration tests are intentionally NOT t.Parallel():
+// they drive a real fsnotify watcher + debounce timer and assert within wall-clock
+// deadlines (waitFor, 5s), which starve and flake when competing with the rest of
+// the parallel suite for CPU. Keep them serial.
 func TestRunWatch_RegeneratesOnGsxChange(t *testing.T) {
 	root := t.TempDir()
 	writeMod(t, root)
@@ -87,6 +91,7 @@ func countGenerated(s string, ok bool) int {
 
 // A burst of writes within the debounce window coalesces into a single cycle.
 func TestRunWatch_DebounceCoalesces(t *testing.T) {
+	// Serial: see the note on TestRunWatch_RegeneratesOnGsxChange (real-timer deadlines).
 	root := t.TempDir()
 	writeMod(t, root)
 	gsxPath := filepath.Join(root, "views", "page.gsx")

--- a/gen/watch_test.go
+++ b/gen/watch_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestExcludedDir_OnlyOwnBasename(t *testing.T) {
+	t.Parallel()
 	cases := map[string]bool{
 		"/private/tmp/proj/views":      false, // ancestor "tmp" must NOT exclude
 		"/tmp/proj/views":              false,
@@ -27,6 +28,7 @@ func TestExcludedDir_OnlyOwnBasename(t *testing.T) {
 // runWatch returns promptly with exit 0 when there are no dirs to watch, and
 // writes nothing to stdout that isn't valid (empty is fine here).
 func TestRunWatch_NoDirsReturnsCleanly(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir() // no .gsx files
 	var out, errb bytes.Buffer
 	code := runWatch(watchConfig{

--- a/gen/watchemit_test.go
+++ b/gen/watchemit_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestEmitter_NDJSON_GeneratedOK(t *testing.T) {
+	t.Parallel()
 	var out, errb bytes.Buffer
 	e := &emitter{ndjson: true, stdout: &out, stderr: &errb}
 	e.cycle(cycleResult{Dir: "/m/views", Written: []string{"/m/views/page.x.go"}, OK: true})
@@ -28,6 +29,7 @@ func TestEmitter_NDJSON_GeneratedOK(t *testing.T) {
 }
 
 func TestEmitter_NDJSON_OperationalErrorSurfaces(t *testing.T) {
+	t.Parallel()
 	var out, errb bytes.Buffer
 	e := &emitter{ndjson: true, stdout: &out, stderr: &errb}
 	e.cycle(cycleResult{Dir: "/m/views", OK: false, Err: errors.New("disk full"), Diags: nil})
@@ -49,6 +51,7 @@ func TestEmitter_NDJSON_OperationalErrorSurfaces(t *testing.T) {
 }
 
 func TestEmitter_NDJSON_DiagnosticsShapeMatchesRenderJSON(t *testing.T) {
+	t.Parallel()
 	d := diag.Diagnostic{Severity: diag.Error, Code: "x", Message: "boom"}
 	var want bytes.Buffer
 	_ = diag.RenderJSON(&want, []diag.Diagnostic{d})

--- a/gen/watchsession_test.go
+++ b/gen/watchsession_test.go
@@ -13,6 +13,7 @@ import (
 // the package's own .go files in its type-check, or the symbol reads as
 // "undefined" on every warm regenerate even though the cold generate resolved it.
 func TestNewModuleResolver_SiblingGoSymbol(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	write := func(p, s string) {
 		full := filepath.Join(root, p)
@@ -53,6 +54,7 @@ func TestNewModuleResolver_SiblingGoSymbol(t *testing.T) {
 // it. The whole-module resolver must let `views` regenerate with the cross-
 // package ref resolved (no "cached importer: not loaded" error).
 func TestNewModuleResolver_CrossPackage(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	write := func(p, s string) {
 		full := filepath.Join(root, p)
@@ -114,6 +116,7 @@ func writeMod(t *testing.T, root string) {
 // TestWatchSession_WarmRegen proves that a pure .gsx edit regenerates via the
 // warm resolver and updates the .x.go on disk.
 func TestWatchSession_WarmRegen(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	writeMod(t, root)
 	gsxPath := filepath.Join(root, "views", "page.gsx")
@@ -139,6 +142,7 @@ func TestWatchSession_WarmRegen(t *testing.T) {
 // TestWatchSession_RegenError proves that a broken .gsx yields OK=false with
 // diagnostics.
 func TestWatchSession_RegenError(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	writeMod(t, root)
 	gsxPath := filepath.Join(root, "views", "page.gsx")

--- a/internal/codegen/analyze_test.go
+++ b/internal/codegen/analyze_test.go
@@ -15,6 +15,7 @@ import (
 // TestResolveAttrExprType checks that an attribute expression's type is resolved
 // (not just interpolations).
 func TestResolveAttrExprType(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxa\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -66,6 +67,7 @@ func TestResolveAttrExprType(t *testing.T) {
 // is used) and Attrs (single-root) fields — EXACTLY what the skeleton/emitter
 // synthesize, so emit ≡ probe.
 func TestComponentPropFieldsFor(t *testing.T) {
+	t.Parallel()
 	// Card: single-root function component using {children} → CardProps has
 	//   {Title, Featured, Children, Attrs}.
 	// (p Pg) Grid: single-root method component (no children) → PgGridProps has
@@ -120,6 +122,7 @@ func keysOf(m map[string]map[string]bool) []string {
 // TestIsGsxNodeType checks that isGsxNodeType recognises exactly "gsx.Node"
 // (with optional surrounding whitespace) and nothing else.
 func TestIsGsxNodeType(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		typ  string
 		want bool
@@ -147,6 +150,7 @@ func TestIsGsxNodeType(t *testing.T) {
 // when a component uses {children} and has a single root) are NOT promoted into
 // nodeProps — only declared gsx.Node params should appear there.
 func TestNodePropsSignal(t *testing.T) {
+	t.Parallel()
 	src := "package views\n\n" +
 		"component Card(title gsx.Node, n int) {\n\t<div>{title}</div>\n}\n"
 
@@ -215,6 +219,7 @@ func TestNodePropsSignal(t *testing.T) {
 // _gsxstd.Upper(...) call resolves. Without the threading the skeleton would
 // not import std and type resolution would fail.
 func TestChildPropPipelineSkeletonImportsStd(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxa\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/attrclass_css_wire_test.go
+++ b/internal/codegen/attrclass_css_wire_test.go
@@ -15,6 +15,7 @@ import (
 // composable ClassAttr; a user CSS-context attribute reaches emitExprAttr, whose
 // CtxCSS branch was a fail-closed error before this slice unlocked it.
 func TestCustomCSSAttrRuleEmitsCSSContext(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxcsswire\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -51,6 +52,7 @@ component Widget(userStyle string) {
 // A gsx.RawCSS value in a custom CSS-context attribute opts out of the value
 // filter: codegen emits it raw via gw.S, the author's vouch.
 func TestCustomCSSAttrRuleRawCSSOptsOut(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxcssraw\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/attrclass_wire_test.go
+++ b/internal/codegen/attrclass_wire_test.go
@@ -14,6 +14,7 @@ import (
 // (ExprAttr) since the parser does not yet know about user-defined JS attrs
 // (that is Task 3); codegen classifies the ExprAttr via the custom Classifier.
 func TestCustomJSAttrRuleEmitsJSContext(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxwire\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -46,6 +47,7 @@ component Widget(action string) {
 // (AttrValue, not JSValAttr) — proving the rule, not a regression, caused the
 // change above.
 func TestBuiltinClassifierLeavesCustomAttrPlain(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxwire\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/batch_crosspkg_test.go
+++ b/internal/codegen/batch_crosspkg_test.go
@@ -58,6 +58,7 @@ func resultKeysOf(m map[string]*PackageResult) []string {
 }
 
 func TestCrossPkgReferencesRouted(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -76,6 +77,7 @@ func TestCrossPkgReferencesRouted(t *testing.T) {
 }
 
 func TestSingleDirReferencesNoRegression(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}

--- a/internal/codegen/batch_override_test.go
+++ b/internal/codegen/batch_override_test.go
@@ -10,6 +10,7 @@ import (
 // TestSrcOverrideReplacesDiskContent: a .gsx on disk is clean, but an override
 // buffer introduces a type error; the override must drive the diagnostics.
 func TestSrcOverrideReplacesDiskContent(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "go.mod"),

--- a/internal/codegen/batch_test.go
+++ b/internal/codegen/batch_test.go
@@ -35,6 +35,7 @@ func makeSubPkg(t *testing.T, moduleDir, subdir, gsxSrc string) string {
 // TestGeneratePackages_Equivalence checks that GeneratePackages produces output
 // that is byte-equal to GeneratePackage run on each individual directory.
 func TestGeneratePackages_Equivalence(t *testing.T) {
+	t.Parallel()
 	tmp := tempModule(t, "gsxbatch")
 
 	dirA := makeSubPkg(t, tmp, "a",
@@ -91,6 +92,7 @@ func TestGeneratePackages_Equivalence(t *testing.T) {
 // TestGeneratePackages_ErrorIsolation checks that a type-resolution failure in
 // one package does not prevent the others from generating successfully.
 func TestGeneratePackages_ErrorIsolation(t *testing.T) {
+	t.Parallel()
 	tmp := tempModule(t, "gsxbatch")
 
 	dirA := makeSubPkg(t, tmp, "a",
@@ -133,6 +135,7 @@ func TestGeneratePackages_ErrorIsolation(t *testing.T) {
 // packages resolved in a single GeneratePackages call and no pre-generated
 // .x.go files on disk.
 func TestGeneratePackages_CrossPackage(t *testing.T) {
+	t.Parallel()
 	tmp := tempModule(t, "gsxbatch")
 
 	dirUI := filepath.Join(tmp, "ui")
@@ -175,6 +178,7 @@ func TestGeneratePackages_CrossPackage(t *testing.T) {
 // Fix 1, such a path would never match the go/packages-returned absolute dir,
 // causing a silent zero-output result.
 func TestGeneratePackages_NonCanonicalDir(t *testing.T) {
+	t.Parallel()
 	tmp := tempModule(t, "gsxbatch")
 
 	dirA := makeSubPkg(t, tmp, "a",
@@ -212,6 +216,7 @@ func mapKeys(m map[string]*PackageResult) []string {
 }
 
 func TestGeneratePackagesWithFilters_CustomFilter(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxbatchf\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/byo_lsp_test.go
+++ b/internal/codegen/byo_lsp_test.go
@@ -31,6 +31,7 @@ import (
 //
 // This is a guard test: it asserts the redesign did NOT break the LSP contract.
 func TestByoLSPContract(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, dir, "go.mod",

--- a/internal/codegen/classify_test.go
+++ b/internal/codegen/classify_test.go
@@ -42,6 +42,7 @@ func sigOf(t *testing.T, scope *types.Scope, name string) *types.Signature {
 }
 
 func TestClassifyFilter(t *testing.T) {
+	t.Parallel()
 	const src = `package x
 
 import "context"
@@ -91,6 +92,7 @@ func TooManyResults(s string) (string, string) { return s, s }
 // TestIsCurriedShape proves the curried-shape detector used by the WithFilter
 // migration diagnostic distinguishes the removed shape from seed-first filters.
 func TestIsCurriedShape(t *testing.T) {
+	t.Parallel()
 	const src = `package x
 
 func Curried(n int) func(string) string { return func(s string) string { return s } }
@@ -112,6 +114,7 @@ func TwoResults(s string) (string, error) { return s, nil }
 // TestIsContextContext proves the context.Context detector accepts only the
 // real stdlib type and rejects look-alikes.
 func TestIsContextContext(t *testing.T) {
+	t.Parallel()
 	const src = `package x
 
 import (

--- a/internal/codegen/coalesce_test.go
+++ b/internal/codegen/coalesce_test.go
@@ -12,6 +12,7 @@ func wrap(body string) string {
 }
 
 func TestCoalesceMergesAdjacentStaticWrites(t *testing.T) {
+	t.Parallel()
 	in := wrap("\t_gsxgw.S(\"<div\")\n\t_gsxgw.S(\">\")\n\t_gsxgw.S(\"x\")\n\t_gsxgw.S(\"</div>\")")
 	got := string(coalesceStaticWrites([]byte(in)))
 	if !strings.Contains(got, `_gsxgw.S("<div>x</div>")`) {
@@ -23,6 +24,7 @@ func TestCoalesceMergesAdjacentStaticWrites(t *testing.T) {
 }
 
 func TestCoalesceDynamicCallBreaksRun(t *testing.T) {
+	t.Parallel()
 	// A non-S call (gw.Node) between two static writes must NOT be swallowed.
 	in := wrap("\t_gsxgw.S(\"a\")\n\t_gsxgw.Node(ctx, X())\n\t_gsxgw.S(\"b\")")
 	got := string(coalesceStaticWrites([]byte(in)))
@@ -35,6 +37,7 @@ func TestCoalesceDynamicCallBreaksRun(t *testing.T) {
 }
 
 func TestCoalesceNonLiteralArgNotMerged(t *testing.T) {
+	t.Parallel()
 	// _gsxgw.S(string(raw)) and _gsxgw.S(strconv...) take non-literal args (RawCSS,
 	// numeric formatting) and must never be merged into a string literal.
 	in := wrap("\t_gsxgw.S(string(raw))\n\t_gsxgw.S(\"b\")")
@@ -48,6 +51,7 @@ func TestCoalesceNonLiteralArgNotMerged(t *testing.T) {
 }
 
 func TestCoalescePreservesLineDirective(t *testing.T) {
+	t.Parallel()
 	// A //line directive between two static writes must NOT be displaced/swallowed:
 	// the run breaks at the comment, so both S calls remain (each keeps its mapping).
 	in := wrap("\t_gsxgw.S(\"a\")\n//line input.gsx:4:7\n\t_gsxgw.S(\"b\")")
@@ -61,6 +65,7 @@ func TestCoalescePreservesLineDirective(t *testing.T) {
 }
 
 func TestCoalesceMergesInsideSwitchCase(t *testing.T) {
+	t.Parallel()
 	// switch/select clause bodies are []Stmt, not *BlockStmt; their static writes
 	// must coalesce too (the generator emits case bodies flat, not brace-wrapped).
 	in := "package p\nfunc f() {\n\tswitch k {\n\tcase \"a\":\n\t\t_gsxgw.S(\"<b\")\n\t\t_gsxgw.S(\">x</b>\")\n\tdefault:\n\t\t_gsxgw.S(\"<i\")\n\t\t_gsxgw.S(\">y</i>\")\n\t}\n}\n"
@@ -74,6 +79,7 @@ func TestCoalesceMergesInsideSwitchCase(t *testing.T) {
 }
 
 func TestCoalesceRequotesEscapes(t *testing.T) {
+	t.Parallel()
 	// Merging must unquote/requote correctly so embedded quotes survive.
 	in := wrap("\t_gsxgw.S(\"<a href=\\\"\")\n\t_gsxgw.S(\"x\")\n\t_gsxgw.S(\"\\\"\")")
 	got := string(coalesceStaticWrites([]byte(in)))

--- a/internal/codegen/codegen_test.go
+++ b/internal/codegen/codegen_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestLineDirectives(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxl\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/column_accuracy_test.go
+++ b/internal/codegen/column_accuracy_test.go
@@ -27,6 +27,7 @@ import (
 // byte 8 = len("_gsxuse(")) reports col 7+8=15.
 // After this fix: column must be 9.
 func TestInterpColumnAccuracy(t *testing.T) {
+	t.Parallel()
 	mod := tempModule(t, "gsxcoltest")
 	viewsDir := filepath.Join(mod, "views")
 	if err := os.MkdirAll(viewsDir, 0o755); err != nil {
@@ -88,6 +89,7 @@ func TestInterpColumnAccuracy(t *testing.T) {
 // The '{' col is 1, so base anchored col = 1+8 = 9.
 // Assertion: reported column ≤ (col of '{') + 8.
 func TestInterpShallowColumnNoRegression(t *testing.T) {
+	t.Parallel()
 	mod := tempModule(t, "gsxshallowtest")
 	viewsDir := filepath.Join(mod, "views")
 	if err := os.MkdirAll(viewsDir, 0o755); err != nil {

--- a/internal/codegen/crossindex_test.go
+++ b/internal/codegen/crossindex_test.go
@@ -9,6 +9,7 @@ import (
 // TestCrossIndex: a component Card declared in card.gsx, called from main.go and
 // used as <Card/> in page.gsx, is indexed with its .gsx Decl and both refs.
 func TestCrossIndex(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, dir, "go.mod",

--- a/internal/codegen/diag_recovery_test.go
+++ b/internal/codegen/diag_recovery_test.go
@@ -9,6 +9,7 @@ import (
 // Two components each with a distinct codegen error must BOTH be reported
 // (component-boundary recovery), and each diagnostic must carry a .gsx position.
 func TestComponentRecoveryReportsAllPositioned(t *testing.T) {
+	t.Parallel()
 	mod := tempModule(t, "gsxrecoverytest")
 	dir := filepath.Join(mod, "views")
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/internal/codegen/diag_wire_test.go
+++ b/internal/codegen/diag_wire_test.go
@@ -9,6 +9,7 @@ import (
 
 // A file with TWO independent type errors must report BOTH (not just the first).
 func TestAllTypeErrorsReported(t *testing.T) {
+	t.Parallel()
 	// Create a temp module rooted at a real Go module so packages.Load works.
 	mod := tempModule(t, "gsxdiagwiretest")
 

--- a/internal/codegen/emit.go
+++ b/internal/codegen/emit.go
@@ -30,7 +30,7 @@ func generateFile(file *ast.File, resolved map[ast.Node]types.Type, table filter
 		cls = attrclass.Builtin()
 	}
 	fm = fieldMatcherOrDefault(fm)
-	interpTemp = 0
+	interpTemp := 0
 	// Minify the static CSS of <style> blocks. cssMin is nil for the built-in
 	// safe minifier, or a custom override (e.g. tdewolff) threaded from
 	// gen.WithCSSMinifier. Custom minifiers only ever receive complete, valid CSS
@@ -99,7 +99,7 @@ func generateFile(file *ast.File, resolved map[ast.Node]types.Type, table filter
 			// On failure, the diagnostic is already in bag — skip this component's
 			// output and continue to the next (report ALL components' errors).
 			var cbuf bytes.Buffer
-			if genComponent(&cbuf, v, resolved, table, structFields, nodeProps, byo, imports, fset, cls, fm, bag) {
+			if genComponent(&cbuf, v, resolved, table, structFields, nodeProps, byo, imports, &interpTemp, fset, cls, fm, bag) {
 				body.Write(cbuf.Bytes())
 			} else {
 				ok = false
@@ -194,7 +194,7 @@ func writeImports(b *bytes.Buffer, imports map[string]bool, aliased []importSpec
 	b.WriteString(")\n\n")
 }
 
-func genComponent(b *bytes.Buffer, c *ast.Component, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, fset *token.FileSet, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
+func genComponent(b *bytes.Buffer, c *ast.Component, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, interpTemp *int, fset *token.FileSet, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
 	params, err := parseParams(c.Params)
 	if err != nil {
 		bag.Errorf(c.Pos(), c.End(), "invalid-syntax", "%s", strings.TrimPrefix(err.Error(), "codegen: "))
@@ -248,7 +248,7 @@ func genComponent(b *bytes.Buffer, c *ast.Component, resolved map[ast.Node]types
 		b.WriteString("\treturn gsx.Func(func(ctx context.Context, _gsxw io.Writer) error {\n")
 		b.WriteString("\t\t_gsxgw := gsx.W(_gsxw)\n")
 		for _, m := range c.Body {
-			if !genNode(b, m, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+			if !genNode(b, m, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 				return false
 			}
 		}
@@ -357,12 +357,12 @@ func genComponent(b *bytes.Buffer, c *ast.Component, resolved map[ast.Node]types
 		// is false, so the root emits via normal genNode and the author's {...attrs}
 		// places the bag.
 		if autoApply && m == ast.Markup(root) {
-			if !emitRootElement(b, root, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+			if !emitRootElement(b, root, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 				return false
 			}
 			continue
 		}
-		if !genNode(b, m, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+		if !genNode(b, m, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 			return false
 		}
 	}
@@ -387,13 +387,13 @@ func genComponent(b *bytes.Buffer, c *ast.Component, resolved map[ast.Node]types
 // A void root cannot receive fallthrough (it has no place for it to matter beyond
 // attrs, but void roots ARE handled: class/style-merge + guarded attrs + spread
 // then `/>`).
-func emitRootElement(b *bytes.Buffer, el *ast.Element, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
+func emitRootElement(b *bytes.Buffer, el *ast.Element, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, interpTemp *int, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
 	emitLine(b, fset, el.Pos())
 	emitS(b, "<"+el.Tag)
 	// AUTO mode: there is no author `{...attrs}`, so the bag spreads at the END and
 	// every root attr is overridable. splitIdx == len(el.Attrs) means "all attrs
 	// precede the (synthetic) spread" → all guarded.
-	if !emitFallthroughAttrs(b, el.Attrs, len(el.Attrs), resolved, table, imports, cls, bag) {
+	if !emitFallthroughAttrs(b, el.Attrs, len(el.Attrs), resolved, table, imports, interpTemp, cls, bag) {
 		return false
 	}
 	if el.Void {
@@ -403,19 +403,19 @@ func emitRootElement(b *bytes.Buffer, el *ast.Element, resolved map[ast.Node]typ
 	emitS(b, ">")
 	if strings.EqualFold(el.Tag, "style") {
 		for _, c := range el.Children {
-			if !genStyleChild(b, c, resolved, table, imports, fset, bag) {
+			if !genStyleChild(b, c, resolved, table, imports, interpTemp, fset, bag) {
 				return false
 			}
 		}
 	} else if strings.EqualFold(el.Tag, "script") {
 		for _, c := range el.Children {
-			if !genScriptChild(b, c, resolved, table, imports, fset, bag) {
+			if !genScriptChild(b, c, resolved, table, imports, interpTemp, fset, bag) {
 				return false
 			}
 		}
 	} else {
 		for _, c := range el.Children {
-			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 				return false
 			}
 		}
@@ -440,7 +440,7 @@ func emitRootElement(b *bytes.Buffer, el *ast.Element, resolved map[ast.Node]typ
 // (ClassMerged / StyleMerged), emitted once at the spread position. The author's
 // `{...attrs}` SpreadAttr itself (when present at splitIdx) is consumed here, not
 // emitted via emitAttr.
-func emitFallthroughAttrs(b *bytes.Buffer, attrs []ast.Attr, splitIdx int, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, cls *attrclass.Classifier, bag *diag.Bag) bool {
+func emitFallthroughAttrs(b *bytes.Buffer, attrs []ast.Attr, splitIdx int, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, cls *attrclass.Classifier, bag *diag.Bag) bool {
 	// Find a composed/static class attr to merge the bag's class into, and a
 	// composed/static style attr whose declarations the bag's style merges over.
 	var classAttr *ast.ClassAttr    // composed class={ … }
@@ -477,14 +477,14 @@ func emitFallthroughAttrs(b *bytes.Buffer, attrs []ast.Attr, splitIdx int, resol
 			// No single static name (Cond) — no caller-wins shadow target; emit
 			// unguarded. (A SpreadAttr at the split position is consumed below, not
 			// here.)
-			return emitAttr(b, a, resolved, table, imports, cls, bag)
+			return emitAttr(b, a, resolved, table, imports, interpTemp, cls, bag)
 		}
 		if !guarded {
 			forcedNames = append(forcedNames, name)
-			return emitAttr(b, a, resolved, table, imports, cls, bag)
+			return emitAttr(b, a, resolved, table, imports, interpTemp, cls, bag)
 		}
 		fmt.Fprintf(b, "\t\tif !_gsxp.Attrs.Has(%s) {\n", strconv.Quote(name))
-		if !emitAttr(b, a, resolved, table, imports, cls, bag) {
+		if !emitAttr(b, a, resolved, table, imports, interpTemp, cls, bag) {
 			return false
 		}
 		b.WriteString("\t\t}\n")
@@ -515,7 +515,7 @@ func emitFallthroughAttrs(b *bytes.Buffer, attrs []ast.Attr, splitIdx int, resol
 			fmt.Fprintf(b, "\t\t\t_gsxgw.StyleMerged(%s, _gsxp.Attrs.Style())\n", styleStr)
 			b.WriteString("\t\t} else {\n")
 			if staticStyle != nil {
-				if !emitAttr(b, staticStyle, resolved, table, imports, cls, bag) {
+				if !emitAttr(b, staticStyle, resolved, table, imports, interpTemp, cls, bag) {
 					return false
 				}
 			} else {
@@ -619,9 +619,9 @@ func emitFallthroughAttrs(b *bytes.Buffer, attrs []ast.Attr, splitIdx int, resol
 // root attrs before the spread are caller-overridable, attrs after are forced
 // (root wins). splitIdx is the bag SpreadAttr's index in el.Attrs (guaranteed
 // unique by the caller).
-func emitManualSpreadElement(b *bytes.Buffer, el *ast.Element, splitIdx int, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
+func emitManualSpreadElement(b *bytes.Buffer, el *ast.Element, splitIdx int, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, interpTemp *int, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
 	emitS(b, "<"+el.Tag)
-	if !emitFallthroughAttrs(b, el.Attrs, splitIdx, resolved, table, imports, cls, bag) {
+	if !emitFallthroughAttrs(b, el.Attrs, splitIdx, resolved, table, imports, interpTemp, cls, bag) {
 		return false
 	}
 	if el.Void {
@@ -631,19 +631,19 @@ func emitManualSpreadElement(b *bytes.Buffer, el *ast.Element, splitIdx int, res
 	emitS(b, ">")
 	if strings.EqualFold(el.Tag, "style") {
 		for _, c := range el.Children {
-			if !genStyleChild(b, c, resolved, table, imports, fset, bag) {
+			if !genStyleChild(b, c, resolved, table, imports, interpTemp, fset, bag) {
 				return false
 			}
 		}
 	} else if strings.EqualFold(el.Tag, "script") {
 		for _, c := range el.Children {
-			if !genScriptChild(b, c, resolved, table, imports, fset, bag) {
+			if !genScriptChild(b, c, resolved, table, imports, interpTemp, fset, bag) {
 				return false
 			}
 		}
 	} else {
 		for _, c := range el.Children {
-			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 				return false
 			}
 		}
@@ -754,7 +754,7 @@ func rootStyleString(styleAttr *ast.ClassAttr, staticStyle *ast.StaticAttr, tabl
 // component's receiver var + type name (empty for a function component); they
 // thread down to genChildComponent for the method-vs-package disambiguation of a
 // dotted child-component tag.
-func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
+func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, interpTemp *int, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
 	switch t := n.(type) {
 	case *ast.Text:
 		emitS(b, t.Value)
@@ -777,7 +777,7 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 	case *ast.Element:
 		emitLine(b, fset, t.Pos())
 		if isComponentTag(t.Tag) {
-			return genChildComponent(b, t, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag)
+			return genChildComponent(b, t, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag)
 		}
 		// MANUAL fallthrough: an element carrying the author's `{...attrs}` bag spread
 		// gets position-aware precedence (pre-spread overridable, post-spread forced).
@@ -787,11 +787,11 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 			bag.Errorf(t.Pos(), t.End(), "attr-fallthrough", "%s", strings.TrimPrefix(err.Error(), "codegen: "))
 			return false
 		} else if found {
-			return emitManualSpreadElement(b, t, splitIdx, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag)
+			return emitManualSpreadElement(b, t, splitIdx, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag)
 		}
 		emitS(b, "<"+t.Tag)
 		for _, a := range t.Attrs {
-			if !emitAttr(b, a, resolved, table, imports, cls, bag) {
+			if !emitAttr(b, a, resolved, table, imports, interpTemp, cls, bag) {
 				return false
 			}
 		}
@@ -802,29 +802,29 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 		emitS(b, ">")
 		if strings.EqualFold(t.Tag, "style") {
 			for _, c := range t.Children {
-				if !genStyleChild(b, c, resolved, table, imports, fset, bag) {
+				if !genStyleChild(b, c, resolved, table, imports, interpTemp, fset, bag) {
 					return false
 				}
 			}
 		} else if strings.EqualFold(t.Tag, "script") {
 			for _, c := range t.Children {
-				if !genScriptChild(b, c, resolved, table, imports, fset, bag) {
+				if !genScriptChild(b, c, resolved, table, imports, interpTemp, fset, bag) {
 					return false
 				}
 			}
 		} else {
 			for _, c := range t.Children {
-				if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+				if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 					return false
 				}
 			}
 		}
 		emitS(b, "</"+t.Tag+">")
 	case *ast.Interp:
-		return genInterp(b, t, resolved, table, imports, fset, bag)
+		return genInterp(b, t, resolved, table, imports, interpTemp, fset, bag)
 	case *ast.Fragment:
 		for _, c := range t.Children {
-			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 				return false
 			}
 		}
@@ -832,7 +832,7 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 		emitLine(b, fset, t.Pos())
 		fmt.Fprintf(b, "for %s {\n", t.Clause)
 		for _, c := range t.Body {
-			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 				return false
 			}
 		}
@@ -841,7 +841,7 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 		emitLine(b, fset, t.Pos())
 		fmt.Fprintf(b, "if %s {\n", t.Cond)
 		for _, c := range t.Then {
-			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+			if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 				return false
 			}
 		}
@@ -849,7 +849,7 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 		if t.Else != nil {
 			b.WriteString(" else {\n")
 			for _, c := range t.Else {
-				if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+				if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 					return false
 				}
 			}
@@ -866,7 +866,7 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 				fmt.Fprintf(b, "case %s:\n", cc.List)
 			}
 			for _, c := range cc.Body {
-				if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+				if !genNode(b, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 					return false
 				}
 			}
@@ -886,7 +886,7 @@ func genNode(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, ta
 // genInterp emits the type-aware writer call for an interpolation. The type comes
 // from the go/types resolution pass; the expression is emitted verbatim (params
 // are in scope as locals).
-func genInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, fset *token.FileSet, bag *diag.Bag) bool {
+func genInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, fset *token.FileSet, bag *diag.Bag) bool {
 	emitLine(b, fset, n.Pos())
 	expr := strings.TrimSpace(n.Expr)
 	if len(n.Stages) > 0 {
@@ -917,17 +917,13 @@ func genInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type,
 			return false
 		}
 		// v, err := expr; if err != nil { return err }; then render v by its type.
-		tmp := fmt.Sprintf("_gsxv%d", interpTemp)
-		interpTemp++
+		tmp := fmt.Sprintf("_gsxv%d", *interpTemp)
+		*interpTemp++
 		fmt.Fprintf(b, "\t\t%s, _gsxerr := %s\n\t\tif _gsxerr != nil {\n\t\t\treturn _gsxerr\n\t\t}\n", tmp, expr)
 		return emitRender(b, tmp, tup.At(0).Type(), imports, n, bag)
 	}
 	return emitRender(b, expr, t, imports, n, bag)
 }
-
-// interpTemp gives unique unwrap temp names within a generated file. It is reset
-// at the start of generateFile.
-var interpTemp int
 
 // emitLine writes a //line directive mapping subsequent output to the gsx node's
 // source position, so Go compiler errors point at the .gsx file. The directive
@@ -980,13 +976,13 @@ func emitS(b *bytes.Buffer, s string) {
 // genStyleChild emits one child of a <style> element. Text is raw CSS (verbatim);
 // an Interp is rendered in CSS context (auto-sanitized). <style> bodies contain
 // only Text and @{ } interps (parser guarantee).
-func genStyleChild(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, fset *token.FileSet, bag *diag.Bag) bool {
+func genStyleChild(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, fset *token.FileSet, bag *diag.Bag) bool {
 	switch t := n.(type) {
 	case *ast.Text:
 		emitS(b, t.Value)
 		return true
 	case *ast.Interp:
-		return emitCSSInterp(b, t, resolved, table, imports, fset, bag)
+		return emitCSSInterp(b, t, resolved, table, imports, interpTemp, fset, bag)
 	default:
 		bag.Errorf(n.Pos(), n.End(), "unsupported-style-node", "<style> body may contain only text and @{ } interpolations, got %T", n)
 		return false
@@ -994,7 +990,7 @@ func genStyleChild(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Ty
 }
 
 // emitCSSInterp renders a <style> interpolation value in CSS block context.
-func emitCSSInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, fset *token.FileSet, bag *diag.Bag) bool {
+func emitCSSInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, fset *token.FileSet, bag *diag.Bag) bool {
 	expr := strings.TrimSpace(n.Expr)
 	if len(n.Stages) > 0 {
 		lowered, usedPkgs, err := lowerPipe(n.Expr, n.Stages, table)
@@ -1017,8 +1013,8 @@ func emitCSSInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.T
 			bag.Errorf(n.Pos(), n.End(), "invalid-tuple", "<style> interpolation %q returns %s; only (T, error) is supported", expr, t)
 			return false
 		}
-		tmp := fmt.Sprintf("_gsxv%d", interpTemp)
-		interpTemp++
+		tmp := fmt.Sprintf("_gsxv%d", *interpTemp)
+		*interpTemp++
 		fmt.Fprintf(b, "\t\t%s, _gsxerr := %s\n\t\tif _gsxerr != nil {\n\t\t\treturn _gsxerr\n\t\t}\n", tmp, expr)
 		return emitRenderCSS(b, tmp, tup.At(0).Type(), imports, n, bag)
 	}
@@ -1058,13 +1054,13 @@ func emitRenderCSS(b *bytes.Buffer, expr string, t types.Type, imports map[strin
 // (verbatim); an Interp is rendered through the JS escaper selected by its
 // JSCtx (set by internal/jsx). Comment-context holes were already un-split to
 // Text by jsx.ResolveScripts, so they arrive here as Text.
-func genScriptChild(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, fset *token.FileSet, bag *diag.Bag) bool {
+func genScriptChild(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, fset *token.FileSet, bag *diag.Bag) bool {
 	switch t := n.(type) {
 	case *ast.Text:
 		emitS(b, t.Value)
 		return true
 	case *ast.Interp:
-		return emitJSInterp(b, t, resolved, table, imports, fset, bag)
+		return emitJSInterp(b, t, resolved, table, imports, interpTemp, fset, bag)
 	default:
 		bag.Errorf(n.Pos(), n.End(), "unsupported-script-node", "<script> body may contain only text and @{ } interpolations, got %T", n)
 		return false
@@ -1074,7 +1070,7 @@ func genScriptChild(b *bytes.Buffer, n ast.Markup, resolved map[ast.Node]types.T
 // emitJSInterp renders a <script> interpolation value through the runtime JS
 // escaper chosen by its JSCtx. It mirrors emitCSSInterp's pipeline-stage handling
 // and (T, error) tuple auto-unwrap.
-func emitJSInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, fset *token.FileSet, bag *diag.Bag) bool {
+func emitJSInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, fset *token.FileSet, bag *diag.Bag) bool {
 	expr := strings.TrimSpace(n.Expr)
 	if len(n.Stages) > 0 {
 		lowered, usedPkgs, err := lowerPipe(n.Expr, n.Stages, table)
@@ -1098,8 +1094,8 @@ func emitJSInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Ty
 			bag.Errorf(n.Pos(), n.End(), "invalid-tuple", "<script> interpolation %q returns %s; only (T, error) is supported", expr, t)
 			return false
 		}
-		tmp := fmt.Sprintf("_gsxv%d", interpTemp)
-		interpTemp++
+		tmp := fmt.Sprintf("_gsxv%d", *interpTemp)
+		*interpTemp++
 		fmt.Fprintf(b, "\t\t%s, _gsxerr := %s\n\t\tif _gsxerr != nil {\n\t\t\treturn _gsxerr\n\t\t}\n", tmp, expr)
 		return emitJSValue(b, n.JSCtx, tmp, tup.At(0).Type(), imports, n, bag)
 	}
@@ -1170,16 +1166,16 @@ func spreadAttrExpr(a *ast.SpreadAttr, table filterTable, imports map[string]boo
 // emitAttr emits one element attribute. Static values are escaped at codegen and
 // always double-quoted; bool attrs use gw.BoolAttr. Expr attrs are handled in a
 // later task; the deferred attr kinds error clearly.
-func emitAttr(b *bytes.Buffer, a ast.Attr, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, cls *attrclass.Classifier, bag *diag.Bag) bool {
+func emitAttr(b *bytes.Buffer, a ast.Attr, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, cls *attrclass.Classifier, bag *diag.Bag) bool {
 	switch t := a.(type) {
 	case *ast.StaticAttr:
 		fmt.Fprintf(b, "\t\t_gsxgw.S(%s)\n", strconv.Quote(" "+t.Name+`="`+htmlAttrEscape(t.Value)+`"`))
 	case *ast.BoolAttr:
 		fmt.Fprintf(b, "\t\t_gsxgw.BoolAttr(%s, true)\n", strconv.Quote(t.Name))
 	case *ast.ExprAttr:
-		return emitExprAttr(b, t, resolved, table, imports, cls, bag)
+		return emitExprAttr(b, t, resolved, table, imports, interpTemp, cls, bag)
 	case *ast.JSAttr:
-		return emitJSAttr(b, t, resolved, table, imports, bag)
+		return emitJSAttr(b, t, resolved, table, imports, interpTemp, bag)
 	case *ast.ClassAttr:
 		// class -> token merge (gw.Class); style -> '; '-joined declarations
 		// (gw.Style) with dynamic parts CSS-value-filtered.
@@ -1214,14 +1210,14 @@ func emitAttr(b *bytes.Buffer, a ast.Attr, resolved map[ast.Node]types.Type, tab
 		// control construct, and each nested attr emit carries its own line map.)
 		fmt.Fprintf(b, "\t\tif %s {\n", t.Cond)
 		for _, inner := range t.Then {
-			if !emitAttr(b, inner, resolved, table, imports, cls, bag) {
+			if !emitAttr(b, inner, resolved, table, imports, interpTemp, cls, bag) {
 				return false
 			}
 		}
 		if len(t.Else) > 0 {
 			b.WriteString("\t\t} else {\n")
 			for _, inner := range t.Else {
-				if !emitAttr(b, inner, resolved, table, imports, cls, bag) {
+				if !emitAttr(b, inner, resolved, table, imports, interpTemp, cls, bag) {
 					return false
 				}
 			}
@@ -1239,14 +1235,14 @@ func emitAttr(b *bytes.Buffer, a ast.Attr, resolved map[ast.Node]types.Type, tab
 // @{ } holes (form 2a, e.g. x-data="{ tab: @{ x } }"). Static JS text is
 // HTML-attr-escaped at codegen so <,>,& survive the attribute; each hole is
 // escaped by its JSCtx and then HTML-attr-escaped (the *Attr escapers do both).
-func emitJSAttr(b *bytes.Buffer, a *ast.JSAttr, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, bag *diag.Bag) bool {
+func emitJSAttr(b *bytes.Buffer, a *ast.JSAttr, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, bag *diag.Bag) bool {
 	fmt.Fprintf(b, "\t\t_gsxgw.S(%s)\n", strconv.Quote(" "+a.Name+`="`))
 	for _, seg := range a.Segments {
 		switch s := seg.(type) {
 		case *ast.Text:
 			fmt.Fprintf(b, "\t\t_gsxgw.S(%s)\n", strconv.Quote(htmlAttrEscape(s.Value)))
 		case *ast.Interp:
-			if !emitJSAttrInterp(b, s, resolved, table, imports, bag) {
+			if !emitJSAttrInterp(b, s, resolved, table, imports, interpTemp, bag) {
 				return false
 			}
 		default:
@@ -1262,7 +1258,7 @@ func emitJSAttr(b *bytes.Buffer, a *ast.JSAttr, resolved map[ast.Node]types.Type
 // the runtime *Attr escaper chosen by its JSCtx. It mirrors emitJSInterp's
 // pipeline-stage handling and (T, error) tuple auto-unwrap, but routes to the
 // JS*Attr methods (which additionally HTML-attr-escape).
-func emitJSAttrInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, bag *diag.Bag) bool {
+func emitJSAttrInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, bag *diag.Bag) bool {
 	expr := strings.TrimSpace(n.Expr)
 	if len(n.Stages) > 0 {
 		lowered, usedPkgs, err := lowerPipe(n.Expr, n.Stages, table)
@@ -1285,8 +1281,8 @@ func emitJSAttrInterp(b *bytes.Buffer, n *ast.Interp, resolved map[ast.Node]type
 			bag.Errorf(n.Pos(), n.End(), "invalid-tuple", "JS attribute interpolation %q returns %s; only (T, error) is supported", expr, t)
 			return false
 		}
-		tmp := fmt.Sprintf("_gsxv%d", interpTemp)
-		interpTemp++
+		tmp := fmt.Sprintf("_gsxv%d", *interpTemp)
+		*interpTemp++
 		fmt.Fprintf(b, "\t\t%s, _gsxerr := %s\n\t\tif _gsxerr != nil {\n\t\t\treturn _gsxerr\n\t\t}\n", tmp, expr)
 		return emitJSAttrValue(b, n.JSCtx, tmp, tup.At(0).Type(), n, bag)
 	}
@@ -1431,7 +1427,7 @@ func htmlAttrEscape(s string) string {
 // context is contextually sanitized (gw.CSS) with a gsx.RawCSS author opt-out; a
 // JS context routes through gw.JSValAttr. Both are handled in the value-emit
 // section below by their respective branches.
-func emitExprAttr(b *bytes.Buffer, a *ast.ExprAttr, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, cls *attrclass.Classifier, bag *diag.Bag) bool {
+func emitExprAttr(b *bytes.Buffer, a *ast.ExprAttr, resolved map[ast.Node]types.Type, table filterTable, imports map[string]bool, interpTemp *int, cls *attrclass.Classifier, bag *diag.Bag) bool {
 	// (1) value expression: lower a pipeline to nested std calls (same lowerPipe
 	// the probe used, so resolved[a] is already the pipeline's RESULT type), else
 	// the bare trimmed expr.
@@ -1461,8 +1457,8 @@ func emitExprAttr(b *bytes.Buffer, a *ast.ExprAttr, resolved map[ast.Node]types.
 			bag.Errorf(a.Pos(), a.End(), "invalid-tuple", "attribute %q value %q returns %s; only (T, error) is supported", a.Name, a.Expr, t)
 			return false
 		}
-		tmp := fmt.Sprintf("_gsxv%d", interpTemp)
-		interpTemp++
+		tmp := fmt.Sprintf("_gsxv%d", *interpTemp)
+		*interpTemp++
 		fmt.Fprintf(b, "\t\t%s, _gsxerr := %s\n\t\tif _gsxerr != nil {\n\t\t\treturn _gsxerr\n\t\t}\n", tmp, expr)
 		expr = tmp
 		t = tup.At(0).Type()
@@ -1829,7 +1825,7 @@ func childInvocation(el *ast.Element, byo *byoData, recvVar, recvTypeName string
 // recvVar/recvTypeName are the ENCLOSING component's receiver var + type name
 // (empty for a function component); they drive the method-vs-package
 // disambiguation via childInvocation.
-func genChildComponent(b *bytes.Buffer, el *ast.Element, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
+func genChildComponent(b *bytes.Buffer, el *ast.Element, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, interpTemp *int, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) bool {
 	// A bare-call candidate tag (isBareCallCandidate — a hand-written same-package
 	// func, or a .gsx no-props component) was probed via _gsxcompsig, so harvest
 	// stored its real signature in resolved[el]. A nullary func is a bare call
@@ -1872,7 +1868,7 @@ func genChildComponent(b *bytes.Buffer, el *ast.Element, resolved map[ast.Node]t
 	// When splatExpr is non-empty, the call is a whole-struct splat: emit
 	// callTarget(splatExpr) directly, bypassing the Props{…} literal.
 	fields, splatExpr, usedPkgs, err := childPropsLiteral(el, propsType, "gsx", table, structFields, nodeProps[propsType], byo, fm, func(nodes []ast.Markup) (string, error) {
-		s, ok := emitSlotClosure(nodes, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag)
+		s, ok := emitSlotClosure(nodes, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag)
 		if !ok {
 			return "", fmt.Errorf("slot closure failed")
 		}
@@ -1944,12 +1940,12 @@ func childPropsErrorCode(err error) string {
 // EXACTLY — same reserved idents (_gsxw/_gsxgw), gsx.W/gsx.Func, and trailing
 // Err() — so the slot streams to the same output, in THIS (parent) scope. It is
 // shared by the Children slot and every named markup slot so they cannot drift.
-func emitSlotClosure(nodes []ast.Markup, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) (string, bool) {
+func emitSlotClosure(nodes []ast.Markup, resolved map[ast.Node]types.Type, table filterTable, structFields, nodeProps map[string]map[string]bool, byo *byoData, imports map[string]bool, interpTemp *int, fset *token.FileSet, recvVar, recvTypeName string, cls *attrclass.Classifier, fm FieldMatcher, bag *diag.Bag) (string, bool) {
 	var slot bytes.Buffer
 	slot.WriteString("gsx.Func(func(ctx context.Context, _gsxw io.Writer) error {\n")
 	slot.WriteString("\t\t_gsxgw := gsx.W(_gsxw)\n")
 	for _, c := range nodes {
-		if !genNode(&slot, c, resolved, table, structFields, nodeProps, byo, imports, fset, recvVar, recvTypeName, cls, fm, bag) {
+		if !genNode(&slot, c, resolved, table, structFields, nodeProps, byo, imports, interpTemp, fset, recvVar, recvTypeName, cls, fm, bag) {
 			return "", false
 		}
 	}

--- a/internal/codegen/fieldmatch_test.go
+++ b/internal/codegen/fieldmatch_test.go
@@ -3,6 +3,7 @@ package codegen
 import "testing"
 
 func TestDefaultFieldMatcher(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		attr      string
 		fields    []string
@@ -33,6 +34,7 @@ func TestDefaultFieldMatcher(t *testing.T) {
 }
 
 func TestAttrToFieldCandidate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		attr string
 		want string

--- a/internal/codegen/filters_ctx_test.go
+++ b/internal/codegen/filters_ctx_test.go
@@ -36,6 +36,7 @@ func goRun(t *testing.T, dir string) string {
 //   - emit ≡ probe: the SAME lowered call type-checks (probe) and renders (emit),
 //     which is guaranteed because generation would fail if they diverged.
 func TestWithFilterCtxInjectionAndErrorUnwrap(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-run render test in -short mode")
 	}
@@ -131,6 +132,7 @@ func main() {
 // the fix, only the reserved-alias import was emitted and the direct reference
 // was `undefined: <pkg>`.
 func TestWithFilterPackageAlsoImportedDirectly(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-run render test in -short mode")
 	}
@@ -207,6 +209,7 @@ func main() {
 // registered via a FilterAlias surfaces the migration diagnostic rather than
 // silently miscompiling.
 func TestWithFilterCurriedMigrationDiagnostic(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/codegen/filters_multi_test.go
+++ b/internal/codegen/filters_multi_test.go
@@ -88,6 +88,7 @@ func main() {
 // reserved _gsxf0 alias (shout → myfilters.Shout) WHILE a std filter in the SAME
 // interpolation file still resolves under _gsxstd (upper → std.Upper).
 func TestMultiFilterUserAndStd(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-build filter test in -short mode")
 	}
@@ -117,6 +118,7 @@ component C(n string) {
 // TestMultiFilterLastWins proves last-wins precedence: a user Upper listed AFTER
 // std shadows std's built-in upper.
 func TestMultiFilterLastWins(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-build filter test in -short mode")
 	}
@@ -143,6 +145,7 @@ component C(n string) {
 // TestMultiFilterStdWinsWhenListedLast proves order matters: with std listed
 // AFTER the user package, std's upper wins for the same name.
 func TestMultiFilterStdWinsWhenListedLast(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-build filter test in -short mode")
 	}
@@ -169,6 +172,7 @@ component C(n string) {
 // TestMultiFilterUnknownErrors proves an unknown filter (present in neither
 // package) is a clean codegen error.
 func TestMultiFilterUnknownErrors(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatal(err)
@@ -199,6 +203,7 @@ func TestMultiFilterUnknownErrors(t *testing.T) {
 // stdImportPath keeps _gsxstd; each non-std package gets a stable _gsxf<i> by
 // position among non-std packages, independent of where std sits in the list.
 func TestFilterAliasAssignment(t *testing.T) {
+	t.Parallel()
 	got := filterAliases([]string{stdImportPath, "example.com/a", "example.com/b"})
 	want := map[string]string{
 		stdImportPath:   "_gsxstd",

--- a/internal/codegen/filters_test.go
+++ b/internal/codegen/filters_test.go
@@ -17,6 +17,7 @@ func repoRoot(t *testing.T) string {
 }
 
 func TestFilterHarvest(t *testing.T) {
+	t.Parallel()
 	table, err := loadFilterTable(repoRoot(t))
 	if err != nil {
 		t.Fatalf("loadFilterTable: %v", err)

--- a/internal/codegen/import_diag_test.go
+++ b/internal/codegen/import_diag_test.go
@@ -25,6 +25,7 @@ import (
 //	line 4: \t"context"     ← unused; error must land here
 //	line 5: )
 func TestUnusedImportDiagnosticMapsToSource(t *testing.T) {
+	t.Parallel()
 	mod := tempModule(t, "gsximporttest")
 	viewsDir := filepath.Join(mod, "views")
 	if err := os.MkdirAll(viewsDir, 0o755); err != nil {
@@ -73,6 +74,7 @@ func TestUnusedImportDiagnosticMapsToSource(t *testing.T) {
 //	line 5: \tx "context"   ← unused alias; error must land here
 //	line 6: )
 func TestUnusedImportDiagnosticPerImportLine(t *testing.T) {
+	t.Parallel()
 	mod := tempModule(t, "gsximportline")
 	viewsDir := filepath.Join(mod, "views")
 	if err := os.MkdirAll(viewsDir, 0o755); err != nil {

--- a/internal/codegen/line_anchor_test.go
+++ b/internal/codegen/line_anchor_test.go
@@ -91,6 +91,7 @@ func assertFuncAnchor(t *testing.T, genSrc, file, name string, wantLine int) {
 // Regression guard for go-to-definition on a component referenced as a Go call in
 // a `{ }` hole (cross-package path), which jumped to a drifted body line before.
 func TestComponentFuncLineAnchorCodegen(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxa\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -165,6 +166,7 @@ func assertFuncNameAnchorColumn(t *testing.T, skel, src, name string) {
 // each component func-decl points to the NAME column (not the `component` keyword
 // column). This makes LSP go-to-definition land on the component name precisely.
 func TestComponentFuncNameColumnAnchorSkeleton(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxa\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -203,6 +205,7 @@ func TestComponentFuncNameColumnAnchorSkeleton(t *testing.T) {
 // Regression guard for the SAME-package go-to-definition path (`{ LocalComp(…) }`),
 // which resolves through the skeleton, not the on-disk .x.go.
 func TestComponentFuncLineAnchorSkeleton(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxa\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/minify_gate_test.go
+++ b/internal/codegen/minify_gate_test.go
@@ -33,6 +33,7 @@ func genStyle(t *testing.T, cssMinify bool) string {
 }
 
 func TestMinifyGate_CSS(t *testing.T) {
+	t.Parallel()
 	on := genStyle(t, true)
 	if !strings.Contains(on, "1px 2px") || strings.Contains(on, "1px  2px") {
 		t.Fatalf("cssMinify=true should minify; got:\n%s", on)

--- a/internal/codegen/module_diag_test.go
+++ b/internal/codegen/module_diag_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestModulePackageSurfacesTypeErrors(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -35,6 +36,7 @@ func TestModulePackageSurfacesTypeErrors(t *testing.T) {
 }
 
 func TestModuleResetPackageCacheKeepsExternalWarm(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/module_stale_xgo_test.go
+++ b/internal/codegen/module_stale_xgo_test.go
@@ -24,6 +24,7 @@ import (
 //     output and must not contain StaleMarker (belt-and-suspenders check that
 //     the emitted code is derived from the .gsx, not the stale disk file).
 func TestModuleIgnoresStaleOnDiskXGo(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod",

--- a/internal/codegen/module_test.go
+++ b/internal/codegen/module_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestImportPathDirRoundTrip(t *testing.T) {
+	t.Parallel()
 	root := "/m"
 	mod := "example.com/app"
 	// dir under root → import path
@@ -38,6 +39,7 @@ func TestImportPathDirRoundTrip(t *testing.T) {
 }
 
 func TestCheckSkeletonPackageReturnsPkg(t *testing.T) {
+	t.Parallel()
 	src := "package p\n\nfunc F() int { return 1 }\n"
 	fset := token.NewFileSet()
 	f, err := goparser.ParseFile(fset, "/m/p/p.go", src, goparser.SkipObjectResolution)
@@ -57,6 +59,7 @@ func TestCheckSkeletonPackageReturnsPkg(t *testing.T) {
 }
 
 func TestModuleSourceOverrideThenDisk(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	onDisk := filepath.Join(dir, "a.gsx")
 	if err := os.WriteFile(onDisk, []byte("DISK"), 0o644); err != nil {
@@ -82,6 +85,7 @@ func TestModuleSourceOverrideThenDisk(t *testing.T) {
 }
 
 func TestModuleImporterCrossPackageNoXGo(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -133,6 +137,7 @@ func TestModuleImporterCrossPackageNoXGo(t *testing.T) {
 }
 
 func TestModulePackageRetainsAnalysis(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -160,6 +165,7 @@ func TestModulePackageRetainsAnalysis(t *testing.T) {
 // bytes (keyed by gsx path) containing the expected package declaration and
 // function signature.
 func TestModuleGenerateProducesXGo(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -185,6 +191,7 @@ func TestModuleGenerateProducesXGo(t *testing.T) {
 // moduleImporter.Import returns an error (not an infinite recursion/hang) when
 // two gsx packages mutually import each other.
 func TestModuleImporterRejectsImportCycle(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/cycle\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -218,6 +225,7 @@ func TestModuleImporterRejectsImportCycle(t *testing.T) {
 // output (empty map) while still returning a non-empty diagnostics slice —
 // matching batch's package-level-skip semantics.
 func TestModuleGenerateSkipsPackageOnScriptResolutionFailure(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
@@ -253,6 +261,7 @@ func TestModuleGenerateSkipsPackageOnScriptResolutionFailure(t *testing.T) {
 // generateFile). Multiple goroutines call m.Package concurrently on different
 // project packages within a single Module.
 func TestModuleConcurrentPackage(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/navindex_test.go
+++ b/internal/codegen/navindex_test.go
@@ -13,6 +13,7 @@ import (
 //   - "CardProps" (struct ref)  → card.gsx component decl
 //   - "Title"     (field ref)   → card.gsx param position for "title"
 func TestNavIndex(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, dir, "go.mod",

--- a/internal/codegen/rawcss_test.go
+++ b/internal/codegen/rawcss_test.go
@@ -11,6 +11,7 @@ import (
 // CSS value-filter: codegen emits it raw via gw.S, while a plain string goes through
 // gw.CSS. The alias case exercises types.Unalias in isRawCSS.
 func TestRawCSSAliasOptsOut(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxl\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/rawurl_test.go
+++ b/internal/codegen/rawurl_test.go
@@ -13,6 +13,7 @@ import (
 // (gw.AttrValue — still entity-escaped, scheme unchecked). A plain string in the
 // same position must still be sanitized via gw.URL.
 func TestRawURLBypassesSchemeCheck(t *testing.T) {
+	t.Parallel()
 	repoRoot, _ := filepath.Abs("../..")
 	tmp := t.TempDir()
 	writeFile(t, tmp, "go.mod", "module gsxl\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")

--- a/internal/codegen/resolve_filters_test.go
+++ b/internal/codegen/resolve_filters_test.go
@@ -9,6 +9,7 @@ import (
 // TestResolveFiltersStd resolves the std filter package and checks the table is
 // sorted by Name and carries the expected entries with empty Shadows.
 func TestResolveFiltersStd(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatal(err)
@@ -58,6 +59,7 @@ func TestResolveFiltersStd(t *testing.T) {
 // TestResolveFiltersEmptyDefaultsToStd proves an empty filterPkgs defaults to
 // the std package (matching GeneratePackageWithFilters).
 func TestResolveFiltersEmptyDefaultsToStd(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatal(err)
@@ -83,6 +85,7 @@ func TestResolveFiltersEmptyDefaultsToStd(t *testing.T) {
 // TestResolveFiltersShadowing proves a user Upper listed AFTER std wins (Pkg ==
 // user pkg) and records the shadowed std import path in Shadows.
 func TestResolveFiltersShadowing(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping module-load shadowing test in -short mode")
 	}
@@ -121,6 +124,7 @@ func TestResolveFiltersShadowing(t *testing.T) {
 
 // TestResolveFiltersBadPkg proves a non-existent filter package is a clean error.
 func TestResolveFiltersBadPkg(t *testing.T) {
+	t.Parallel()
 	repoRoot, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/codegen/resolver_test.go
+++ b/internal/codegen/resolver_test.go
@@ -119,6 +119,7 @@ func itoa(n int) string {
 // string and count to int — confirming the cached importer correctly threads
 // the github.com/gsxhq/gsx package (required for _gsxrt.Node) and context.
 func TestCachedResolverMatchesPackagesLoad(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	overlay := map[string][]byte{
 		dir + "/comp.x.go": []byte(skeletonFixture),

--- a/internal/codegen/retention_test.go
+++ b/internal/codegen/retention_test.go
@@ -11,6 +11,7 @@ import (
 // TestRetentionPopulated: the package result carries Fset/Info and an ExprMap
 // whose entry for the `{ title }` interp is the skeleton ident `title`.
 func TestRetentionPopulated(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, dir, "go.mod",

--- a/internal/codegen/spread_pipeline_test.go
+++ b/internal/codegen/spread_pipeline_test.go
@@ -13,6 +13,7 @@ import (
 // filter operates on gsx.Attrs (std has no Attrs filter), so this exercises a real
 // filter package via the multi-filter render harness.
 func TestSpreadPipelineElement(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping go-run render test in -short mode")
 	}
@@ -57,6 +58,7 @@ component C(extra gsx.Attrs) {
 // while a cross-package filter cannot name a package-local type (import cycle). The
 // lowering itself (the unit under test) is package-agnostic.
 func TestSplatPipelineComponent(t *testing.T) {
+	t.Parallel()
 	table := filterTable{
 		"loud": {funcName: "Loud", alias: "_gsxf0", pkgPath: "gsxmf/myfilters"},
 	}

--- a/internal/codegen/unused_imports_test.go
+++ b/internal/codegen/unused_imports_test.go
@@ -10,6 +10,7 @@ import (
 // TestUnusedImportsDetected: a .gsx that imports "strings" and "os" but uses
 // neither lists both in UnusedImports; a used import is absent.
 func TestUnusedImportsDetected(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, dir, "go.mod",
@@ -43,6 +44,7 @@ func TestUnusedImportsDetected(t *testing.T) {
 // be resolved (typo'd / not fetched) produces a "could not import" error on the
 // import line, NOT "imported and not used". It must never be reported unused.
 func TestUnusedImportsGateOnBrokenImport(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, dir, "go.mod",
@@ -67,6 +69,7 @@ func TestUnusedImportsGateOnBrokenImport(t *testing.T) {
 // error, UnusedImports stays empty even though an unused import is present —
 // removing under uncertainty is unsafe.
 func TestUnusedImportsGateOnOtherError(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
 	writeFile(t, dir, "go.mod",


### PR DESCRIPTION
## Summary

Speeds up `make ci` and the local test loop, and makes the GitHub workflow a thin wrapper over the Makefile.

The headline: parallelizing the test suite required making the code **reentrant** — and `go test -race` flushed out two genuine latent concurrency bugs (not test artifacts).

## Changes

- **`perf(ci)`** — `make ci` runs its independent lanes via `make -j3` (root build/vet/test, playground, format), after a serial examples regen (playground `//go:embed`s `examples.json`, so its build must not race the regen).
- **`fix(codegen)`** — `internal/codegen` had a package-global `interpTemp` counter → raced whenever two codegen/LSP analyses ran concurrently (the LSP server does exactly this). `go test -race` flagged **29 data races**. Fixed by threading it as a per-file `*int`; generated output is **byte-identical** (corpus goldens unchanged).
- **`perf(gen)`** — the gen CLI ran in-process and `-C` used process-global `os.Chdir`, so parallel tests stomped each other's cwd. Replaced with an explicit threaded `workDir`; the command is now reentrant. Then added `t.Parallel()` across gen/codegen (Setenv/Chdir tests and the real-timer `TestRunWatch_*` tests stay serial).
- **`feat(make)`** — added `make check`: same checks as `ci` but drops `-count=1` so the Go test cache skips unchanged packages — fast inner loop. `make ci` stays the authoritative uncached run.
- **`ci`** — the GitHub workflow now calls Makefile targets (`ci-gomod`/`ci-playground`/`ci-examples`/`ci-format`) instead of duplicating commands, so CI and local `make ci` can't drift.

## Verification

- Full gen+codegen `-race -count=1`: **0 data races**, all pass.
- `make ci`: green (all packages, examples drift, format, playground).
- `-C` e2e tests (spec for `-C` semantics) and corpus goldens unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_013HWANRc6DP9NoouseuzX2H