### PR TITLE
feat(init): /__vite/ dev-asset base (single-exclusion proxy)

### DIFF
--- a/gen/templates/init/simple/main.go.tmpl
+++ b/gen/templates/init/simple/main.go.tmpl
@@ -22,7 +22,7 @@ var publicFS embed.FS
 
 func main() {
 	devURL := os.Getenv("VITE_DEV_URL") // "" in prod
-	v, err := vite.New(vite.Config{DevURL: devURL, Dist: distFS, DistDir: "dist"})
+	v, err := vite.New(vite.Config{DevURL: devURL, DevBase: "/__vite/", Dist: distFS, DistDir: "dist"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/gen/templates/init/simple/vite.config.ts
+++ b/gen/templates/init/simple/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, loadEnv, createLogger } from "vite";
 import { gsx, devFallback } from "@gsxhq/vite-plugin-gsx";
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const goPort = env.GO_PORT || "7777";
   const vitePort = parseInt(env.VITE_PORT || "5173", 10);
@@ -20,16 +20,22 @@ export default defineConfig(({ mode }) => {
 
   return {
     clearScreen: false,
+    // Dev serves all Vite assets under /__vite/ (matches gsxhq/vite DevBase);
+    // prod uses the default base ("/") since hashed assets are served from
+    // /static via gsxhq/vite.
+    base: command === "serve" ? "/__vite/" : "/",
     publicDir: false,
     customLogger: logger,
     plugins: [gsx(), fallback.plugin],
     server: {
       port: vitePort,
       proxy: {
-        // Everything except Vite-owned namespaces (and /__dev/status, served by
-        // the fallback plugin) goes to the Go server. No `ws: true` — the Go
-        // server has no WebSocket; proxying ws would capture Vite's HMR socket.
-        "^(?!/@vite|/@id|/@fs|/web/|/node_modules|/__reload|/__dev).*": {
+        // Everything except /__vite/ (Vite's own dev-asset namespace) and
+        // /__dev/ (fallback plugin status) goes to the Go server.
+        // Single exclusion — no source-dir denylist, no app-route collisions.
+        // No `ws: true` — the Go server has no WebSocket; proxying ws would
+        // capture Vite's HMR socket.
+        "^(?!/__vite/|/__dev).*": {
           target: `http://localhost:${goPort}`,
           changeOrigin: true,
           configure: fallback.configureProxy,


### PR DESCRIPTION
## Summary
Standardizes the init template so all Vite-served dev assets live under `/__vite/` (Vite `base` + gsxhq/vite `DevBase`), letting the front-door proxy forward everything else to Go with one exclusion — no source-dir denylist, no app-route collisions. Validated in a consuming app (one-learning).

- `main.go.tmpl`: adds `DevBase: "/__vite/"` to `vite.Config`
- `vite.config.ts`: receives `command` in config callback, sets `base: command === "serve" ? "/__vite/" : "/"`, and replaces the multi-path proxy regex with the single `^(?!/__vite/|/__dev).*` exclusion

https://claude.ai/code/session_016MokH6cPAuosotxAkrHaou