### PR TITLE
docs(skills): templ→gsx migration, attr fallthrough, DOM-equivalence harness

### DIFF
--- a/skills/gsx-attr-fallthrough/SKILL.md
+++ b/skills/gsx-attr-fallthrough/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: gsx-attr-fallthrough
+description: Use when understanding or using gsx's attribute fallthrough — how caller attrs auto-apply to a root element, how class merges, how type/non-class attrs use caller-wins semantics, and how to configure a Tailwind-aware ClassMerger.
+---
+
+# gsx attribute fallthrough
+
+Learned while migrating one-learning's button layer from templ to gsx.
+This feature completely replaces templ's hand-written `classFromAttrs`/`attrFromAttrs` helpers.
+
+Corpus reference: `internal/corpus/testdata/cases/fallthrough/`
+
+## Auto-generated Props for nullary components
+
+A component with a single root element and `{children}` placement gets an
+auto-generated `Props` struct with **no explicit `attrs` parameter needed**:
+
+```gsx
+// button.gsx
+component Button(variant string) {
+    <button class="btn" type="button" data-variant={variant}>{children}</button>
+}
+```
+
+Generated props (simplified):
+
+```go
+type ButtonProps struct {
+    Variant  string
+    Children gsx.Node
+    Attrs    gsx.Attrs   // injected automatically; caller attrs land here
+}
+```
+
+You do NOT need to declare `attrs gsx.Attrs` yourself.
+
+## Non-class attribute semantics: caller-wins
+
+Static defaults on the root element are **overridden** by matching caller attributes.
+The generated guard looks like:
+
+```go
+if !_gsxp.Attrs.Has("type") {
+    // emit type="button"
+}
+```
+
+Example:
+
+```gsx
+// definition
+component Button(variant string) {
+    <button type="button">{children}</button>
+}
+
+// call site
+<Button variant="primary" type="submit">Save</Button>
+// renders: <button type="submit">Save</button>
+```
+
+## `class` semantics: merge, not override
+
+`class` values from the component definition and from the call site are **merged**,
+not overridden. By default, `gsx.ClassMerger` deduplicates tokens with last-occurrence-wins
+and joins with a space.
+
+```gsx
+// definition
+component Button(variant string) {
+    <button class="btn">{children}</button>
+}
+
+// call site — caller adds extra classes
+<Button variant="primary" class="w-full" hx-post="/go">Save</Button>
+// renders: <button class="btn w-full" data-variant="primary" hx-post="/go">Save</button>
+```
+
+Corpus: `internal/corpus/testdata/cases/fallthrough/call_site_button.txtar`
+
+## Spread and `Attrs.Without`
+
+The generated spread excludes `class` and `style` (which have dedicated merge paths)
+to prevent double-emission:
+
+```go
+// generated (simplified)
+_gsxp.Attrs.Without("class", "style").Render(ctx, w)
+```
+
+## Pluggable `gsx.ClassMerger` for Tailwind
+
+`gsx.ClassMerger` is a package-level hook (set once at `init`):
+
+```go
+var ClassMerger func(tokens []string) string
+```
+
+To install a Tailwind-aware merger that resolves conflicting utility classes
+(e.g. `p-2` vs `p-4` → last wins per Tailwind specificity rules):
+
+```go
+import twmerge "github.com/jackielii/tailwind-merge-go"
+
+func init() {
+    gsx.ClassMerger = func(tokens []string) string {
+        return twmerge.Merge(strings.Join(tokens, " "))
+    }
+}
+```
+
+Without this, `class="p-2 p-4"` both render (CSS cascade decides); with it,
+`class="p-4"` is emitted — the correct Tailwind behaviour.
+
+## What this replaces in templ
+
+templ required explicit helper functions at every component boundary:
+
+```go
+// templ (hand-written boilerplate)
+func classFromAttrs(attrs templ.Attributes) string { … }
+func attrFromAttrs(attrs templ.Attributes) templ.Attributes { … }
+
+templ Button(attrs templ.Attributes) {
+    <button class={ "btn", classFromAttrs(attrs) } { attrFromAttrs(attrs)... }>
+        { children... }
+    </button>
+}
+```
+
+In gsx, none of that boilerplate exists. The compiler handles it.

--- a/skills/gsx-attr-fallthrough/SKILL.md
+++ b/skills/gsx-attr-fallthrough/SKILL.md
@@ -10,10 +10,13 @@ This feature completely replaces templ's hand-written `classFromAttrs`/`attrFrom
 
 Corpus reference: `internal/corpus/testdata/cases/fallthrough/`
 
-## Auto-generated Props for nullary components
+## Auto-generated Props (no explicit `attrs` param needed)
 
-A component with a single root element and `{children}` placement gets an
-auto-generated `Props` struct with **no explicit `attrs` parameter needed**:
+`Attrs gsx.Attrs` is injected for **any single-root-element component** — with
+or without `{children}`. The `Children gsx.Node` field is added separately,
+only when the component body contains a `{children}` placement.
+
+Example with both:
 
 ```gsx
 // button.gsx
@@ -84,7 +87,7 @@ to prevent double-emission:
 
 ```go
 // generated (simplified)
-_gsxp.Attrs.Without("class", "style").Render(ctx, w)
+_gsxgw.Spread(ctx, _gsxp.Attrs.Without("class", "style"))
 ```
 
 ## Pluggable `gsx.ClassMerger` for Tailwind

--- a/skills/gsx-dom-equivalence-harness/SKILL.md
+++ b/skills/gsx-dom-equivalence-harness/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: gsx-dom-equivalence-harness
+description: Use when verifying a templ→gsx migration with DOM-level equivalence tests — covers the domtest harness API, Normalize semantics, why string-diff fails, how to render templ components with children in tests, and how to inject a structpages URL context.
+---
+
+# gsx DOM-equivalence test harness
+
+Learned while migrating one-learning's button layer from templ to gsx.
+The harness lives in `internal/domtest` of the consuming app.
+
+## Philosophy
+
+This is a loose regression **guardrail**, not a byte-exact oracle.
+The goal is **behaviour parity** — not identical raw HTML strings.
+Intended improvements (e.g. removing a trailing space, deduplicated attrs) are
+re-baselined rather than treated as regressions.
+
+## API
+
+```go
+// Render a component and return its HTML string.
+func Render(t *testing.T, n Renderable) string
+
+// Render with an explicit context (e.g. one carrying URL state).
+func RenderCtx(t *testing.T, ctx context.Context, n Renderable) string
+
+// Normalize an HTML fragment for comparison.
+func Normalize(t *testing.T, html string) string
+
+// Assert two HTML fragments are DOM-equivalent.
+func AssertEqual(t *testing.T, want, got string)
+
+// Assert DOM-equivalence with an explicit context.
+func AssertEqualCtx(t *testing.T, ctx context.Context, want, got string)
+```
+
+`Renderable` is any value with `Render(ctx context.Context, w io.Writer) error` —
+both `templ.Component` and `gsx.Node` satisfy it without a wrapper.
+
+## What `Normalize` does
+
+1. Parses the fragment with `atom.Body` as the context node (correct HTML5 fragment parsing).
+2. Sorts attributes by `(namespace, key)` — order-independent comparison.
+3. Collapses text-node whitespace via `strings.Fields` — insignificant whitespace differences vanish.
+4. Canonicalises token-list attributes (`class`, `rel`) only — splits on whitespace, sorts tokens,
+   rejoins. Other attribute values keep significant whitespace intact.
+
+## Why string-diff fails here
+
+templ has two known quirks that produce correct HTML but non-identical raw strings:
+
+1. **Duplicate attributes:** a `type` attribute emitted both explicitly and via rest-spread
+   (`{ attrs... }`) appears twice in raw output; the HTML5 parser merges to the first occurrence.
+2. **Trailing space in empty class merge:** `class="base "` when the caller class is empty.
+
+Both are absorbed by `Normalize` + the HTML5 parser. A raw `strings.Compare` would
+falsely fail on both.
+
+## Rendering a templ component with children in a test
+
+templ children are threaded through `context`, so you need `templ.WithChildren`:
+
+```go
+// Render a templ component that accepts children, passing literal HTML as the child.
+comp.Render(templ.WithChildren(ctx, templ.Raw(childHTML)), w)
+```
+
+Wrap this in a `domtest.Renderable`-compatible helper (`wrapTemplChild`) so it fits
+the same `AssertEqual` call as the gsx version.
+
+## Injecting a structpages URL context
+
+`structpages.URLFor` (the `url` filter target) reads page context from the request
+context via an unexported key (`pcCtx`). You cannot inject it directly.
+
+**Pattern: mount a minimal one-page structpages tree and capture the context.**
+
+```go
+var capturedCtx context.Context
+
+router := structpages.New(/* minimal route tree */)
+router.WithMiddlewares(func(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        capturedCtx = r.Context()   // captured AFTER structpages applies withPcCtx
+        next.ServeHTTP(w, r)
+    })
+})
+
+req := httptest.NewRequest("GET", "/", nil)
+rw := httptest.NewRecorder()
+router.ServeHTTP(rw, req)
+
+// Now use capturedCtx for both templ and gsx renders:
+domtest.AssertEqualCtx(t, capturedCtx, templHTML, gsxHTML)
+```
+
+**Assumption:** structpages applies `withPcCtx` before calling user middlewares.
+If that ordering ever changes, this pattern breaks — document it as a known coupling.
+
+## When DOM-equivalence is not enough
+
+Alpine.js and other client-side behaviours (`x-data`, `@click`, `:class`) cannot
+be verified by static HTML comparison. Add a **Playwright behavioural check** for
+components whose correctness depends on runtime interactivity.

--- a/skills/templ-to-gsx-migration/SKILL.md
+++ b/skills/templ-to-gsx-migration/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: templ-to-gsx-migration
+description: Use when migrating templ components to gsx — covers the component-declaration rewrite, children syntax, cross-package calls, URL filter, and the critical children-boundary rule that determines migration order.
+---
+
+# Migrating templ components to gsx
+
+Learned while migrating one-learning's button/UI layer from templ to gsx.
+The corpus at `internal/corpus/testdata/cases/` is the canonical syntax reference.
+
+## Component declarations
+
+| templ | gsx |
+|---|---|
+| `templ Foo(args) { }` | `component Foo(args) { }` |
+| `templ (p P) M(props) { }` | `component (p P) M(props) { }` |
+
+Method components generate `func (p P) M(props) gsx.Node`.
+Invocation: `P{}.M(props)` (or `{P{}.M(props)}` inline).
+
+## Children syntax
+
+**Placement inside the component body:**
+
+```
+// templ
+{ children... }
+
+// gsx
+{children}
+```
+
+**Passing children at the call site:**
+
+```
+// templ
+@Child(args) { <span>content</span> }
+
+// gsx
+<Child ...><span>content</span></Child>
+```
+
+**Embedding a bare `gsx.Node` value (childless):**
+
+```gsx
+{ node }
+```
+
+## Cross-package component calls
+
+Import the package; the tag prefix is the package alias.
+
+```gsx
+import "example.com/app/ui"
+
+component Page() {
+    <ui.Button label="Save"/>
+}
+```
+
+This lowers to `ui.Button(ui.ButtonProps{Label: "Save"})`.
+With children: `<ui.Button label="Save">text</ui.Button>` sets `Children: gsx.Func(...)`.
+
+Corpus reference: `internal/corpus/testdata/cases/xpkg/cross_package.txtar`
+
+## URL / routing
+
+templ required explicit `ctx` threading:
+
+```go
+// templ
+href={ UrlFor(ctx, page, args...) }
+```
+
+gsx uses the `url` filter — `ctx` is auto-injected when the first parameter is `context.Context`,
+and a `(string, error)` return is auto-unwrapped:
+
+```gsx
+href={ page |> url }            // no extra args
+href={ page |> url(id) }        // fixed arg
+href={ page |> url(args...) }   // variadic spread
+```
+
+`url` is wired to `structpages.URLFor` in structpages-integrated apps.
+
+## THE CHILDREN-BOUNDARY RULE (most important for migration order)
+
+**templ and gsx pass children differently:**
+
+- **templ** threads children through `context` via `templ.WithChildren` / `templ.GetChildren`.
+- **gsx** passes children as a `Children gsx.Node` field in the generated `Props` struct,
+  set by the `<Comp>…</Comp>` call site.
+
+**Consequence:** a component that *takes children* cannot be called across the boundary.
+Caller and the child-accepting component must be on the **same side**.
+
+**Childless** components (no `{children}` placement) embed freely in *both* directions
+because `gsx.Node` and `templ.Component` are the same interface:
+
+```go
+type Component interface {
+    Render(ctx context.Context, w io.Writer) error
+}
+```
+
+A childless gsx node can be passed into templ via `templ.FromGoHTML`-style embedding
+and vice versa: `{ node }` inside a gsx body accepts any value satisfying the interface.
+
+**Migration strategy: bottom-up by subtree.**
+Convert leaf components (no child slots) first. A parent page migrates to gsx only
+once *every child-accepting sub-component it calls* is already gsx.
+
+```
+Templ page
+  └── templ ChildA (takes children)  ← must migrate FIRST
+        └── gsx LeafButton           ← already migrated (childless, crosses freely)
+```
+
+Once `ChildA` is gsx, the parent page can be migrated.
+
+## Build coexistence
+
+Generated files from both tools live side-by-side:
+
+| Generator | Output pattern | gitignore |
+|---|---|---|
+| `gsx generate` | `*.x.go` | yes |
+| `templ generate` | `*_templ.go` | yes |
+
+Run both generators in the build; both outputs are regenerated, never committed.
+
+Invoke gsx via module path to avoid Ghostscript name collision:
+
+```sh
+go run github.com/gsxhq/gsx/cmd/gsx generate
+```

--- a/skills/templ-to-gsx-migration/SKILL.md
+++ b/skills/templ-to-gsx-migration/SKILL.md
@@ -103,8 +103,10 @@ type Component interface {
 }
 ```
 
-A childless gsx node can be passed into templ via `templ.FromGoHTML`-style embedding
-and vice versa: `{ node }` inside a gsx body accepts any value satisfying the interface.
+Because `gsx.Node` and `templ.Component` are structurally identical interfaces
+(`Render(ctx context.Context, w io.Writer) error`), a childless gsx node is used
+directly wherever a `templ.Component` is expected — no adapter is needed.
+(`templ.FromGoHTML` is for `html/template` objects, not gsx nodes.)
 
 **Migration strategy: bottom-up by subtree.**
 Convert leaf components (no child slots) first. A parent page migrates to gsx only


### PR DESCRIPTION
Three gsx skills captured while migrating one-learning's button family from templ to gsx (foundation slice):

- **templ-to-gsx-migration** — idiom cheatsheet (`templ Foo` → `component Foo`, method-components, `@Child{}` → `<Child>`, cross-package tags, `UrlFor` → `url` filter) + the **children-boundary rule**: children don't cross the templ↔gsx boundary (templ uses context, gsx a `Children` prop), so migrate bottom-up by subtree; childless components embed both ways via the identical `Render(ctx,w) error` interface.
- **gsx-attr-fallthrough** — nullary component auto-generates `Props{Children gsx.Node; Attrs gsx.Attrs}`; caller-wins for non-class attrs (`!Attrs.Has` guard), class merges via the pluggable `ClassMerger`; replaces templ's `classFromAttrs`/`attrFromAttrs`.
- **gsx-dom-equivalence-harness** — verifying a migration with a loose DOM-equivalence harness (normalize attr order + class/rel whitespace), the structpages render-context capture pattern, and when to add a Playwright behavioural check.

All technical claims verified against the gsx runtime + corpus (one critical Spread snippet + three wording fixes applied after an accuracy review).

https://claude.ai/code/session_016MokH6cPAuosotxAkrHaou