### PR TITLE
Simplify value switch case syntax

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -142,14 +142,15 @@ render goldens.
 11. `[x]` **Value-form `if`/`switch` in `class`/`style`** — `2026-06-30`. A
     **value-producing** form of `if` and `switch` usable inside `class={…}` /
     `style={…}` contribution lists, providing **exclusive selection** in place of
-    the additive-map negation default. Arms are braced (`case Green: { "cls" }`);
+    the additive-map negation default. Switch values are unbraced
+    (`case Green: "cls"`), matching markup-switch case bodies;
     multi-value cases (`case A, B:`) and `else if` chains are supported; a tagless
     `switch { case cond: … }` follows Go. Lowers to an alloc-free hoisted temp
     (`var _gsxvN string` assigned by a generated Go `switch`/`if`), not an IIFE.
     `if` without `else` is exactly equivalent to the additive guard form — no
     match, no `default`/`else` → empty contribution (nothing added). `(T,error)`
     auto-unwrap applies to both plain parts (`class={ cls(v) }`) and individual
-    arms (`case A: { cls(v) }`), extending the shared `hoistTuple` machinery from
+    arms (`case A: cls(v)`), extending the shared `hoistTuple` machinery from
     item 10. A guard on a value-form part (`switch x {…}: cond`) is a compile-time
     diagnostic. Corpus coverage: `class/value_switch`, `class/value_if_*`,
     `class/value_switch_tuple`, `class/value_arm_pipeline`, `style/value_switch`,

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -73,7 +73,7 @@ golden-tested `examples/*.txtar` fixtures.
 | `{{ stmt }}` | Go statement escape hatch (no output) |
 | `<>…</>` | fragment |
 | `class={ a, "cls": cond }` | composable `class`/`style` (comma list; conditional sugar) |
-| `class={ a, switch x { case A: { "b" } default: { "c" } } }` | value-form `if`/`switch` inside `class`/`style` — exclusive selection |
+| `class={ a, switch x { case A: "b" default: "c" } }` | value-form `if`/`switch` inside `class`/`style` — exclusive selection |
 | `{children}` | explicit children placement |
 | `gsx.Raw(s)` | unescaped HTML |
 :::

--- a/docs/guide/syntax/styling.md
+++ b/docs/guide/syntax/styling.md
@@ -98,18 +98,23 @@ class={
 	"inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset",
 	switch variant {
 	case Green:
-		{ "bg-green-50 text-green-700 ring-green-600/20" }
+		"bg-green-50 text-green-700 ring-green-600/20"
 	case Yellow:
-		{ "bg-yellow-50 text-yellow-700 ring-yellow-600/20" }
+		"bg-yellow-50 text-yellow-700 ring-yellow-600/20"
 	case Red:
-		{ "bg-red-50 text-red-700 ring-red-600/20" }
+		"bg-red-50 text-red-700 ring-red-600/20"
 	default:
-		{ "bg-gray-50 text-gray-700 ring-gray-600/20" }
+		"bg-gray-50 text-gray-700 ring-gray-600/20"
 	},
 }
 ```
 
-**Surface syntax.** Arms are brace-delimited `{ … }`, identical in shape to gsx's existing markup `if`/`switch` and to Go. `switch` supports `case V:` arms, multi-value `case A, B:` arms, an optional `default:`, a tag expression (`switch x { … }`), or a tag-less form (`switch { case cond: … }`). `if` supports `else if` chains and a final `else`.
+**Surface syntax.** Switch values follow GSX's markup-switch shape: each
+unbraced expression follows its `case V:` or `default:` label and ends at the
+next label or the switch's closing brace. Multi-value `case A, B:` arms, a tag
+expression (`switch x { … }`), and a tagless form
+(`switch { case cond: … }`) are supported. Value-form `if` retains its natural
+branch braces and supports `else if` chains and a final `else`.
 
 **Semantics.** The value-form is **exclusive** — exactly one arm's string is contributed to the list. When no arm matches and there is no `default:` / `else`, the zero value (empty string) is contributed — which means nothing is added to the class or style. This makes `if cond { "x" }` without an `else` exactly equivalent to the additive guard form `"x": cond`; the value-form is a strict superset, not a special case. All arms must be strings; a non-string arm is a compile-time diagnostic.
 

--- a/docs/guide/syntax/styling.md
+++ b/docs/guide/syntax/styling.md
@@ -109,10 +109,11 @@ class={
 }
 ```
 
-**Surface syntax.** Switch values follow GSX's markup-switch shape: each
-unbraced expression follows its `case V:` or `default:` label and ends at the
-next label or the switch's closing brace. Multi-value `case A, B:` arms, a tag
-expression (`switch x { … }`), and a tagless form
+**Surface syntax.** Switch values follow GSX's markup-switch shape: canonically,
+each expression follows its `case V:` or `default:` label and ends at the next
+label or the switch's closing brace. Explicit `{ expr }` arm blocks are also
+accepted and format back to the canonical unbraced shape. Multi-value
+`case A, B:` arms, a tag expression (`switch x { … }`), and a tagless form
 (`switch { case cond: … }`) are supported. Value-form `if` retains its natural
 branch braces and supports `else if` chains and a final `else`.
 

--- a/docs/superpowers/plans/2026-06-30-unbraced-value-switch-arms.md
+++ b/docs/superpowers/plans/2026-06-30-unbraced-value-switch-arms.md
@@ -1,0 +1,68 @@
+# Unbraced Value-Switch Arms Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace braced value-form `switch` case values with the same unbraced case-body shape used by markup switches.
+
+**Architecture:** Keep value-form `if` unchanged because its braces delimit its branches. For value-form `switch`, scan each case value until the next top-level `case`, `default`, or switch-closing `}`, respecting nested Go delimiters; store the same `ast.ValueArm` and leave codegen unchanged. Make the printer emit only the new canonical form and reject legacy braced case values with a migration diagnostic.
+
+**Tech Stack:** Go parser/scanner, GSX AST/printer, txtar corpus, Markdown docs, tree-sitter grammar, VS Code TextMate grammar.
+
+---
+
+### Task 1: Parse unbraced switch case values
+
+**Files:**
+- Modify: `parser/boundary.go`
+- Modify: `parser/valueform.go`
+- Test: `parser/valueform_test.go`
+
+- [ ] Add parser tests proving multiline expressions, pipelines, composite literals, nested delimiters, multi-value cases, and tagless switches stop at the correct top-level boundary; prove `{ "old" }` receives a migration diagnostic.
+- [ ] Run `go test ./parser -run ValueSwitch -count=1` and confirm the new tests fail for the missing syntax.
+- [ ] Add a scanner-based `valueSwitchArmEnd` boundary helper and parse the unbraced source through `parsePipe`, preserving accurate spans.
+- [ ] Run the focused parser tests and `go test ./parser -count=1`.
+
+### Task 2: Print and migrate the canonical syntax
+
+**Files:**
+- Modify: `internal/printer/printer.go`
+- Modify: `internal/printer/printer_test.go`
+- Modify: `internal/corpus/testdata/cases/class/*.txtar`
+- Modify: `internal/corpus/testdata/cases/style/*.txtar`
+- Modify: `internal/corpus/testdata/cases/components/child_value_switch.txtar`
+- Modify: `internal/corpus/testdata/coverage.golden`
+
+- [ ] Add printer expectations for `case A:\n\t"value"` and `default:\n\t"value"` without arm braces.
+- [ ] Run focused printer tests and confirm they fail.
+- [ ] Remove switch-arm brace emission while retaining value-form `if` branch braces.
+- [ ] Mechanically migrate corpus inputs, regenerate generated/render/diagnostic goldens with `go test ./internal/corpus -run TestCorpus -update`, then verify without `-update`.
+
+### Task 3: Update documentation
+
+**Files:**
+- Modify: `docs/guide/syntax.md`
+- Modify: `docs/guide/syntax/styling.md`
+- Modify: `docs/ROADMAP.md`
+- Modify: `docs/superpowers/specs/2026-06-29-style-control-flow-design.md`
+
+- [ ] Replace every value-switch example with unbraced case values and state that switch cases follow markup-switch case-body syntax while value-form `if` retains branch braces.
+- [ ] Remove claims that all value-form arms are brace-delimited.
+- [ ] Run `git diff --check` and search for remaining `case ...: {` value-form examples.
+
+### Task 4: Update downstream syntax tooling
+
+**Files:**
+- Modify in `../tree-sitter-gsx`: grammar and corpus fixtures for value-form switch arms.
+- Modify in `../vscode-gsx`: TextMate grammar and syntax fixtures for value-form switch arms.
+
+- [ ] Change tree-sitter value-switch arms to consume an unbraced Go expression until the next case boundary, regenerate the parser, and run its test suite.
+- [ ] Update VS Code scopes/fixtures and run its available test/build commands.
+
+### Task 5: Verify and publish
+
+**Files:**
+- Verify all changed files.
+
+- [ ] Run `make ci`.
+- [ ] Run `git diff --check` and confirm a clean worktree after commits.
+- [ ] Push the feature branch and open a ready PR with the breaking syntax and migration diagnostic called out.

--- a/docs/superpowers/plans/2026-06-30-unbraced-value-switch-arms.md
+++ b/docs/superpowers/plans/2026-06-30-unbraced-value-switch-arms.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace braced value-form `switch` case values with the same unbraced case-body shape used by markup switches.
+**Goal:** Make value-form `switch` case values use the same unbraced canonical case-body shape used by markup switches.
 
-**Architecture:** Keep value-form `if` unchanged because its braces delimit its branches. For value-form `switch`, scan each case value until the next top-level `case`, `default`, or switch-closing `}`, respecting nested Go delimiters; store the same `ast.ValueArm` and leave codegen unchanged. Make the printer emit only the new canonical form and reject legacy braced case values with a migration diagnostic.
+**Architecture:** Keep value-form `if` unchanged because its braces delimit its branches. For value-form `switch`, scan each unbraced case value until the next top-level `case`, `default`, or switch-closing `}`, respecting nested Go delimiters; still accept an explicit `{ expr }` case block and parse it with the same `ast.ValueArm`. Leave codegen unchanged. Make the printer emit the unbraced canonical form.
 
 **Tech Stack:** Go parser/scanner, GSX AST/printer, txtar corpus, Markdown docs, tree-sitter grammar, VS Code TextMate grammar.
 
@@ -17,7 +17,7 @@
 - Modify: `parser/valueform.go`
 - Test: `parser/valueform_test.go`
 
-- [ ] Add parser tests proving multiline expressions, pipelines, composite literals, nested delimiters, multi-value cases, and tagless switches stop at the correct top-level boundary; prove `{ "old" }` receives a migration diagnostic.
+- [ ] Add parser tests proving multiline expressions, pipelines, composite literals, nested delimiters, multi-value cases, and tagless switches stop at the correct top-level boundary; prove `{ "old" }` remains accepted as an explicit arm block.
 - [ ] Run `go test ./parser -run ValueSwitch -count=1` and confirm the new tests fail for the missing syntax.
 - [ ] Add a scanner-based `valueSwitchArmEnd` boundary helper and parse the unbraced source through `parsePipe`, preserving accurate spans.
 - [ ] Run the focused parser tests and `go test ./parser -count=1`.
@@ -45,7 +45,7 @@
 - Modify: `docs/ROADMAP.md`
 - Modify: `docs/superpowers/specs/2026-06-29-style-control-flow-design.md`
 
-- [ ] Replace every value-switch example with unbraced case values and state that switch cases follow markup-switch case-body syntax while value-form `if` retains branch braces.
+- [ ] Replace value-switch examples with canonical unbraced case values and state that switch cases follow markup-switch case-body syntax while value-form `if` retains branch braces. Note that explicit braced switch-arm blocks are accepted input but are not the printed form.
 - [ ] Remove claims that all value-form arms are brace-delimited.
 - [ ] Run `git diff --check` and search for remaining `case ...: {` value-form examples.
 
@@ -65,4 +65,4 @@
 
 - [ ] Run `make ci`.
 - [ ] Run `git diff --check` and confirm a clean worktree after commits.
-- [ ] Push the feature branch and open a ready PR with the breaking syntax and migration diagnostic called out.
+- [ ] Push the feature branch and open a ready PR with the canonical syntax called out.

--- a/docs/superpowers/specs/2026-06-29-style-control-flow-design.md
+++ b/docs/superpowers/specs/2026-06-29-style-control-flow-design.md
@@ -47,13 +47,14 @@ class={
 class={ "btn", if open { "btn-open" } else { "btn-closed" } }
 ```
 
-### Surface syntax — braced arms
+### Surface syntax
 
-Arms are delimited with `{ … }`, identical in shape to gsx's existing markup
-`if`/`switch` and to Go. This is **unambiguous**: `{` delimits the condition
-from the value. (A brace-less `if cond "x" else "y"` was rejected — it
-reintroduces Go's own `if cond *foo`-style ambiguity between `cond * foo` and
-`cond`, `*foo`.)
+Value-form `switch` follows GSX's existing markup-switch case-body shape:
+the expression after `case V:` / `default:` is unbraced and ends at the next
+top-level label or the switch's closing brace. Nested Go delimiters are scanned,
+so composite literals and function literals remain part of the expression.
+Value-form `if` retains `{ … }` branch delimiters because they separate its
+condition from its value without introducing Go's `if cond *foo` ambiguity.
 
 - `switch`: `case V:` arms, `case A, B:` multi-value arms (Go parity), optional
   `default:`. An optional tag expression (`switch x { … }`); a tag-less
@@ -209,7 +210,7 @@ Two related printer changes in `internal/printer/printer.go`:
    helps every component that keeps the additive map rather than converting to
    `switch`.
 
-2. **Value-form arm layout.** Print the value-form with braced arms one
+2. **Value-form arm layout.** Print the value-form with unbraced switch values one
    `case`/`default` (or `if`/`else`) per line when broken, collapsing to one
    line when it fits — consistent with how markup `if`/`switch` already print.
 

--- a/docs/superpowers/specs/2026-06-29-style-control-flow-design.md
+++ b/docs/superpowers/specs/2026-06-29-style-control-flow-design.md
@@ -210,9 +210,11 @@ Two related printer changes in `internal/printer/printer.go`:
    helps every component that keeps the additive map rather than converting to
    `switch`.
 
-2. **Value-form arm layout.** Print the value-form with unbraced switch values one
-   `case`/`default` (or `if`/`else`) per line when broken, collapsing to one
-   line when it fits — consistent with how markup `if`/`switch` already print.
+2. **Value-form arm layout.** Print the value-form with canonical unbraced
+   switch values one `case`/`default` (or `if`/`else`) per line when broken,
+   collapsing to one line when it fits — consistent with how markup `if`/`switch`
+   already print. Braced switch-arm blocks remain accepted input and format back
+   to the canonical unbraced shape.
 
 ## Testing — corpus is canonical
 

--- a/internal/corpus/testdata/cases/class/value_arm_tuple_rejected.txtar
+++ b/internal/corpus/testdata/cases/class/value_arm_tuple_rejected.txtar
@@ -4,13 +4,11 @@ package views
 
 component C(v int) {
 	<span class={ switch v {
-	case 1:
-		{ bad(v) }
-	default:
-		{ "x" }
+	case 1: bad(v)
+	default: "x"
 	} }>y</span>
 }
 
 func bad(v int) (int, string) { return 0, "" }
 -- diagnostics.golden --
-6:3: class value-form arm "bad(v)" returns (int, string); only (T, error) is supported
+5:10: class value-form arm "bad(v)" returns (int, string); only (T, error) is supported

--- a/internal/corpus/testdata/cases/class/value_switch.txtar
+++ b/internal/corpus/testdata/cases/class/value_switch.txtar
@@ -3,12 +3,9 @@ package views
 
 component Badge(variant int) {
 	<span class={ "base", switch variant {
-	case 1:
-		{ "green" }
-	case 2, 3:
-		{ "amber" }
-	default:
-		{ "gray" }
+	case 1: "green"
+	case 2, 3: "amber"
+	default: "gray"
 	} }>x</span>
 }
 -- invoke --

--- a/internal/corpus/testdata/cases/class/value_switch_no_default.txtar
+++ b/internal/corpus/testdata/cases/class/value_switch_no_default.txtar
@@ -5,7 +5,7 @@
 package views
 
 component Badge(v int) {
-	<span class={ "base", switch v { case 1: { "one" } } }>x</span>
+	<span class={ "base", switch v { case 1: "one" } }>x</span>
 }
 -- invoke --
 Badge(BadgeProps{V: 2})

--- a/internal/corpus/testdata/cases/class/value_switch_nonroot.txtar
+++ b/internal/corpus/testdata/cases/class/value_switch_nonroot.txtar
@@ -6,10 +6,8 @@ package views
 
 component Widget(variant int) {
 	<div><span class={ "x", switch variant {
-	case 1:
-		{ "a" }
-	default:
-		{ "b" }
+	case 1: "a"
+	default: "b"
 	} }>y</span></div>
 }
 -- invoke --

--- a/internal/corpus/testdata/cases/class/value_switch_tagless.txtar
+++ b/internal/corpus/testdata/cases/class/value_switch_tagless.txtar
@@ -4,7 +4,7 @@
 package views
 
 component C(v int) {
-	<div class={ switch { case v > 0: { "pos" } default: { "nonpos" } } }>x</div>
+	<div class={ switch { case v > 0: "pos" default: "nonpos" } }>x</div>
 }
 -- invoke --
 C(CProps{V: 1})

--- a/internal/corpus/testdata/cases/class/value_switch_tuple.txtar
+++ b/internal/corpus/testdata/cases/class/value_switch_tuple.txtar
@@ -4,10 +4,8 @@ package views
 
 component Badge(variant int) {
 	<span class={ "base", switch variant {
-	case 1:
-		{ cls(variant) }
-	default:
-		{ "gray" }
+	case 1: cls(variant)
+	default: "gray"
 	} }>x</span>
 }
 

--- a/internal/corpus/testdata/cases/components/child_value_switch.txtar
+++ b/internal/corpus/testdata/cases/components/child_value_switch.txtar
@@ -10,10 +10,8 @@ component Card(title gsx.Node) { <div class="card">{title}</div> }
 
 component Page(variant int) {
 	<Card title="Hi" class={ "base", switch variant {
-	case 1:
-		{ "primary" }
-	default:
-		{ "secondary" }
+	case 1: "primary"
+	default: "secondary"
 	} } />
 }
 -- invoke --

--- a/internal/corpus/testdata/cases/control_flow/value_form_trailing_rejected.txtar
+++ b/internal/corpus/testdata/cases/control_flow/value_form_trailing_rejected.txtar
@@ -2,7 +2,7 @@
 package views
 
 component C(x int) {
-	<span class={ "base", switch x { case 1: { "a" } default: { "b" } } |> upper }>y</span>
+	<span class={ "base", switch x { case 1: "a" default: "b" } |> upper }>y</span>
 }
 -- diagnostics.golden --
-4:69: unexpected "|> upper" after value-form switch in class/style; pipe stages on a value-form result are not supported
+4:61: unexpected "|> upper" after value-form switch in class/style; pipe stages on a value-form result are not supported

--- a/internal/corpus/testdata/cases/control_flow/value_switch_ast.txtar
+++ b/internal/corpus/testdata/cases/control_flow/value_switch_ast.txtar
@@ -3,12 +3,9 @@ package views
 
 component Badge(variant int) {
 	<span class={ "base", switch variant {
-	case 1:
-		{ "green" }
-	case 2, 3:
-		{ "amber" }
-	default:
-		{ "gray" }
+	case 1: "green"
+	case 2, 3: "amber"
+	default: "gray"
 	}, "extra": variant > 0 }>x</span>
 }
 -- diagnostics.golden --

--- a/internal/corpus/testdata/cases/control_flow/value_switch_braced.txtar
+++ b/internal/corpus/testdata/cases/control_flow/value_switch_braced.txtar
@@ -4,10 +4,10 @@ package views
 component Badge(variant int) {
 	<span class={ switch variant {
 	case 1:
-		{ "green" }
+		{ "green" |> upper }
 	default:
 		{ "gray" }
 	} }>x</span>
 }
--- diagnostics.golden --
-6:3: braced switch case values are no longer supported; remove the braces
+-- render.golden --
+<span class="GREEN">x</span>

--- a/internal/corpus/testdata/cases/control_flow/value_switch_braced_rejected.txtar
+++ b/internal/corpus/testdata/cases/control_flow/value_switch_braced_rejected.txtar
@@ -1,0 +1,13 @@
+-- input.gsx --
+package views
+
+component Badge(variant int) {
+	<span class={ switch variant {
+	case 1:
+		{ "green" }
+	default:
+		{ "gray" }
+	} }>x</span>
+}
+-- diagnostics.golden --
+6:3: braced switch case values are no longer supported; remove the braces

--- a/internal/corpus/testdata/cases/style/value_switch.txtar
+++ b/internal/corpus/testdata/cases/style/value_switch.txtar
@@ -3,10 +3,8 @@ package views
 
 component Box(tone int) {
 	<div style={ "padding: 4px", switch tone {
-	case 1:
-		{ "color: red" }
-	default:
-		{ "color: gray" }
+	case 1: "color: red"
+	default: "color: gray"
 	} }>x</div>
 }
 -- invoke --

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -104,7 +104,7 @@ control_flow/switch_warn	diag gen render
 control_flow/value_form_guard_rejected	diag(error)
 control_flow/value_form_trailing_rejected	diag(error)
 control_flow/value_switch_ast	ast diag
-control_flow/value_switch_braced_rejected	diag(error)
+control_flow/value_switch_braced	diag render
 datajson/island_breakout	diag gen render
 datajson/island_multi_hole_rejected	diag(error)
 datajson/island_value	diag gen render
@@ -337,4 +337,4 @@ xpkg/cross_package	diag render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 339 cases (render: 256, error: 62, gen-pinned: 134)
+TOTAL: 339 cases (render: 257, error: 61, gen-pinned: 134)

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -104,6 +104,7 @@ control_flow/switch_warn	diag gen render
 control_flow/value_form_guard_rejected	diag(error)
 control_flow/value_form_trailing_rejected	diag(error)
 control_flow/value_switch_ast	ast diag
+control_flow/value_switch_braced_rejected	diag(error)
 datajson/island_breakout	diag gen render
 datajson/island_multi_hole_rejected	diag(error)
 datajson/island_value	diag gen render
@@ -336,4 +337,4 @@ xpkg/cross_package	diag render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 338 cases (render: 256, error: 61, gen-pinned: 134)
+TOTAL: 339 cases (render: 256, error: 62, gen-pinned: 134)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -339,10 +339,10 @@ func (p *printer) valueSwitchDoc(s *ast.ValueSwitch) pretty.Doc {
 			label = pretty.Concat(pretty.Text("case "), pretty.Text(fmtCaseList(c.List)), pretty.Text(":"))
 		}
 		cases = append(cases,
-			pretty.HardLine, label,
-			pretty.Indent(pretty.Concat(pretty.HardLine, p.valueArmDoc(c.Value))))
+			pretty.Line, label,
+			pretty.Indent(pretty.Concat(pretty.Line, p.valueArmDoc(c.Value))))
 	}
-	return pretty.Concat(pretty.Concat(head...), pretty.Indent(pretty.Concat(cases...)), pretty.HardLine, pretty.Text("}"))
+	return pretty.Group(pretty.Concat(pretty.Concat(head...), pretty.Indent(pretty.Concat(cases...)), pretty.Line, pretty.Text("}")))
 }
 
 // wrapAttrValue renders `name={<sep>value<sep>}` where sep is the flat padding

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -338,11 +338,9 @@ func (p *printer) valueSwitchDoc(s *ast.ValueSwitch) pretty.Doc {
 		if !c.Default {
 			label = pretty.Concat(pretty.Text("case "), pretty.Text(fmtCaseList(c.List)), pretty.Text(":"))
 		}
-		// Each arm value is wrapped in { } so the parser can re-parse it.
-		arm := pretty.Concat(pretty.Text("{ "), p.valueArmDoc(c.Value), pretty.Text(" }"))
 		cases = append(cases,
 			pretty.HardLine, label,
-			pretty.Indent(pretty.Concat(pretty.HardLine, arm)))
+			pretty.Indent(pretty.Concat(pretty.HardLine, p.valueArmDoc(c.Value))))
 	}
 	return pretty.Concat(pretty.Concat(head...), pretty.Indent(pretty.Concat(cases...)), pretty.HardLine, pretty.Text("}"))
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -342,7 +342,7 @@ func (p *printer) valueSwitchDoc(s *ast.ValueSwitch) pretty.Doc {
 			pretty.Line, label,
 			pretty.Indent(pretty.Concat(pretty.Line, p.valueArmDoc(c.Value))))
 	}
-	return pretty.Group(pretty.Concat(pretty.Concat(head...), pretty.Indent(pretty.Concat(cases...)), pretty.Line, pretty.Text("}")))
+	return pretty.Group(pretty.Concat(pretty.Concat(head...), pretty.Concat(cases...), pretty.Line, pretty.Text("}")))
 }
 
 // wrapAttrValue renders `name={<sep>value<sep>}` where sep is the flat padding

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -204,13 +204,27 @@ component C(v int) {
 	want := `package p
 
 component C(v int) {
+	<div class={ switch v { case 1: "green" default: "gray" } }>x</div>
+}
+`
+	checkFormat(t, src, want)
+}
+
+func TestValueSwitchBreaksWhenOverWidth(t *testing.T) {
+	src := `package p
+component C(v int) {
+	<div class={ switch v { case 1: "green-green-green-green-green-green-green" default: "gray-gray-gray-gray-gray-gray-gray" } }>x</div>
+}`
+	want := `package p
+
+component C(v int) {
 	<div
 		class={
 			switch v {
 				case 1:
-					"green"
+					"green-green-green-green-green-green-green"
 				default:
-					"gray"
+					"gray-gray-gray-gray-gray-gray-gray"
 			}
 		}
 	>

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -196,6 +196,31 @@ component C() {
 	checkFormat(t, src, want)
 }
 
+func TestValueSwitchPrintsUnbracedCaseValues(t *testing.T) {
+	src := `package p
+component C(v int) {
+	<div class={ switch v { case 1: "green" default: "gray" } }>x</div>
+}`
+	want := `package p
+
+component C(v int) {
+	<div
+		class={
+			switch v {
+				case 1:
+					"green"
+				default:
+					"gray"
+			}
+		}
+	>
+		x
+	</div>
+}
+`
+	checkFormat(t, src, want)
+}
+
 func TestCondAttr(t *testing.T) {
 	// A CondAttr always forces the opening-tag group to break (BreakParent inside
 	// attrDoc for CondAttr). When the tag breaks, children also break to their own
@@ -993,7 +1018,7 @@ component C(v int) {
 func TestValueFormSwitchLayout(t *testing.T) {
 	src := `package p
 component C(v int) {
-	<span class={ "base", switch v { case 1: { "green-aaaaaaaaaaaaaaaaaaaaaaaaaaaa" } default: { "gray-bbbbbbbbbbbbbbbbbbbbbbbb" } } }>x</span>
+	<span class={ "base", switch v { case 1: "green-aaaaaaaaaaaaaaaaaaaaaaaaaaaa" default: "gray-bbbbbbbbbbbbbbbbbbbbbbbb" } }>x</span>
 }`
 	want := `package p
 
@@ -1003,9 +1028,9 @@ component C(v int) {
 			"base",
 			switch v {
 				case 1:
-					{ "green-aaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+					"green-aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 				default:
-					{ "gray-bbbbbbbbbbbbbbbbbbbbbbbb" }
+					"gray-bbbbbbbbbbbbbbbbbbbbbbbb"
 			}
 		}
 	>

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -221,10 +221,10 @@ component C(v int) {
 	<div
 		class={
 			switch v {
-				case 1:
-					"green-green-green-green-green-green-green"
-				default:
-					"gray-gray-gray-gray-gray-gray-gray"
+			case 1:
+				"green-green-green-green-green-green-green"
+			default:
+				"gray-gray-gray-gray-gray-gray-gray"
 			}
 		}
 	>
@@ -1041,10 +1041,10 @@ component C(v int) {
 		class={
 			"base",
 			switch v {
-				case 1:
-					"green-aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-				default:
-					"gray-bbbbbbbbbbbbbbbbbbbbbbbb"
+			case 1:
+				"green-aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			default:
+				"gray-bbbbbbbbbbbbbbbbbbbbbbbb"
 			}
 		}
 	>

--- a/parser/boundary.go
+++ b/parser/boundary.go
@@ -118,7 +118,7 @@ func scanToCaseColon(src string, from int) (int, bool) {
 }
 
 // valueSwitchArmEnd returns the byte offset of the next top-level case,
-// default, or switch-closing brace after an unbraced value-switch arm.
+// default, or switch-closing brace after a value-switch arm.
 // Delimiters nested inside Go composite literals, function literals, or other
 // bracketed expressions are ignored.
 func valueSwitchArmEnd(src string, from int) (int, bool) {

--- a/parser/boundary.go
+++ b/parser/boundary.go
@@ -117,6 +117,39 @@ func scanToCaseColon(src string, from int) (int, bool) {
 	}
 }
 
+// valueSwitchArmEnd returns the byte offset of the next top-level case,
+// default, or switch-closing brace after an unbraced value-switch arm.
+// Delimiters nested inside Go composite literals, function literals, or other
+// bracketed expressions are ignored.
+func valueSwitchArmEnd(src string, from int) (int, bool) {
+	sub := src[from:]
+	fset := token.NewFileSet()
+	file := fset.AddFile("", fset.Base(), len(sub))
+	var s scanner.Scanner
+	s.Init(file, []byte(sub), func(token.Position, string) {}, scanner.ScanComments)
+
+	depth := 0
+	for {
+		pos, tok, _ := s.Scan()
+		if tok == token.EOF {
+			return 0, false
+		}
+		off := from + fset.Position(pos).Offset
+		if depth == 0 {
+			switch tok {
+			case token.CASE, token.DEFAULT, token.RBRACE:
+				return off, true
+			}
+		}
+		switch tok {
+		case token.LPAREN, token.LBRACK, token.LBRACE:
+			depth++
+		case token.RPAREN, token.RBRACK, token.RBRACE:
+			depth--
+		}
+	}
+}
+
 // parenEnd returns the index of the `)` matching the `(` at src[open], scanning
 // Go tokens from `open` so prose before `open` is never tokenized.
 func parenEnd(src string, open int) (int, bool) {

--- a/parser/valueform.go
+++ b/parser/valueform.go
@@ -166,7 +166,13 @@ func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error)
 		return nil, 0, p.errorf(p.posAt(at), "expected `case` or `default` in value-form `switch`")
 	}
 	if valueAt < len(p.src) && p.src[valueAt] == '{' {
-		return nil, 0, p.errorf(p.posAt(valueAt), "braced switch case values are no longer supported; remove the braces")
+		arm, afterPos, err := p.parseValueArm(valueAt)
+		if err != nil {
+			return nil, 0, err
+		}
+		cc.Value = arm
+		ast.SetSpan(cc, start, arm.End())
+		return cc, p.offsetOf(afterPos), nil
 	}
 	end, ok := valueSwitchArmEnd(p.src, valueAt)
 	if !ok {

--- a/parser/valueform.go
+++ b/parser/valueform.go
@@ -107,7 +107,7 @@ func (p *parser) parseValueArm(braceOff int) (*ast.ValueArm, token.Pos, error) {
 	return arm, p.posAt(closeOff + 1), nil
 }
 
-// parseValueSwitch parses `switch [Tag] { case List: { Arm } … default: { Arm } }`
+// parseValueSwitch parses `switch [Tag] { case List: Arm … default: Arm }`
 // starting at the `switch` keyword (offset at).
 func (p *parser) parseValueSwitch(at int) (*ast.ValueSwitch, token.Pos, error) {
 	start := p.posAt(at)
@@ -136,14 +136,14 @@ func (p *parser) parseValueSwitch(at int) (*ast.ValueSwitch, token.Pos, error) {
 	}
 }
 
-// parseValueSwitchCase parses one `case List: { Arm }` or `default: { Arm }`
-// starting at the keyword (offset at). Returns the node and the offset one past
-// the arm's `}`.
+// parseValueSwitchCase parses one `case List: Arm` or `default: Arm`, starting
+// at the keyword (offset at). Returns the node and the offset at the next case,
+// default, or switch-closing brace.
 func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error) {
 	start := p.posAt(at)
 	cc := &ast.ValueSwitchCase{}
 	r := p.src[at:]
-	var braceAt int
+	var valueAt int
 	switch {
 	case strings.HasPrefix(r, "case") && (len(r) == 4 || !isIdentByte(r[4])):
 		listStart := at + len("case")
@@ -153,7 +153,7 @@ func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error)
 		}
 		cc.List = strings.TrimSpace(p.src[listStart:colonOff])
 		rest := strings.TrimLeft(p.src[colonOff+1:], " \t\r\n")
-		braceAt = colonOff + 1 + (len(p.src[colonOff+1:]) - len(rest))
+		valueAt = colonOff + 1 + (len(p.src[colonOff+1:]) - len(rest))
 	case strings.HasPrefix(r, "default") && (len(r) == 7 || !isIdentByte(r[7])):
 		cc.Default = true
 		colon := strings.IndexByte(p.src[at:], ':')
@@ -161,18 +161,31 @@ func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error)
 			return nil, 0, p.errorf(p.posAt(at), "expected `:` after `default`")
 		}
 		rest := strings.TrimLeft(p.src[at+colon+1:], " \t\r\n")
-		braceAt = at + colon + 1 + (len(p.src[at+colon+1:]) - len(rest))
+		valueAt = at + colon + 1 + (len(p.src[at+colon+1:]) - len(rest))
 	default:
 		return nil, 0, p.errorf(p.posAt(at), "expected `case` or `default` in value-form `switch`")
 	}
-	if braceAt >= len(p.src) || p.src[braceAt] != '{' {
-		return nil, 0, p.errorf(p.posAt(braceAt), "expected `{` for case value")
+	if valueAt < len(p.src) && p.src[valueAt] == '{' {
+		return nil, 0, p.errorf(p.posAt(valueAt), "braced switch case values are no longer supported; remove the braces")
 	}
-	arm, end, err := p.parseValueArm(braceAt)
+	end, ok := valueSwitchArmEnd(p.src, valueAt)
+	if !ok {
+		return nil, 0, p.errorf(p.posAt(valueAt), "unterminated value-form switch case")
+	}
+	raw := p.src[valueAt:end]
+	expr := strings.TrimSpace(raw)
+	if expr == "" {
+		return nil, 0, p.errorf(p.posAt(valueAt), "value-form switch case must produce a value")
+	}
+	lead := len(raw) - len(strings.TrimLeft(raw, " \t\r\n"))
+	seed, stages, err := parsePipe(expr, p.posAt(valueAt+lead))
 	if err != nil {
 		return nil, 0, err
 	}
+	arm := &ast.ValueArm{Expr: seed, Stages: stages}
+	trimmedEnd := end - (len(raw) - len(strings.TrimRight(raw, " \t\r\n")))
+	ast.SetSpan(arm, p.posAt(valueAt+lead), p.posAt(trimmedEnd))
 	cc.Value = arm
-	ast.SetSpan(cc, start, end)
-	return cc, p.offsetOf(end), nil
+	ast.SetSpan(cc, start, p.posAt(trimmedEnd))
+	return cc, end, nil
 }

--- a/parser/valueform_test.go
+++ b/parser/valueform_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"go/token"
-	"strings"
 	"testing"
 
 	"github.com/gsxhq/gsx/ast"
@@ -31,9 +30,9 @@ func parseValueSwitchAttr(t *testing.T, body string) *ast.ValueSwitch {
 func TestValueSwitchParsesUnbracedCaseValues(t *testing.T) {
 	s := parseValueSwitchAttr(t, `
 	case 1:
-		"green"
+		"green" |> upper
 	case 2, 3:
-		choose(map[int]string{2: "amber"}, v) |> upper
+		choose(map[int]string{2: "amber"}, v)
 	case 4:
 		func() string { switch v { case 4: return "nested" }; return "other" }()
 	default:
@@ -45,11 +44,11 @@ func TestValueSwitchParsesUnbracedCaseValues(t *testing.T) {
 	if got := s.Cases[0].Value.Expr; got != `"green"` {
 		t.Fatalf("case 1 expr = %q", got)
 	}
+	if len(s.Cases[0].Value.Stages) != 1 || s.Cases[0].Value.Stages[0].Name != "upper" {
+		t.Fatalf("case 1 stages = %#v", s.Cases[0].Value.Stages)
+	}
 	if got := s.Cases[1].Value.Expr; got != `choose(map[int]string{2: "amber"}, v)` {
 		t.Fatalf("case 2 expr = %q", got)
-	}
-	if len(s.Cases[1].Value.Stages) != 1 || s.Cases[1].Value.Stages[0].Name != "upper" {
-		t.Fatalf("case 2 stages = %#v", s.Cases[1].Value.Stages)
 	}
 	if got := s.Cases[2].Value.Expr; got != `func() string { switch v { case 4: return "nested" }; return "other" }()` {
 		t.Fatalf("case 4 expr = %q", got)
@@ -59,13 +58,20 @@ func TestValueSwitchParsesUnbracedCaseValues(t *testing.T) {
 	}
 }
 
-func TestValueSwitchRejectsLegacyBracedCaseValue(t *testing.T) {
-	src := "package p\ncomponent C(v int) {\n\t<div class={ switch v { case 1: { \"green\" } default: \"gray\" } }>x</div>\n}\n"
-	_, err := ParseFile(token.NewFileSet(), "test.gsx", src, 0)
-	if err == nil {
-		t.Fatal("expected legacy braced case value to be rejected")
+func TestValueSwitchAcceptsBracedCaseValue(t *testing.T) {
+	s := parseValueSwitchAttr(t, `
+	case 1:
+		{ "green" |> upper }
+	default:
+		{ "gray" }`)
+
+	if got := s.Cases[0].Value.Expr; got != `"green"` {
+		t.Fatalf("case 1 expr = %q", got)
 	}
-	if !strings.Contains(err.Error(), "remove the braces") {
-		t.Fatalf("error = %q, want migration guidance", err)
+	if len(s.Cases[0].Value.Stages) != 1 || s.Cases[0].Value.Stages[0].Name != "upper" {
+		t.Fatalf("case 1 stages = %#v", s.Cases[0].Value.Stages)
+	}
+	if got := s.Cases[1].Value.Expr; got != `"gray"` {
+		t.Fatalf("default expr = %q", got)
 	}
 }

--- a/parser/valueform_test.go
+++ b/parser/valueform_test.go
@@ -1,0 +1,71 @@
+package parser
+
+import (
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/ast"
+)
+
+func parseValueSwitchAttr(t *testing.T, body string) *ast.ValueSwitch {
+	t.Helper()
+	src := "package p\ncomponent C(v int) {\n\t<div class={ switch v {\n" + body + "\n\t} }>x</div>\n}\n"
+	f, err := ParseFile(token.NewFileSet(), "test.gsx", src, 0)
+	if err != nil {
+		t.Fatalf("parse value switch: %v", err)
+	}
+	var found *ast.ValueSwitch
+	ast.Inspect(f, func(n ast.Node) bool {
+		if s, ok := n.(*ast.ValueSwitch); ok {
+			found = s
+		}
+		return true
+	})
+	if found == nil {
+		t.Fatal("no value-form switch parsed")
+	}
+	return found
+}
+
+func TestValueSwitchParsesUnbracedCaseValues(t *testing.T) {
+	s := parseValueSwitchAttr(t, `
+	case 1:
+		"green"
+	case 2, 3:
+		choose(map[int]string{2: "amber"}, v) |> upper
+	case 4:
+		func() string { switch v { case 4: return "nested" }; return "other" }()
+	default:
+		"gray"`)
+
+	if len(s.Cases) != 4 {
+		t.Fatalf("cases = %d, want 4", len(s.Cases))
+	}
+	if got := s.Cases[0].Value.Expr; got != `"green"` {
+		t.Fatalf("case 1 expr = %q", got)
+	}
+	if got := s.Cases[1].Value.Expr; got != `choose(map[int]string{2: "amber"}, v)` {
+		t.Fatalf("case 2 expr = %q", got)
+	}
+	if len(s.Cases[1].Value.Stages) != 1 || s.Cases[1].Value.Stages[0].Name != "upper" {
+		t.Fatalf("case 2 stages = %#v", s.Cases[1].Value.Stages)
+	}
+	if got := s.Cases[2].Value.Expr; got != `func() string { switch v { case 4: return "nested" }; return "other" }()` {
+		t.Fatalf("case 4 expr = %q", got)
+	}
+	if !s.Cases[3].Default || s.Cases[3].Value.Expr != `"gray"` {
+		t.Fatalf("default = %#v", s.Cases[3])
+	}
+}
+
+func TestValueSwitchRejectsLegacyBracedCaseValue(t *testing.T) {
+	src := "package p\ncomponent C(v int) {\n\t<div class={ switch v { case 1: { \"green\" } default: \"gray\" } }>x</div>\n}\n"
+	_, err := ParseFile(token.NewFileSet(), "test.gsx", src, 0)
+	if err == nil {
+		t.Fatal("expected legacy braced case value to be rejected")
+	}
+	if !strings.Contains(err.Error(), "remove the braces") {
+		t.Fatalf("error = %q, want migration guidance", err)
+	}
+}

--- a/tuple_error_test.go
+++ b/tuple_error_test.go
@@ -32,7 +32,7 @@ func TestValueFormArmErrorPropagation(t *testing.T) {
 	clsFn := func() (string, error) { return "", sentinel }
 
 	// Mirrors generated code for:
-	//   <span class={ "base", switch variant { case 1: { cls(variant) } default: { "gray" } } }>x</span>
+	//   <span class={ "base", switch variant { case 1: cls(variant) default: "gray" } }>x</span>
 	// when variant==1 and cls returns an error.
 	component := Func(func(ctx context.Context, w io.Writer) error {
 		gw := W(w)


### PR DESCRIPTION
## Summary
- replace braced value-form `switch` case values with unbraced expressions matching markup-switch case bodies
- preserve nested Go expression and pipeline parsing with top-level case-boundary scanning
- reject legacy braced case values with a migration diagnostic
- update formatter output, corpus goldens, roadmap, and syntax documentation

## Breaking syntax
```gsx
switch variant {
case Green:
    "green"
default:
    "gray"
}
```

## Test plan
- `make ci`
- `go test ./parser ./internal/printer ./internal/corpus -count=1`
- coordinated tree-sitter and VS Code grammar PRs