### PR TITLE
feat(lsp): go-to-definition on type-parameter names and constraints

### DIFF
--- a/docs/superpowers/plans/2026-07-02-typeparams-lsp.md
+++ b/docs/superpowers/plans/2026-07-02-typeparams-lsp.md
@@ -1,0 +1,44 @@
+# Component Type-Parameter LSP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add hover and go-to-definition support for identifiers inside component type-parameter declarations and constraints.
+
+**Architecture:** Extend the existing signature-type bridge by recording type-parameter name and constraint spans in `buildSigTypeRefs`. Reuse `signatureTypeIdentAt`, `handleHover`, and `handleDefinition` without adding a new resolver path.
+
+**Tech Stack:** Go, `go/ast`, `go/types`, gsx parser/codegen analysis, internal LSP tests.
+
+---
+
+### Task 1: Pin Type-Parameter Constraint Resolution
+
+**Files:**
+- Modify: `internal/lsp/definition_test.go`
+- Read: `internal/codegen/module_test.go`
+
+- [ ] Add a helper-backed LSP test that builds a temporary module with `store.ID` and a `.gsx` component `Box[T store.ID]`.
+- [ ] Assert `signatureTypeIdentAt` resolves a cursor on `ID` to a `*types.TypeName` named `ID`.
+- [ ] Assert `signatureTypeIdentAt` resolves a cursor on `store` to a `*types.PkgName`.
+- [ ] Assert `signatureTypeIdentAt` resolves a cursor on declared `T` to a `*types.TypeName` named `T`.
+- [ ] Run `GOCACHE=/tmp/gsx-typeparams-lsp-gocache go test ./internal/lsp -run 'TestSignatureTypeIdentAtTypeParam' -count=1` and verify the tests fail before implementation.
+
+### Task 2: Record Type-Parameter Spans
+
+**Files:**
+- Modify: `internal/codegen/analyze.go`
+
+- [ ] In `buildSigTypeRefs`, inspect the skeleton component function's `Type.TypeParams`.
+- [ ] For each type-parameter name, compute its source span inside `c.TypeParams` from a synthetic Go parse of `func _[` + `c.TypeParams` + `]() {}`.
+- [ ] For each type-parameter constraint, compute its source span inside `c.TypeParams` from the same synthetic parse.
+- [ ] Append `SigTypeRef` entries pairing `.gsx` spans with corresponding skeleton `go/ast` identifiers and constraint expressions.
+- [ ] Keep receiver and parameter type behavior unchanged.
+
+### Task 3: Verify and Clean Up
+
+**Files:**
+- Modify as needed: `internal/codegen/analyze.go`, `internal/lsp/definition_test.go`
+
+- [ ] Run the focused LSP test and verify it passes.
+- [ ] Run `GOCACHE=/tmp/gsx-typeparams-lsp-gocache go test ./internal/lsp ./internal/codegen -count=1`.
+- [ ] Run `gofmt -w internal/lsp/definition_test.go internal/codegen/analyze.go`.
+- [ ] Run `GOCACHE=/tmp/gsx-typeparams-lsp-gocache make check` for final verification.

--- a/docs/superpowers/specs/2026-07-02-typeparams-lsp-design.md
+++ b/docs/superpowers/specs/2026-07-02-typeparams-lsp-design.md
@@ -1,0 +1,32 @@
+# Component Type-Parameter LSP Design
+
+## Goal
+
+Support hover and go-to-definition for identifiers inside component type-parameter lists, such as `store.ID` in `component Box[T store.ID](value T)`.
+
+## Scope
+
+This covers the component declaration's type-parameter list only. It does not add new behavior for every later use of the type parameter in the component body, except where that behavior already exists through ordinary expression analysis.
+
+## Architecture
+
+The LSP already resolves identifiers inside component signature types by recording `SigTypeRef` spans during codegen analysis and bridging a `.gsx` cursor into the type-checked skeleton AST. Extend that path to include type-parameter names and constraint expressions.
+
+`Component.TypeParamsPos` is the `.gsx` anchor for the trimmed type-parameter list. `buildSigTypeRefs` records each type parameter name and constraint type as spans relative to that anchor and pairs them with the corresponding skeleton `go/ast` nodes. Existing `signatureTypeIdentAt`, hover, and definition handlers can then resolve through `go/types` without a separate generic-specific resolver.
+
+## Behavior
+
+Hover on an identifier inside a constraint returns the same object string as hovering the equivalent Go type expression. Go-to-definition on a type name jumps to its declaration. Go-to-definition on a package qualifier in a constraint jumps to the imported package's package clauses, matching the existing parameter-type behavior.
+
+Hover and go-to-definition on the declared type parameter name resolve to that type parameter's own `go/types.TypeName` and source span.
+
+## Tests
+
+Add focused tests for `signatureTypeIdentAt` using a generated package analysis fixture:
+
+- cursor on `store.ID` type name inside `component Box[T store.ID](value T)` resolves to the imported type declaration
+- cursor on the `store` qualifier in the same constraint resolves as a package name
+- cursor on the declared type parameter name `T` resolves to a type-name object and the `T` span
+- cursor outside the recorded type-parameter span still returns no signature-type result
+
+These tests pin the mapping layer. Existing `handleHover` and `handleDefinition` already delegate to `signatureTypeIdentAt`, so the feature is covered without spinning up a JSON-RPC server.

--- a/gen/definition_sigtype_e2e_test.go
+++ b/gen/definition_sigtype_e2e_test.go
@@ -219,3 +219,68 @@ func TestDefinitionSignatureParamTypeSamePkg(t *testing.T) {
 		t.Fatalf("`Form` (BYO param) resolved to %v, want types.go", loc)
 	}
 }
+
+// gd on a TYPE-PARAMETER CONSTRAINT in a component signature resolves through
+// the real server pipeline (Module analysis → adaptPackageResult → lsp.SigTypes):
+// `ID` in `component Box[T store.ID]` jumps to the type definition in the
+// imported package, and the `store` qualifier jumps into its package clause.
+func TestDefinitionSignatureTypeParamConstraint(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	must := func(p, c string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, p)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/x\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	must("store/store.go", "package store\n\ntype ID string\n")
+	src := "package blog\n\nimport \"example.com/x/store\"\n\ncomponent Box[T store.ID](value T) {\n\t<span>{ value }</span>\n}\n"
+	must("blog/comp.gsx", src)
+	lines := strings.Split(src, "\n")
+
+	var sigLine int
+	for i, l := range lines {
+		if strings.Contains(l, "[T store.ID]") {
+			sigLine = i
+			break
+		}
+	}
+	storeCol := strings.Index(lines[sigLine], "store.ID")
+	idCol := storeCol + len("store.")
+
+	// Case 1: `ID` constraint type → the type definition in store/store.go.
+	loc := sigTypeDefAt(t, dir, "blog/comp.gsx", src, sigLine, idCol)
+	if loc == nil {
+		t.Fatalf("gd on `ID` type-param constraint returned null")
+	}
+	if !strings.HasSuffix(loc.URI, filepath.Join("store", "store.go")) {
+		t.Fatalf("`ID` resolved to %q, want store/store.go", loc.URI)
+	}
+
+	// Case 2: `store` qualifier → the package clause of store/store.go.
+	locs := sigTypeDefLocations(t, dir, "blog/comp.gsx", src, sigLine, storeCol)
+	if len(locs) == 0 {
+		t.Fatalf("gd on `store` qualifier in constraint returned no locations")
+	}
+	found := false
+	for _, l := range locs {
+		if strings.HasSuffix(l.URI, filepath.Join("store", "store.go")) {
+			found = true
+			if l.Range.Start.Line != 0 || l.Range.Start.Character != len("package ") {
+				t.Fatalf("`store` landed at L%d:C%d, want L0:C%d (the package name)",
+					l.Range.Start.Line, l.Range.Start.Character, len("package "))
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("`store` resolved to %v, want store/store.go package clause", locs)
+	}
+}

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -434,13 +434,13 @@ type ctrlRef struct {
 	Node        goast.Node
 }
 
-// SigTypeRef bridges one TYPE in a component signature (a parameter type or the
-// method receiver type) to its type-checked skeleton type expression. GSXPos is
-// the type's first byte in the .gsx and Len its byte length; SkelTyp is the
-// corresponding skeleton type expression (a props-struct field type, the sole
-// param type of a BYO component, or the receiver type), whose bytes are
-// identical to the .gsx source span — so the LSP bridges a cursor into it by
-// relative offset and resolves via go/types.
+// SigTypeRef bridges one navigable identifier region in a component signature
+// (a parameter type, method receiver type, type-parameter name, or
+// type-parameter constraint) to its type-checked skeleton expression. GSXPos is
+// the region's first byte in the .gsx and Len its byte length; SkelTyp is the
+// corresponding skeleton expression, whose bytes are identical to the .gsx
+// source span — so the LSP bridges a cursor into it by relative offset and
+// resolves via go/types.
 type SigTypeRef struct {
 	GSXPos  token.Pos
 	Len     int
@@ -1468,19 +1468,52 @@ func recvTypeIdent(e goast.Expr) string {
 	return ""
 }
 
-// buildSigTypeRefs pairs each TYPE in component c's signature — its parameter
-// types and (for a method component) its receiver type — with the corresponding
-// type-checked skeleton type expression, for the LSP's go-to-definition / hover.
-// Parameter types live in the generated props struct's fields (in param order),
-// or, for a BYO component, in the sole func parameter; the receiver type is the
-// skeleton method's receiver. Returns nil when c's skeleton shape cannot be
-// located (a skipped/stub component) or it carries no navigable types.
+// buildSigTypeRefs pairs each navigable signature type/name region in component
+// c — parameter types, type-parameter names/constraints, and (for a method
+// component) its receiver type — with the corresponding type-checked skeleton
+// expression, for the LSP's go-to-definition / hover. Parameter types live in
+// the generated props struct's fields (in param order), or, for a BYO component,
+// in the sole func parameter; the receiver type is the skeleton method's
+// receiver. Returns nil when c's skeleton shape cannot be located (a
+// skipped/stub component) or it carries no navigable types.
 func buildSigTypeRefs(gf *goast.File, c *gsxast.Component, byo *byoData) []SigTypeRef {
 	fd := funcDeclForKey(gf, componentKey(c))
 	if fd == nil {
 		return nil
 	}
 	var refs []SigTypeRef
+
+	// Type-parameter names and constraints. The skeleton emits the type-param
+	// list verbatim, so offsets from a synthetic parse of c.TypeParams align with
+	// the matching skeleton TypeParams fields.
+	if c.TypeParams != "" && c.TypeParamsPos.IsValid() && fd.Type.TypeParams != nil {
+		if tpl, tpFset, err := parseTypeParamFieldList(c.TypeParams); err == nil && tpl != nil {
+			off := func(p token.Pos) int { return tpFset.Position(p).Offset - len(typeParamSynthPrefix) }
+			for i, field := range tpl.List {
+				if i >= len(fd.Type.TypeParams.List) {
+					break
+				}
+				skelField := fd.Type.TypeParams.List[i]
+				for j, name := range field.Names {
+					if j >= len(skelField.Names) {
+						break
+					}
+					refs = append(refs, SigTypeRef{
+						GSXPos:  c.TypeParamsPos + token.Pos(off(name.Pos())),
+						Len:     len(name.Name),
+						SkelTyp: skelField.Names[j],
+					})
+				}
+				if field.Type != nil && skelField.Type != nil {
+					refs = append(refs, SigTypeRef{
+						GSXPos:  c.TypeParamsPos + token.Pos(off(field.Type.Pos())),
+						Len:     off(field.Type.End()) - off(field.Type.Pos()),
+						SkelTyp: skelField.Type,
+					})
+				}
+			}
+		}
+	}
 
 	// Parameter types.
 	if params, err := parseParams(c.Params); err == nil && len(params) > 0 {
@@ -2506,23 +2539,40 @@ func parseParams(src string) ([]param, error) {
 	return out, nil
 }
 
-func parseTypeParamNames(src string) ([]string, error) {
+// typeParamSynthPrefix is the synthetic wrapper prepended to a component's raw
+// type-param source so it parses as a generic func declaration. Offsets in the
+// parsed result relate to the trimmed source by subtracting len(typeParamSynthPrefix).
+const typeParamSynthPrefix = "package p\nfunc _["
+
+// parseTypeParamFieldList parses a component's raw type-param source (the text
+// between the signature's brackets) via the synthetic wrapper and returns the
+// type-param field list plus the FileSet that resolves its positions. The
+// FieldList is nil (with a nil error) for an empty or bracket-less list.
+func parseTypeParamFieldList(src string) (*goast.FieldList, *token.FileSet, error) {
 	src = strings.TrimSpace(src)
 	if src == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	fset := token.NewFileSet()
-	synth := "package p\nfunc _[" + src + "]() {}"
+	synth := typeParamSynthPrefix + src + "]() {}"
 	f, err := parser.ParseFile(fset, "", synth, 0)
 	if err != nil {
-		return nil, fmt.Errorf("codegen: parse type params %q: %w", src, err)
+		return nil, nil, fmt.Errorf("codegen: parse type params %q: %w", src, err)
 	}
-	fn := f.Decls[0].(*goast.FuncDecl)
-	if fn.Type.TypeParams == nil {
-		return nil, nil
+	fd, ok := f.Decls[0].(*goast.FuncDecl)
+	if !ok {
+		return nil, nil, fmt.Errorf("codegen: parse type params %q: unexpected declaration shape", src)
+	}
+	return fd.Type.TypeParams, fset, nil
+}
+
+func parseTypeParamNames(src string) ([]string, error) {
+	tpl, _, err := parseTypeParamFieldList(src)
+	if err != nil || tpl == nil {
+		return nil, err
 	}
 	var names []string
-	for _, field := range fn.Type.TypeParams.List {
+	for _, field := range tpl.List {
 		for _, nm := range field.Names {
 			names = append(names, nm.Name)
 		}

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -798,9 +798,10 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 		maps.Copy(ctrlMap, sub)
 	}
 
-	// Build SigTypes: per component, the byte span of each parameter TYPE in the
-	// .gsx signature paired with its type-checked skeleton type expression, so the
-	// LSP can resolve go-to-def / hover on identifiers inside a parameter type.
+	// Build SigTypes: per component, the byte span of each navigable signature
+	// region in the .gsx — parameter types, type-parameter names/constraints,
+	// and a method receiver type — paired with its type-checked skeleton
+	// expression, so the LSP can resolve go-to-def / hover on identifiers there.
 	sigTypes := map[*gsxast.Component][]SigTypeRef{}
 	for _, gf := range goFiles {
 		fname := fset.Position(gf.Pos()).Filename

--- a/internal/codegen/results.go
+++ b/internal/codegen/results.go
@@ -50,9 +50,10 @@ type PackageResult struct {
 	// skeleton for go-to-definition on loop variables and condition identifiers.
 	CtrlMap map[gsxast.Node]ctrlRef
 
-	// SigTypes maps each component to the type spans in its parameter list, so the
-	// LSP can answer go-to-definition / hover on the identifiers inside a parameter
-	// TYPE (e.g. `store.Comment` in `component C(c []store.Comment)`).
+	// SigTypes maps each component to the navigable spans in its signature —
+	// parameter types (e.g. `store.Comment` in `component C(c []store.Comment)`),
+	// type-parameter names and constraints, and a method receiver type — so the
+	// LSP can answer go-to-definition / hover on the identifiers inside them.
 	SigTypes map[*gsxast.Component][]SigTypeRef
 
 	// UnusedImports lists, per .gsx file path, the imports the file declares but

--- a/internal/lsp/analysis.go
+++ b/internal/lsp/analysis.go
@@ -35,12 +35,12 @@ type CtrlRef struct {
 	Node        ast.Node // skeleton node scoping innermostIdent
 }
 
-// SigTypeRef is the LSP mirror of codegen.SigTypeRef: one signature TYPE's
-// position (GSXPos) and byte length (Len) in the .gsx — a parameter type or a
-// method receiver type — paired with the type-checked skeleton type expression
-// (SkelTyp) whose bytes are identical to that source span. The LSP bridges a
-// cursor into SkelTyp by relative offset and resolves the identifier via
-// go/types.
+// SigTypeRef is the LSP mirror of codegen.SigTypeRef: one navigable signature
+// span's position (GSXPos) and byte length (Len) in the .gsx — a parameter
+// type, a type-parameter name or constraint, or a method receiver type —
+// paired with the type-checked skeleton expression (SkelTyp) whose bytes are
+// identical to that source span. The LSP bridges a cursor into SkelTyp by
+// relative offset and resolves the identifier via go/types.
 type SigTypeRef struct {
 	GSXPos  token.Pos
 	Len     int

--- a/internal/lsp/definition_test.go
+++ b/internal/lsp/definition_test.go
@@ -2,10 +2,14 @@ package lsp
 
 import (
 	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/codegen"
 	gsxparser "github.com/gsxhq/gsx/parser"
 )
 
@@ -19,6 +23,107 @@ func parseOnlyPackage(t *testing.T, name, src string) (*Package, string) {
 		t.Fatal(err)
 	}
 	return &Package{GSXFset: fset, Files: map[string]*gsxast.File{name: f}}, name
+}
+
+func writeLSPTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func analyzedLSPPackage(t *testing.T, src string) (*Package, string) {
+	t.Helper()
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeLSPTestFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	storeDir := filepath.Join(root, "store")
+	writeLSPTestFile(t, storeDir, "store.go", "package store\n\ntype ID string\n")
+	pageDir := filepath.Join(root, "page")
+	gsxPath := filepath.Join(pageDir, "page.gsx")
+	writeLSPTestFile(t, pageDir, "page.gsx", src)
+
+	m, err := codegen.Open(codegen.Options{ModuleRoot: root, ModulePath: "example.com/app", FilterPkgs: []string{codegen.StdImportPath}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr, err := m.Package(pageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %+v", pr.Diags)
+	}
+	sigTypes := map[*gsxast.Component][]SigTypeRef{}
+	for c, refs := range pr.SigTypes {
+		for _, r := range refs {
+			sigTypes[c] = append(sigTypes[c], SigTypeRef{
+				GSXPos:  r.GSXPos,
+				Len:     r.Len,
+				SkelTyp: r.SkelTyp,
+			})
+		}
+	}
+	return &Package{
+		GSXFset:  pr.GSXFset,
+		Fset:     pr.Fset,
+		Info:     pr.Info,
+		Types:    pr.Types,
+		Files:    pr.GSXFiles,
+		SigTypes: sigTypes,
+	}, gsxPath
+}
+
+func TestSignatureTypeIdentAtTypeParams(t *testing.T) {
+	src := "package page\n\nimport \"example.com/app/store\"\n\ncomponent Box[T store.ID](value T) {\n\t<span>{value}</span>\n}\n"
+	pkg, path := analyzedLSPPackage(t, src)
+
+	idOff := strings.Index(src, "store.ID") + len("store.")
+	obj, gsxStart, idLen, ok := signatureTypeIdentAt(pkg, path, idOff)
+	if !ok {
+		t.Fatal("signatureTypeIdentAt returned false for type-param constraint type")
+	}
+	if _, ok := obj.(*types.TypeName); !ok || obj.Name() != "ID" {
+		t.Fatalf("obj = %T %q, want *types.TypeName ID", obj, obj.Name())
+	}
+	if got := src[gsxStart : gsxStart+idLen]; got != "ID" {
+		t.Fatalf("range = %q, want ID", got)
+	}
+
+	pkgOff := strings.Index(src, "store.ID")
+	obj, gsxStart, idLen, ok = signatureTypeIdentAt(pkg, path, pkgOff)
+	if !ok {
+		t.Fatal("signatureTypeIdentAt returned false for type-param constraint package qualifier")
+	}
+	if _, ok := obj.(*types.PkgName); !ok || obj.Name() != "store" {
+		t.Fatalf("obj = %T %q, want *types.PkgName store", obj, obj.Name())
+	}
+	if got := src[gsxStart : gsxStart+idLen]; got != "store" {
+		t.Fatalf("range = %q, want store", got)
+	}
+
+	tOff := strings.Index(src, "[T store.ID]") + 1
+	obj, gsxStart, idLen, ok = signatureTypeIdentAt(pkg, path, tOff)
+	if !ok {
+		t.Fatal("signatureTypeIdentAt returned false for type-param declaration name")
+	}
+	if _, ok := obj.(*types.TypeName); !ok || obj.Name() != "T" {
+		t.Fatalf("obj = %T %q, want *types.TypeName T", obj, obj.Name())
+	}
+	if got := src[gsxStart : gsxStart+idLen]; got != "T" {
+		t.Fatalf("range = %q, want T", got)
+	}
+
+	outside := strings.Index(src, "component Box")
+	if _, _, _, ok := signatureTypeIdentAt(pkg, path, outside); ok {
+		t.Fatal("signatureTypeIdentAt unexpectedly resolved outside type-param list")
+	}
 }
 
 func TestExprNodeAtOffset(t *testing.T) {


### PR DESCRIPTION
## Summary

Extends `SigTypes` to carry **type-parameter name and constraint spans**, so LSP go-to-definition / hover work on `T` and `store.ID` in `component Box[T store.ID](value T)`. The skeleton emits the type-param list verbatim, so spans from a synthetic parse of `c.TypeParams` bridge into the type-checked skeleton fields by relative offset — same mechanism as parameter types and method receivers.

## Review

Ran a high-effort multi-agent review before pushing; no correctness bugs survived verification. Applied the cleanup findings:

- **Shared parse helper** — `parseTypeParamFieldList` is now the single synthetic-wrapper parse used by both the emitter's `parseTypeParamNames` and the new span mapping (previously two independent copies of the same parse).
- **Dropped over-structured span types** — `buildSigTypeRefs` walks the parsed `*goast.FieldList` in lockstep with the skeleton fields directly; the three intermediate span structs (with dead/always-true `ok` fields) are gone.
- **Real adapter path tested** — added `TestDefinitionSignatureTypeParamConstraint` in `gen`, driving the full server pipeline (Module analysis → `adaptPackageResult` → `textDocument/definition`) rather than only the test-local conversion in `internal/lsp`.
- **Doc drift fixed** — `SigTypes`/`SigTypeRef` docs in `results.go`, `lsp/analysis.go`, and `module_importer.go` now describe the full span set.

One refuted candidate (Unicode-whitespace span shift from TrimLeft/TrimSpace mismatch) did not reproduce. Known remaining nit: the temp-module `go.mod` fixture is duplicated once more in `internal/lsp` — a shared test fixture helper across ~20 existing copies is left as a separate cleanup.

## Testing

- `make check` passes (build/vet/test both modules, examples drift, gofmt + gsx fmt).
- New: `internal/lsp` unit test on `signatureTypeIdentAt` (constraint type, package qualifier, type-param name, outside-span miss) + `gen` e2e test through the real LSP JSON-RPC loop.

https://claude.ai/code/session_011frpaWAFYtX24u9gUuENVM