### PR TITLE
[codex] fix dev port selection

### DIFF
--- a/gen/dev.go
+++ b/gen/dev.go
@@ -44,8 +44,12 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 
 	// --- env + ports ---
 	env := append(os.Environ(), loadDotEnv(workDir)...)
+	env, viteURL, err := resolveViteDevEnv(env)
+	if err != nil {
+		fmt.Fprintf(stderr, "gsx dev: %v\n", err)
+		return 1
+	}
 	goPort := envPort(env, "GO_PORT", "7777")
-	viteURL := envValue(env, "VITE_DEV_URL", "http://localhost:5173")
 	healthURL := "http://localhost:" + goPort + "/healthz"
 
 	var termMu sync.Mutex
@@ -197,12 +201,18 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			if envDirty {
 				envDirty = false
 				env = append(os.Environ(), loadDotEnv(workDir)...)
+				var envErr error
+				env, viteURL, envErr = resolveViteDevEnv(env)
+				if envErr != nil {
+					fmt.Fprintf(stderr, "gsx dev: %v\n", envErr)
+					overlayUp = true
+					continue
+				}
 				// Vite reads .env itself (loadEnv + native .env watch), so only the Go server is restarted here.
 				srv.env = env
 				goPort = envPort(env, "GO_PORT", "7777")
 				healthURL = "http://localhost:" + goPort + "/healthz"
 				srv.healthURL = healthURL
-				viteURL = envValue(env, "VITE_DEV_URL", "http://localhost:5173")
 				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
 					postReload(viteURL)
 					overlayUp = false

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -3,16 +3,41 @@
 package gen
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 )
+
+func TestDevExitsWhenExplicitVitePortIsInUse(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:5173")
+	if err != nil {
+		t.Skipf("default Vite port unavailable before test: %v", err)
+	}
+	defer l.Close()
+
+	proj := t.TempDir()
+	writeFile(t, proj, ".env", "VITE_PORT=5173\n")
+
+	var stdout, stderr bytes.Buffer
+	code := runDev(nil, &stdout, &stderr, config{}, nil, proj)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "VITE_PORT 5173 is already in use") {
+		t.Fatalf("stderr = %q, want port-in-use error", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "watching") {
+		t.Fatalf("runDev should exit before watching when VITE_PORT is in use; stdout=%q", stdout.String())
+	}
+}
 
 // TestDevTeardownAndRestart is a full-stack integration test for `gsx dev`:
 //   - builds the gsx binary

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -5,14 +5,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -62,17 +67,86 @@ func loadDotEnv(dir string) []string {
 
 // envPort reads KEY's value from a KEY=VALUE env slice, returning def if absent.
 func envPort(env []string, key, def string) string {
-	pre := key + "="
-	for _, e := range env {
-		if strings.HasPrefix(e, pre) {
-			return strings.TrimPrefix(e, pre)
-		}
+	if v, ok := envLookup(env, key); ok {
+		return v
 	}
 	return def
 }
 
+func envLookup(env []string, key string) (string, bool) {
+	pre := key + "="
+	for _, e := range env {
+		if v, ok := strings.CutPrefix(e, pre); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
 // envValue is envPort by another name for non-port keys (VITE_DEV_URL).
 func envValue(env []string, key, def string) string { return envPort(env, key, def) }
+
+func resolveViteDevEnv(env []string) ([]string, string, error) {
+	port, ok := envLookup(env, "VITE_PORT")
+	var err error
+	if ok {
+		if _, err := strconv.Atoi(port); err != nil {
+			return nil, "", fmt.Errorf("invalid VITE_PORT %q", port)
+		}
+		if !portAvailable(port) {
+			return nil, "", fmt.Errorf("VITE_PORT %s is already in use", port)
+		}
+	} else {
+		port, err = nextAvailablePort("5173")
+	}
+	if err != nil {
+		return nil, "", err
+	}
+	viteURL := "http://localhost:" + port
+	env = setEnvValue(env, "VITE_PORT", port)
+	env = setEnvValue(env, "VITE_DEV_URL", viteURL)
+	return env, viteURL, nil
+}
+
+func nextAvailablePort(start string) (string, error) {
+	port, err := strconv.Atoi(start)
+	if err != nil {
+		return "", fmt.Errorf("invalid VITE_PORT %q", start)
+	}
+	for ; port <= 65535; port++ {
+		candidate := strconv.Itoa(port)
+		if portAvailable(candidate) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("choose Vite dev port: no free port at or above %s", start)
+}
+
+func portAvailable(port string) bool {
+	for _, addr := range []string{"127.0.0.1:" + port, "[::1]:" + port} {
+		l, err := net.Listen("tcp", addr)
+		if err == nil {
+			l.Close()
+			continue
+		}
+		if errors.Is(err, syscall.EADDRINUSE) {
+			return false
+		}
+	}
+	return true
+}
+
+func setEnvValue(env []string, key, value string) []string {
+	pre := key + "="
+	for i, e := range env {
+		if strings.HasPrefix(e, pre) {
+			out := slices.Clone(env)
+			out[i] = pre + value
+			return out
+		}
+	}
+	return append(env, pre+value)
+}
 
 // waitHealthy polls url until it returns any HTTP status (2xx–5xx ⇒ the server
 // is accepting connections) or timeout elapses. A refused connection retries.

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,6 +39,73 @@ func TestLoadDotEnv(t *testing.T) {
 	env := loadDotEnv(dir)
 	if envPort(env, "GO_PORT", "x") != "7777" {
 		t.Errorf("GO_PORT not parsed: %v", env)
+	}
+}
+
+func TestResolveViteDevEnvSkipsBoundDefaultPort(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:5173")
+	if err != nil {
+		t.Skipf("default Vite port unavailable before test: %v", err)
+	}
+	defer l.Close()
+	wantPort, err := nextAvailablePort("5173")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantURL := "http://localhost:" + wantPort
+	if viteURL != wantURL {
+		t.Fatalf("viteURL = %q, want %s", viteURL, wantURL)
+	}
+	if got := envPort(env, "VITE_PORT", ""); got != wantPort {
+		t.Fatalf("VITE_PORT = %q, want %s", got, wantPort)
+	}
+	if envValue(env, "VITE_DEV_URL", "") != viteURL {
+		t.Fatalf("VITE_DEV_URL env and returned URL differ: env=%q url=%q", envValue(env, "VITE_DEV_URL", ""), viteURL)
+	}
+}
+
+func TestResolveViteDevEnvSkipsIPv6BoundDefaultPort(t *testing.T) {
+	l, err := net.Listen("tcp", "[::1]:5173")
+	if err != nil {
+		t.Skipf("IPv6 default Vite port unavailable before test: %v", err)
+	}
+	defer l.Close()
+	wantPort, err := nextAvailablePort("5173")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantURL := "http://localhost:" + wantPort
+	if viteURL != wantURL {
+		t.Fatalf("viteURL = %q, want %s", viteURL, wantURL)
+	}
+	if got := envPort(env, "VITE_PORT", ""); got != wantPort {
+		t.Fatalf("VITE_PORT = %q, want %s", got, wantPort)
+	}
+}
+
+func TestResolveViteDevEnvRejectsBoundExplicitVitePort(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:5173")
+	if err != nil {
+		t.Skipf("default Vite port unavailable before test: %v", err)
+	}
+	defer l.Close()
+
+	_, _, err = resolveViteDevEnv([]string{"VITE_PORT=5173"})
+	if err == nil {
+		t.Fatal("expected bound explicit VITE_PORT to fail")
+	}
+	if !strings.Contains(err.Error(), "VITE_PORT 5173 is already in use") {
+		t.Fatalf("error = %q, want port-in-use message", err)
 	}
 }
 

--- a/gen/init_test.go
+++ b/gen/init_test.go
@@ -314,6 +314,10 @@ func TestScaffoldSimpleTemplate(t *testing.T) {
 	if !strings.Contains(string(appgsx), "{{ v := vite.FromContext(ctx) }}") {
 		t.Errorf("app.gsx lost its {{ }} block: %s", appgsx)
 	}
+	env, _ := os.ReadFile(filepath.Join(dest, ".env"))
+	if strings.Contains(string(env), "VITE_PORT") || strings.Contains(string(env), "VITE_DEV_URL") {
+		t.Errorf(".env should let gsx dev choose the Vite front-door port: %s", env)
+	}
 }
 
 func TestInitScaffoldHasDevCommand(t *testing.T) {

--- a/gen/templates/init/simple/README.md.tmpl
+++ b/gen/templates/init/simple/README.md.tmpl
@@ -17,7 +17,7 @@ npm install
 ```sh
 npm run dev   # = go tool gsx dev
 ```
-Open http://localhost:5173. Edit `app.gsx` or any `.go` file and save — gsx dev
+Open the URL printed by `npm run dev`. Edit `app.gsx` or any `.go` file and save — gsx dev
 regenerates, rebuilds the server, and live-reloads the browser.
 
 ## Production build
@@ -30,6 +30,7 @@ go build -o app # embeds dist/, serves /static/, reads the manifest
 ## How it works
 - `gsx dev` owns the loop: it watches `.gsx`/`.go`/`.env`, regenerates with the
   warm compiler, rebuilds + restarts the Go server, and drives Vite's browser
-  reload + error overlay. Vite is the front door (proxy + HMR for JS/CSS assets).
+  reload + error overlay. It chooses an available Vite front-door port, then Vite
+  serves the proxy + HMR for JS/CSS assets.
 - `main.go` builds a `*vite.Vite` from `VITE_DEV_URL` and injects it into each
   request via `v.Middleware`; `app.gsx` reads the asset bundle from the context.

--- a/gen/templates/init/simple/dot-env
+++ b/gen/templates/init/simple/dot-env
@@ -1,3 +1,1 @@
 GO_PORT=7777
-VITE_PORT=5173
-VITE_DEV_URL=http://localhost:5173

--- a/gen/templates/init/simple/dot-env.example
+++ b/gen/templates/init/simple/dot-env.example
@@ -1,3 +1,1 @@
 GO_PORT=7777
-VITE_PORT=5173
-VITE_DEV_URL=http://localhost:5173

--- a/gen/templates/init/simple/vite.config.ts
+++ b/gen/templates/init/simple/vite.config.ts
@@ -43,9 +43,8 @@ export default defineConfig(({ command, mode }) => {
     ],
     server: {
       port: vitePort,
-      // Fail loudly if VITE_PORT is already taken (e.g. another gsx app),
-      // instead of silently moving to the next port — the Go server's
-      // VITE_DEV_URL and the printed URL both assume this exact port.
+      // `gsx dev` chooses an available VITE_PORT and matching VITE_DEV_URL before
+      // starting Vite. Keep Vite strict so proxy, overlay, and printed URL agree.
       strictPort: true,
       proxy: {
         // Everything except /__vite/ (Vite's own dev-asset namespace) and


### PR DESCRIPTION
## Summary

Fix the `gsx init` dev-loop port behavior so generated projects do not require port 5173 to be free.

- Fresh init scaffolds no longer pin `VITE_PORT` or `VITE_DEV_URL` in `.env`.
- `gsx dev` now chooses the next available Vite front-door port from 5173 upward when `VITE_PORT` is absent.
- Explicit `VITE_PORT` remains authoritative, but `gsx dev` now exits before starting the Go server/watch loop if that explicit port is already in use.
- Port availability checks cover both IPv4 loopback and IPv6 loopback, matching the real Vite conflict case seen locally.

## Root Cause

The starter template wrote `VITE_PORT=5173` and `VITE_DEV_URL=http://localhost:5173`, so `npm run dev` treated 5173 as an explicit requirement. When Vite failed on a port conflict, `gsx dev` had already started the Go server and watcher, leaving the dev loop in a misleading half-running state.

## Validation

- `GOCACHE=/tmp/gsx-gocache go test ./gen -run 'TestResolveViteDevEnv|TestDevExitsWhenExplicitVitePortIsInUse|TestScaffoldSimpleTemplate' -count=1`
- `GOCACHE=/tmp/gsx-gocache go test ./gen -count=1`
- `git diff --check`
- End-to-end smoke: `go install ./cmd/gsx`, `/Users/jackieli/go/bin/gsx init --yes --force` in `/tmp/hello-gsx-smoke.IDMUCa`, then `/Users/jackieli/go/bin/gsx dev` with 5173 already occupied. Vite started successfully on `http://localhost:5175/`.

Note: `/opt/homebrew/bin/gsx` is Ghostscript on this machine, so the smoke used `/Users/jackieli/go/bin/gsx` for the installed Go binary.