### PR TITLE
Add conservative golangci-lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ name: CI
 #   docs        — build the VitePress site against this checkout (catches gsx docs/guide
 #                 markdown that breaks the site — e.g. raw {{ }} / <tags> in prose)
 #   format      — `make ci-format` (gofmt + gsx fmt)
+#   lint        — conservative golangci-lint suite over each Go module
 
 on:
   push:
@@ -23,6 +24,7 @@ permissions:
 
 env:
   GO_VERSION: '1.26.1'
+  GOLANGCI_LINT_VERSION: 'v2.10.1'
 
 jobs:
   build-test:
@@ -97,6 +99,23 @@ jobs:
           cache: true
       - name: gofmt + gsx fmt
         run: make ci-format
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          install-only: true
+      - name: Run lint
+        run: make lint
 
   go-tip:
     name: go tip (generic-method tests)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     staticcheck:
       checks:
         - SA*
+        - QF*
 
 issues:
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - modernize
     - staticcheck
     - unused
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - asciicheck
+    - bidichk
+    - durationcheck
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+
+  exclusions:
+    generated: strict
+    paths:
+      - '.*\.x\.go$'
+
+  settings:
+    staticcheck:
+      checks:
+        - SA*
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+output:
+  show-stats: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Any syntax change should be accompanied by rigorous tests, documentation and sib
 - ../vscode-gsx
 - ../gsxhq.github.io/ CodeMirror & VitePress syntax
 
+Run `make lint`
+
 ## Testing — the txtar corpus is canonical
 
 `internal/corpus/testdata/cases/**/*.txtar` is the authoritative syntax reference (parsed → generated → rendered → goldens pinned). Learn syntax from there, not from prose; Also `examples/*.txtar`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # gsx developer tasks. Use tabs for recipe indentation.
-.PHONY: test check cover cover-html examples ci ci-gomod ci-playground ci-examples ci-format ci-tailwind-example ci-tailwind-example-drift reload-probe test-gotip
+.PHONY: test check lint cover cover-html examples ci ci-gomod ci-playground ci-examples ci-format ci-tailwind-example ci-tailwind-example-drift reload-probe test-gotip
 
 # COUNT is the go-test cache control. -count=1 disables the test cache so every
 # run re-executes — the authoritative behaviour `ci` uses to mirror GitHub CI.
@@ -32,6 +32,11 @@ ci:
 # GitHub CI's -count=1 run (and `make ci`) remain the authoritative gate.
 check:
 	$(MAKE) ci COUNT=
+
+lint:
+	golangci-lint run ./...
+	cd playground/server && golangci-lint run ./...
+	cd examples/tailwind-merge && golangci-lint run ./...
 
 # Manual, repeatable local test of `gsx dev`'s browser-reload behavior (NOT in
 # `ci` — it spawns a live dev loop). Asserts that introducing a .gsx/main.go

--- a/attrs.go
+++ b/attrs.go
@@ -173,9 +173,10 @@ func (gw *Writer) Spread(ctx context.Context, a Attrs) {
 		if last[kv.Key] != i {
 			continue
 		}
-		if kv.Key == "class" {
+		switch kv.Key {
+		case "class":
 			kv.Value = a.Class()
-		} else if kv.Key == "style" {
+		case "style":
 			kv.Value = a.Style()
 		}
 		if b, ok := kv.Value.(bool); ok {

--- a/escape.go
+++ b/escape.go
@@ -36,10 +36,10 @@ const blockedURL = "about:invalid#gsx"
 // an allow-listed scheme (http, https, mailto, tel — case-insensitive); any
 // other scheme (javascript:, vbscript:, data:, …) yields blockedURL.
 func urlSanitize(s string) string {
-	if i := strings.IndexByte(s, ':'); i >= 0 {
+	if before, _, ok := strings.Cut(s, ":"); ok {
 		// A scheme exists only when no '/', '?', or '#' precedes the ':'.
-		if !strings.ContainsAny(s[:i], "/?#") {
-			switch strings.ToLower(s[:i]) {
+		if !strings.ContainsAny(before, "/?#") {
+			switch strings.ToLower(before) {
 			case "http", "https", "mailto", "tel":
 				// allowed
 			default:
@@ -172,8 +172,8 @@ func isCSSNmchar(r rune) bool {
 
 // decodeCSS decodes CSS3 escape sequences in s.
 func decodeCSS(s []byte) []byte {
-	i := bytes.IndexByte(s, '\\')
-	if i == -1 {
+	found := bytes.Contains(s, []byte{'\\'})
+	if !found {
 		return s
 	}
 	b := make([]byte, 0, len(s))

--- a/escape_diff_test.go
+++ b/escape_diff_test.go
@@ -79,17 +79,17 @@ var knownDivergences = map[diffKey]string{
 //     In a browser, <a href="#foo:bar"> is a fragment link, not a protocol handler;
 //     no script execution or irreversible side effect can occur.
 func isKnownURLDivergence(s string) bool {
-	i := strings.IndexByte(s, ':')
-	if i < 0 {
+	before, _, ok := strings.Cut(s, ":")
+	if !ok {
 		return false
 	}
 	// Class 1: tel: scheme intentionally allowed by gsx.
-	if strings.EqualFold(s[:i], "tel") {
+	if strings.EqualFold(before, "tel") {
 		return true
 	}
 	// Class 2: '#' or '?' precedes ':' — gsx treats this as non-scheme context.
 	// stdlib blocks conservatively; gsx follows RFC 3986.
-	return strings.ContainsAny(s[:i], "#?")
+	return strings.ContainsAny(before, "#?")
 }
 
 func TestEscaperMatchesStdlib(t *testing.T) {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -69,8 +69,8 @@ func refreshURLRef(s string) (string, bool) {
 	if p < len(s) && (s[p] == '\'' || s[p] == '"') {
 		quote := s[p]
 		rest := s[p+1:]
-		if j := strings.IndexByte(rest, quote); j >= 0 {
-			return rest[:j], true
+		if before, _, ok := strings.Cut(rest, string(quote)); ok {
+			return before, true
 		}
 		return rest, true
 	}

--- a/gen/definition_e2e_test.go
+++ b/gen/definition_e2e_test.go
@@ -260,12 +260,12 @@ func declStart(t *testing.T, src, decl string, nameOff int) (line, character int
 func definitionResult(t *testing.T, out string, id int) *lsp.Location {
 	t.Helper()
 	marker := `"id":` + strconv.Itoa(id) + `,`
-	for _, part := range strings.Split(out, "Content-Length:") {
-		i := strings.Index(part, "\r\n\r\n")
-		if i < 0 {
+	for part := range strings.SplitSeq(out, "Content-Length:") {
+		_, after, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
 			continue
 		}
-		body := part[i+4:]
+		body := after
 		if !strings.Contains(body, marker) {
 			continue
 		}

--- a/gen/definition_sigtype_e2e_test.go
+++ b/gen/definition_sigtype_e2e_test.go
@@ -61,12 +61,12 @@ func sigTypeDefLocations(t *testing.T, dir, gsxPath, src string, line, character
 		t.Fatalf("runLSP=%d stderr=%s", code, errBuf.String())
 	}
 	marker := `"id":2,`
-	for _, part := range strings.Split(out.String(), "Content-Length:") {
-		i := strings.Index(part, "\r\n\r\n")
-		if i < 0 {
+	for part := range strings.SplitSeq(out.String(), "Content-Length:") {
+		_, after, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
 			continue
 		}
-		body := part[i+4:]
+		body := after
 		if !strings.Contains(body, marker) {
 			continue
 		}

--- a/gen/formatting_e2e_test.go
+++ b/gen/formatting_e2e_test.go
@@ -132,12 +132,12 @@ func formattingEdits(t *testing.T, uri, text string) []lsp.TextEdit {
 		t.Fatalf("runLSP=%d stderr=%s", code, errBuf.String())
 	}
 	marker := `"id":2,`
-	for _, part := range strings.Split(out.String(), "Content-Length:") {
-		i := strings.Index(part, "\r\n\r\n")
-		if i < 0 {
+	for part := range strings.SplitSeq(out.String(), "Content-Length:") {
+		_, after, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
 			continue
 		}
-		body := part[i+4:]
+		body := after
 		if !strings.Contains(body, marker) {
 			continue
 		}

--- a/gen/hover_e2e_test.go
+++ b/gen/hover_e2e_test.go
@@ -66,12 +66,12 @@ func hoverAt(t *testing.T, dir, file, text, needle string, cursorOff int) *lsp.H
 		t.Fatalf("hover leaked a generated-code path; out:\n%s", out.String())
 	}
 	marker := `"id":2,`
-	for _, part := range strings.Split(out.String(), "Content-Length:") {
-		i := strings.Index(part, "\r\n\r\n")
-		if i < 0 {
+	for part := range strings.SplitSeq(out.String(), "Content-Length:") {
+		_, after, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
 			continue
 		}
-		body := part[i+4:]
+		body := after
 		if !strings.Contains(body, marker) {
 			continue
 		}

--- a/gen/minify_test.go
+++ b/gen/minify_test.go
@@ -70,7 +70,7 @@ func TestLoadConfig_Minify(t *testing.T) {
 	}
 
 	// Invalid level → error naming the key.
-	if _, err := loadConfig(writeTOML(t, "[minify]\ncss = \"agressive\"\n")); err == nil {
+	if _, err := loadConfig(writeTOML(t, "[minify]\ncss = \"not-a-level\"\n")); err == nil {
 		t.Fatal("invalid minify.css should error")
 	}
 }

--- a/gen/options.go
+++ b/gen/options.go
@@ -158,7 +158,8 @@ func isExportedIdent(s string) bool {
 		return false
 	}
 	for _, c := range s[1:] {
-		if !(c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+		isIdentChar := c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		if !isIdentChar {
 			return false
 		}
 	}

--- a/gen/perf_test.go
+++ b/gen/perf_test.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -172,7 +172,7 @@ func TestPerfBaseline(t *testing.T) {
 		const iters = 100000
 		start := time.Now()
 		var sink int
-		for i := 0; i < iters; i++ {
+		for range iters {
 			cr := pkg.CrossIndex[key] // real map lookup
 			sink += len(cr.Refs)
 		}
@@ -183,8 +183,8 @@ func TestPerfBaseline(t *testing.T) {
 	}
 
 	// ---------- report ----------
-	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
-	sort.Slice(warmLatencies, func(i, j int) bool { return warmLatencies[i] < warmLatencies[j] })
+	slices.Sort(latencies)
+	slices.Sort(warmLatencies)
 	median := func(s []time.Duration) time.Duration { return s[len(s)/2] }
 
 	t.Logf("=== cold Analyze latency ===")

--- a/gen/pipe_nav_e2e_test.go
+++ b/gen/pipe_nav_e2e_test.go
@@ -147,12 +147,12 @@ func pipeHoverAt(t *testing.T, dir, src, needle string, off int) *lsp.Hover {
 		t.Fatalf("runLSP=%d stderr=%s", code, errBuf.String())
 	}
 	marker := `"id":2,`
-	for _, part := range strings.Split(out.String(), "Content-Length:") {
-		i := strings.Index(part, "\r\n\r\n")
-		if i < 0 {
+	for part := range strings.SplitSeq(out.String(), "Content-Length:") {
+		_, after, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
 			continue
 		}
-		body := part[i+4:]
+		body := after
 		if !strings.Contains(body, marker) {
 			continue
 		}

--- a/gen/watch_depchange_test.go
+++ b/gen/watch_depchange_test.go
@@ -86,10 +86,6 @@ func TestWatchDepChange(t *testing.T) {
 			if !r.OK {
 				t.Fatalf("reopen cycleResult for blogDir not OK: err=%v diags=%v", r.Err, r.Diags)
 			}
-			if len(r.Written) == 0 && r.Err == nil {
-				// Written may be empty if hash-gated restore found identical
-				// content; that is still a valid (non-silent) cycle result.
-			}
 			break
 		}
 	}

--- a/gen/watch_integration_test.go
+++ b/gen/watch_integration_test.go
@@ -81,7 +81,7 @@ func waitFor(t *testing.T, d time.Duration, cond func() bool) {
 
 func countGenerated(s string, ok bool) int {
 	n := 0
-	for _, line := range strings.Split(s, "\n") {
+	for line := range strings.SplitSeq(s, "\n") {
 		var ev map[string]any
 		if json.Unmarshal([]byte(line), &ev) != nil {
 			continue

--- a/gen/watch_test.go
+++ b/gen/watch_test.go
@@ -41,7 +41,7 @@ func TestRunWatch_NoDirsReturnsCleanly(t *testing.T) {
 		t.Fatalf("runWatch exit = %d, want 0; stderr=%s", code, errb.String())
 	}
 	// stdout in ndjson mode must never contain a non-JSON line.
-	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(out.String()), "\n") {
 		if line != "" && !strings.HasPrefix(line, "{") {
 			t.Fatalf("non-JSON stdout line: %q", line)
 		}

--- a/gen/watchemit_test.go
+++ b/gen/watchemit_test.go
@@ -39,7 +39,7 @@ func TestEmitter_NDJSON_OperationalErrorSurfaces(t *testing.T) {
 		t.Fatalf("operational error not surfaced in NDJSON: %q", out.String())
 	}
 	// Every stdout line must still be valid JSON (stream discipline).
-	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(out.String()), "\n") {
 		if line == "" {
 			continue
 		}

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -474,10 +474,7 @@ func buildCtrlMap(f *goast.File, fset *token.FileSet, ctrlOff map[gsxast.Node]in
 	for node, off := range ctrlOff {
 		text := clauseText[node]
 		start := tf.Pos(off)
-		endOff := off + len(text)
-		if endOff > tf.Size() {
-			endOff = tf.Size()
-		}
+		endOff := min(off+len(text), tf.Size())
 		end := tf.Pos(endOff)
 		var smallest goast.Node
 		goast.Inspect(f, func(n goast.Node) bool {

--- a/internal/codegen/byo_lsp_test.go
+++ b/internal/codegen/byo_lsp_test.go
@@ -107,10 +107,7 @@ component Page(someVar string, pd Props) {
 	// Decl must point at the 'B' of "Button" in the component declaration.
 	if data, err := os.ReadFile(cr.Decl.Filename); err == nil {
 		if cr.Decl.Offset >= len(data) || data[cr.Decl.Offset] != 'B' {
-			end := cr.Decl.Offset + 8
-			if end > len(data) {
-				end = len(data)
-			}
+			end := min(cr.Decl.Offset+8, len(data))
 			t.Errorf("CrossIndex[.Button].Decl should land on 'B' of component name; Decl=%v src[off]=%q",
 				cr.Decl, string(data[cr.Decl.Offset:end]))
 		}

--- a/internal/codegen/diag_wire_test.go
+++ b/internal/codegen/diag_wire_test.go
@@ -41,9 +41,10 @@ component X() {
 }
 
 func diagMsgs(dr DirResult) string {
-	var s string
+	var s strings.Builder
 	for _, d := range dr.Diags {
-		s += d.Message + "\n"
+		s.WriteString(d.Message)
+		s.WriteString("\n")
 	}
-	return s
+	return s.String()
 }

--- a/internal/codegen/fset_growth_test.go
+++ b/internal/codegen/fset_growth_test.go
@@ -46,7 +46,7 @@ func TestFsetGrowthIsBounded(t *testing.T) {
 	// Force frequent rebuilds: tiny threshold.
 	m.fsetRebuildBytes = 4096
 	var maxBase int
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		// Each edit changes content (distinct label text) so the dir is marked dirty
 		// and re-parsed, growing the fset.
 		src := fmt.Appendf(nil, "package util\n\ncomponent Y(label string) {\n\t<span>%d:{label}</span>\n}\n", i)
@@ -74,7 +74,7 @@ func TestFsetRebuildDisabledAtZero(t *testing.T) {
 	m.fsetRebuildBytes = 0 // disabled
 	util := filepath.Join(root, "util")
 	utilFile := filepath.Join(util, "util.gsx")
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		m.SetOverride(utilFile, fmt.Appendf(nil, "package util\n\ncomponent Y(label string) {\n\t<b>%d:{label}</b>\n}\n", i))
 		if _, err := m.Package(util); err != nil {
 			t.Fatal(err)
@@ -317,7 +317,7 @@ func TestConcurrentRebuildAndPackage(t *testing.T) {
 	comp := filepath.Join(root, "components")
 	card := filepath.Join(comp, "card.gsx")
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/internal/codegen/invalidation_test.go
+++ b/internal/codegen/invalidation_test.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 
@@ -43,10 +44,8 @@ func setupChainModule(t *testing.T) (*Module, string) {
 
 func assertEdge(t *testing.T, g map[string][]string, from, to string) {
 	t.Helper()
-	for _, s := range g[from] {
-		if s == to {
-			return
-		}
+	if slices.Contains(g[from], to) {
+		return
 	}
 	t.Errorf("expected edge %s -> %s; from-neighbors: %v", from, to, g[from])
 }
@@ -130,12 +129,7 @@ func TestImportGraphIncludesGoFileImports(t *testing.T) {
 }
 
 func contains(ss []string, s string) bool {
-	for _, x := range ss {
-		if x == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ss, s)
 }
 
 func TestImportGraphEdgeReplacedOnImportRemoval(t *testing.T) {
@@ -356,7 +350,7 @@ func TestConcurrentSetOverrideAndPackage(t *testing.T) {
 	m, root := setupChainModule(t)
 	comp := filepath.Join(root, "components")
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		wg.Add(2)
 		go func() { defer wg.Done(); m.SetOverride(filepath.Join(comp, "card.gsx"), componentsEdited) }()
 		go func() { defer wg.Done(); _, _ = m.Package(comp) }()

--- a/internal/codegen/line_anchor_test.go
+++ b/internal/codegen/line_anchor_test.go
@@ -109,13 +109,13 @@ func TestComponentFuncLineAnchorCodegen(t *testing.T) {
 	if hasDiagErrors(dr.Diags) {
 		t.Fatalf("generate: unexpected errors: %v", dr.Diags)
 	}
-	var gen string
+	var gen strings.Builder
 	for _, b := range dr.Files {
-		gen += string(b)
+		gen.WriteString(string(b))
 	}
 
 	for _, name := range []string{"First", "Page", "Last"} {
-		assertFuncAnchor(t, gen, "views.gsx", name, declLine(t, lineAnchorSrc, name))
+		assertFuncAnchor(t, gen.String(), "views.gsx", name, declLine(t, lineAnchorSrc, name))
 	}
 }
 
@@ -151,10 +151,7 @@ func assertFuncNameAnchorColumn(t *testing.T, skel, src, name string) {
 			// genNameCol: 1-based column of `name` within the generated func line.
 			genNameCol := strings.Index(l, name+"(") + 1
 			// The directive column C satisfies C + (genNameCol-1) == wantNameCol.
-			wantDirectiveCol := wantNameCol - genNameCol + 1
-			if wantDirectiveCol < 1 {
-				wantDirectiveCol = 1
-			}
+			wantDirectiveCol := max(wantNameCol-genNameCol+1, 1)
 			want := fmt.Sprintf(":%d:%d", wantLine, wantDirectiveCol)
 			if !strings.HasPrefix(prev, "//line ") || !strings.Contains(prev, want) {
 				t.Errorf("func %s: anchor = %q, want a //line ending %s (name %q at gen col %d maps to src col %d)",

--- a/internal/codegen/module_diag_test.go
+++ b/internal/codegen/module_diag_test.go
@@ -173,7 +173,6 @@ component Page(bag gsx.Attrs) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			root := t.TempDir()

--- a/internal/codegen/module_test.go
+++ b/internal/codegen/module_test.go
@@ -300,11 +300,11 @@ func TestModuleConcurrentPackage(t *testing.T) {
 	var wg sync.WaitGroup
 	errChan := make(chan error, numGoroutines*loopsPerGoroutine)
 
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			for loop := 0; loop < loopsPerGoroutine; loop++ {
+			for loop := range loopsPerGoroutine {
 				// Mix which dir is accessed by rotating through the list.
 				dir := dirs[(id+loop)%len(dirs)]
 				_, err := m.Package(dir)

--- a/internal/codegen/snapshot_cache_test.go
+++ b/internal/codegen/snapshot_cache_test.go
@@ -356,7 +356,7 @@ func TestConcurrentPackageResultCache(t *testing.T) {
 	m, root := setupChainModule(t)
 	comp := filepath.Join(root, "components")
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/internal/corpus/batch.go
+++ b/internal/corpus/batch.go
@@ -3,6 +3,7 @@ package corpus
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -103,9 +104,7 @@ func batchCodegen(repoRoot string, candidates []*caseDoc) (map[string]*caseCodeg
 		if merr != nil {
 			return nil, fmt.Errorf("batchCodegen: codegenDirs(%s): %w", cs.c.name, merr)
 		}
-		for k, v := range mergerResults {
-			pkgResults[k] = v
-		}
+		maps.Copy(pkgResults, mergerResults)
 	}
 
 	// Step 4: reassemble per-case results.
@@ -338,12 +337,12 @@ func formatDiagLine(buf *bytes.Buffer, d diag.Diagnostic) {
 
 func splitBatchOutput(out string) map[string]string {
 	res := map[string]string{}
-	for _, p := range strings.Split(out, caseMarkerPrefix) {
-		end := strings.Index(p, caseMarkerSuffix)
-		if end < 0 {
+	for p := range strings.SplitSeq(out, caseMarkerPrefix) {
+		before, after, ok := strings.Cut(p, caseMarkerSuffix)
+		if !ok {
 			continue
 		}
-		res[p[:end]] = strings.TrimPrefix(p[end+len(caseMarkerSuffix):], "\n")
+		res[before] = strings.TrimPrefix(after, "\n")
 	}
 	return res
 }

--- a/internal/corpus/codegen.go
+++ b/internal/corpus/codegen.go
@@ -102,10 +102,10 @@ func normalizeDiagPaths(diag []byte, tmpDir string) []byte {
 }
 
 func packageNameOf(src []byte) string {
-	for _, line := range strings.Split(string(src), "\n") {
+	for line := range strings.SplitSeq(string(src), "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "package ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "package "))
+		if after, ok := strings.CutPrefix(line, "package "); ok {
+			return strings.TrimSpace(after)
 		}
 	}
 	return "views"

--- a/internal/corpus/corpus_test.go
+++ b/internal/corpus/corpus_test.go
@@ -78,7 +78,6 @@ func TestCorpus(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			cl := classif[c.name]
 			astDump := cl.astDump

--- a/internal/corpus/docmeta.go
+++ b/internal/corpus/docmeta.go
@@ -18,7 +18,7 @@ type docMeta struct {
 // are ignored; a missing or unparseable `order` is 0.
 func parseDocMeta(b []byte) docMeta {
 	var m docMeta
-	for _, line := range strings.Split(string(b), "\n") {
+	for line := range strings.SplitSeq(string(b), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/corpus/examples_test.go
+++ b/internal/corpus/examples_test.go
@@ -47,7 +47,6 @@ func TestExamples(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			r := cg[c.name]
 			if r == nil {

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -22,7 +22,7 @@ func TestSeverityString(t *testing.T) {
 func TestBagErrorfResolvesAndHasErrors(t *testing.T) {
 	fset := token.NewFileSet()
 	f := fset.AddFile("views.gsx", fset.Base(), 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if i == 20 || i == 40 {
 			f.AddLine(i)
 		}

--- a/internal/examplegen/examplegen.go
+++ b/internal/examplegen/examplegen.go
@@ -136,7 +136,9 @@ func joinSource(files []SourceFile) string {
 	}
 	var b strings.Builder
 	for _, f := range files {
-		b.WriteString("-- " + f.Name + " --\n")
+		b.WriteString("-- ")
+		b.WriteString(f.Name)
+		b.WriteString(" --\n")
 		body := f.Body
 		if !strings.HasSuffix(body, "\n") {
 			body += "\n"
@@ -147,7 +149,7 @@ func joinSource(files []SourceFile) string {
 }
 
 func parseDoc(ex *Example, b []byte) {
-	for _, line := range strings.Split(string(b), "\n") {
+	for line := range strings.SplitSeq(string(b), "\n") {
 		key, val, ok := strings.Cut(strings.TrimSpace(line), ":")
 		if !ok {
 			continue
@@ -175,10 +177,10 @@ func parseDoc(ex *Example, b []byte) {
 }
 
 func packageName(src []byte) string {
-	for _, line := range strings.Split(string(src), "\n") {
+	for line := range strings.SplitSeq(string(src), "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "package ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "package "))
+		if after, ok := strings.CutPrefix(line, "package "); ok {
+			return strings.TrimSpace(after)
 		}
 	}
 	return ""
@@ -218,18 +220,25 @@ func RenderMarkdown(exs []Example) []byte {
 		}
 	}
 	for _, cat := range order {
-		b.WriteString("## " + proseEscaper.Replace(cat) + "\n\n")
+		b.WriteString("## ")
+		b.WriteString(proseEscaper.Replace(cat))
+		b.WriteString("\n\n")
 		for _, e := range exs {
 			if e.Category != cat {
 				continue
 			}
-			b.WriteString("### " + proseEscaper.Replace(e.Name) + "\n\n")
+			b.WriteString("### ")
+			b.WriteString(proseEscaper.Replace(e.Name))
+			b.WriteString("\n\n")
 			if e.Summary != "" {
-				b.WriteString(proseEscaper.Replace(e.Summary) + "\n\n")
+				b.WriteString(proseEscaper.Replace(e.Summary))
+				b.WriteString("\n\n")
 			}
 			for _, f := range e.Files {
 				if len(e.Files) > 1 {
-					b.WriteString("**" + f.Name + "**\n\n")
+					b.WriteString("**")
+					b.WriteString(f.Name)
+					b.WriteString("**\n\n")
 				}
 				b.WriteString("```gsx\n")
 				body := f.Body
@@ -239,7 +248,9 @@ func RenderMarkdown(exs []Example) []byte {
 				b.WriteString(body)
 				b.WriteString("```\n\n")
 			}
-			b.WriteString("[▶ Open in Playground](/playground#try=" + tryPayload(e.Source, e.Invoke) + ")\n\n")
+			b.WriteString("[▶ Open in Playground](/playground#try=")
+			b.WriteString(tryPayload(e.Source, e.Invoke))
+			b.WriteString(")\n\n")
 		}
 	}
 	return []byte(b.String())
@@ -277,7 +288,9 @@ func RenderPartial(e Example) []byte {
 	b.WriteString("<!-- GENERATED from examples/*.txtar by cmd/gsx-examples — do not edit. -->\n\n")
 	for _, f := range e.Files {
 		if len(e.Files) > 1 {
-			b.WriteString("**" + f.Name + "**\n\n")
+			b.WriteString("**")
+			b.WriteString(f.Name)
+			b.WriteString("**\n\n")
 		}
 		b.WriteString("```gsx\n")
 		body := f.Body
@@ -294,7 +307,9 @@ func RenderPartial(e Example) []byte {
 	}
 	b.WriteString(r)
 	b.WriteString("```\n\n")
-	b.WriteString("[▶ Open in Playground](/playground#try=" + tryPayload(e.Source, e.Invoke) + ")\n")
+	b.WriteString("[▶ Open in Playground](/playground#try=")
+	b.WriteString(tryPayload(e.Source, e.Invoke))
+	b.WriteString(")\n")
 	return []byte(b.String())
 }
 

--- a/internal/lsp/convert.go
+++ b/internal/lsp/convert.go
@@ -49,13 +49,7 @@ func convertPos(p token.Position, lineAt func(line1 int) string, enc encoding) P
 // charForByteCol converts a 1-based byte column within lineText to a 0-based LSP
 // character offset in enc. A column past the line end clamps to the line length.
 func charForByteCol(lineText string, col int, enc encoding) int {
-	byteOff := col - 1
-	if byteOff < 0 {
-		byteOff = 0
-	}
-	if byteOff > len(lineText) {
-		byteOff = len(lineText)
-	}
+	byteOff := min(max(col-1, 0), len(lineText))
 	prefix := lineText[:byteOff]
 	if enc == encUTF8 {
 		return len(prefix)
@@ -81,7 +75,7 @@ func utf16Len(s string) int {
 // character past the end clamps to the end of the line / text.
 func byteOffsetForPosition(text string, line, character int, enc encoding) int {
 	off := 0
-	for l := 0; l < line; l++ {
+	for range line {
 		nl := strings.IndexByte(text[off:], '\n')
 		if nl < 0 {
 			return len(text)

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -204,10 +204,7 @@ func packageClauseLocation(filename string, enc encoding) (Location, bool) {
 		return Location{}, false
 	}
 	p := fset.Position(f.Name.Pos())
-	line := p.Line - 1
-	if line < 0 {
-		line = 0
-	}
+	line := max(p.Line-1, 0)
 	char := charForByteCol(lineAtFunc(string(data))(p.Line), p.Column, enc)
 	pos := Position{Line: line, Character: char}
 	return Location{URI: pathToURI(filename), Range: Range{Start: pos, End: pos}}, true
@@ -466,7 +463,7 @@ func (s *Server) handleGoDefinition(f frame, uri, path string) error {
 // lineStartOffset returns the byte offset of the start of the 0-based line.
 func lineStartOffset(text string, line int) int {
 	off := 0
-	for i := 0; i < line; i++ {
+	for range line {
 		nl := strings.IndexByte(text[off:], '\n')
 		if nl < 0 {
 			return len(text)
@@ -483,10 +480,7 @@ func (s *Server) locationForPos(dp token.Position) Location {
 	if data, err := os.ReadFile(dp.Filename); err == nil {
 		char = charForByteCol(lineAtFunc(string(data))(dp.Line), dp.Column, s.enc)
 	}
-	line := dp.Line - 1
-	if line < 0 {
-		line = 0
-	}
+	line := max(dp.Line-1, 0)
 	pos := Position{Line: line, Character: char}
 	return Location{URI: pathToURI(dp.Filename), Range: Range{Start: pos, End: pos}}
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -208,12 +209,9 @@ func (s *Server) handleInitialize(f frame) error {
 	_ = json.Unmarshal(f.Params, &p) // absent or malformed params -> defaults
 	s.enc = encUTF16
 	encName := "utf-16"
-	for _, e := range p.Capabilities.General.PositionEncodings {
-		if e == "utf-8" {
-			s.enc = encUTF8
-			encName = "utf-8"
-			break
-		}
+	if slices.Contains(p.Capabilities.General.PositionEncodings, "utf-8") {
+		s.enc = encUTF8
+		encName = "utf-8"
 	}
 	return s.reply(f.ID, initializeResult{Capabilities: serverCapabilities{
 		PositionEncoding:           encName,

--- a/internal/pretty/doc.go
+++ b/internal/pretty/doc.go
@@ -5,6 +5,8 @@
 // markup today; JS and CSS bodies later).
 package pretty
 
+import "slices"
+
 // kind tags the Doc variant.
 type kind uint8
 
@@ -84,12 +86,7 @@ func containsForcedBreak(d Doc) bool {
 	case kindIndent:
 		return containsForcedBreak(d.parts[0])
 	case kindConcat, kindFill:
-		for _, p := range d.parts {
-			if containsForcedBreak(p) {
-				return true
-			}
-		}
-		return false
+		return slices.ContainsFunc(d.parts, containsForcedBreak)
 	case kindIfBreak:
 		// Only the broken branch (parts[0]) participates in the break decision:
 		// when the enclosing group is flat it renders parts[1], so a forced

--- a/internal/printer/corpus_test.go
+++ b/internal/printer/corpus_test.go
@@ -62,7 +62,7 @@ func corpusGsxSources(t *testing.T) []corpusSource {
 	return out
 }
 
-func normPrint(t *testing.T, src string) (string, error) {
+func normPrint(_ *testing.T, src string) (string, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "x.gsx", src, 0)
 	if err != nil {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -795,7 +795,7 @@ component C(p Props) {
 }
 
 func lineContaining(s, sub string) string {
-	for _, ln := range strings.Split(s, "\n") {
+	for ln := range strings.SplitSeq(s, "\n") {
 		if strings.Contains(ln, sub) {
 			return ln
 		}

--- a/internal/printer/segment.go
+++ b/internal/printer/segment.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/gsxhq/gsx/ast"
@@ -81,10 +82,5 @@ func blockLevel(n ast.Markup) bool {
 // hasBlockChild reports whether nodes contains at least one block-level child,
 // i.e. whether the list should break structurally (regardless of width).
 func hasBlockChild(nodes []ast.Markup) bool {
-	for _, n := range nodes {
-		if blockLevel(n) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(nodes, blockLevel)
 }

--- a/internal/rawfmt/format_test.go
+++ b/internal/rawfmt/format_test.go
@@ -92,7 +92,7 @@ func TestFormatBlankLinesHaveNoTrailingTabs(t *testing.T) {
 		t.Fatal("unexpected fallback")
 	}
 	out := render(doc)
-	for _, ln := range strings.Split(out, "\n") {
+	for ln := range strings.SplitSeq(out, "\n") {
 		if strings.TrimRight(ln, " \t") == "" && ln != "" {
 			t.Fatalf("blank line has trailing whitespace %q in:\n%s", ln, out)
 		}

--- a/internal/reindent/reindent_test.go
+++ b/internal/reindent/reindent_test.go
@@ -20,21 +20,21 @@ func (fake) Tokenize(src []byte) ([]Token, bool) {
 	var toks []Token
 	i := 0
 	for i < len(s) {
-		switch c := s[i]; {
-		case c == '\n':
+		switch c := s[i]; c {
+		case '\n':
 			toks = append(toks, Token{Newline, "\n"})
 			i++
-		case c == ' ' || c == '\t':
+		case ' ', '\t':
 			j := i
 			for j < len(s) && (s[j] == ' ' || s[j] == '\t') {
 				j++
 			}
 			toks = append(toks, Token{Space, s[i:j]})
 			i = j
-		case c == '{':
+		case '{':
 			toks = append(toks, Token{Open, "{"})
 			i++
-		case c == '}':
+		case '}':
 			toks = append(toks, Token{Close, "}"})
 			i++
 		default:

--- a/internal/reindent/reindent_test.go
+++ b/internal/reindent/reindent_test.go
@@ -83,7 +83,7 @@ func TestReindentPreservesBlankLines(t *testing.T) {
 		t.Fatalf("got %q want %q", got, want)
 	}
 	// The blank line must carry NO trailing whitespace.
-	for _, ln := range strings.Split(got, "\n") {
+	for ln := range strings.SplitSeq(got, "\n") {
 		if ln != strings.TrimRight(ln, " \t") {
 			t.Fatalf("line %q has trailing whitespace", ln)
 		}

--- a/internal/txtar/txtar.go
+++ b/internal/txtar/txtar.go
@@ -46,7 +46,9 @@ func Format(a *Archive) []byte {
 	var buf bytes.Buffer
 	buf.Write(fixNL(a.Comment))
 	for _, f := range a.Files {
-		buf.WriteString("-- " + f.Name + " --\n")
+		buf.WriteString("-- ")
+		buf.WriteString(f.Name)
+		buf.WriteString(" --\n")
 		buf.Write(fixNL(f.Data))
 	}
 	return buf.Bytes()
@@ -77,8 +79,8 @@ func findFileMarker(data []byte) (before []byte, name string, after []byte) {
 	var b []byte
 	for len(data) > 0 {
 		var line []byte
-		if i := bytes.IndexByte(data, '\n'); i >= 0 {
-			line, data = data[:i], data[i+1:]
+		if before0, after0, ok := bytes.Cut(data, []byte{'\n'}); ok {
+			line, data = before0, after0
 		} else {
 			line, data = data, nil
 		}

--- a/js.go
+++ b/js.go
@@ -206,9 +206,10 @@ func jsValEscaper(arg any) string {
 	for i := 0; i < len(b); {
 		r, n := utf8.DecodeRune(b[i:])
 		repl := ""
-		if r == 0x2028 {
+		switch r {
+		case 0x2028:
 			repl = "\\u2028"
-		} else if r == 0x2029 {
+		case 0x2029:
 			repl = "\\u2029"
 		}
 		if repl != "" {

--- a/parser/boundary.go
+++ b/parser/boundary.go
@@ -138,7 +138,7 @@ func skipQuotedOrComment(src string, i int) (int, bool) {
 			return i, true
 		case '*':
 			i += 2
-			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
+			for i+1 < len(src) && (src[i] != '*' || src[i+1] != '/') {
 				i++
 			}
 			if i+1 < len(src) {

--- a/playground/playbundle/examples_test.go
+++ b/playground/playbundle/examples_test.go
@@ -60,7 +60,7 @@ func splitForTest(src string) map[string][]byte {
 			files[cur] = []byte(strings.Join(buf, "\n"))
 		}
 	}
-	for _, ln := range strings.Split(src, "\n") {
+	for ln := range strings.SplitSeq(src, "\n") {
 		t := strings.TrimSpace(ln)
 		if strings.HasPrefix(t, "-- ") && strings.HasSuffix(t, " --") {
 			flush()

--- a/playground/server/render.go
+++ b/playground/server/render.go
@@ -75,8 +75,8 @@ func txtarFindMarker(data []byte) (before []byte, name string, after []byte) {
 	var b []byte
 	for len(data) > 0 {
 		var line []byte
-		if i := bytes.IndexByte(data, '\n'); i >= 0 {
-			line, data = data[:i], data[i+1:]
+		if before0, after0, ok := bytes.Cut(data, []byte{'\n'}); ok {
+			line, data = before0, after0
 		} else {
 			line, data = data, nil
 		}
@@ -260,7 +260,7 @@ func newPool(gsxMod, work string, size int) (p *pool, err error) {
 	}
 	p = &pool{gocache: gocache, free: make(chan *workspace, size), cache: newRespCache(512)}
 
-	for i := 0; i < size; i++ {
+	for i := range size {
 		ws := &workspace{play: filepath.Join(work, fmt.Sprintf("play%d", i))}
 		ws.viewDir = filepath.Join(ws.play, "views")
 		if err = os.MkdirAll(ws.viewDir, 0o755); err != nil {

--- a/playground/server/render_test.go
+++ b/playground/server/render_test.go
@@ -134,7 +134,7 @@ func TestPoolConcurrent(t *testing.T) {
 	const n = 12
 	results := make([]string, n)
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -147,7 +147,7 @@ func TestPoolConcurrent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		want := "<p>U" + strconv.Itoa(i) + "</p>"
 		if results[i] != want {
 			t.Errorf("req %d: got %q want %q", i, results[i], want)

--- a/std/marker_test.go
+++ b/std/marker_test.go
@@ -8,7 +8,7 @@ import (
 // TestPkgMarkerPath proves std.Pkg's type lives in the std package, so
 // gen.WithFilters can recover the std import path from it via reflection.
 func TestPkgMarkerPath(t *testing.T) {
-	got := reflect.TypeOf(Pkg).PkgPath()
+	got := reflect.TypeFor[pkgMarker]().PkgPath()
 	want := "github.com/gsxhq/gsx/std"
 	if got != want {
 		t.Fatalf("reflect.TypeOf(std.Pkg).PkgPath() = %q, want %q", got, want)

--- a/val_test.go
+++ b/val_test.go
@@ -1,12 +1,17 @@
 package gsx
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-func renderNode(n Node) string { var b strings.Builder; _ = n.Render(nil, &b); return b.String() }
+func renderNode(n Node) string {
+	var b strings.Builder
+	_ = n.Render(context.Background(), &b)
+	return b.String()
+}
 
 type stringerT struct{}
 
@@ -30,7 +35,7 @@ func TestVal(t *testing.T) {
 }
 func TestValError(t *testing.T) {
 	var b strings.Builder
-	err := Val(struct{}{}).Render(nil, &b)
+	err := Val(struct{}{}).Render(context.Background(), &b)
 	if err == nil {
 		t.Error("Val(struct{}{}) should return error, got nil")
 	}


### PR DESCRIPTION
Adds a **merge-blocking golangci-lint gate** wired into CI (`lint` job) and `make lint`, over all three Go modules (root, `playground/server`, `examples/tailwind-merge`).

## Linter set (`.golangci.yml`)
`default: none`, then explicitly enabled:
- `staticcheck` — `SA*` (correctness) + `QF*` (quickfix/readability)
- `modernize` — modern language/stdlib simplifications (auto-fixable; CI-enforced going forward)
- `govet`, `ineffassign`, `unused` — real-mistake catchers
- `asciicheck`, `bidichk`, `durationcheck`, `misspell` — cheap hygiene

Generated `*.x.go` excluded.

## Fixes applied
- **`QF*`** (staticcheck quickfix): if/else-if → tagged `switch`; De Morgan's; readability helpers.
- **`modernize`** across the tree: `strings`/`bytes.Cut`/`Contains`, `CutPrefix`, `SplitSeq`, range-over-int, `slices.Sort`/`Contains`/`ContainsFunc`, `maps.Copy`, `min`/`max`, `strings.Builder`, `reflect.TypeFor`.

All behavior-preserving (the security-sensitive `escape.go` rewrites were hand-verified — the `Cut`/`Contains` forms are faithful to the old index logic); imports tidied with `goimports`.

## errcheck — evaluated, deliberately left disabled
Enabling errcheck surfaced 46 sites, **none latent bugs** — the actionable paths (e.g. `storePut`'s `Close`/`Write`) are already checked; the rest are unactionable stdout/cleanup calls. It would only force `_ =` ceremony without catching real defects. Left off.

## Verification
- `gopls check -severity=hint` → **0 remaining hints**, all modules
- `make lint` green (fresh cache), `go build ./...` OK
- root + `internal/codegen` + `internal/txtar` + playground test suites pass

## Notes on tooling divergence
golangci-lint's `modernize` (newer x/tools) aligns with `gopls check` — unlike the standalone `modernize` command, it does **not** flag `slices.Backward`, and it catches a few `bytes.Cut`/`stringsbuilder` sites the local gopls v0.22 missed. So the enabled linter is both CI-enforceable and faithful to what the editor surfaces.

https://claude.ai/code/session_019oQPGJn3Z5iaptHRaBJ7s1