### PR TITLE
[codex] Refine public documentation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@
 A templating language for Go: **templ-style `component` declarations** with a
 **JSX-style markup body**, compiled to plain Go.
 
-> **Status — alpha.** gsx is runnable end-to-end: `gsx generate` compiles
-> `.gsx` → `.x.go` (plus `gsx fmt` and `gsx info`). Codegen covers interpolation,
-> control flow, attributes with contextual escaping, the `|>` pipeline + filters,
-> components/props/`{children}`, method components, named slots, and explicit
-> attribute forwarding. Still in progress: some CLI commands (`vet`/`lsp`), `style`
-> composition, and structured diagnostics. See the [roadmap](docs/ROADMAP.md).
+> **Status — alpha.** gsx is runnable end-to-end. `gsx init` scaffolds a Go and
+> Vite application, `gsx dev` runs the warm generate/build/reload loop, and
+> `gsx lsp` provides diagnostics, navigation, hover, references, and formatting.
+> The language and APIs are usable but may still change before a stable release.
+> See the [status](docs/guide/status.md) and [roadmap](docs/ROADMAP.md).
 
 ## What is gsx
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 A templating language for Go: **templ-style `component` declarations** with a
 **JSX-style markup body**, compiled to plain Go.
 
-> **Status — alpha.** gsx is runnable end-to-end. `gsx init` scaffolds a Go and
-> Vite application, `gsx dev` runs the warm generate/build/reload loop, and
-> `gsx lsp` provides diagnostics, navigation, hover, references, and formatting.
-> The language and APIs are usable but may still change before a stable release.
-> See the [status](docs/guide/status.md) and [roadmap](docs/ROADMAP.md).
+> **Status — alpha.** gsx is usable end to end, but the language and APIs may
+> change before a stable release. See [Status](docs/guide/status.md) and
+> [Roadmap](docs/ROADMAP.md).
 
 ## What is gsx
 
@@ -19,7 +17,7 @@ Go compiler type-checks and builds:
 .gsx → parser → AST → codegen → .x.go → go build → HTML
 ```
 
-- **Type-safe by construction** — components become plain Go; props are generated
+- **Checked by Go** — components become plain Go; props are generated
   structs, so gsx owns the field names (no symbol-resolver guesswork).
 - **Close to HTML and to Go** — JSX-style markup for templates; ordinary Go for
   everything else. Capitalization decides component-vs-element (`<div>` vs `<Card>`).
@@ -50,7 +48,6 @@ component Card(title string, featured bool) {
   canonical syntax reference (every case parses, generates Go, and pins its
   rendered output).
 - **Roadmap & status** — [docs/ROADMAP.md](docs/ROADMAP.md).
-- **Design docs** — [docs/superpowers/specs/](docs/superpowers/specs/).
 
 ## Documentation site
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -346,7 +346,7 @@ vocabulary remains a design aspiration, not the current API.
   **SHIPPED** (configurable merger seam; Tailwind wrapper idiom; `--watch` validates at
   startup; cache-keyed; corpus + example coverage). **Pending:** GSXnnnn numeric
   codes (codes are string-based today, e.g. `invalid-syntax`); `vet`/`render`/`explain`;
-  `--watch`/incremental.
+  finer-grained incremental invalidation beyond the current warm watcher.
 - `[ ]` **Codegen niceties** — coalesce adjacent `gw.S` static writes; `//line`
   trailing-state reset; `data:image` URL allowance.
 - `[ ]` **Tooling performance measurement on a realistic large corpus** — the
@@ -360,16 +360,14 @@ vocabulary remains a design aspiration, not the current API.
 
 ## Documentation backlog
 
-- `[x]` **Examples gallery — SHIPPED.** A single-source, CI-checked **Examples**
-  gallery (live: <https://gsxhq.github.io/guide/examples>). Each `examples/*.txtar`
-  fixture (a `-- doc --` metadata block + `package views` `.gsx` files + `-- invoke --`
-  + `-- render.golden --`) is the **one source** feeding three consumers: (1) a render
-  test (`internal/corpus` `TestExamples`), (2) the docs page `docs/guide/examples.md`,
-  (3) the playground presets. A generator (`internal/examplegen` + `cmd/gsx-examples`,
-  `make examples`) emits the docs page + byte-identical preset JSONs. **19 examples
-  across 6 sections** — Basics · Control flow · Components & composition · Styling ·
-  Transforming values · Interactive & whole-page. Spec/plan
-  `2026-06-24-gsx-examples-framework*`.
+- `[x]` **Examples framework — SHIPPED.** `examples/*.txtar` fixtures (a `-- doc --`
+  metadata block + `package views` `.gsx` files + `-- invoke --` + `-- render.golden --`)
+  are the single source feeding render tests, per-topic syntax includes under
+  `docs/guide/syntax/_generated/**`, and playground presets. A generator
+  (`internal/examplegen` + `cmd/gsx-examples`, `make examples`) emits the generated
+  snippets + byte-identical preset JSONs. The public site no longer has a separate
+  Examples page; examples live beside the syntax they document and jump to the
+  playground.
 - `[x]` **Examples → Playground links — SHIPPED.** Each example emits an "Open in
   Playground" `#try=` deep-link (std-base64 of `{s:source,i:invoke}`); multi-file
   examples ride the Go-Playground txtar format (`-- file --` separators).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@ generator/CLI may use `golang.org/x/tools`.
 |---|---|
 | Parser + AST | `[x]` Part 2 grammar + pipeline parsing + positioned, recoverable errors |
 | Runtime (`gsx`) | `[x]` done |
-| Codegen | `[~]` interpolation + control flow + full attributes (security core, composable class **and element-level style**, spread, conditional) + pipeline `\|>` + child props/`{children}` + method components + named slots + attribute fallthrough (auto class-merge/spread + manual `{...attrs}`) + custom attribute classification (`WithJSAttrs`/`WithURLAttrs`/`WithCSSAttrs` + `WithAttrClassifier`) + node-prop promotion (`gsx.Val`/`Text`/`Fragment`) + ordered attrs (`{{ }}` / `gsx.OrderedAttrs`) + uniform `(T,error)` auto-unwrap (all expression positions) + value-form `if`/`switch` in `class`/`style` (exclusive selection) done; composable `style` **on a component invocation** + `[]string` class parts pending |
+| Codegen | `[~]` interpolation + control flow + full attributes (security core, composable class **and element-level style**, spread, conditional) + pipeline `\|>` + child props/`{children}` + method components + named slots + attribute fallthrough (auto class-merge/spread + manual `{...attrs}`) + custom attribute classification (`WithJSAttrs`/`WithURLAttrs`/`WithCSSAttrs` + `WithAttrClassifier`) + node-prop promotion (`gsx.Val`/`Text`/`Fragment`) + ordered attrs (`{{ }}` lowering to `gsx.Attrs`) + uniform `(T,error)` auto-unwrap (all expression positions) + value-form `if`/`switch` in `class`/`style` (exclusive selection) done; composable `style` **on a component invocation** + `[]string` class parts pending |
 | Whitespace model | `[x]` JSX-style: `internal/wsnorm.Normalize` (parser lossless) wired into codegen + powers `gsx fmt`. render-faithful + idempotent over the whole corpus. |
 | Pipeline `\|>` end-to-end | `[x]` seed-first forward-application lowering + `std` filters + user filter packages (`gen.WithFilters` + `gen.WithFilter` aliases, multi-pkg last-wins) + `ctx` injection + `(T,error)` implicit auto-unwrap. Works in interp / attr / class / style / spread / child-prop values / `{{ }}` pairs (all expression positions). Initialism-aware naming pending. |
 | CLI (`gsx`) / `gen.Main` | `[~]` `generate` (incl. `--watch`/`--format=ndjson`) · `fmt` · `info` · `init` · `lsp` · `clean --cache` · `version` · `help` ship, with `--json` + structured diagnostics. `vet`/`render`/`explain`/numeric codes pending. `WithClassMerger` + `class_merger` TOML knob shipped. |
@@ -36,12 +36,12 @@ recover at the `component` boundary (one diagnostic per broken component).
 
 **Runtime** (`gsx`, module root) — `Node`/`Func`/`Raw`, error-threading `Writer`
 with streaming text/attr/URL/JS/CSS escapers, class/style compose + gen-configured
-class merger (`class_merger` / `gen.WithClassMerger`), `Attrs` bag + deterministic `Spread`. `gsx.Val(any)` /
-`gsx.Text(string)` / `gsx.Fragment(nodes…)` value-Node boxes. `gsx.Raw` /
-`gsx.RawJS` / `gsx.RawCSS` / `gsx.RawURL` typed escape hatches.
-`gsx.OrderedAttrs` (`[]gsx.Attr`) + `Writer.SpreadOrdered` — insertion-ordered,
-duplicate-tolerant attribute bag; renders in slice order (contrast: `Spread` sorts
-`Attrs`). Independent-review SHIP.
+class merger (`class_merger` / `gen.WithClassMerger`), ordered `Attrs` bag
+(`[]gsx.Attr`) + deterministic `Spread` in slice order. `gsx.AttrMap.ToAttrs`
+keeps map-shaped construction explicit and sorts keys before converting to
+`Attrs`. `gsx.Val(any)` / `gsx.Text(string)` / `gsx.Fragment(nodes…)`
+value-Node boxes. `gsx.Raw` / `gsx.RawJS` / `gsx.RawCSS` / `gsx.RawURL` typed
+escape hatches. Independent-review SHIP.
 
 **Codegen phase 1** (`internal/codegen`) — `GeneratePackage(dir)`: `go/packages`
 + `Overlay` skeleton type resolution (cross-file, cross-component); arity-safe
@@ -119,11 +119,11 @@ render goldens.
    the `FProps{…}` convention. Passing attributes or children to a zero-arg component
    is a clean diagnostic (was a raw `undefined: FProps`). **Deferred:** non-`gsx.Node`
    renderable returns; cross-package nullary funcs.
-9. `[x]` **Ordered attributes** (`{{ }}` / `gsx.OrderedAttrs`) — `2026-06-29`.
+9. `[x]` **Ordered attributes** (`{{ }}` lowering to `gsx.Attrs`) — `2026-06-29`.
    A `{{ "key": goExpr, … }}` literal in attribute-value position binds to a
-   declared `gsx.OrderedAttrs` component prop; the bag is spread onto an element with
-   `{ prop... }` via `Writer.SpreadOrdered`, which emits pairs in **slice order** (not
-   sorted). Keys must be quoted string literals (enables kebab/colon names); values
+   declared `gsx.Attrs` component prop; the bag is spread onto an element with
+   `{ prop... }` via `Writer.Spread`, which emits pairs in **slice order**.
+   Keys must be quoted string literals (enables kebab/colon names); values
    are arbitrary Go expressions (`|>` pipelines not supported inside the literal);
    `bool` values toggle bare/omitted. Duplicate keys and trailing commas are allowed;
    an empty `{{ }}` renders nothing. Using `{{ }}` directly on a plain-element

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ generator/CLI may use `golang.org/x/tools`.
 | Whitespace model | `[x]` JSX-style: `internal/wsnorm.Normalize` (parser lossless) wired into codegen + powers `gsx fmt`. render-faithful + idempotent over the whole corpus. |
 | Pipeline `\|>` end-to-end | `[x]` seed-first forward-application lowering + `std` filters + user filter packages (`gen.WithFilters` + `gen.WithFilter` aliases, multi-pkg last-wins) + `ctx` injection + `(T,error)` implicit auto-unwrap. Works in interp / attr / class / style / spread / child-prop values / `{{ }}` pairs (all expression positions). Initialism-aware naming pending. |
 | CLI (`gsx`) / `gen.Main` | `[~]` `generate` (incl. `--watch`/`--format=ndjson`) · `fmt` · `info` · `init` · `lsp` · `clean --cache` · `version` · `help` ship, with `--json` + structured diagnostics. `vet`/`render`/`explain`/numeric codes pending. `WithClassMerger` + `class_merger` TOML knob shipped. |
-| Language server (`gsx lsp`) | `[~]` diagnostics (debounced) + go-to-definition (incl. inside pipelines) + hover (incl. pipelines) + find-references + formatting ship; completion / cross-package deferred. |
+| Language server (`gsx lsp`) | `[~]` diagnostics (debounced) + go-to-definition (incl. inside pipelines) + hover (incl. pipelines) + find-references + formatting ship; completion and external/non-project references deferred; references cover project components discovered during module analysis. |
 | Developer experience (Vite + `init`) | `[x]` `gsx init` scaffold + `@gsxhq/vite-plugin-gsx` (npm v0.2.1) + `github.com/gsxhq/vite` (v0.2.0). |
 
 ## Done
@@ -181,7 +181,7 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   identifier or expression; component-tag hover shows the component signature
   (answered from the AST even when type-checking fails mid-edit).
 - `[x]` **Find-references** (`textDocument/references`) — `.go` call sites + `.gsx`
-  tag sites for a component, in-package.
+  tag sites for project components discovered during module analysis; external/non-project packages are skipped.
 - `[x]` **Formatting** (`textDocument/formatting`) — canonical form with
   unused-import removal (reuses `gen.Format` / `gsxfmt.FormatRemovingImports`).
 - `[x]` **Pipeline-aware definition + hover** (`internal/lsp/pipe.go`) — go-to-def
@@ -192,8 +192,9 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
 - `[x]` **Debounced diagnostics** (`internal/lsp/server.go`) — a per-directory
   timer (250 ms) coalesces edit bursts; analysis runs off the read loop and
   version-tags its publishes. `didOpen` publishes promptly (no debounce).
-- **Deferred:** completion (needs AST repair + ranking; no importable library);
-  cross-package references; dotted/cross-package component tags (`<ui.Button/>`).
+- **Deferred:** completion and external/non-project references; references cover
+  project components discovered during module analysis. Dotted/cross-package
+  component tags (`<ui.Button/>`) are deferred.
 
 Specs: `2026-06-23-gsx-lsp-design.md`, `2026-06-24-gsx-lsp-slice2a-goto-definition-design.md`,
 `2026-06-24-gsx-lsp-go-to-gsx-design.md`, `2026-06-24-gsx-lsp-hover-design.md`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ generator/CLI may use `golang.org/x/tools`.
 | Pipeline `\|>` end-to-end | `[x]` seed-first forward-application lowering + `std` filters + user filter packages (`gen.WithFilters` + `gen.WithFilter` aliases, multi-pkg last-wins) + `ctx` injection + `(T,error)` implicit auto-unwrap. Works in interp / attr / class / style / spread / child-prop values / `{{ }}` pairs (all expression positions). Initialism-aware naming pending. |
 | CLI (`gsx`) / `gen.Main` | `[~]` `generate` (incl. `--watch`/`--format=ndjson`) · `fmt` · `info` · `init` · `lsp` · `clean --cache` · `version` · `help` ship, with `--json` + structured diagnostics. `vet`/`render`/`explain`/numeric codes pending. `WithClassMerger` + `class_merger` TOML knob shipped. |
 | Language server (`gsx lsp`) | `[~]` diagnostics (debounced) + go-to-definition (incl. inside pipelines) + hover (incl. pipelines) + find-references + formatting ship; completion and external/non-project references deferred; references cover project components discovered during module analysis. |
-| Developer experience (Vite + `init`) | `[x]` `gsx init` scaffold + `@gsxhq/vite-plugin-gsx` (npm v0.2.1) + `github.com/gsxhq/vite` (v0.2.0). |
+| Developer experience (Vite + `init`) | `[x]` `gsx init` scaffold + `@gsxhq/vite-plugin-gsx` (npm v0.4.0) + `github.com/gsxhq/vite` (v0.2.0). |
 
 ## Done
 
@@ -220,10 +220,10 @@ pieces. Save → warm generate → build-then-swap Go server → browser reloads
   process that keeps the type-resolution environment warm (`gen.CachedResolver`)
   and regenerates in-process on each change, streaming NDJSON diagnostics. Measured:
   a warm regenerate is **~1–2 ms** vs **~140 ms** for a cold one-shot `gsx generate`
-  (~70–100×), so the inner save-loop is effectively instant. Rebuilds the resolver
+  (~70–100×). Rebuilds the resolver
   on `.go`/go.mod changes; pure `.gsx` edits take the fast path. Slice 2 (fine-grained
   per-package invalidation) is deferred — the measured warm time made it unnecessary.
-- `[x]` **`@gsxhq/vite-plugin-gsx`** (npm **v0.3.0**, `~/personal/gsxhq/vite-plugin-gsx`) —
+- `[x]` **`@gsxhq/vite-plugin-gsx`** (npm **v0.4.0**, `~/personal/gsxhq/vite-plugin-gsx`) —
   receives generation/build events from `gsx dev`, surfaces diagnostics in the
   Vite error overlay (auto-clears on recovery), and full-reloads after the server
   becomes ready; `devFallback()` serves a self-recovering interstitial while the

--- a/docs/examples.json
+++ b/docs/examples.json
@@ -128,7 +128,7 @@
   {
     "name": "Auto-escaping & safe raw",
     "category": "Basics",
-    "source": "package views\n\n// User input is HTML-escaped by construction — no XSS.\ncomponent Comment(body string) {\n\t<blockquote>{ body }</blockquote>\n}\n",
+    "source": "package views\n\n// User input in normal interpolation is HTML-escaped.\ncomponent Comment(body string) {\n\t<blockquote>{ body }</blockquote>\n}\n",
     "invoke": "Comment(CommentProps{Body: \"<img src=x onerror=alert(1)>\"})"
   },
   {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -32,8 +32,8 @@ gsx [global flags] <command> [arguments]
 
 ### Global flags
 
-Global flags apply to any command and **must come before the command name**
-(`gsx -v generate`, not `gsx generate -v`):
+These flags are accepted before the command name. `generate` also accepts `-q`
+and `-v` after the path arguments:
 
 | Flag | Effect |
 |------|--------|
@@ -41,7 +41,7 @@ Global flags apply to any command and **must come before the command name**
 | `-q` | quiet: suppress success output |
 | `-v` | verbose: list each written file |
 
-`-q` / `-v` only affect `generate`'s success output; other commands ignore them.
+`-q` / `-v` only affect `generate`'s success output.
 
 ## gsx init
 
@@ -259,7 +259,7 @@ Formatting embedded code is **correct-or-verbatim**: if a body can't be parsed
 cleanly, gsx leaves it byte-for-byte untouched rather than risk mangling it —
 the same safety rule as Go-fragment formatting. The built-in CSS formatter is
 deliberately minimal and **replaceable** with your own (e.g. a Prettier
-shell-out) — see [Extending gsx](./extensions.md#custom-css-js-formatter).
+shell-out) — see [Extending gsx](./extensions.md#custom-cssjs-formatter).
 
 > **In development.** Embedded `<style>` CSS formatting is being built now
 > (`<script>` JS after it). On the current release, `<style>` and `<script>`

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -331,10 +331,10 @@ as JSON-RPC. It is launched by an editor, not invoked by hand:
 gsx lsp                 # blocks, reading LSP messages on stdin
 ```
 
-The server analyzes each open package with the stock (std-filter) codegen
-pipeline and publishes diagnostics — it never writes `.x.go` to disk. It is an
-early slice: editing existing `.gsx` files is analyzed live, but a new buffer
-that has never been saved to disk is not yet picked up.
+The server analyzes each open package using the resolved configuration and
+provides diagnostics, definition, hover, references, and formatting without
+writing `.x.go` to disk. Existing saved `.gsx` files are analyzed live;
+brand-new unsaved buffers are not yet picked up.
 
 ## version
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -357,7 +357,6 @@ custom binary configures a CSS/JS minifier (functions are not hashable).
 
 ## Status
 
-> **Alpha.** `generate`, `fmt`, `init`, `info`, `clean`, `version`, and `lsp`
-> (an early diagnostics-only slice) are implemented. A checker (`vet`) and richer
-> language-server features are on the
-> [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).
+> **Alpha.** The shipped command set is listed above. Planned commands and
+> deferred diagnostics work are tracked in [Status](./status.md) and the
+> [Roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -112,7 +112,7 @@ existing `go.mod`/`package.json` without `--force`); `1` on a step failure or
 I/O error. When a step fails the remaining commands are printed to stderr.
 
 > **Planned template:** `structpages` — a struct-based routing starter built on
-> the [structpages](https://github.com/gsxhq/gsx/tree/main/structpages) framework
+> the [structpages](https://github.com/jackielii/structpages) framework
 > (htmx + templ). Not yet available; only `simple` is currently implemented.
 
 ## gsx dev

--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -10,7 +10,7 @@ Use gsx when you want JSX-like authoring inside Go projects. Use templ directly 
 
 ## gsx and html/template
 
-`html/template` is stable, standard-library, and excellent for string-template workflows. gsx adds typed components, generated props, compiler-checked composition, contextual escaping by construction, and a formatter/LSP path.
+`html/template` is stable, standard-library, contextually auto-escaping, and excellent for string-template workflows. gsx preserves contextual escaping while adding typed components, generated props, compiler-checked composition, and a formatter/LSP path.
 
 Use `html/template` when you need runtime-loaded templates or the standard package alone. Use gsx when templates are part of the compiled application.
 

--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -1,0 +1,31 @@
+# Comparisons
+
+gsx sits between Go template engines and JSX-like markup systems: templates stay close to HTML, data stays typed Go, and output compiles to ordinary Go.
+
+## gsx and templ
+
+Both gsx and templ compile components to Go values with `Render(ctx, w) error`. gsx differs in surface syntax: component declarations are templ-style, while the body is JSX-style markup. This makes HTML-like structure easier to scan while keeping structural compatibility with `templ.Component`.
+
+Use gsx when you want JSX-like authoring inside Go projects. Use templ directly when you prefer templ's existing syntax, ecosystem, or render-once primitive.
+
+## gsx and html/template
+
+`html/template` is stable, standard-library, and excellent for string-template workflows. gsx adds typed components, generated props, compiler-checked composition, contextual escaping by construction, and a formatter/LSP path.
+
+Use `html/template` when you need runtime-loaded templates or the standard package alone. Use gsx when templates are part of the compiled application.
+
+## gsx and JSX
+
+JSX makes markup part of JavaScript. gsx borrows the readable tag structure, but expressions are Go, components compile to Go, and there is no virtual DOM.
+
+Use client-side JSX for interactive browser applications. Use gsx for server-rendered Go components, optionally with JavaScript islands.
+
+## gsx and Jinja-style templates
+
+Jinja-style templates provide a compact template language with filters, blocks, and inheritance. gsx instead leans on Go for data, functions, imports, and control flow, with pipelines for common formatting.
+
+Use Jinja-style templates when a dynamic template language is the product requirement. Use gsx when compile-time checking and Go-native component composition matter more.
+
+## Interop
+
+See [Interop](./syntax/interop) for examples that compose gsx with templ, `html/template`, and client-side islands.

--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -10,7 +10,7 @@ Use gsx when you want JSX-like authoring inside Go projects. Use templ directly 
 
 ## gsx and html/template
 
-`html/template` is stable, standard-library, contextually auto-escaping, and excellent for string-template workflows. gsx preserves contextual escaping while adding typed components, generated props, compiler-checked composition, and a formatter/LSP path.
+`html/template` is stable, standard-library, and contextually auto-escaping. gsx preserves contextual escaping while adding typed components, generated props, compiler-checked composition, and a formatter/LSP path.
 
 Use `html/template` when you need runtime-loaded templates or the standard package alone. Use gsx when templates are part of the compiled application.
 

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -34,6 +34,8 @@ no_web = true
 
 CLI flags override this table. See the [`gsx dev` reference](./cli#gsx-dev).
 
+## Example: pipeline filters
+
 ```toml
 # gsx.toml — typically at the repo root
 [filters]
@@ -42,7 +44,7 @@ id     = "github.com/jackielii/structpages.ID"
 target = "github.com/jackielii/structpages.IDTarget"
 ```
 
-With that file in place, `gsx generate` makes `url`/`id`/`target` available as
+With that config, `gsx generate` makes `url`/`id`/`target` available as
 pipeline filters in any `.gsx` file:
 
 ```gsx
@@ -177,7 +179,7 @@ js  = "full"
 | `none` *(default)* | Emit the asset **verbatim** — no minification. Keeps generated output readable and the incremental cache warm; best for the dev loop. A custom minifier (below) is not called. |
 | `full` | Maximal **safe** compression via a full parse (tdewolff): collapses whitespace *and* newlines (ASI-safe — explicit semicolons are emitted) for the smallest output. It **never renames identifiers and never obfuscates** — variable names are preserved. Best for production builds; note it **bypasses the incremental codegen cache**, so reserve it for prod rather than the dev loop. |
 
-A [custom minifier](./extensions.md#custom-cssjs-minifier)
+A [custom minifier](./extensions.md#minify-level)
 (`gen.WithCSSMinifier` / `gen.WithJSMinifier`), if installed, **replaces** the
 built-in `full` minifier. At `none` no minifier runs.
 

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -28,7 +28,7 @@ gsx lsp                 # blocks, reading LSP messages on stdin
 | **Diagnostics** | `publishDiagnostics` | positioned parse + type errors (with severity, code, help) from the shared diagnostics engine; re-analyzed on every change, with multi-error and component-boundary recovery |
 | **Go-to-definition** | `textDocument/definition` | jump from a Go symbol in a `{ }`/attribute expression to its `.go` definition; from a `<Card/>` tag to its `component` declaration; and from a `.go` component reference back to the `.gsx` |
 | **Hover** | `textDocument/hover` | gopls-style type/signature for an identifier or expression; a component tag shows its signature (answered from the AST even mid-edit when type-checking can't complete) |
-| **Find references** | `textDocument/references` | `.go` call sites and `.gsx` tag sites for a component, within the package |
+| **Find references** | `textDocument/references` | `.go` call sites and `.gsx` tag sites for project components discovered by module analysis; external/non-project packages are skipped |
 | **Formatting** | `textDocument/formatting` | canonical `gsx fmt` form, including unused-import removal — wire it to format-on-save |
 
 **Deferred:** completion. References cover project components discovered during

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -31,8 +31,8 @@ gsx lsp                 # blocks, reading LSP messages on stdin
 | **Find references** | `textDocument/references` | `.go` call sites and `.gsx` tag sites for a component, within the package |
 | **Formatting** | `textDocument/formatting` | canonical `gsx fmt` form, including unused-import removal — wire it to format-on-save |
 
-**Deferred:** completion and broader cross-package reference coverage. See
-[Status](./status.md) and the
+**Deferred:** completion. References cover project components discovered during
+module analysis; external packages are skipped. See [Status](./status.md) and the
 [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) for current scope.
 
 ### Configure your editor

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -118,8 +118,14 @@ formatting work out of the box — no generic LSP client to wire up.
   **gsx: Install/Update Language Server** and **gsx: Restart Language Server**
   help when it's missing or stale.
 
-It is not on the Marketplace yet. For now, build the `.vsix` from the repo and
-install it:
+Install it from the
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=gsxhq.gsx):
+
+```bash
+code --install-extension gsxhq.gsx
+```
+
+To test an unreleased build, package the `.vsix` from the repo:
 
 ```bash
 git clone https://github.com/gsxhq/vscode-gsx && cd vscode-gsx

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -31,10 +31,9 @@ gsx lsp                 # blocks, reading LSP messages on stdin
 | **Find references** | `textDocument/references` | `.go` call sites and `.gsx` tag sites for a component, within the package |
 | **Formatting** | `textDocument/formatting` | canonical `gsx fmt` form, including unused-import removal — wire it to format-on-save |
 
-**Not yet:** completion, pipeline-aware definition/hover (an expression behind a
-`|>` returns nothing today), cross-package references, and dotted/cross-package
-component tags (`<ui.Button/>`). See the
-[roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) for status.
+**Deferred:** completion and broader cross-package reference coverage. See
+[Status](./status.md) and the
+[roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) for current scope.
 
 ### Configure your editor
 

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -32,7 +32,7 @@ gsx lsp                 # blocks, reading LSP messages on stdin
 | **Formatting** | `textDocument/formatting` | canonical `gsx fmt` form, including unused-import removal — wire it to format-on-save |
 
 **Deferred:** completion. References cover project components discovered during
-module analysis; external packages are skipped. See [Status](./status.md) and the
+module analysis; external/non-project references are deferred. See [Status](./status.md) and the
 [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) for current scope.
 
 ### Configure your editor

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -87,7 +87,9 @@ The production binary embeds the generated `dist/` assets and does not run Vite.
 
 ## Where to go next
 
-- Read the [syntax overview](./syntax) and [basic syntax](./syntax/basic-syntax).
+- Follow [Learn gsx](./learn) for the first component, props, children, attrs, and styling.
+- Keep the [syntax reference](./syntax) open while writing `.gsx`.
+- Use the [playground](/playground) for quick experiments.
 - See the [`gsx dev` CLI reference](./cli#gsx-dev) for custom build, run, log,
   and front-door commands.
 - Configure filters, asset processing, and the dev loop in

--- a/docs/guide/learn.md
+++ b/docs/guide/learn.md
@@ -1,0 +1,116 @@
+# Learn gsx
+
+This path starts after `gsx init`, when you have a working app and a `.gsx`
+file open. Keep the examples small at first: write a component, save, and let
+`gsx dev` regenerate the Go code.
+
+## 1. A component is Go plus markup
+
+A `.gsx` file begins like any Go file, then adds `component` declarations. The
+component body is markup, so there is no return type and no `return`.
+
+```gsx
+package views
+
+component Greeting(name string) {
+	<p>Hello, {name}</p>
+}
+```
+
+Expressions inside `{ ... }` are Go expressions. gsx writes context-aware HTML
+escaping into the generated `.x.go` file.
+
+## 2. Props are typed
+
+Component parameters are Go parameters. Use ordinary Go types, imports, and
+expressions.
+
+```gsx
+package views
+
+import "fmt"
+
+component Meter(value int, color string) {
+	<div
+		class={ "meter", "meter-full": value >= 100 }
+		style={ fmt.Sprintf("width: %d%%", value), "color: " + color }
+	/>
+}
+```
+
+Callers pass values with Go syntax:
+
+```gsx
+<Meter value={72} color={"rebeccapurple"} />
+```
+
+## 3. Components compose with children
+
+Components receive children explicitly. Place `{children}` where nested content
+should render.
+
+```gsx
+component Panel(title string) {
+	<section class="panel">
+		<h2>{title}</h2>
+		<div class="panel-body">{children}</div>
+	</section>
+}
+
+component Home() {
+	<Panel title="Dashboard">
+		<p>Server-rendered content can be composed like HTML.</p>
+	</Panel>
+}
+```
+
+## 4. Attributes are explicit
+
+Static attributes look like HTML. Dynamic attributes use Go expressions. Boolean
+attributes are controlled by their value.
+
+```gsx
+component SaveButton(disabled bool, label string) {
+	<button type="submit" disabled={disabled}>
+		{label}
+	</button>
+}
+```
+
+Use `class={ ... }` and `style={ ... }` lists when values need to compose.
+
+## 5. Style and script stay close to HTML
+
+`<style>` and `<script>` stay in the component tree. Use the syntax reference for
+the exact interpolation rules in each context.
+
+```gsx
+component InlineExample(message string) {
+	<div class="notice">{message}</div>
+	<style>
+		.notice { padding: 0.75rem; border: 1px solid #ccc; }
+	</style>
+	<script>
+		console.log("notice mounted")
+	</script>
+}
+```
+
+## 6. The development loop is one command
+
+The starter runs the full development loop with:
+
+```sh
+npm run dev
+```
+
+That script runs `go tool gsx dev`. It watches `.gsx`, `.go`, and `.env` files,
+regenerates `.x.go`, rebuilds the Go server, and asks Vite to reload the
+browser.
+
+## Next
+
+- Keep the [syntax reference](./syntax) open while writing `.gsx`.
+- Use the [playground](/playground) to try small components.
+- Configure the dev loop, filters, minification, and class merging in [`gsx.toml`](./config).
+- Check [Status](./status) before relying on alpha or deferred features.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -4,6 +4,18 @@ gsx renders by streaming HTML straight to your `io.Writer` — no intermediate
 document, no per-component buffer pool. Generated code is direct write calls, and
 the escaper writes safe runs in place, so rendering allocates very little.
 
+## Reproduce
+
+The benchmark source lives at [github.com/gsxhq/gsx-bench](https://github.com/gsxhq/gsx-bench).
+
+```sh
+git clone https://github.com/gsxhq/gsx-bench
+cd gsx-bench
+go test -bench . -benchmem
+```
+
+The numbers below are a snapshot from Apple M3 Ultra with Go 1.26.1. Treat them as directional; use the command above on your hardware for local decisions.
+
 ## Numbers
 
 Apple M3 Ultra, Go 1.26.1, rendering into a pooled `bytes.Buffer` (as an HTTP
@@ -36,7 +48,4 @@ escaper never allocates:
 
 - gsx is roughly **5× faster than `html/template`** and consistently ahead of
   templ, with a fraction of the allocations.
-- Numbers are machine- and version-specific — run them on your hardware.
-- Source, methodology, and every scenario:
-  [github.com/gsxhq/gsx-bench](https://github.com/gsxhq/gsx-bench)
-  (`go test -bench . -benchmem`).
+- Numbers are machine- and version-specific.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -46,6 +46,6 @@ escaper never allocates:
 
 ## Notes
 
-- gsx is roughly **5× faster than `html/template`** and consistently ahead of
-  templ, with a fraction of the allocations.
+- In this benchmark snapshot, gsx is faster than `html/template` and templ with
+  fewer allocations.
 - Numbers are machine- and version-specific.

--- a/docs/guide/principles.md
+++ b/docs/guide/principles.md
@@ -6,7 +6,7 @@ decisions you'll meet in the [syntax guide](./syntax).
 ## Stay close to HTML and to Go
 
 Markup looks like HTML/JSX; helpers, variant functions, and everything that isn't a
-template are ordinary Go. There is no third language between them — the seam is the
+template are ordinary Go. There is no third language between them; the boundary is the
 `component` keyword and `{ }` interpolation.
 
 ## Syntax tidiness is the top priority
@@ -26,12 +26,11 @@ surprise.
 
 gsx compiles `.gsx` → `.x.go` → `go build` rather than interpreting templates at
 runtime — that compile step is what makes the type-safety above possible. We treat it
-as a feature, not a tax: `gsx dev` keeps generation warm, safely rebuilds and
-restarts the Go server, and uses Vite for browser errors and reloads. `gsx init`
-wires the whole loop to `npm run dev`, so a build step you never wait on is just
-a faster, safer template.
+as part of the toolchain: `gsx dev` keeps generation warm, rebuilds and restarts
+the Go server, and uses Vite for browser errors and reloads. `gsx init` wires the
+loop to `npm run dev`.
 
-## Secure by construction
+## Escape by default
 
 Interpolation is auto-escaped by default, and escaping is **context-aware**: text,
 attribute, URL, and CSS contexts each get the right treatment — determined at
@@ -41,7 +40,7 @@ value-filter, attribute values are always quoted, and JS contexts with no safe
 encoding yet (bare expressions in `on*`/event handlers) are **compile errors**, not
 runtime surprises.
 
-The opt-outs are explicit and auditable — each a deliberate, grep-able bypass of one
+The opt-outs are explicit and auditable: each is a bypass of one
 specific check: `gsx.Raw(s)` for trusted HTML, `gsx.RawURL(s)` for a URL whose
 scheme you vouch for, and `gsx.RawCSS(s)` for trusted CSS. Type-driven attributes
 mean a `bool` renders as a bare or omitted attribute rather than the string `"true"`.

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -12,7 +12,8 @@ gsx is alpha software. It is usable end to end, but the language and APIs may st
 
 ## Partial
 
-- LSP completion and cross-package reference coverage are deferred.
+- LSP completion is deferred.
+- References cover project components discovered during module analysis; external packages are skipped.
 - CLI `vet`, `render`, `explain`, and stable numeric diagnostic codes are deferred.
 - Component-invocation `style={...}` composition and `[]string` class parts are deferred.
 

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -1,0 +1,26 @@
+# Status
+
+gsx is alpha software. It is usable end to end, but the language and APIs may still change before a stable release.
+
+## Shipped
+
+- `gsx init`, `gsx dev`, `gsx generate`, `gsx fmt`, `gsx info`, `gsx clean`, `gsx lsp`, `gsx version`, and `gsx help`.
+- Component declarations, method components, generated props, bring-your-own props, `{children}`, named slots, and explicit attribute forwarding.
+- Interpolation, control flow, attributes, contextual escaping, pipelines, `(T, error)` auto-unwrap, fragments, raw Go blocks, raw-text elements, composable `class`, element-level composable `style`, class/style merge, ordered attrs, and value-form `if`/`switch` in class/style lists.
+- Vite-backed development loop with warm generation, server rebuild, browser reload, and browser error overlay.
+- Language server diagnostics, go-to-definition, hover, references, formatting, and editor integration paths.
+
+## Partial
+
+- LSP completion and cross-package reference coverage are deferred.
+- CLI `vet`, `render`, `explain`, and stable numeric diagnostic codes are deferred.
+- Component-invocation `style={...}` composition and `[]string` class parts are deferred.
+
+## Known Gaps
+
+- There is no built-in render-once primitive equivalent to `templ.Once`.
+- CSP nonce threading for emitted `<script>` and `<style>` is not implemented.
+
+## Detailed Roadmap
+
+The detailed engineering roadmap lives in [Roadmap & Status](../ROADMAP.md).

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -24,4 +24,5 @@ gsx is alpha software. It is usable end to end, but the language and APIs may st
 
 ## Detailed Roadmap
 
-The detailed engineering roadmap lives in [Roadmap & Status](../ROADMAP.md).
+The detailed engineering roadmap lives in
+[Roadmap & Status](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -13,7 +13,7 @@ gsx is alpha software. It is usable end to end, but the language and APIs may st
 ## Partial
 
 - LSP completion is deferred.
-- References cover project components discovered during module analysis; external packages are skipped.
+- References cover project components discovered during module analysis; external/non-project references are deferred.
 - CLI `vet`, `render`, `explain`, and stable numeric diagnostic codes are deferred.
 - Component-invocation `style={...}` composition and `[]string` class parts are deferred.
 

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -19,7 +19,7 @@ gsx is alpha software. It is usable end to end, but the language and APIs may st
 
 ## Known Gaps
 
-- There is no built-in render-once primitive equivalent to `templ.Once`.
+- There is no built-in render-once primitive equivalent to `templ.Once`; see [Render-once](./syntax/render-once).
 - CSP nonce threading for emitted `<script>` and `<style>` is not implemented.
 
 ## Detailed Roadmap

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -78,6 +78,7 @@ golden-tested `examples/*.txtar` fixtures.
 | `gsx.Raw(s)` | unescaped HTML |
 :::
 
-> **Status — alpha.** `.gsx` compiles to plain Go via `gsx generate`; syntax is
-> stable but still evolving. Follow the
-> [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).
+> **Status — alpha.** Syntax is stable enough for real projects, but not frozen.
+> Follow [Status](./status.md) and the
+> [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) before relying
+> on deferred features.

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -1,6 +1,6 @@
 # Syntax reference
 
-> **Syntax is roughly fixed, not frozen.** This page is the compact reference and
+> **Syntax is alpha.** This page is the compact reference and
 > topic hub. If you are new to gsx, start with [Learn gsx](./learn), then use this
 > page while writing templates.
 
@@ -75,7 +75,6 @@ golden-tested `examples/*.txtar` fixtures.
 | `gsx.Raw(s)` | unescaped HTML |
 :::
 
-> **Status — alpha.** Syntax is stable enough for real projects, but not frozen.
-> Follow [Status](./status.md) and the
+> **Status — alpha.** Follow [Status](./status.md) and the
 > [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) before relying
 > on deferred features.

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -1,11 +1,8 @@
 # Syntax
 
-> **Syntax is roughly fixed, not frozen.** This page is a quick reference and
-> topic hub. The
-> [test corpus](https://github.com/gsxhq/gsx/tree/main/internal/corpus/testdata/cases)
-> is the canonical, always-current reference — every accepted form is a case that
-> parses, generates Go, and pins its rendered output, so it can never drift from
-> what the compiler actually does.
+> **Syntax is roughly fixed, not frozen.** This page is the compact reference and
+> topic hub. If you are new to gsx, start with [Learn gsx](./learn), then use this
+> page while writing templates.
 
 A `.gsx` file is ordinary Go (package, imports, types, funcs) plus `component`
 declarations. A component has a templ-style header and a JSX-style body — the

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -1,4 +1,4 @@
-# Syntax
+# Syntax reference
 
 > **Syntax is roughly fixed, not frozen.** This page is the compact reference and
 > topic hub. If you are new to gsx, start with [Learn gsx](./learn), then use this

--- a/docs/guide/syntax/_generated/escaping/010-auto-escaping-safe-raw.md
+++ b/docs/guide/syntax/_generated/escaping/010-auto-escaping-safe-raw.md
@@ -3,7 +3,7 @@
 ```gsx
 package views
 
-// User input is HTML-escaped by construction — no XSS.
+// User input in normal interpolation is HTML-escaped.
 component Comment(body string) {
 	<blockquote>{ body }</blockquote>
 }
@@ -15,4 +15,4 @@ Renders:
 <blockquote>&lt;img src=x onerror=alert(1)&gt;</blockquote>
 ```
 
-[▶ Open in Playground](/playground#try=eyJzIjoicGFja2FnZSB2aWV3c1xuXG4vLyBVc2VyIGlucHV0IGlzIEhUTUwtZXNjYXBlZCBieSBjb25zdHJ1Y3Rpb24g4oCUIG5vIFhTUy5cbmNvbXBvbmVudCBDb21tZW50KGJvZHkgc3RyaW5nKSB7XG5cdFx1MDAzY2Jsb2NrcXVvdGVcdTAwM2V7IGJvZHkgfVx1MDAzYy9ibG9ja3F1b3RlXHUwMDNlXG59XG4iLCJpIjoiQ29tbWVudChDb21tZW50UHJvcHN7Qm9keTogXCJcdTAwM2NpbWcgc3JjPXggb25lcnJvcj1hbGVydCgxKVx1MDAzZVwifSkifQ==)
+[▶ Open in Playground](/playground#try=eyJzIjoicGFja2FnZSB2aWV3c1xuXG4vLyBVc2VyIGlucHV0IGluIG5vcm1hbCBpbnRlcnBvbGF0aW9uIGlzIEhUTUwtZXNjYXBlZC5cbmNvbXBvbmVudCBDb21tZW50KGJvZHkgc3RyaW5nKSB7XG5cdFx1MDAzY2Jsb2NrcXVvdGVcdTAwM2V7IGJvZHkgfVx1MDAzYy9ibG9ja3F1b3RlXHUwMDNlXG59XG4iLCJpIjoiQ29tbWVudChDb21tZW50UHJvcHN7Qm9keTogXCJcdTAwM2NpbWcgc3JjPXggb25lcnJvcj1hbGVydCgxKVx1MDAzZVwifSkifQ==)

--- a/docs/guide/syntax/attributes.md
+++ b/docs/guide/syntax/attributes.md
@@ -30,7 +30,8 @@ The `{ if … { … } }` block can contain any combination of attribute bindings
 
 ## Spread `{ x… }` — ordered
 
-To forward a bag of attributes — commonly used for passthrough components — declare a parameter of type `gsx.Attrs` and spread it onto an element with `{ bag… }`.
+To forward a bag of attributes in a passthrough component, declare a parameter of
+type `gsx.Attrs` and spread it onto an element with `{ bag… }`.
 
 <!--@include: ./_generated/attributes/040-spread-attributes.md-->
 
@@ -52,7 +53,7 @@ attrs = gsx.AttrMap(m).ToAttrs()
 ## Ordered-attrs literal `&#123;&#123; "k": v &#125;&#125;`
 
 ::: v-pre
-When attribute order matters — for example, `data-*` directives consumed by Datastar where a signal must be declared before it is read — use the `&#123;&#123; "key": value &#125;&#125;` literal in a **component invocation** to pass an ordered attribute bag. The literal lowers to `gsx.Attrs` (an ordered slice), the same type as any declared `Attrs gsx.Attrs` prop and the `{ bag… }` spread. This removes the old friction where the literal required a separately-typed prop.
+When attribute order matters — for example, `data-*` directives consumed by Datastar where a signal must be declared before it is read — use the `&#123;&#123; "key": value &#125;&#125;` literal in a **component invocation** to pass an ordered attribute bag. The literal lowers to `gsx.Attrs` (an ordered slice), the same type as any declared `Attrs gsx.Attrs` prop and the `{ bag… }` spread.
 
 Use `&#123;&#123; "k": v &#125;&#125;` any time key order matters: Datastar `data-*` directives, JSX-style overrides through duplicate scalar keys, or explicit ordering that a map would scramble.
 :::

--- a/docs/guide/syntax/composition.md
+++ b/docs/guide/syntax/composition.md
@@ -28,7 +28,11 @@ When a component needs more than one content hole — a header, a body, a footer
 
 <!--@include: ./_generated/composition/030-named-slots.md-->
 
-`Panel` declares `header gsx.Node` and `footer gsx.Node`. The call site passes markup as `header={ <h1>H</h1> }` (JSX-style expression attribute) and a string literal as `footer="F"`. Strings satisfy `gsx.Node`, so either works. The component renders each slot by interpolating `{header}` and `{footer}` exactly like any other variable.
+`Panel` declares `header gsx.Node` and `footer gsx.Node`. The call site passes
+markup as `header={ <h1>H</h1> }` and a string literal as `footer="F"`. For
+`gsx.Node` params, codegen converts string literals to renderable text nodes.
+The component renders each slot by interpolating `{header}` and `{footer}`
+exactly like any other variable.
 
 This is distinct from `{children}`: a `gsx.Node` param is a named, typed field in the props struct, passed as a named attribute. `{children}` is the implicit content between the open and close tags.
 

--- a/docs/guide/syntax/context.md
+++ b/docs/guide/syntax/context.md
@@ -30,6 +30,7 @@ Context is a blunt instrument. When a helper function passes a value through fiv
 
 For the data a component **specifically needs**, gsx steers you toward explicit, typed props. A component that receives `user User` as a prop is self-documenting: the call site shows exactly what is being passed, the type is checked by the compiler, and the component is fully testable in isolation with no ambient state.
 
-This preference is a design lean, not a prohibition. The [vision](../vision#type-safe-by-construction) sums it up: "a component's props are a Go struct — either one **you define and own** … or one **gsx generates** from inline params." The struct is yours; the type is explicit.
+This preference is a design lean, not a prohibition. See
+[Why gsx](../vision#checked-by-go) for the props model behind it.
 
 Use context for **cross-cutting, request-scoped values** that are legitimately global to a request — auth, locale, tracing — and explicit props for the data that defines what a component renders. When in doubt, start with props: you can always add a context read inside a helper if the value really is ambient.

--- a/docs/guide/syntax/elements.md
+++ b/docs/guide/syntax/elements.md
@@ -33,7 +33,8 @@ A `disabled={disabled}` attribute on the `<input/>` renders as `disabled` when t
 
 <!--@include: ./_generated/elements/030-raw-text-elements.md-->
 
-Note that `<style>` bodies additionally go through a whitespace-only CSS minifier at codegen time, so the rendered output is compacted compared to the source. `<script>` bodies are emitted verbatim with no minification.
+By default, raw-text bodies are emitted without minification. Configure
+`css_minifier` or `js_minifier` to minify `<style>` or `<script>` output.
 
 Both `<script>` and `<style>` support `@{ expr }` interpolation for dynamic values — see [Style blocks](./styling) and [JavaScript](./javascript) for details.
 

--- a/docs/guide/syntax/escaping.md
+++ b/docs/guide/syntax/escaping.md
@@ -1,10 +1,13 @@
 # Escaping
 
-gsx uses **escape-by-construction**: the code generator knows *where* every value appears (text node, attribute value, URL attribute, JS-context attribute, `<script>` body, `<style>` body) and emits the correct escaper automatically. You never call an escape function on your data; the template structure itself is the guarantee.
+gsx escapes by position: the code generator knows *where* every value appears
+(text node, attribute value, URL attribute, JS-context attribute, `<script>`
+body, `<style>` body) and emits the matching escaper automatically.
 
-## Escape by construction
+## Escape by default
 
-A plain `{ expr }` in body text or an attribute value is HTML-escaped. No XSS is possible through the normal interpolation path — hostile HTML in a user-supplied string is neutralized at render time.
+A plain `{ expr }` in body text or an attribute value is HTML-escaped. Hostile
+HTML in a user-supplied string renders as text rather than elements.
 
 <!--@include: ./_generated/escaping/010-auto-escaping-safe-raw.md-->
 

--- a/docs/guide/syntax/fragments.md
+++ b/docs/guide/syntax/fragments.md
@@ -1,6 +1,6 @@
 # Fragments
 
-A gsx component normally has a single root element. **Fragments** let a component return multiple sibling elements with no wrapper element in between.
+**Fragments** group multiple sibling elements without adding a wrapper element.
 
 ## Multiple roots
 
@@ -8,4 +8,6 @@ The fragment syntax is `<> … </>` — an open angle-bracket pair with no tag n
 
 <!--@include: ./_generated/fragments/010-fragments.md-->
 
-Fragments are useful when a component is designed to be slotted into a parent that controls the layout — for example, a pair of `<dt>`/`<dd>` rows for a description list, or a run of table cells. Wrapping them in a `<div>` would break the DOM structure; a fragment returns them as bare siblings.
+Fragments are useful when a nested expression needs one syntactic child but the
+rendered output should stay flat — for example, a pair of `<dt>`/`<dd>` rows for
+a description list or a run of table cells.

--- a/docs/guide/syntax/interop.md
+++ b/docs/guide/syntax/interop.md
@@ -2,6 +2,8 @@
 
 gsx components are plain Go values that implement a single interface. That design makes them composable with the wider Go templating ecosystem without any bridging layer.
 
+For a higher-level choice guide, see [Comparisons](../comparisons).
+
 ## Working with templ
 
 `gsx.Node` is declared in `node.go` as:

--- a/docs/guide/syntax/interop.md
+++ b/docs/guide/syntax/interop.md
@@ -72,7 +72,7 @@ The `<p>` block is stored in context by templ's runtime but `gsxCard` reads `Chi
 
 ### Framework composition
 
-Any framework that renders a `Render(ctx context.Context, w io.Writer) error` value — including [structpages](https://github.com/gsxhq/structpages) — composes gsx and templ components without knowing which is which. In practice, gsx is commonly used for leaf and subtree components inside templ page layouts; the two coexist in the same page tree with no glue code.
+Any framework that renders a `Render(ctx context.Context, w io.Writer) error` value — including [structpages](https://github.com/jackielii/structpages) — composes gsx and templ components without knowing which is which. In practice, gsx is commonly used for leaf and subtree components inside templ page layouts; the two coexist in the same page tree with no glue code.
 
 ## Working with html/template
 

--- a/docs/guide/syntax/interop.md
+++ b/docs/guide/syntax/interop.md
@@ -72,7 +72,9 @@ The `<p>` block is stored in context by templ's runtime but `gsxCard` reads `Chi
 
 ### Framework composition
 
-Any framework that renders a `Render(ctx context.Context, w io.Writer) error` value — including [structpages](https://github.com/jackielii/structpages) — composes gsx and templ components without knowing which is which. In practice, gsx is commonly used for leaf and subtree components inside templ page layouts; the two coexist in the same page tree with no glue code.
+Any framework that renders a `Render(ctx context.Context, w io.Writer) error`
+value — including [structpages](https://github.com/jackielii/structpages) — can
+render gsx and templ components through the same method shape.
 
 ## Working with html/template
 

--- a/docs/guide/syntax/props.md
+++ b/docs/guide/syntax/props.md
@@ -1,6 +1,8 @@
 # Props
 
-gsx's distinctive feature is that the **author owns the props type**. Rather than generating a fixed props class that the framework controls, gsx lets the component author decide: bring your own named struct, let gsx generate one from inline params, or declare no params at all. The param shape at the declaration site is the discriminator — no config, no annotations.
+The component author owns the props type. Bring your own named struct, let gsx
+generate one from inline params, or declare no params at all. The param shape at
+the declaration site is the discriminator: no config, no annotations.
 
 ## The three props models
 

--- a/docs/guide/syntax/props.md
+++ b/docs/guide/syntax/props.md
@@ -26,7 +26,9 @@ When the sole non-receiver param is a named struct from the same package, gsx us
 
 <!--@include: ./_generated/props/010-bring-your-own-props.md-->
 
+::: v-pre
 `Button` declares a `Props` struct with `Variant string`, `Children gsx.Node`, and `Attrs gsx.Attrs`. The call `<Button variant="primary" data-test="save">Save</Button>` maps: `variant` → `Variant: "primary"`, `data-test` (no matching `DataTest` field) → `Attrs: gsx.Attrs{{Key: "data-test", Value: "save"}}`, and the text content → `Children`. Inside the body, `{ p.Attrs... }` spreads the collected attrs onto the `<button>` element.
+:::
 
 ## The discriminator heuristic
 

--- a/docs/guide/syntax/props.md
+++ b/docs/guide/syntax/props.md
@@ -26,7 +26,7 @@ When the sole non-receiver param is a named struct from the same package, gsx us
 
 <!--@include: ./_generated/props/010-bring-your-own-props.md-->
 
-`Button` declares a `Props` struct with `Variant string`, `Children gsx.Node`, and `Attrs gsx.Attrs`. The call `<Button variant="primary" data-test="save">Save</Button>` maps: `variant` → `Variant: "primary"`, `data-test` (no matching `DataTest` field) → `Attrs: gsx.Attrs{"data-test": "save"}`, and the text content → `Children`. Inside the body, `{ p.Attrs... }` spreads the collected attrs onto the `<button>` element.
+`Button` declares a `Props` struct with `Variant string`, `Children gsx.Node`, and `Attrs gsx.Attrs`. The call `<Button variant="primary" data-test="save">Save</Button>` maps: `variant` → `Variant: "primary"`, `data-test` (no matching `DataTest` field) → `Attrs: gsx.Attrs{{Key: "data-test", Value: "save"}}`, and the text content → `Children`. Inside the body, `{ p.Attrs... }` spreads the collected attrs onto the `<button>` element.
 
 ## The discriminator heuristic
 
@@ -34,7 +34,7 @@ The byo path activates only for a **single** non-receiver param whose type resol
 
 <!--@include: ./_generated/props/020-props-heuristic.md-->
 
-`Greeting(name string)` has a single non-struct param → gsx generates `GreetingProps{Name string; Attrs gsx.Attrs}`. `Card(title string, n int)` has multiple params → gsx generates `CardProps{Title string; N int; Attrs gsx.Attrs}`. `Panel(p Props)` has a single named-struct param → byo path; `Props` is used directly, no wrapper.
+`Greeting(name string)` has a single non-struct param → gsx generates `GreetingProps{Name string}`. `Card(title string, n int)` has multiple params → gsx generates `CardProps{Title string; N int}`. `Panel(p Props)` has a single named-struct param → byo path; `Props` is used directly, no wrapper.
 
 The generated `<Name>Props` struct gets an `Attrs gsx.Attrs` field when the component body explicitly references `attrs`, and a `Children gsx.Node` field when the body uses `{children}` — not unconditionally. The byo struct has neither unless the author declares them.
 

--- a/docs/guide/syntax/render-once.md
+++ b/docs/guide/syntax/render-once.md
@@ -1,16 +1,17 @@
 # Render-once
 
-This page documents the current render-once status so applications can make an explicit layout choice today.
+gsx does not yet have a render-once primitive. Put shared page resources in a
+layout or shell component that renders once per request.
 
-## templ has `templ.Once`; gsx does not
+## Status
 
-templ ships `templ.Once` / `templ.OnceHandle` — a mechanism for components that emit shared page-level resources (a `<style>` block, a `<script>` module, a `<link>` preload) to guarantee those resources appear in the output at most once per page, regardless of how many times the component is rendered.
+There is no `gsx.Once`, no `OnceHandle`, and no built-in deduplication of
+repeated HTML. The gap is tracked in the
+[Roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).
 
-**gsx has no equivalent primitive.** There is no `gsx.Once`, no `OnceHandle`, no built-in deduplication of repeated HTML. This is an acknowledged gap — see the [Roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) for the feature's planned status.
+## Workaround: layout or shell component
 
-## Current workaround: single layout / shell component
-
-The practical workaround is to emit shared page-level resources exactly once, from a component that itself renders once per page — typically your layout or shell component.
+Emit shared resources from a component that renders once per page:
 
 ```go
 // layout.gsx — renders once per request; safe to place shared resources here
@@ -31,14 +32,9 @@ component Layout(p LayoutProps) {
 }
 ```
 
-Leaf components that need a shared resource — say, a `<script>` for a custom element — have two choices:
+Leaf components that need a shared resource have two choices:
 
 1. **Move the resource to the layout.** Add the `<script>` tag once in the shell and rely on the module script's own idempotency (`<script type="module">` executes once per page regardless of how many `<script>` tags point to the same URL).
 
-2. **Accept the duplicate.** For small inline snippets, emitting the same `<style>` or `<script>` block more than once is usually harmless — browsers handle duplicate `<style>` declarations correctly, and `<script>` blocks that are idempotent (defining a custom element with `customElements.define` guarded by `if (!customElements.get(...))`) execute safely more than once.
-
-Neither workaround is a replacement for a real once primitive; they impose architectural constraints that `templ.Once` avoids. The feature is tracked in the roadmap.
-
-## What `templ.Once` provides (for reference)
-
-In templ you call `templ.NewOnceHandle()` to obtain a handle, then wrap a component with `.Once()` at the call site. The first render emits the wrapped content; subsequent renders of the same handle on the same request are no-ops. gsx's request-scoped `context.Context` thread already reaches every component, so when gsx adds a similar primitive it will use the same `ctx` mechanism — but the API does not exist yet.
+2. **Accept the duplicate.** Use this only for snippets that are safe when emitted
+   more than once, such as guarded custom-element registration.

--- a/docs/guide/syntax/render-once.md
+++ b/docs/guide/syntax/render-once.md
@@ -1,4 +1,6 @@
-# Render-once (gap note)
+# Render-once
+
+This page documents the current render-once status so applications can make an explicit layout choice today.
 
 ## templ has `templ.Once`; gsx does not
 

--- a/docs/guide/syntax/styling.md
+++ b/docs/guide/syntax/styling.md
@@ -1,6 +1,8 @@
 # Styling
 
-gsx provides first-class support for composable `class` and `style` attributes. Both follow the same conditional-list pattern: a `{ }` literal whose entries are either always-on strings or `"value": cond` toggles. When a component explicitly places `{ attrs... }`, caller-supplied class and style merge at that position.
+gsx supports composable `class` and `style` attributes. Both use a `{ }` list
+whose entries are always-on strings or `"value": cond` toggles. When a component
+places `{ attrs... }`, caller-supplied class and style merge at that position.
 
 ## Composable class
 
@@ -10,7 +12,9 @@ The `class` attribute accepts a composable list instead of a plain string. Each 
 class={ "base", "modifier": condition }
 ```
 
-This is gsx's built-in equivalent of `clsx` / Vue `:class`. The entries are evaluated at render time; on-entries are collected and merged into the final `class` value. The default merge strategy (`DefaultClassMerge`) deduplicates tokens keeping the last occurrence of each, so if the same token appears more than once across all contributing sources it is included exactly once.
+Entries are evaluated at render time. On-entries are collected into the final
+`class` value. When multiple class sources are merged, the default merge strategy
+(`DefaultClassMerge`) deduplicates tokens and keeps the last occurrence.
 
 <!--@include: ./_generated/styling/010-composable-class.md-->
 
@@ -45,11 +49,17 @@ When a caller also supplies a `style` attribute, the component's composed style 
 
 ## Class & style merging {#class-style-merging}
 
-A component receives an `Attrs` bag only when its body references `attrs`. When `{ attrs... }` places a bag containing `class` or `style`, gsx merges them with the element's own attributes rather than blindly overwriting them.
+A component receives an `Attrs` bag only when its body references `attrs`. When
+`{ attrs... }` places a bag containing `class` or `style`, gsx merges them with
+the element's own attributes.
 
-**Class merge — token-deduped, caller-wins.** The component's class sources (static string, composable list entries) and the caller's `class` string are all collected in source order, with the caller's contribution last. The merge function deduplicates tokens keeping the last occurrence of each — so if both the component and the caller supply the same token, the caller's copy survives (and the component's earlier copy is dropped), while tokens that only one side provides are always kept.
-
-**Style merge — per CSS property, caller-wins.** The component's style declarations and the caller's style declarations are concatenated in the same order (component first, caller last). Property names are compared case-insensitively; when the same property appears on both sides the caller's declaration survives (property-level last-wins). The split is property-aware and will not break on `;` characters inside `url(…)` or quoted strings.
+- **Class:** component classes and caller classes are collected in source order.
+  Caller classes come last. Duplicate tokens keep the last occurrence.
+- **Style:** component declarations and caller declarations are collected in the
+  same order. Property names compare case-insensitively. Duplicate properties
+  keep the caller declaration.
+- **Parsing:** style splitting is property-aware and does not split on `;`
+  inside `url(...)` or quoted strings.
 
 <!--@include: ./_generated/styling/030-class-style-merging.md-->
 
@@ -57,7 +67,9 @@ In the example above the component declares `class="card"` and `style="color: re
 
 ### Tailwind-aware class merging
 
-The default merge strategy (`DefaultClassMerge`) is correct for vanilla CSS but not for Tailwind, where conflicting utility pairs like `px-4 px-8` must collapse to `px-8` rather than both surviving. gsx provides a `class_merger` configuration seam for exactly this case.
+The default merge strategy (`DefaultClassMerge`) deduplicates exact tokens.
+Tailwind needs conflict-aware merging, where utility pairs like `px-4 px-8`
+collapse to `px-8`. Configure `class_merger` for that case.
 
 Set `class_merger` in `gsx.toml` to the fully-qualified name of an exported `func([]string) string` that implements Tailwind-aware merging:
 
@@ -66,11 +78,13 @@ Set `class_merger` in `gsx.toml` to the fully-qualified name of an exported `fun
 class_merger = "myapp/twcfg.Merge"
 ```
 
-A working example that wires `tailwind-merge-go` lives in [`examples/tailwind-merge/`](https://github.com/gsxhq/gsx/tree/main/examples/tailwind-merge). Full configuration reference — including the signature contract and the option-based route (`gen.WithClassMerger`) — is in [Configuration → `class_merger`](../config#class_merger-tailwind-aware-class-merge-strategy).
+A working example that wires `tailwind-merge-go` lives in [`examples/tailwind-merge/`](https://github.com/gsxhq/gsx/tree/main/examples/tailwind-merge). Full configuration reference — including the signature contract and the option-based route (`gen.WithClassMerger`) — is in [Configuration](../config).
 
 ## Exclusive selection — value-form `if` / `switch`
 
-The composable `class={…}` / `style={…}` list is **additive** — every entry whose guard is true contributes, and multiple can fire at once. For **exclusive selection** — pick exactly one string out of N based on a single discriminant — an additive list forces either a fragile negation default (`x != A && x != B && …`) or duplicated tokens. A value-form `if`/`switch` inside the composed list expresses this cleanly.
+The composable `class={...}` / `style={...}` list is additive: every true guard
+contributes. Use value-form `if` or `switch` when exactly one string should be
+selected.
 
 Use a value-form `if` for a binary toggle:
 
@@ -109,34 +123,13 @@ class={
 }
 ```
 
-**Surface syntax.** Switch values follow GSX's markup-switch shape: canonically,
-each expression follows its `case V:` or `default:` label and ends at the next
-label or the switch's closing brace. Explicit `{ expr }` arm blocks are also
-accepted and format back to the canonical unbraced shape. Multi-value
-`case A, B:` arms, a tag expression (`switch x { … }`), and a tagless form
-(`switch { case cond: … }`) are supported. Value-form `if` retains its natural
-branch braces and supports `else if` chains and a final `else`.
+Rules:
 
-**Semantics.** The value-form is **exclusive** — exactly one arm's string is contributed to the list. When no arm matches and there is no `default:` / `else`, the zero value (empty string) is contributed — which means nothing is added to the class or style. This makes `if cond { "x" }` without an `else` exactly equivalent to the additive guard form `"x": cond`; the value-form is a strict superset, not a special case. All arms must be strings; a non-string arm is a compile-time diagnostic.
-
-**Scope.** This value-form is only available inside `class={…}` and `style={…}` composed-list blocks. It does not apply to general attribute values (use the existing cond-attr form `{ if cond { data-x="…" } }` for whole-attribute toggles) or to markup children (which already dispatch `if`/`switch` to markup control-flow). A pipe stage on the value-form result is not supported.
-
-::: v-pre
-## Why not `style={{ "color": color }}`?
-
-GSX currently has one inline-style model: ordered declaration contributions.
-An object-like property/value form would reduce string composition for heavily
-dynamic inline styles, but it would also introduce a second way to express the
-same output, with additional grammar, formatting, code generation, and
-documentation surface. Current project usage has not shown enough repeated
-dynamic declaration construction to justify that cost.
-
-The form is deferred rather than rejected. It can be reconsidered if real
-projects commonly build many dynamic declarations and the native contribution
-syntax becomes a material usability problem. A future design should prefer
-quoted native CSS names such as `"font-size"` and `"--accent"`; it should not
-adopt JSX camelCase conversion or automatic numeric units.
-:::
+- Exactly one matched arm contributes a string.
+- If no arm matches and there is no `default` or `else`, nothing is added.
+- All arms must be strings.
+- This form only works inside composed `class={...}` and `style={...}` lists.
+- A pipe stage on the value-form result is not supported.
 
 ## `<style>` blocks
 

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -1,27 +1,14 @@
 # Why gsx
 
-Generating HTML from Go has always meant giving something up.
+gsx is a Go template compiler with JSX-style markup, `html/template`-style
+pipelines, and generated Go output.
 
-`html/template` ships in the standard library, auto-escapes, and has the
-ergonomic everyone quietly loves — the **pipe**: <code v-pre>{{ .Name | upper }}</code> reads
-left-to-right and composes cleanly. But it is stringly-typed. Templates parse at
-runtime, errors surface late, and refactoring across templates is unsafe.
+It is for teams that want to keep UI templates inside Go, but still want markup
+that scans like HTML and call sites checked by `go build`.
 
-[JSX](https://react.dev/learn/writing-markup-with-jsx) went the other way on
-ergonomics: markup that *reads like HTML*, with components that nest and compose
-exactly like elements. It made writing UI feel like writing HTML again — but it
-lives in JavaScript/TypeScript, with none of Go's guarantees.
+## Markup That Reads Like HTML
 
-[templ](https://templ.guide) brought type-safety to Go templating by compiling
-templates to Go. It solved the late-errors problem — but its component syntax is
-its own dialect, and writing markup in it never quite feels like writing HTML.
-
-gsx takes the ergonomics people already reach for — **JSX's markup and
-html/template's pipe** — and compiles them to type-safe, auto-escaping Go.
-
-## Ergonomics first: markup that reads like HTML
-
-This is the whole point. You write markup, not a bespoke template dialect:
+Components use a Go-like header and an HTML-like body:
 
 ```gsx
 component Card(title string, featured bool) {
@@ -32,18 +19,11 @@ component Card(title string, featured bool) {
 }
 ```
 
-- **JSX-style inline components.** `<Card>` nests and composes exactly like
-  `<div>`. **Capitalization** decides the meaning — `<div>` is an HTML element,
-  `<Card>` is a component — so there is no inference about what a lowercase tag is.
-- **The pipe, kept.** html/template's <code v-pre>{{ . | f }}</code> is the transform ergonomic gsx
-  preserves as a `|>` filter pipeline — `{ name |> trim |> upper }` — except the
-  filters are real, type-checked Go functions resolved at codegen, not stringly
-  dispatched at runtime.
-- **Everything else is ordinary Go.** Helpers, variant logic, anything that isn't
-  a template is plain Go. The only seam is the `component` keyword and `{ }`
-  interpolation — there is no third language in between.
+- `<div>` is an HTML element; `<Card>` is a component.
+- `{ name |> trim |> upper }` applies registered Go filter functions left to right.
+- Helpers, types, imports, and branching logic outside markup are ordinary Go.
 
-## Type-safe by construction
+## Checked By Go
 
 Components compile to plain Go, and a component's props are a Go struct — either one
 **you define and own** (pass a single struct param and gsx uses your type verbatim)
@@ -56,44 +36,30 @@ Interpolation is auto-escaped, and escaping is **context-aware**: text, attribut
 URL, and CSS contexts each get the right treatment, determined at codegen from where
 the value sits. JS contexts with no safe encoding are compile errors rather than
 silent holes. The opt-outs (`gsx.Raw`, `gsx.RawURL`, `gsx.RawCSS`) are explicit and
-grep-able. This compile-time safety is gsx's core differentiator. See
-[Principles](./principles) for the full model.
+grep-able. See [Principles](./principles) for the full model.
 
-## A build step — and a dev loop that earns it
+## Build Step And Dev Loop
 
-gsx compiles: `.gsx` → `.x.go` → `go build`. That's a real build step, and we don't
-apologize for it — it's exactly what buys compile-time type safety and contextual
-escaping. A build step is only worth paying for if the feedback is instant, so gsx
-ships the loop that makes it disappear.
+gsx compiles: `.gsx` → `.x.go` → `go build`. That build step gives Go type
+checking and generated escaping code.
 
-**`gsx dev`** owns the complete loop in one foreground process: it watches `.gsx`,
-`.go`, and `.env` files, regenerates with a warm compiler, safely rebuilds and swaps
-the Go server, and supervises Vite. The
-[`@gsxhq/vite-plugin-gsx`](https://github.com/gsxhq/vite-plugin-gsx) bridge surfaces
-diagnostics in Vite's error overlay and reloads the browser — the Vite development
-experience front-end developers already reach for, now driving Go HTML. `gsx init`
-wires it up out of the box: `npm run dev`, edit, see it live. The
-`github.com/gsxhq/vite` Go helper resolves development assets and production
-manifests.
+**`gsx dev`** runs that loop in one foreground process: watch `.gsx`, `.go`, and
+`.env` files; regenerate with a warm compiler; rebuild and swap the Go server; and
+supervise Vite. `gsx init` wires the starter project to `npm run dev`.
 
-A build step you never wait on doesn't feel like one. That's the bet.
+## Bounded Symbol Resolution
 
-## The design lesson: bounded symbol resolution
+gsx resolves symbols with `go/packages` and type-checks with `go/types` so it can
+handle type-aware interpolation, context-aware escaping, and props checked against
+real Go types. The design keeps that resolution bounded.
 
-To deliver those ergonomics, gsx *does* resolve symbols — it loads packages with
-`go/packages` and type-checks with `go/types` so it can do type-aware interpolation,
-context-aware escaping, and props checked against real Go types. The question was
-never whether to resolve symbols, but how to keep that resolution from becoming a
-tar pit.
-
-The trap is the open-ended *inference*, not the resolution itself. Try to map markup
+The risk is open-ended *inference*, not resolution itself. Try to map markup
 attributes onto *positional* function parameters, or to infer whether a lowercase
 tag is a component, and the resolver has to chase those guesses across packages —
 straight into overlay module-boundary bugs and performance cliffs. gsx never takes
 that on.
 
-gsx makes design choices that keep its resolution bounded — it asks the type checker
-for facts instead of guessing:
+gsx keeps resolution bounded:
 
 - the **`component` keyword** identifies templates — no inference about what is a
   template;
@@ -101,43 +67,24 @@ for facts instead of guessing:
 - components take a **named props struct** — yours or generated — so attributes bind
   to struct fields, never to reverse-engineered positional parameters.
 
-A related discipline: where markup embeds Go, gsx **finds where the Go expression
-ends and hands it to the real `go/parser`** rather than reimplementing one. And
-`{ <div/> }` (markup) versus `{ a < b }` (Go) is disambiguated positionally — the
-same rule Babel uses for JSX. What's left is plain Go that `go/types` checks
-directly.
-
 ## Relationship to templ
 
 gsx shares no code with templ, but it is built to interoperate. `gsx.Node` — the
 universal renderable — has the **identical method set to `templ.Component`**
 (`Render(ctx, w) error`). Because the method sets match, a `gsx.Node` is accepted
 anywhere a `templ.Component` is expected (structpages and other templ-ecosystem
-tools) **without importing templ**. You can adopt gsx incrementally inside an
-existing templ project.
+tools) **without importing templ**.
 
 For a practical side-by-side with templ, `html/template`, JSX, and Jinja-style
 templates, see [Comparisons](./comparisons).
 
 ## What gsx is not
 
-gsx is templating only — no router, no HTTP handlers, no framework. It is a way to
-write HTML as a first-class, composable Go value. Everything non-template is
-ordinary Go, and the runtime package imports nothing outside the standard library.
+gsx is templating only: no router, no HTTP handlers, no framework. Everything
+non-template is ordinary Go, and the runtime package imports nothing outside the
+standard library.
 
 ---
 
-> **Status — alpha.** gsx is runnable end-to-end, and it's a toolchain, not just a
-> compiler:
->
-> - **CLI** — `gsx generate` compiles `.gsx` → `.x.go`; plus `gsx fmt`, `gsx info`,
->   and `gsx init` to scaffold a ready-to-run project.
-> - **Editor** — `gsx lsp` language server: Go ↔ `.gsx` navigation, formatting, and
->   diagnostics.
-> - **Dev loop** — `gsx dev` performs warm generation, build-then-swap server
->   restarts, and Vite browser feedback; `gsx init` wires it to `npm run dev`.
->
-> Codegen covers interpolation, control flow, attributes with contextual escaping,
-> the `|>` pipeline + filters, components/props/`{children}`, method components,
-> named slots, explicit attribute forwarding, and `style` composition. See the
-> [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).
+> **Status — alpha.** See [Status](./status) for shipped commands, partial
+> features, and known gaps.

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -116,6 +116,9 @@ anywhere a `templ.Component` is expected (structpages and other templ-ecosystem
 tools) **without importing templ**. You can adopt gsx incrementally inside an
 existing templ project.
 
+For a practical side-by-side with templ, `html/template`, JSX, and Jinja-style
+templates, see [Comparisons](./comparisons).
+
 ## What gsx is not
 
 gsx is templating only — no router, no HTTP handlers, no framework. It is a way to

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,24 +7,20 @@ a **JSX-style markup body**, compiled to plain Go.
 .gsx → parser → AST → codegen → .x.go → go build → HTML
 ```
 
-> **Status — alpha.** gsx is runnable end-to-end. `gsx init` scaffolds a Go and
-> Vite application, `gsx dev` runs the warm generate/build/reload loop, and
-> `gsx lsp` provides diagnostics, navigation, hover, references, and formatting.
-> The language and APIs are usable but may still change before a stable release.
-> See the [status](./guide/status.md) and [roadmap](./ROADMAP.md).
+> **Status — alpha.** gsx is usable end to end, but the language and APIs may
+> change before a stable release. See [Status](./guide/status.md) and
+> [Roadmap](./ROADMAP.md).
 
 ## Start here
 
-- **[Why gsx](./guide/vision.md)** — the problem it solves and the bet behind it.
+- **[Why gsx](./guide/vision.md)** — where gsx fits and what it avoids.
 - **[Principles](./guide/principles.md)** — the design commitments.
-- **[Syntax](./guide/syntax.md)** — a quick tour; the
+- **[Syntax](./guide/syntax.md)** — the topic hub. The
   [test corpus](https://github.com/gsxhq/gsx/tree/main/internal/corpus/testdata/cases)
-  is the canonical, always-current reference (every accepted form is a case that
-  parses, generates Go, and pins its rendered output).
-- **[Configuration](./guide/config.md)** — the `gsx.toml` file: pipeline filters, filter packages, and attribute rules read by the stock binary.
-- **[Extensions](./guide/extensions.md)** — the code escape hatch (`cmd/gsx` + `gen.Main`) for function-valued options: custom minifier, classifier predicate, field matcher.
+  pins accepted syntax with parse, codegen, and render goldens.
+- **[Configuration](./guide/config.md)** — `gsx.toml` for filters and attribute rules.
+- **[Extensions](./guide/extensions.md)** — code-based setup for function-valued options.
 
 ## Reference
 
 - [Roadmap & status](./ROADMAP.md)
-- [Design docs](./superpowers/specs/) — the internal specifications.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,12 +7,11 @@ a **JSX-style markup body**, compiled to plain Go.
 .gsx → parser → AST → codegen → .x.go → go build → HTML
 ```
 
-> **Status — alpha.** gsx is runnable end-to-end: `gsx generate` compiles
-> `.gsx` → `.x.go` (plus `gsx fmt` and `gsx info`). Codegen covers interpolation,
-> control flow, attributes with contextual escaping, the `|>` pipeline + filters,
-> components/props/`{children}`, method components, named slots, and attribute
-> fallthrough. Still in progress: some CLI commands (`vet`/`lsp`), `style`
-> composition, and structured diagnostics. See the [roadmap](./ROADMAP.md).
+> **Status — alpha.** gsx is runnable end-to-end. `gsx init` scaffolds a Go and
+> Vite application, `gsx dev` runs the warm generate/build/reload loop, and
+> `gsx lsp` provides diagnostics, navigation, hover, references, and formatting.
+> The language and APIs are usable but may still change before a stable release.
+> See the [status](./guide/status.md) and [roadmap](./ROADMAP.md).
 
 ## Start here
 

--- a/docs/superpowers/plans/2026-06-30-docs-information-architecture.md
+++ b/docs/superpowers/plans/2026-06-30-docs-information-architecture.md
@@ -1,0 +1,816 @@
+# GSX Documentation Information Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the GSX documentation so it has a clear learning path, accurate status, stronger reference structure, and playground jump links without embedding live examples in content pages.
+
+**Architecture:** Keep `gsx/docs/guide/**` as the authoritative documentation source, and keep `../gsxhq.github.io` as the VitePress publishing shell that syncs those source docs at build time. Documentation improvements land in small slices: source-of-truth cleanup, learning path, reference/navigation split, comparison/status pages, and site verification.
+
+**Tech Stack:** Markdown, generated example includes from `internal/examplegen`, Go tests, VitePress in `../gsxhq.github.io`, Node/npm for site build.
+
+---
+
+## File Structure
+
+- Modify `README.md`: align alpha/status language and public docs pointers with current shipped features.
+- Modify `docs/index.md`: make it a concise docs landing page for repository readers and align it with the public site.
+- Modify `docs/ROADMAP.md`: keep detailed project state, but make public-facing status easier to summarize from it.
+- Modify `docs/guide/getting-started.md`: add a short learning path after the first successful run.
+- Create `docs/guide/learn.md`: connected tutorial path for first component, props, children, attrs, class/style, and dev loop.
+- Modify `docs/guide/syntax.md`: make this page explicitly a syntax reference hub, not the primary tutorial.
+- Modify `docs/guide/syntax/render-once.md`: move gap-note framing out of the syntax learning path.
+- Create `docs/guide/status.md`: public alpha/status page with shipped, partial, and deferred features.
+- Create `docs/guide/comparisons.md`: explain GSX vs templ, html/template, JSX, and Jinja-style templates.
+- Modify `docs/guide/performance.md`: add reproducibility metadata and exact benchmark command.
+- Modify `docs/guide/editor.md`: align LSP feature status with current roadmap.
+- Modify `docs/guide/cli.md`: align CLI status wording with current roadmap.
+- Modify `docs/guide/syntax/attributes.md` and `docs/guide/syntax/std-functions.md`: verify current `gsx.Attrs` / `gsx.OrderedAttrs` text against runtime code and corpus, then update only if runtime semantics have changed.
+- Modify `../gsxhq.github.io/.vitepress/config.mts`: restructure public nav/sidebar into Start, Learn, Reference, Tooling, Interop, Status.
+- Modify `../gsxhq.github.io/index.md`: point home actions at the new learning path and status page.
+- Leave `scripts/sync-docs.mjs` unchanged unless execution discovers contributors are editing generated `../gsxhq.github.io/guide/**` files directly; the current script already documents the sync direction.
+
+## Out Of Scope
+
+- Do not embed live interactive examples inside documentation pages.
+- Do keep generated `Open in Playground` links emitted by the existing example pipeline.
+- Do not move internal `docs/superpowers/**` specs/plans into the public VitePress site.
+- Do not redesign the VitePress theme or playground component.
+
+## Task 1: Baseline Verification
+
+**Files:**
+- Read: `attrs.go`
+- Read: `orderedattrs.go`
+- Read: `docs/ROADMAP.md`
+- Read: `docs/guide/editor.md`
+- Read: `docs/guide/cli.md`
+- Read: `docs/guide/syntax/attributes.md`
+- Read: `docs/guide/syntax/std-functions.md`
+- Read: `../gsxhq.github.io/.vitepress/config.mts`
+
+- [ ] **Step 1: Confirm clean worktrees**
+
+Run:
+
+```bash
+git -C /Users/jackieli/personal/gsxhq/gsx status --short
+git -C /Users/jackieli/personal/gsxhq/gsxhq.github.io status --short
+```
+
+Expected: no output, or only known user changes that are unrelated to docs IA. If there are unrelated user changes, leave them untouched.
+
+- [ ] **Step 2: Confirm attribute runtime shape**
+
+Run:
+
+```bash
+rg -n "type Attrs|type OrderedAttrs|type AttrMap|type Attr struct" attrs.go orderedattrs.go
+```
+
+Expected with the current source tree:
+
+```text
+orderedattrs.go:8:type Attr struct {
+orderedattrs.go:17:type OrderedAttrs []Attr
+attrs.go:20:type Attrs map[string]any
+```
+
+Use this result to decide whether `docs/guide/syntax/attributes.md` and `docs/guide/syntax/std-functions.md` need content changes. The docs must match runtime source and corpus, not an ignored synced copy in `../gsxhq.github.io/guide`.
+
+- [ ] **Step 3: Confirm docs site sync direction**
+
+Run:
+
+```bash
+sed -n '1,90p' /Users/jackieli/personal/gsxhq/gsxhq.github.io/scripts/sync-docs.mjs
+```
+
+Expected: the script copies or links `../gsx/docs/guide` into `../gsxhq.github.io/guide`. Treat `gsx/docs/guide/**` as authoritative.
+
+- [ ] **Step 4: Confirm generated playground links already exist**
+
+Run:
+
+```bash
+rg -n "Open in Playground" docs/guide/syntax/_generated | head
+```
+
+Expected: multiple generated snippets already include `[▶ Open in Playground](/playground#try=...)`. The implementation should preserve these jump links and avoid adding embedded live examples.
+
+- [ ] **Step 5: Commit baseline if no changes were made**
+
+No commit is needed for this task if it only reads files.
+
+## Task 2: Public Status Source Of Truth
+
+**Files:**
+- Create: `docs/guide/status.md`
+- Modify: `README.md`
+- Modify: `docs/index.md`
+- Modify: `docs/guide/cli.md`
+- Modify: `docs/guide/editor.md`
+- Modify: `docs/guide/syntax.md`
+
+- [ ] **Step 1: Add `docs/guide/status.md`**
+
+Create a public-facing status page with this structure:
+
+```markdown
+# Status
+
+gsx is alpha software. It is usable end to end, but the language and APIs may still change before a stable release.
+
+## Shipped
+
+- `gsx init`, `gsx dev`, `gsx generate`, `gsx fmt`, `gsx info`, `gsx clean`, `gsx lsp`, `gsx version`, and `gsx help`.
+- Component declarations, method components, generated props, bring-your-own props, `{children}`, named slots, and explicit attribute forwarding.
+- Interpolation, control flow, attributes, contextual escaping, pipelines, `(T, error)` auto-unwrap, fragments, raw Go blocks, raw-text elements, composable `class`, element-level composable `style`, class/style merge, ordered attrs, and value-form `if`/`switch` in class/style lists.
+- Vite-backed development loop with warm generation, server rebuild, browser reload, and browser error overlay.
+- Language server diagnostics, go-to-definition, hover, references, formatting, and editor integration paths.
+
+## Partial
+
+- LSP completion and cross-package reference coverage are deferred.
+- CLI `vet`, `render`, `explain`, and stable numeric diagnostic codes are deferred.
+- Component-invocation `style={...}` composition and `[]string` class parts are deferred.
+
+## Known Gaps
+
+- There is no built-in render-once primitive equivalent to `templ.Once`.
+- CSP nonce threading for emitted `<script>` and `<style>` is not implemented.
+
+## Detailed Roadmap
+
+The detailed engineering roadmap lives in [Roadmap & Status](../ROADMAP.md).
+```
+
+- [ ] **Step 2: Update `README.md` alpha paragraph**
+
+Replace the stale paragraph at the top of `README.md` with:
+
+```markdown
+> **Status — alpha.** gsx is runnable end-to-end. `gsx init` scaffolds a Go and
+> Vite application, `gsx dev` runs the warm generate/build/reload loop, and
+> `gsx lsp` provides diagnostics, navigation, hover, references, and formatting.
+> The language and APIs are usable but may still change before a stable release.
+> See the [status](docs/guide/status.md) and [roadmap](docs/ROADMAP.md).
+```
+
+- [ ] **Step 3: Update `docs/index.md` alpha paragraph**
+
+Use the same wording as `README.md`, with links relative to `docs/index.md`:
+
+```markdown
+> **Status — alpha.** gsx is runnable end-to-end. `gsx init` scaffolds a Go and
+> Vite application, `gsx dev` runs the warm generate/build/reload loop, and
+> `gsx lsp` provides diagnostics, navigation, hover, references, and formatting.
+> The language and APIs are usable but may still change before a stable release.
+> See the [status](./guide/status.md) and [roadmap](./ROADMAP.md).
+```
+
+- [ ] **Step 4: Update CLI status section**
+
+In `docs/guide/cli.md`, make the final status block point at the new public status page:
+
+```markdown
+> **Alpha.** The shipped command set is listed above. Planned commands and
+> deferred diagnostics work are tracked in [Status](./status.md) and the
+> [Roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md).
+```
+
+- [ ] **Step 5: Update editor deferred-feature wording**
+
+In `docs/guide/editor.md`, replace stale LSP limitations with:
+
+```markdown
+**Deferred:** completion and broader cross-package reference coverage. See
+[Status](./status.md) and the
+[roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) for current scope.
+```
+
+- [ ] **Step 6: Link syntax page to status**
+
+In `docs/guide/syntax.md`, replace the closing alpha note with:
+
+```markdown
+> **Status — alpha.** Syntax is stable enough for real projects, but not frozen.
+> Follow [Status](./status.md) and the
+> [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) before relying
+> on deferred features.
+```
+
+- [ ] **Step 7: Verify links in source docs**
+
+Run:
+
+```bash
+rg -n "status.md|guide/status|Roadmap|roadmap" README.md docs/index.md docs/guide/cli.md docs/guide/editor.md docs/guide/syntax.md docs/guide/status.md
+```
+
+Expected: each updated file links either to `docs/guide/status.md`, `./status.md`, or `./guide/status.md` with a valid relative path.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add README.md docs/index.md docs/guide/status.md docs/guide/cli.md docs/guide/editor.md docs/guide/syntax.md
+git commit -m "docs: add public status source of truth"
+```
+
+## Task 3: Learning Path Without Live Embedded Examples
+
+**Files:**
+- Create: `docs/guide/learn.md`
+- Modify: `docs/guide/getting-started.md`
+- Modify: `docs/guide/syntax.md`
+
+- [ ] **Step 1: Create `docs/guide/learn.md`**
+
+Create the page with this structure and concise examples:
+
+````markdown
+# Learn gsx
+
+This path starts after `gsx init` and shows the core model in the order most projects use it: components, data, composition, attributes, styling, and the dev loop.
+
+## 1. A component is Go plus markup
+
+```gsx
+package views
+
+component Hello(name string) {
+	<p>Hello, { name }</p>
+}
+```
+
+`component` declares a Go function-like value. The body is the HTML result; there is no return type and no `return`.
+
+## 2. Props are typed
+
+```gsx
+component Card(title string, featured bool) {
+	<section class={ "card", "card-featured": featured }>
+		<h2>{ title }</h2>
+		{ children }
+	</section>
+}
+```
+
+The generator creates a props struct for call sites. Boolean props can use the bare attribute shorthand.
+
+## 3. Components compose with children
+
+```gsx
+component Page() {
+	<Card title="Dashboard" featured>
+		<p>Welcome back.</p>
+	</Card>
+}
+```
+
+Nested content is available through `{ children }`, exactly where the component places it.
+
+## 4. Attributes are explicit
+
+```gsx
+component Button(variant string) {
+	<button class={ "btn", variant } { attrs... }>
+		{ children }
+	</button>
+}
+```
+
+Undeclared call-site attributes are accepted only when the component explicitly spreads `{ attrs... }`.
+
+## 5. Style and script stay close to HTML
+
+```gsx
+package views
+
+import "fmt"
+
+component Meter(value int, color string) {
+	<div
+		class={ "meter", "meter-full": value >= 100 }
+		style={ fmt.Sprintf("width: %d%%", value), "color: " + color }
+	/>
+}
+```
+
+`class` and `style` support composable lists. Dynamic values are escaped or sanitized for their context.
+
+## 6. The development loop is one command
+
+```sh
+npm run dev
+```
+
+The starter runs `go tool gsx dev`, which keeps generation warm, rebuilds the Go server, and reloads the browser through Vite.
+
+## Next
+
+- Keep the [syntax reference](./syntax) open while writing `.gsx`.
+- Use the [playground](/playground) to try small components.
+- Configure the dev loop, filters, minification, and class merging in [`gsx.toml`](./config).
+- Check [Status](./status) before relying on alpha or deferred features.
+````
+
+- [ ] **Step 2: Update `docs/guide/getting-started.md` next steps**
+
+Replace the final list with:
+
+```markdown
+## Where to go next
+
+- Follow [Learn gsx](./learn) for the first component, props, children, attrs, and styling.
+- Keep the [syntax reference](./syntax) open while writing `.gsx`.
+- Use the [playground](/playground) for quick experiments.
+- See the [`gsx dev` CLI reference](./cli#gsx-dev) for custom build, run, log,
+  and front-door commands.
+- Configure filters, asset processing, and the dev loop in
+  [`gsx.toml`](./config).
+```
+
+- [ ] **Step 3: Update `docs/guide/syntax.md` intro**
+
+Change the opening description so it does not present syntax as the first learning path:
+
+```markdown
+> **Syntax is roughly fixed, not frozen.** This page is the compact reference and
+> topic hub. If you are new to gsx, start with [Learn gsx](./learn), then use this
+> page while writing templates.
+```
+
+- [ ] **Step 4: Verify examples parse through existing docs/example tests**
+
+Run:
+
+```bash
+go test ./internal/examplegen ./gen
+```
+
+Expected: pass. If `docs/guide/learn.md` contains examples that are not covered by tests, keep them short and copied from already-tested syntax forms.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add docs/guide/learn.md docs/guide/getting-started.md docs/guide/syntax.md
+git commit -m "docs: add guided learning path"
+```
+
+## Task 4: Reference Structure And Gap Placement
+
+**Files:**
+- Modify: `docs/guide/syntax.md`
+- Modify: `docs/guide/syntax/render-once.md`
+- Modify: `docs/guide/status.md`
+- Modify: `docs/guide/performance.md`
+
+- [ ] **Step 1: Rename syntax page heading text**
+
+In `docs/guide/syntax.md`, change:
+
+```markdown
+# Syntax
+```
+
+to:
+
+```markdown
+# Syntax reference
+```
+
+Keep the file path unchanged to avoid breaking existing links.
+
+- [ ] **Step 2: Keep render-once as status/reference material**
+
+In `docs/guide/syntax/render-once.md`, change:
+
+```markdown
+# Render-once (gap note)
+```
+
+to:
+
+```markdown
+# Render-once
+```
+
+Then change the opening paragraph to:
+
+```markdown
+This page documents the current render-once status so applications can make an explicit layout choice today.
+```
+
+- [ ] **Step 3: Add render-once to status known gaps**
+
+Ensure `docs/guide/status.md` links to the render-once page:
+
+```markdown
+- There is no built-in render-once primitive equivalent to `templ.Once`; see [Render-once](./syntax/render-once).
+```
+
+- [ ] **Step 4: Add reproducibility metadata to performance page**
+
+In `docs/guide/performance.md`, after the opening paragraph and before `## Numbers`, add:
+
+````markdown
+## Reproduce
+
+The benchmark source lives at [github.com/gsxhq/gsx-bench](https://github.com/gsxhq/gsx-bench).
+
+```sh
+git clone https://github.com/gsxhq/gsx-bench
+cd gsx-bench
+go test -bench . -benchmem
+```
+
+The numbers below are a snapshot from Apple M3 Ultra with Go 1.26.1. Treat them as directional; use the command above on your hardware for local decisions.
+````
+
+Then remove duplicate command wording from the final notes if it repeats the same command.
+
+- [ ] **Step 5: Verify Markdown headings**
+
+Run:
+
+```bash
+rg -n "^(#|##) " docs/guide/syntax.md docs/guide/syntax/render-once.md docs/guide/performance.md docs/guide/status.md
+```
+
+Expected: headings show `Syntax reference`, `Render-once`, `Reproduce`, and `Known Gaps`.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add docs/guide/syntax.md docs/guide/syntax/render-once.md docs/guide/status.md docs/guide/performance.md
+git commit -m "docs: clarify reference and gap pages"
+```
+
+## Task 5: Comparisons Page
+
+**Files:**
+- Create: `docs/guide/comparisons.md`
+- Modify: `docs/guide/vision.md`
+- Modify: `docs/guide/syntax/interop.md`
+
+- [ ] **Step 1: Create `docs/guide/comparisons.md`**
+
+Create:
+
+```markdown
+# Comparisons
+
+gsx sits between Go template engines and JSX-like markup systems: templates stay close to HTML, data stays typed Go, and output compiles to ordinary Go.
+
+## gsx and templ
+
+Both gsx and templ compile components to Go values with `Render(ctx, w) error`. gsx differs in surface syntax: component declarations are templ-style, while the body is JSX-style markup. This makes HTML-like structure easier to scan while keeping structural compatibility with `templ.Component`.
+
+Use gsx when you want JSX-like authoring inside Go projects. Use templ directly when you prefer templ's existing syntax, ecosystem, or render-once primitive.
+
+## gsx and html/template
+
+`html/template` is stable, standard-library, and excellent for string-template workflows. gsx adds typed components, generated props, compiler-checked composition, contextual escaping by construction, and a formatter/LSP path.
+
+Use `html/template` when you need runtime-loaded templates or the standard package alone. Use gsx when templates are part of the compiled application.
+
+## gsx and JSX
+
+JSX makes markup part of JavaScript. gsx borrows the readable tag structure, but expressions are Go, components compile to Go, and there is no virtual DOM.
+
+Use client-side JSX for interactive browser applications. Use gsx for server-rendered Go components, optionally with JavaScript islands.
+
+## gsx and Jinja-style templates
+
+Jinja-style templates provide a compact template language with filters, blocks, and inheritance. gsx instead leans on Go for data, functions, imports, and control flow, with pipelines for common formatting.
+
+Use Jinja-style templates when a dynamic template language is the product requirement. Use gsx when compile-time checking and Go-native component composition matter more.
+
+## Interop
+
+See [Interop](./syntax/interop) for examples that compose gsx with templ, `html/template`, and client-side islands.
+```
+
+- [ ] **Step 2: Link from `vision.md`**
+
+Add this sentence near the relationship discussion:
+
+```markdown
+For a practical side-by-side with templ, `html/template`, JSX, and Jinja-style templates, see [Comparisons](./comparisons).
+```
+
+- [ ] **Step 3: Link from interop page**
+
+Add this sentence near the top of `docs/guide/syntax/interop.md`:
+
+```markdown
+For a higher-level choice guide, see [Comparisons](../comparisons).
+```
+
+- [ ] **Step 4: Verify comparison links**
+
+Run:
+
+```bash
+rg -n "Comparisons|comparisons" docs/guide/vision.md docs/guide/syntax/interop.md docs/guide/comparisons.md
+```
+
+Expected: all three files contain links or headings.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add docs/guide/comparisons.md docs/guide/vision.md docs/guide/syntax/interop.md
+git commit -m "docs: add framework comparisons"
+```
+
+## Task 6: Attribute Docs Accuracy Check
+
+**Files:**
+- Verify: `attrs.go`
+- Verify: `orderedattrs.go`
+- Verify: `internal/corpus/testdata/cases/orderedattrs/**`
+- Modify when runtime and docs disagree: `docs/guide/syntax/attributes.md`
+- Modify when runtime and docs disagree: `docs/guide/syntax/std-functions.md`
+- Modify when runtime and docs disagree: `docs/guide/syntax.md`
+
+- [ ] **Step 1: Compare docs to runtime and corpus**
+
+Run:
+
+```bash
+rg -n "type Attrs|type OrderedAttrs|type Attr struct" attrs.go orderedattrs.go
+rg -n "OrderedAttrs|AttrMap|Attrs" internal/corpus/testdata/cases/orderedattrs examples docs/examples.json | head -80
+```
+
+Expected in the current runtime: `gsx.Attrs` is map-backed and sorted; `gsx.OrderedAttrs` is slice-backed and preserves order.
+
+- [ ] **Step 2: Fix text only when it contradicts source**
+
+If current runtime reports `type Attrs map[string]any`, leave the existing `Attrs` / `OrderedAttrs` model intact and make no commit for this task.
+
+If current runtime reports `type Attrs []Attr`, update:
+
+```text
+docs/guide/syntax/attributes.md
+docs/guide/syntax/std-functions.md
+docs/guide/syntax.md
+```
+
+so the quick reference and runtime helper table describe the slice-backed model.
+
+- [ ] **Step 3: Regenerate generated example docs if examples changed**
+
+Run only if `examples/*.txtar` or `docs/examples.json` are edited:
+
+```bash
+go run ./cmd/gsx-examples
+```
+
+Expected: generated Markdown under `docs/guide/syntax/_generated/**` is updated consistently.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+go test ./internal/examplegen ./gen
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit if files changed**
+
+Run:
+
+```bash
+git status --short
+git add docs/guide/syntax/attributes.md docs/guide/syntax/std-functions.md docs/guide/syntax.md docs/guide/syntax/_generated docs/examples.json
+git commit -m "docs: align attribute reference with runtime"
+```
+
+If `git status --short` shows no docs changes from this task, skip the commit.
+
+## Task 7: VitePress Navigation And Homepage
+
+**Files:**
+- Modify: `../gsxhq.github.io/.vitepress/config.mts`
+- Modify: `../gsxhq.github.io/index.md`
+
+- [ ] **Step 1: Update VitePress nav**
+
+In `../gsxhq.github.io/.vitepress/config.mts`, replace:
+
+```ts
+nav: [
+  { text: 'Guide', link: '/guide/getting-started' },
+  { text: 'Playground', link: '/playground' },
+],
+```
+
+with:
+
+```ts
+nav: [
+  { text: 'Start', link: '/guide/getting-started' },
+  { text: 'Learn', link: '/guide/learn' },
+  { text: 'Reference', link: '/guide/syntax' },
+  { text: 'Playground', link: '/playground' },
+],
+```
+
+- [ ] **Step 2: Restructure sidebar groups**
+
+Replace the two existing sidebar groups with these groups:
+
+```ts
+{
+  text: 'Start',
+  items: [
+    { text: 'Getting started', link: '/guide/getting-started' },
+    { text: 'Learn gsx', link: '/guide/learn' },
+    { text: 'Why gsx', link: '/guide/vision' },
+    { text: 'Principles', link: '/guide/principles' },
+    { text: 'Status', link: '/guide/status' },
+  ],
+},
+{
+  text: 'Reference',
+  items: [
+    { text: 'Syntax reference', link: '/guide/syntax' },
+    { text: 'Basic syntax', link: '/guide/syntax/basic-syntax' },
+    { text: 'Raw Go', link: '/guide/syntax/raw-go' },
+    { text: 'Elements', link: '/guide/syntax/elements' },
+    { text: 'Comments', link: '/guide/syntax/comments' },
+    { text: 'Fragments', link: '/guide/syntax/fragments' },
+    { text: 'Interpolation & expressions', link: '/guide/syntax/interpolation' },
+    { text: 'Attributes', link: '/guide/syntax/attributes' },
+    { text: 'Control flow', link: '/guide/syntax/control-flow' },
+    { text: 'Components & composition', link: '/guide/syntax/composition' },
+    { text: 'Props model', link: '/guide/syntax/props' },
+    { text: 'Styling', link: '/guide/syntax/styling' },
+    { text: 'JavaScript & scripts', link: '/guide/syntax/javascript' },
+    { text: 'Pipelines & filters', link: '/guide/syntax/pipelines' },
+    { text: 'Rendering raw HTML', link: '/guide/syntax/raw-html' },
+    { text: 'Security & escaping', link: '/guide/syntax/escaping' },
+    { text: 'Context', link: '/guide/syntax/context' },
+    { text: 'Runtime helpers', link: '/guide/syntax/std-functions' },
+    { text: 'Forms', link: '/guide/syntax/forms' },
+  ],
+},
+{
+  text: 'Tooling',
+  items: [
+    { text: 'CLI', link: '/guide/cli' },
+    { text: 'Configuration', link: '/guide/config' },
+    { text: 'Extensions', link: '/guide/extensions' },
+    { text: 'Editor support', link: '/guide/editor' },
+    { text: 'Performance', link: '/guide/performance' },
+  ],
+},
+{
+  text: 'Interop and Gaps',
+  items: [
+    { text: 'Comparisons', link: '/guide/comparisons' },
+    { text: 'Interop', link: '/guide/syntax/interop' },
+    { text: 'Render once', link: '/guide/syntax/render-once' },
+  ],
+},
+```
+
+- [ ] **Step 3: Update homepage actions**
+
+In `../gsxhq.github.io/index.md`, change actions to:
+
+```yaml
+actions:
+  - theme: brand
+    text: Get started
+    link: /guide/getting-started
+  - theme: alt
+    text: Learn gsx
+    link: /guide/learn
+  - theme: alt
+    text: Playground
+    link: /playground
+```
+
+Add a status link in the body:
+
+```markdown
+See [Status](/guide/status) for what ships today and what remains deferred.
+```
+
+- [ ] **Step 4: Build site**
+
+Run:
+
+```bash
+cd /Users/jackieli/personal/gsxhq/gsxhq.github.io
+npm run build
+```
+
+Expected: VitePress build completes successfully and pages under `/guide/learn`, `/guide/status`, and `/guide/comparisons` render.
+
+- [ ] **Step 5: Commit in docs site repo**
+
+Run:
+
+```bash
+cd /Users/jackieli/personal/gsxhq/gsxhq.github.io
+git add .vitepress/config.mts index.md
+git commit -m "docs: reorganize public site navigation"
+```
+
+## Task 8: Full Verification
+
+**Files:**
+- Read all changed docs files.
+- Build in `../gsxhq.github.io`.
+
+- [ ] **Step 1: Run Go tests covering docs examples**
+
+Run:
+
+```bash
+cd /Users/jackieli/personal/gsxhq/gsx
+go test ./internal/examplegen ./gen
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run broader docs-relevant tests**
+
+Run:
+
+```bash
+cd /Users/jackieli/personal/gsxhq/gsx
+go test ./...
+```
+
+Expected: pass. If this is too slow or fails outside docs scope, record the failing package and exact error before deciding whether to fix it in this branch.
+
+- [ ] **Step 3: Build VitePress site from synced source docs**
+
+Run:
+
+```bash
+cd /Users/jackieli/personal/gsxhq/gsxhq.github.io
+npm run build
+```
+
+Expected: build complete. The prebuild sync must copy `docs/guide` from the `gsx` repo.
+
+- [ ] **Step 4: Inspect generated routes**
+
+Run:
+
+```bash
+test -f /Users/jackieli/personal/gsxhq/gsxhq.github.io/.vitepress/dist/guide/learn.html
+test -f /Users/jackieli/personal/gsxhq/gsxhq.github.io/.vitepress/dist/guide/status.html
+test -f /Users/jackieli/personal/gsxhq/gsxhq.github.io/.vitepress/dist/guide/comparisons.html
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 5: Check final worktree state**
+
+Run:
+
+```bash
+git -C /Users/jackieli/personal/gsxhq/gsx status --short
+git -C /Users/jackieli/personal/gsxhq/gsxhq.github.io status --short
+```
+
+Expected: only intentional changes remain, or no output if all task commits were made.
+
+- [ ] **Step 6: Final summary**
+
+Prepare a concise summary with:
+
+```markdown
+Changed:
+- Source docs: status, learning path, reference structure, comparisons, performance reproducibility.
+- Public site: navigation/homepage IA.
+
+Verified:
+- `go test ./internal/examplegen ./gen`
+- `go test ./...`
+- `npm run build` in `../gsxhq.github.io`
+```
+
+If any command was not run or failed, include the exact reason and output summary.
+
+## Self-Review
+
+- Spec coverage: The plan covers all accepted recommendations except embedded live examples, which are explicitly out of scope. Playground jump links are preserved through the generated example pipeline.
+- Placeholder scan: The plan avoids unspecified implementation steps; file paths, commands, and expected outcomes are included.
+- Type consistency: The attribute-doc task explicitly verifies runtime type shape before editing, avoiding stale copied-doc assumptions.

--- a/examples/140-style-blocks.txtar
+++ b/examples/140-style-blocks.txtar
@@ -1,6 +1,6 @@
 -- doc --
 name: Style blocks
-summary: A <style> block interpolates values with @{ … }; interpolated values are CSS-sanitized by construction.
+summary: A <style> block interpolates values with @{ … }; interpolated values are CSS-sanitized.
 category: Styling
 order: 140
 page: styling

--- a/examples/30-auto-escaping.txtar
+++ b/examples/30-auto-escaping.txtar
@@ -1,6 +1,6 @@
 -- doc --
 name: Auto-escaping & safe raw
-summary: User input is HTML-escaped by construction — no XSS. Use gsx.Raw / gsx.RawURL to opt out deliberately.
+summary: User input in normal interpolation is HTML-escaped. Use gsx.Raw / gsx.RawURL to opt out deliberately.
 category: Basics
 order: 30
 page: escaping
@@ -8,7 +8,7 @@ pageOrder: 10
 -- input.gsx --
 package views
 
-// User input is HTML-escaped by construction — no XSS.
+// User input in normal interpolation is HTML-escaped.
 component Comment(body string) {
 	<blockquote>{body}</blockquote>
 }

--- a/playground/server/examples.json
+++ b/playground/server/examples.json
@@ -128,7 +128,7 @@
   {
     "name": "Auto-escaping & safe raw",
     "category": "Basics",
-    "source": "package views\n\n// User input is HTML-escaped by construction — no XSS.\ncomponent Comment(body string) {\n\t<blockquote>{ body }</blockquote>\n}\n",
+    "source": "package views\n\n// User input in normal interpolation is HTML-escaped.\ncomponent Comment(body string) {\n\t<blockquote>{ body }</blockquote>\n}\n",
     "invoke": "Comment(CommentProps{Body: \"<img src=x onerror=alert(1)>\"})"
   },
   {


### PR DESCRIPTION
## Summary

Refines the public gsx documentation after the documentation architecture pass:

- adds and wires the public status, learning path, comparisons, and syntax reference flow
- tightens public-facing wording across the README, docs index, guide pages, and syntax topics
- removes broad or stale claims and replaces them with code/test/corpus-backed statements
- fixes factual drift around LSP status, `gsx.Attrs`, minification defaults, class merging, CLI flags, fragments, render-once, VS Code Marketplace install, structpages links, and Vite plugin versions
- regenerates example-derived docs and playground presets from the txtar sources

The sibling VitePress site has a matching commit for the generated preset sync.

## Validation

- `go test -v ./...`
- `GSX_DOCS_SRC=/Users/jackieli/.config/superpowers/worktrees/gsx/docs-information-architecture npm run build` in `gsxhq.github.io`
- authored Markdown link/anchor check for `docs/guide/**` and `docs/index.md`
- byte-for-byte diff check between `docs/examples.json` and the VitePress `.vitepress/theme/presets.generated.json`

## Notes

Opened as draft for final maintainer review before merge.