### PR TITLE
feat(lsp): go-to-definition + hover for every Go-fragment position

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -285,8 +285,12 @@ func (*BoolAttr) attrNode() {}
 // Interp.Stages — the lowered result is the spread/splat subject.
 type SpreadAttr struct {
 	span
-	Expr   string
-	Stages []PipeStage
+	Expr string
+	// ExprPos is the position of the first char of Expr in source, for LSP
+	// cursor mapping. It is NoPos when Expr's text differs from the source
+	// bytes (a parenthesized pipeline unwrapped by the parser).
+	ExprPos token.Pos
+	Stages  []PipeStage
 }
 
 func (*SpreadAttr) attrNode() {}
@@ -356,8 +360,9 @@ func (*ForMarkup) markupNode() {}
 // SwitchMarkup is `{ switch Tag { Cases } }`. Tag is "" for a tagless switch.
 type SwitchMarkup struct {
 	span
-	Tag   string
-	Cases []*CaseClause
+	Tag    string
+	TagPos token.Pos // first char of Tag in source (NoPos for a tagless switch)
+	Cases  []*CaseClause
 }
 
 func (*SwitchMarkup) markupNode() {}
@@ -368,6 +373,7 @@ func (*SwitchMarkup) markupNode() {}
 type CaseClause struct {
 	span
 	List    string
+	ListPos token.Pos // first char of List in source (NoPos for `default:`)
 	Default bool
 	Body    []Markup
 }
@@ -376,9 +382,10 @@ type CaseClause struct {
 // Then and Else are attribute lists; an `else if` is Else = []Attr{<*CondAttr>}.
 type CondAttr struct {
 	span
-	Cond string
-	Then []Attr
-	Else []Attr
+	Cond    string
+	CondPos token.Pos // first char of Cond text in source (NoPos if unavailable)
+	Then    []Attr
+	Else    []Attr
 }
 
 func (*CondAttr) attrNode() {}
@@ -395,8 +402,14 @@ func (*CondAttr) attrNode() {}
 // and CSSSegments are unused.
 type ClassPart struct {
 	span
-	Expr        string
-	Cond        string
+	Expr string
+	// ExprPos is the position of the first char of Expr (the pipe seed) in
+	// source (NoPos for CSS-literal and value-form parts, which have no Expr).
+	ExprPos token.Pos
+	Cond    string
+	// CondPos is the position of the first char of the `: cond` guard text in
+	// source (NoPos when Cond == "").
+	CondPos     token.Pos
 	Stages      []PipeStage
 	CSSSegments []Markup
 	CF          *ValueCF
@@ -417,8 +430,9 @@ func (*ClassAttr) attrNode() {}
 // type harvest + diagnostics) but neither Markup nor Attr.
 type ValueArm struct {
 	span
-	Expr   string
-	Stages []PipeStage
+	Expr    string
+	ExprPos token.Pos // first char of Expr (the pipe seed) in source
+	Stages  []PipeStage
 }
 
 // ValueIf is the value-producing `if Cond { Then } [else if … | else { Else }]`
@@ -437,8 +451,9 @@ type ValueIf struct {
 // Tag is "" for a tagless switch.
 type ValueSwitch struct {
 	span
-	Tag   string
-	Cases []*ValueSwitchCase
+	Tag    string
+	TagPos token.Pos // first char of Tag in source (NoPos for a tagless switch)
+	Cases  []*ValueSwitchCase
 }
 
 // ValueSwitchCase is one `case List:` / `default:` arm of a ValueSwitch. List is
@@ -446,6 +461,7 @@ type ValueSwitch struct {
 type ValueSwitchCase struct {
 	span
 	List    string
+	ListPos token.Pos // first char of List in source (NoPos for `default:`)
 	Default bool
 	Value   *ValueArm
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -219,6 +219,21 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
 - [x] **Debounced diagnostics** (`internal/lsp/server.go`) — a per-directory
   timer (250 ms) coalesces edit bursts; analysis runs off the read loop and
   version-tags its publishes. `didOpen` publishes promptly (no debounce).
+- [x] **Full expression-position coverage matrix** (2026-07-03) — go-to-def AND
+  hover work for identifiers in EVERY Go-fragment position, via two bridges:
+  the ExprMap byte-identical expr bridge (interps, expr attrs, spreads,
+  ordered-attrs pair values, class plain parts, value-form arms) and the
+  CtrlMap statement-clause bridge (for/if/`{{ }}` clauses, markup + value-form
+  switch tags and case lists, in-tag conditional-attribute conds
+  `{ if cond { … } }`, class guard conds `"on": cond`, value-form if conds).
+  Parser records byte-faithful positions for each span (`parser/navpos_test.go`
+  pins the invariant); `TestDefinitionMatrix`/`TestHoverObjectMatrix` pin the
+  full matrix. Known limitations: the EXPR of a *guarded* class part
+  (`expr: cond` — its cond navigates, the expr doesn't: no type harvest for
+  guarded parts), pipeline-stage spans on spreads (parser records no stage
+  positions there), paren-unwrapped spread pipelines (`{ (x |> f)... }` seed),
+  and ctrl spans inside COMPONENT-tag attributes (`<Kid { if c { … } }/>` —
+  the liveness walk that records ctrl offsets only runs for plain elements).
 - **Deferred:** completion and external/non-project references; references cover
   project components discovered during module analysis. Dotted/cross-package
   component tags (`<ui.Button/>`) are deferred.

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -26,8 +26,8 @@ gsx lsp                 # blocks, reading LSP messages on stdin
 | Feature | LSP method | Notes |
 |---|---|---|
 | **Diagnostics** | `publishDiagnostics` | positioned parse + type errors (with severity, code, help) from the shared diagnostics engine; re-analyzed on every change, with multi-error and component-boundary recovery |
-| **Go-to-definition** | `textDocument/definition` | jump from a Go symbol in a `{ }`/attribute expression to its `.go` definition; from a `<Card/>` tag to its `component` declaration; and from a `.go` component reference back to the `.gsx` |
-| **Hover** | `textDocument/hover` | gopls-style type/signature for an identifier or expression; a component tag shows its signature (answered from the AST even mid-edit when type-checking can't complete) |
+| **Go-to-definition** | `textDocument/definition` | jump from a Go symbol anywhere Go appears — `{ }` interpolations, attribute expressions, spreads, class/style parts and their `: cond` guards, `{ if … }` conditional-attribute conditions, value-form `if`/`switch` control expressions and arms, `for`/`if`/`switch` clauses, and `{{ }}` blocks — to its definition; from a `<Card/>` tag to its `component` declaration; and from a `.go` component reference back to the `.gsx` |
+| **Hover** | `textDocument/hover` | gopls-style type/signature for an identifier or expression in all the same positions as go-to-definition; a component tag shows its signature (answered from the AST even mid-edit when type-checking can't complete) |
 | **Find references** | `textDocument/references` | `.go` call sites and `.gsx` tag sites for project components discovered by module analysis; external/non-project packages are skipped |
 | **Formatting** | `textDocument/formatting` | canonical `gsx fmt` form, including unused-import removal — wire it to format-on-save |
 

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -322,7 +322,8 @@ func buildSkeleton(file *gsxast.File, table filterTable, propFields, nodeProps, 
 	// the skeleton type-check).
 	usedFilters := map[string]string{} // alias -> pkgPath
 	var compBuf strings.Builder
-	// ctrlOff maps each control-flow node (ForMarkup/IfMarkup/GoBlock) to the
+	// ctrlOff maps each control-flow node (ForMarkup/IfMarkup/GoBlock, and each
+	// value-form if condition's *ValueIf) to the
 	// byte offset of its clause/cond/code text within the final skeleton string.
 	// Offsets are recorded relative to compBuf during emitComponentSkeleton and
 	// adjusted below (after the prefix is assembled into sb) to be file-relative.
@@ -546,8 +547,12 @@ type SigTypeRef struct {
 	SkelTyp goast.Expr
 }
 
-// ctrlClauseText returns the clause/cond/code text for a control-flow node:
-// ForMarkup → Clause, IfMarkup → Cond, GoBlock → Code.
+// ctrlClauseText returns the clause/cond/code/tag text a control-flow node
+// contributes verbatim to the skeleton at its recorded ctrlOff: ForMarkup →
+// Clause, IfMarkup → Cond, GoBlock → Code, SwitchMarkup → Tag, CaseClause →
+// List, CondAttr → Cond (in-tag `{ if … }` attribute group), ClassPart → Cond
+// (a `: cond` guard in class/style), ValueIf → Cond, ValueSwitch → Tag,
+// ValueSwitchCase → List (value-form if/switch inside class/style).
 func ctrlClauseText(n gsxast.Node) string {
 	switch t := n.(type) {
 	case *gsxast.ForMarkup:
@@ -556,6 +561,20 @@ func ctrlClauseText(n gsxast.Node) string {
 		return t.Cond
 	case *gsxast.GoBlock:
 		return t.Code
+	case *gsxast.SwitchMarkup:
+		return t.Tag
+	case *gsxast.CaseClause:
+		return t.List
+	case *gsxast.CondAttr:
+		return t.Cond
+	case *gsxast.ClassPart:
+		return t.Cond
+	case *gsxast.ValueIf:
+		return t.Cond
+	case *gsxast.ValueSwitch:
+		return t.Tag
+	case *gsxast.ValueSwitchCase:
+		return t.List
 	}
 	return ""
 }
@@ -1261,15 +1280,21 @@ func emitProbes(sb *strings.Builder, nodes []gsxast.Markup, table filterTable, p
 				// harvest), so a var used ONLY in `class={ "on": v }` or in a
 				// value-form if/switch condition must still be referenced here or
 				// it's "declared and not used". The walk yields ready-made liveness
-				// STATEMENTS — `_ = (expr)`, or an empty-bodied if/switch for CF
-				// parts (their tags/case lists are only legal in statement position)
-				// — NOT _gsxuse, so the harvest alignment is intact. CF arms and
-				// unconditional plain parts are excluded (they have _gsxuse probes
-				// above). Spreads are excluded too because their _gsxuseq probes
-				// above also keep them live.
+				// STATEMENTS — `_ = (expr)`, or (via emitValueCFControl) an
+				// empty-bodied if/switch for CF parts (their tags/case lists are
+				// only legal in statement position) — NOT _gsxuse, so the harvest
+				// alignment is intact. Each value-form if condition also records a
+				// ctrlOff entry so the LSP can go-to-definition inside it. CF arms
+				// and unconditional plain parts are excluded (they have _gsxuse
+				// probes above). Spreads are excluded too because their _gsxuseq
+				// probes above also keep them live.
 				walkLivenessAttrExprs(t.Attrs, table, usedFilters, func(stmt string) {
 					sb.WriteString(stmt)
 					sb.WriteByte('\n')
+				}, func(cf *gsxast.ValueCF) {
+					emitValueCFControl(sb, fset, cf, ctrlOff)
+				}, func(node gsxast.Node, cond string, condPos token.Pos) {
+					emitCondLiveness(sb, fset, node, cond, condPos, ctrlOff)
 				})
 				// Then probe each JS-attribute's @{ } interps, in attr source order —
 				// collectExprs walks identically (same walkMarkupAttrs), so the k-th
@@ -1316,11 +1341,17 @@ func emitProbes(sb *strings.Builder, nodes []gsxast.Markup, table filterTable, p
 			}
 			sb.WriteString("\n")
 		case *gsxast.SwitchMarkup:
+			if strings.TrimSpace(t.Tag) != "" {
+				emitSkeletonClauseLine(sb, fset, t.TagPos, len("switch "))
+				ctrlOff[t] = sb.Len() + len("switch ")
+			}
 			fmt.Fprintf(sb, "switch %s {\n", t.Tag)
 			for _, cc := range t.Cases {
 				if cc.Default {
 					sb.WriteString("default:\n")
 				} else {
+					emitSkeletonClauseLine(sb, fset, cc.ListPos, len("case "))
+					ctrlOff[cc] = sb.Len() + len("case ")
 					fmt.Fprintf(sb, "case %s:\n", cc.List)
 				}
 				if err := emitProbes(sb, cc.Body, table, propFields, nodeProps, attrsProps, genericSigs, byo, fm, recvVar, recvTypeName, usedFilters, fset, ctrlOff, registry, bag); err != nil {
@@ -2171,9 +2202,13 @@ func walkClassAttrs(attrs []gsxast.Attr, fn func(*gsxast.ClassAttr)) {
 // these verbatim (gsx.Class/ClassIf/StyleString) so they need no type harvest,
 // but the skeleton must still REFERENCE them or a var used ONLY here (e.g. a
 // for-loop var in `class={ "on": v }`) is rejected as "declared and not used".
-// Plain exprs and guard conds become `_ = (expr)`; a value-form CF part
-// becomes an empty-bodied if/switch statement (valueCFControlStmt) because its
-// tag and case lists are only legal in statement position. Both forms are
+// Plain exprs become `_ = (expr)` via fn; guard conds (a ClassPart's `: cond`,
+// incl. on css literals) and in-tag conditional-attribute conds (*CondAttr) are
+// yielded to fnCond with their owning node and source position, so the caller
+// can emit an `if cond {\n}` statement and record a ctrlOff entry (the LSP's
+// CtrlMap bridge); a value-form CF part is yielded whole to fnCF, which emits
+// its empty-bodied control statement(s) (see emitValueCFControl — its tag and
+// case lists are only legal in statement position) the same way. All forms are
 // invisible to the k-th-probe→k-th-node type-harvest alignment, unlike _gsxuse.
 // A ClassPart carrying a `|>` pipeline must reference the LOWERED
 // expression — the SAME lowerPipe output emit produces — so type resolution and
@@ -2184,7 +2219,7 @@ func walkClassAttrs(attrs []gsxast.Attr, fn func(*gsxast.ClassAttr)) {
 // referencing the bare seed so type-checking proceeds to the POSITIONED
 // unknown-filter diagnostic generateFile reports (the probe's bare error must not
 // pre-empt it). The guard Cond is never piped, so it is referenced verbatim.
-func walkLivenessAttrExprs(attrs []gsxast.Attr, table filterTable, usedFilters map[string]string, fn func(stmt string)) {
+func walkLivenessAttrExprs(attrs []gsxast.Attr, table filterTable, usedFilters map[string]string, fn func(stmt string), fnCF func(cf *gsxast.ValueCF), fnCond func(node gsxast.Node, cond string, condPos token.Pos)) {
 	ref := func(expr string) {
 		fn("_ = (" + expr + ")")
 	}
@@ -2209,11 +2244,12 @@ func walkLivenessAttrExprs(attrs []gsxast.Attr, table filterTable, usedFilters m
 	for _, a := range attrs {
 		switch at := a.(type) {
 		case *gsxast.ClassAttr:
-			for _, p := range at.Parts {
+			// Index (not range-copy) so fnCond is keyed by the SAME *ClassPart
+			// pointer ast.Inspect yields — the identity the LSP looks up in CtrlMap.
+			for i := range at.Parts {
+				p := &at.Parts[i]
 				if p.CSSSegments != nil {
-					if c := strings.TrimSpace(p.Cond); c != "" {
-						ref(c)
-					}
+					fnCond(p, p.Cond, p.CondPos)
 					continue
 				}
 				if p.CF == nil && p.Cond == "" {
@@ -2223,22 +2259,16 @@ func walkLivenessAttrExprs(attrs []gsxast.Attr, table filterTable, usedFilters m
 					continue
 				}
 				if p.CF != nil {
-					if stmt := valueCFControlStmt(p.CF); stmt != "" {
-						fn(stmt)
-					}
+					fnCF(p.CF)
 					continue
 				}
 				emit(p.Expr, p.Stages)
-				if c := strings.TrimSpace(p.Cond); c != "" {
-					ref(c)
-				}
+				fnCond(p, p.Cond, p.CondPos)
 			}
 		case *gsxast.CondAttr:
-			if c := strings.TrimSpace(at.Cond); c != "" {
-				ref(c)
-			}
-			walkLivenessAttrExprs(at.Then, table, usedFilters, fn)
-			walkLivenessAttrExprs(at.Else, table, usedFilters, fn)
+			fnCond(at, at.Cond, at.CondPos)
+			walkLivenessAttrExprs(at.Then, table, usedFilters, fn, fnCF, fnCond)
+			walkLivenessAttrExprs(at.Else, table, usedFilters, fn, fnCF, fnCond)
 		}
 	}
 }
@@ -2526,37 +2556,62 @@ func addValueCFSrc(cf *gsxast.ValueCF, add func(string)) {
 	}
 }
 
-// valueCFControlStmt returns an empty-bodied skeleton statement that
-// references a value-form CF's control expressions in their natural
-// grammatical positions: `if c {} else if c2 {}` for the condition chain, or
-// `switch tag { case list: default: }` mirroring the source clauses. Statement
-// position (not `_ = (expr)`) is required — case lists may contain `nil`, type
-// names under a `.(type)` tag, or untyped constants that only fit the tag's
-// type, none of which are legal as a bare expression. Arm expressions are
-// excluded: emitProbes harvests them with _gsxuse so value-form arms preserve
-// (T, error) auto-unwrapping without disturbing probe order.
-func valueCFControlStmt(cf *gsxast.ValueCF) string {
-	var sb strings.Builder
-	switch {
-	case cf.If != nil:
+// emitCondLiveness writes the empty-bodied `if <cond> {\n}` statement that
+// keeps a guard condition's identifiers live in the skeleton, with a
+// compensated //line and a ctrlOff entry keyed by node — the CtrlMap bridge
+// the LSP uses for go-to-definition/hover inside the condition. Used for
+// in-tag conditional-attribute conds (*CondAttr), class/style `: cond` guards
+// (*ClassPart), and value-form if conditions (*ValueIf).
+func emitCondLiveness(sb *strings.Builder, fset *token.FileSet, node gsxast.Node, cond string, condPos token.Pos, ctrlOff map[gsxast.Node]int) {
+	if strings.TrimSpace(cond) == "" {
+		return
+	}
+	emitSkeletonClauseLine(sb, fset, condPos, len("if "))
+	ctrlOff[node] = sb.Len() + len("if ")
+	fmt.Fprintf(sb, "if %s {\n}\n", cond)
+}
+
+// emitValueCFControl writes the empty-bodied skeleton statement(s) that
+// reference a value-form CF part's control expressions in their natural
+// grammatical positions. Statement position (not `_ = (expr)`) is required —
+// case lists may contain `nil`, type names under a `.(type)` tag, or untyped
+// constants that only fit the tag's type, none of which are legal as a bare
+// expression. Arm expressions are excluded: emitProbes harvests them with
+// _gsxuse so value-form arms preserve (T, error) auto-unwrapping without
+// disturbing probe order.
+//
+// The if-form emits each condition in the chain as its OWN `if <cond> {\n}`
+// statement (not an `else if` chain — the conds are independent bool
+// expressions, so type-checking is identical) so every condition carries a
+// compensated //line and a ctrlOff entry keyed by its *ValueIf. The switch
+// form records ctrlOff for the tag (keyed by the *ValueSwitch) and each case
+// list (keyed by its *ValueSwitchCase) the same way. That is the same CtrlMap
+// bridge IfMarkup uses, making go-to-definition (and positioned type errors)
+// work inside value-form control expressions.
+func emitValueCFControl(sb *strings.Builder, fset *token.FileSet, cf *gsxast.ValueCF, ctrlOff map[gsxast.Node]int) {
+	if cf.If != nil {
 		for vi := cf.If; vi != nil; vi = vi.ElseIf {
-			if vi != cf.If {
-				sb.WriteString(" else ")
-			}
-			fmt.Fprintf(&sb, "if %s {\n}", vi.Cond)
+			emitCondLiveness(sb, fset, vi, vi.Cond, vi.CondPos, ctrlOff)
 		}
-	case cf.Switch != nil:
-		fmt.Fprintf(&sb, "switch %s {\n", strings.TrimSpace(cf.Switch.Tag))
-		for _, c := range cf.Switch.Cases {
+		return
+	}
+	if vs := cf.Switch; vs != nil {
+		if strings.TrimSpace(vs.Tag) != "" {
+			emitSkeletonClauseLine(sb, fset, vs.TagPos, len("switch "))
+			ctrlOff[vs] = sb.Len() + len("switch ")
+		}
+		fmt.Fprintf(sb, "switch %s {\n", strings.TrimSpace(vs.Tag))
+		for _, c := range vs.Cases {
 			if c.Default {
 				sb.WriteString("default:\n")
-			} else {
-				fmt.Fprintf(&sb, "case %s:\n", c.List)
+				continue
 			}
+			emitSkeletonClauseLine(sb, fset, c.ListPos, len("case "))
+			ctrlOff[c] = sb.Len() + len("case ")
+			fmt.Fprintf(sb, "case %s:\n", c.List)
 		}
-		sb.WriteString("}")
+		sb.WriteString("}\n")
 	}
-	return sb.String()
 }
 
 func addValueIfSrc(vi *gsxast.ValueIf, add func(string)) {

--- a/internal/codegen/controlflow_test.go
+++ b/internal/codegen/controlflow_test.go
@@ -89,6 +89,117 @@ func TestModulePackageBuildsCtrlMap(t *testing.T) {
 	}
 }
 
+// TestBuildSkeletonRecordsNavSpanOffsets verifies that every statement-position
+// navigation span gets a ctrlOff entry keyed by its owning node, with the
+// skeleton bytes at that offset byte-faithful to the clause text (the invariant
+// the LSP's relative-offset bridge relies on): value-form if/else-if conds,
+// value-form switch tag + case lists, in-tag conditional-attribute conds,
+// class guard conds, and markup switch tag + case lists.
+func TestBuildSkeletonRecordsNavSpanOffsets(t *testing.T) {
+	src := "package v\n\ncomponent P(disabled bool, busy bool, n int) {\n\t<input\n\t\tclass={\n\t\t\t\"base\",\n\t\t\t\"guard\": busy,\n\t\t\tif disabled { \"off\" } else if busy { \"wait\" },\n\t\t\tswitch n {\n\t\t\tcase 1, n: \"one\"\n\t\t\tdefault: \"d\"\n\t\t\t}\n\t\t}\n\t\t{ if disabled {\n\t\t\tdata-x=\"1\"\n\t\t} }\n\t/>\n\t{ switch n {\n\tcase 2, n:\n\t\t<b>x</b>\n\t} }\n}\n"
+	fset := token.NewFileSet()
+	file, errs := gsxparser.ParseFileWithClassifier(fset, "p.gsx", []byte(src), 0, nil)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	table, _ := loadFilterTable(t.TempDir())
+	pf, np, ap, byo, err := componentPropFieldsFor(t.TempDir(), map[string]*gsxast.File{"p.gsx": file})
+	if err != nil {
+		t.Fatalf("propFields: %v", err)
+	}
+	skel, _, _, ctrlOff, _, err := buildSkeleton(file, table, pf, np, ap, nil, nil, byo, nil, fset, nil, nil)
+	if err != nil {
+		t.Fatalf("buildSkeleton: %v", err)
+	}
+	type want struct {
+		name string
+		node gsxast.Node
+		text string
+	}
+	var wants []want
+	gsxast.Inspect(file, func(n gsxast.Node) bool {
+		switch v := n.(type) {
+		case *gsxast.ValueIf:
+			wants = append(wants, want{"ValueIf cond", v, v.Cond})
+		case *gsxast.ValueSwitch:
+			wants = append(wants, want{"ValueSwitch tag", v, v.Tag})
+		case *gsxast.ValueSwitchCase:
+			if !v.Default {
+				wants = append(wants, want{"ValueSwitchCase list", v, v.List})
+			}
+		case *gsxast.CondAttr:
+			wants = append(wants, want{"CondAttr cond", v, v.Cond})
+		case *gsxast.ClassPart:
+			if v.Cond != "" {
+				wants = append(wants, want{"ClassPart guard cond", v, v.Cond})
+			}
+		case *gsxast.SwitchMarkup:
+			wants = append(wants, want{"SwitchMarkup tag", v, v.Tag})
+		case *gsxast.CaseClause:
+			if !v.Default {
+				wants = append(wants, want{"CaseClause list", v, v.List})
+			}
+		}
+		return true
+	})
+	if len(wants) != 8 {
+		t.Fatalf("collected %d nav spans, want 8", len(wants))
+	}
+	for _, w := range wants {
+		off, ok := ctrlOff[w.node]
+		if !ok {
+			t.Errorf("ctrlOff has no entry for %s %q", w.name, w.text)
+			continue
+		}
+		if got := skel[off : off+len(w.text)]; got != w.text {
+			t.Errorf("%s: skeleton at ctrlOff = %q, want %q (byte-faithful)", w.name, got, w.text)
+		}
+	}
+}
+
+// TestModulePackageBuildsCtrlMapValueIf verifies the Module path surfaces a
+// CtrlMap entry for a value-form if condition, with ClauseStart mapping (via
+// //line) back to the .gsx.
+func TestModulePackageBuildsCtrlMapValueIf(t *testing.T) {
+	root := t.TempDir()
+	repoRoot, _ := filepath.Abs("../..")
+	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	pkgDir := filepath.Join(root, "page")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, pkgDir, "page.gsx", "package page\n\ncomponent Box(disabled bool) {\n\t<input class={\n\t\t\"base\",\n\t\tif disabled { \"off\" }\n\t}/>\n}\n")
+
+	m, _ := Open(Options{ModuleRoot: root, ModulePath: "example.com/app", FilterPkgs: []string{StdImportPath}})
+	pr, err := m.Package(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %+v", pr.Diags)
+	}
+	var vi *gsxast.ValueIf
+	for _, gf := range pr.GSXFiles {
+		gsxast.Inspect(gf, func(n gsxast.Node) bool {
+			if v, ok := n.(*gsxast.ValueIf); ok {
+				vi = v
+			}
+			return true
+		})
+	}
+	if vi == nil {
+		t.Fatal("no ValueIf parsed")
+	}
+	cr, ok := pr.CtrlMap[vi]
+	if !ok || !cr.ClauseStart.IsValid() || cr.Node == nil {
+		t.Fatalf("CtrlMap missing/invalid for ValueIf: %+v ok=%v", cr, ok)
+	}
+	dp := pr.Fset.Position(cr.ClauseStart)
+	if !strings.HasSuffix(dp.Filename, ".gsx") {
+		t.Errorf("ClauseStart maps to %s, want a .gsx position", dp.Filename)
+	}
+}
+
 func TestConditionalBoolAttrCondKeepsLocalLive(t *testing.T) {
 	root := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")

--- a/internal/codegen/results.go
+++ b/internal/codegen/results.go
@@ -44,7 +44,8 @@ type PackageResult struct {
 	CrossIndex map[string]CrossRef // componentKey → cross-boundary index entry
 	NavIndex   []NavRef            // navigable Go references → .gsx targets (func, props-struct, field)
 
-	// CtrlMap maps each control-flow node (ForMarkup/IfMarkup/GoBlock) to its
+	// CtrlMap maps each control-flow node (ForMarkup/IfMarkup/GoBlock, and each
+	// value-form if condition's *ValueIf) to its
 	// skeleton clause position and smallest containing skeleton go/ast node.
 	// Used by the LSP to bridge a cursor in a for/if/goblock clause to the
 	// skeleton for go-to-definition on loop variables and condition identifiers.

--- a/internal/lsp/analysis.go
+++ b/internal/lsp/analysis.go
@@ -64,7 +64,8 @@ type Package struct {
 	CrossIndex map[string]CrossRef
 	NavIndex   []NavRef // navigable Go references → .gsx targets (func, props-struct, field)
 
-	// CtrlMap maps each control-flow node (ForMarkup/IfMarkup/GoBlock) to its
+	// CtrlMap maps each control-flow node (ForMarkup/IfMarkup/GoBlock, and each
+	// value-form if condition's *ValueIf) to its
 	// skeleton clause position and smallest containing skeleton node. Used by the
 	// LSP for go-to-definition on loop variables and condition identifiers.
 	CtrlMap map[gsxast.Node]CtrlRef

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -14,12 +14,72 @@ import (
 	gsxast "github.com/gsxhq/gsx/ast"
 )
 
-// exprNodeAtOffset returns the gsx Interp/ExprAttr whose Go-expression span
-// [ExprPos, ExprPos+len(Expr)) contains the byte offset, together with that
-// node's ExprPos (so the caller need not re-discriminate the node type). Returns
-// (nil, token.NoPos) when no expression node covers the offset. Interp/ExprAttr
-// expressions are opaque strings that never nest, so at most one node matches an
-// offset — the walk's last-write-wins is unambiguous.
+// navSpan is one navigable Go-fragment byte span of a gsx node: pos is the
+// first byte of the (trimmed) fragment text in the .gsx, ln its byte length.
+type navSpan struct {
+	pos token.Pos
+	ln  int
+}
+
+// nodeNavSpans returns a node's navigable Go-fragment spans plus its pipeline
+// stages (whose name/args regions are matched separately). Every span's source
+// bytes spell exactly the stored fragment text — the parser's byte-faithful
+// invariant — so cursors bridge into the skeleton by relative offset. A node
+// can carry more than one span (a ClassPart's expr and its `: cond` guard);
+// spans never overlap across nodes, so at most one (node, span) matches an
+// offset. Nodes with no navigable fragment return nil.
+func nodeNavSpans(n gsxast.Node) (spans []navSpan, stages []gsxast.PipeStage) {
+	switch e := n.(type) {
+	case *gsxast.Interp:
+		return []navSpan{{e.ExprPos, len(e.Expr)}}, e.Stages
+	case *gsxast.ExprAttr:
+		return []navSpan{{e.ExprPos, len(e.Expr)}}, e.Stages
+	case *gsxast.SpreadAttr:
+		return []navSpan{{e.ExprPos, len(e.Expr)}}, e.Stages
+	case *gsxast.OrderedPair:
+		return []navSpan{{e.Pos(), len(e.Value)}}, nil
+	case *gsxast.ClassPart:
+		if e.CF != nil {
+			return nil, nil // the CF's own nodes carry the spans
+		}
+		if e.CSSSegments == nil {
+			spans = append(spans, navSpan{e.ExprPos, len(e.Expr)})
+			stages = e.Stages
+		}
+		if e.Cond != "" {
+			spans = append(spans, navSpan{e.CondPos, len(e.Cond)})
+		}
+		return spans, stages
+	case *gsxast.ValueArm:
+		return []navSpan{{e.ExprPos, len(e.Expr)}}, e.Stages
+	case *gsxast.ValueIf:
+		return []navSpan{{e.CondPos, len(e.Cond)}}, nil
+	case *gsxast.ValueSwitch:
+		return []navSpan{{e.TagPos, len(e.Tag)}}, nil
+	case *gsxast.ValueSwitchCase:
+		return []navSpan{{e.ListPos, len(e.List)}}, nil
+	case *gsxast.CondAttr:
+		return []navSpan{{e.CondPos, len(e.Cond)}}, nil
+	case *gsxast.SwitchMarkup:
+		return []navSpan{{e.TagPos, len(e.Tag)}}, nil
+	case *gsxast.CaseClause:
+		return []navSpan{{e.ListPos, len(e.List)}}, nil
+	case *gsxast.ForMarkup:
+		return []navSpan{{e.ClausePos, len(e.Clause)}}, nil
+	case *gsxast.IfMarkup:
+		return []navSpan{{e.CondPos, len(e.Cond)}}, nil
+	case *gsxast.GoBlock:
+		return []navSpan{{e.CodePos, len(e.Code)}}, nil
+	}
+	return nil, nil
+}
+
+// exprNodeAtOffset returns the gsx node one of whose Go-fragment spans (see
+// nodeNavSpans) contains the byte offset, together with the matched span's
+// start position (so the caller can both bridge by relative offset and tell
+// WHICH fragment of a multi-span node matched). Returns (nil, token.NoPos)
+// when no node covers the offset. Fragment spans never nest across nodes, so
+// at most one (node, span) matches — the walk's last-write-wins is unambiguous.
 func exprNodeAtOffset(pkg *Package, path string, off int) (gsxast.Node, token.Pos) {
 	f := pkg.Files[path]
 	if f == nil || pkg.GSXFset == nil {
@@ -31,42 +91,34 @@ func exprNodeAtOffset(pkg *Package, path string, off int) (gsxast.Node, token.Po
 		if n == nil {
 			return false
 		}
-		var exprPos token.Pos
-		var exprLen int
-		var stages []gsxast.PipeStage
-		switch e := n.(type) {
-		case *gsxast.Interp:
-			exprPos, exprLen = e.ExprPos, len(e.Expr)
-			stages = e.Stages
-		case *gsxast.ExprAttr:
-			exprPos, exprLen = e.ExprPos, len(e.Expr)
-			stages = e.Stages
-		case *gsxast.ForMarkup:
-			exprPos, exprLen = e.ClausePos, len(e.Clause)
-		case *gsxast.IfMarkup:
-			exprPos, exprLen = e.CondPos, len(e.Cond)
-		case *gsxast.GoBlock:
-			exprPos, exprLen = e.CodePos, len(e.Code)
-		default:
+		spans, stages := nodeNavSpans(n)
+		if len(spans) == 0 {
 			return true
 		}
-		if !exprPos.IsValid() {
-			return true
-		}
-		start := pkg.GSXFset.Position(exprPos).Offset
-		if off >= start && off < start+exprLen {
-			found = n
-			foundPos = exprPos
-			return true
+		for _, s := range spans {
+			if !s.pos.IsValid() {
+				continue
+			}
+			start := pkg.GSXFset.Position(s.pos).Offset
+			if off >= start && off < start+s.ln {
+				found = n
+				foundPos = s.pos
+				return true
+			}
 		}
 		// Also match pipeline stage positions (filter name, filter args) so that
-		// pipedTarget can be dispatched for those cursor positions too.
+		// pipedTarget can be dispatched for those cursor positions too. The
+		// reported position is the primary (seed) span's start, matching what
+		// pipedTarget expects.
+		if !spans[0].pos.IsValid() {
+			return true
+		}
 		for _, st := range stages {
 			if st.NamePos.IsValid() {
 				nameStart := pkg.GSXFset.Position(st.NamePos).Offset
 				if off >= nameStart && off < nameStart+len(st.Name) {
 					found = n
-					foundPos = exprPos
+					foundPos = spans[0].pos
 					return true
 				}
 			}
@@ -74,7 +126,7 @@ func exprNodeAtOffset(pkg *Package, path string, off int) (gsxast.Node, token.Po
 				argsStart := pkg.GSXFset.Position(st.ArgsPos).Offset
 				if off >= argsStart && off < argsStart+len(st.Args) {
 					found = n
-					foundPos = exprPos
+					foundPos = spans[0].pos
 					return true
 				}
 			}
@@ -286,13 +338,37 @@ func importedPackageByPath(p *types.Package, importPath string) *types.Package {
 
 // hasPipeStages reports whether the gsx expression node carries pipeline stages
 // (`{ x |> f }`). Such nodes lower to a wrapped call in the skeleton, breaking
-// the byte-identical relative-offset bridge go-to-def relies on.
+// the byte-identical relative-offset bridge go-to-def relies on — they resolve
+// through pipedTarget instead.
 func hasPipeStages(n gsxast.Node) bool {
 	switch e := n.(type) {
 	case *gsxast.Interp:
 		return len(e.Stages) > 0
 	case *gsxast.ExprAttr:
 		return len(e.Stages) > 0
+	case *gsxast.SpreadAttr:
+		return len(e.Stages) > 0
+	case *gsxast.ClassPart:
+		return len(e.Stages) > 0
+	case *gsxast.ValueArm:
+		return len(e.Stages) > 0
+	}
+	return false
+}
+
+// isCtrlSpan reports whether the matched span (see exprNodeAtOffset) resolves
+// through the CtrlMap bridge — a control-flow clause emitted verbatim in
+// statement position — rather than the ExprMap expression bridge. For a
+// ClassPart the two coexist: its `: cond` guard is a ctrl span while its expr
+// is an ExprMap span, so the matched position discriminates.
+func isCtrlSpan(node gsxast.Node, matched token.Pos) bool {
+	switch e := node.(type) {
+	case *gsxast.ForMarkup, *gsxast.IfMarkup, *gsxast.GoBlock,
+		*gsxast.ValueIf, *gsxast.ValueSwitch, *gsxast.ValueSwitchCase,
+		*gsxast.CondAttr, *gsxast.SwitchMarkup, *gsxast.CaseClause:
+		return true
+	case *gsxast.ClassPart:
+		return e.CondPos.IsValid() && matched == e.CondPos
 	}
 	return false
 }
@@ -353,47 +429,39 @@ func (s *Server) handleDefinition(f frame) error {
 		return s.reply(f.ID, res)
 	}
 
+	if dp, ok := exprDefinitionAt(pkg, path, off); ok {
+		return s.reply(f.ID, s.locationForPos(dp))
+	}
+	return s.reply(f.ID, nil)
+}
+
+// exprDefinitionAt answers go-to-definition for a cursor inside any Go-fragment
+// span of a .gsx file (see nodeNavSpans): ctrl spans resolve through CtrlMap,
+// pipelined expressions through pipedTarget, and plain expressions through the
+// ExprMap byte-identical bridge. Ctrl spans are checked first: a ClassPart's
+// `: cond` guard must resolve via CtrlMap even when the part's EXPR carries a
+// pipeline. ok=false when no span covers the offset or nothing resolves to a
+// real source location.
+func exprDefinitionAt(pkg *Package, path string, off int) (token.Position, bool) {
 	node, exprPos := exprNodeAtOffset(pkg, path, off)
 	if node == nil {
-		return s.reply(f.ID, nil)
+		return token.Position{}, false
+	}
+	if isCtrlSpan(node, exprPos) {
+		return ctrlDefinitionPos(pkg, node, exprPos, off)
 	}
 	if hasPipeStages(node) {
 		if obj, _, ok := pipedTarget(pkg, node, exprPos, off); ok && obj.Pos().IsValid() {
 			dp := pkg.Fset.Position(obj.Pos())
 			if dp.Filename != "" && !strings.HasSuffix(dp.Filename, ".x.go") {
-				return s.reply(f.ID, s.locationForPos(dp))
+				return dp, true
 			}
 		}
-		return s.reply(f.ID, nil)
-	}
-	switch node.(type) {
-	case *gsxast.ForMarkup, *gsxast.IfMarkup, *gsxast.GoBlock:
-		cr, ok := pkg.CtrlMap[node]
-		if !ok || cr.Node == nil {
-			return s.reply(f.ID, nil)
-		}
-		clauseStart := pkg.GSXFset.Position(exprPos).Offset
-		skelPos := cr.ClauseStart + token.Pos(off-clauseStart)
-		id := innermostIdent(cr.Node, skelPos)
-		if id == nil {
-			return s.reply(f.ID, nil)
-		}
-		obj := pkg.Info.Uses[id]
-		if obj == nil {
-			obj = pkg.Info.Defs[id]
-		}
-		if obj == nil || !obj.Pos().IsValid() {
-			return s.reply(f.ID, nil)
-		}
-		dp := pkg.Fset.Position(obj.Pos())
-		if dp.Filename == "" || strings.HasSuffix(dp.Filename, ".x.go") {
-			return s.reply(f.ID, nil)
-		}
-		return s.reply(f.ID, s.locationForPos(dp))
+		return token.Position{}, false
 	}
 	skel := pkg.ExprMap[node]
 	if skel == nil {
-		return s.reply(f.ID, nil)
+		return token.Position{}, false
 	}
 
 	// Map the cursor into the skeleton expr by relative byte offset (the gsx and
@@ -403,14 +471,14 @@ func (s *Server) handleDefinition(f frame) error {
 
 	id := innermostIdent(skel, skelPos)
 	if id == nil {
-		return s.reply(f.ID, nil)
+		return token.Position{}, false
 	}
 	obj := pkg.Info.Uses[id]
 	if obj == nil {
 		obj = pkg.Info.Defs[id]
 	}
 	if obj == nil || !obj.Pos().IsValid() {
-		return s.reply(f.ID, nil)
+		return token.Position{}, false
 	}
 	dp := pkg.Fset.Position(obj.Pos())
 	// Only surface real source locations. Params resolve back to .gsx via the
@@ -421,16 +489,53 @@ func (s *Server) handleDefinition(f frame) error {
 	// exist on disk. (`.x.go` is gsx's reserved generated suffix; the only false
 	// positive would be a hand-written dependency file literally named `*.x.go`.)
 	if dp.Filename == "" || strings.HasSuffix(dp.Filename, ".x.go") {
-		return s.reply(f.ID, nil)
+		return token.Position{}, false
 	}
-	loc := s.locationFor(dp)
-	return s.reply(f.ID, loc)
+	return dp, true
 }
 
-// locationFor builds an LSP Location from a resolved definition position. Alias
-// of locationForPos (kept for the slice-2a .gsx-side call sites).
-func (s *Server) locationFor(dp token.Position) Location {
-	return s.locationForPos(dp)
+// ctrlObjectAt resolves a cursor inside a CtrlMap-bridged span (see
+// isCtrlSpan: control-flow clauses, switch tags and case lists, in-tag
+// conditional-attribute conds, class guard conds, and value-form control
+// expressions) to the go/types object of the identifier under the cursor,
+// plus that identifier's byte span in the .gsx (for hover highlight ranges).
+// It bridges the cursor into the skeleton via the node's CtrlMap entry — the
+// clause bytes are emitted verbatim, so relative offsets align both ways.
+// ok=false when the node has no CtrlMap entry or no identifier resolves.
+func ctrlObjectAt(pkg *Package, node gsxast.Node, exprPos token.Pos, off int) (obj types.Object, identStart, identLen int, ok bool) {
+	cr, found := pkg.CtrlMap[node]
+	if !found || cr.Node == nil || pkg.Info == nil {
+		return nil, 0, 0, false
+	}
+	clauseStart := pkg.GSXFset.Position(exprPos).Offset
+	skelPos := cr.ClauseStart + token.Pos(off-clauseStart)
+	id := innermostIdent(cr.Node, skelPos)
+	if id == nil {
+		return nil, 0, 0, false
+	}
+	obj = pkg.Info.Uses[id]
+	if obj == nil {
+		obj = pkg.Info.Defs[id]
+	}
+	if obj == nil {
+		return nil, 0, 0, false
+	}
+	return obj, clauseStart + int(id.Pos()-cr.ClauseStart), len(id.Name), true
+}
+
+// ctrlDefinitionPos resolves a cursor inside a CtrlMap-bridged span to the
+// defining object's source position, rejecting positions still inside
+// generated .x.go overlays.
+func ctrlDefinitionPos(pkg *Package, node gsxast.Node, exprPos token.Pos, off int) (token.Position, bool) {
+	obj, _, _, ok := ctrlObjectAt(pkg, node, exprPos, off)
+	if !ok || !obj.Pos().IsValid() {
+		return token.Position{}, false
+	}
+	dp := pkg.Fset.Position(obj.Pos())
+	if dp.Filename == "" || strings.HasSuffix(dp.Filename, ".x.go") {
+		return token.Position{}, false
+	}
+	return dp, true
 }
 
 // handleGoDefinition answers definition for a cursor in a .go file: if the

--- a/internal/lsp/definition_matrix_test.go
+++ b/internal/lsp/definition_matrix_test.go
@@ -1,0 +1,225 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+)
+
+// matrixSrc exercises every Go-fragment cursor position the LSP navigates:
+// interps, expr attrs, spread, ordered-attrs pair values, class plain parts,
+// class guard conds (incl. on a css literal), value-form if conds and arms,
+// value-form switch tag/case lists/arms, in-tag conditional-attribute conds
+// (if and else-if), markup if/for/switch clauses, and {{ }} Go blocks.
+const matrixSrc = `package page
+
+import "github.com/gsxhq/gsx"
+
+component Box(user string, cond bool, n int, m int) {
+	{{ disabled := cond }}
+	{{ bag := gsx.Attrs{{Key: "a", Value: "b"}} }}
+	<div
+		id={user}
+		{ bag... }
+		class={
+			user,
+			"guard": disabled,
+			if disabled { user + "x" } else if cond { "y" },
+			switch n {
+			case m: user
+			default: "d"
+			}
+		}
+		style={
+			css` + "`color: red`" + `: cond,
+		}
+		{ if disabled {
+			data-x={user}
+		} else if cond {
+			data-y={user}
+		} }
+	>
+		{ user }
+		{ if disabled { <b>a</b> } }
+		{ for i := 0; i < n; i++ { <i>{i}</i> } }
+		{ switch n {
+		case m:
+			<u>c</u>
+		} }
+	</div>
+	<Kid extra={{"data-o": user}}/>
+}
+
+component Kid(extra gsx.Attrs) {
+	<span { extra... }>k</span>
+}
+`
+
+// TestDefinitionMatrix asserts go-to-definition resolves the identifier under
+// the cursor to its declaration for EVERY navigable Go-fragment position — the
+// coverage matrix this feature set closed. Each case names a cursor (anchor
+// substring + delta) and the expected declaration site (anchor + delta).
+func TestDefinitionMatrix(t *testing.T) {
+	src := matrixSrc
+	pkg, path := analyzedLSPPackage(t, src)
+
+	// Declaration anchors.
+	paramUser := strings.Index(src, "user string")
+	paramCond := strings.Index(src, "cond bool")
+	paramN := strings.Index(src, "n int")
+	paramM := strings.Index(src, "m int")
+	localDisabled := strings.Index(src, "disabled := cond")
+	localBag := strings.Index(src, "bag := gsx.Attrs")
+
+	lineCol := func(off int) (int, int) {
+		return strings.Count(src[:off], "\n") + 1, off - strings.LastIndexByte(src[:off], '\n')
+	}
+
+	cases := []struct {
+		name    string
+		anchor  string
+		delta   int
+		declOff int
+	}{
+		{"interp text", "{ user }", 2, paramUser},
+		{"expr-attr value", "id={user}", len("id={"), paramUser},
+		{"spread expr", "{ bag... }", 2, localBag},
+		{"ordered pair value", `extra={{"data-o": user}}`, len(`extra={{"data-o": `), paramUser},
+		{"class plain part expr", "user,", 0, paramUser},
+		{"class guard cond", `"guard": disabled`, len(`"guard": `), localDisabled},
+		{"css literal guard cond", "`: cond,", len("`: "), paramCond},
+		{"value-if cond", "if disabled { user", len("if "), localDisabled},
+		{"value-else-if cond", "else if cond {", len("else if "), paramCond},
+		{"value-if arm expr", `{ user + "x" }`, 2, paramUser},
+		{"value-switch tag", "switch n {\n\t\t\tcase", len("switch "), paramN},
+		{"value-switch case list", "case m: user", len("case "), paramM},
+		{"value-switch arm", "case m: user", len("case m: "), paramUser},
+		{"cond-attr cond", "{ if disabled {\n\t\t\tdata-x", len("{ if "), localDisabled},
+		{"cond-attr else-if cond", "else if cond {\n\t\t\tdata-y", len("else if "), paramCond},
+		{"cond-attr nested expr-attr", "data-x={user}", len("data-x={"), paramUser},
+		{"if-markup cond", "{ if disabled { <b>", len("{ if "), localDisabled},
+		{"for-markup clause", "i < n; i++", len("i < "), paramN},
+		{"switch-markup tag", "{ switch n {", len("{ switch "), paramN},
+		{"switch-markup case list", "case m:\n", len("case "), paramM},
+		{"goblock code", "disabled := cond", len("disabled := "), paramCond},
+	}
+	for _, tc := range cases {
+		idx := strings.Index(src, tc.anchor)
+		if idx < 0 {
+			t.Errorf("%s: cursor anchor %q not found", tc.name, tc.anchor)
+			continue
+		}
+		if tc.declOff < 0 {
+			t.Errorf("%s: declaration anchor not found", tc.name)
+			continue
+		}
+		dp, ok := exprDefinitionAt(pkg, path, idx+tc.delta)
+		if !ok {
+			t.Errorf("%s: no definition resolved", tc.name)
+			continue
+		}
+		wantLine, wantCol := lineCol(tc.declOff)
+		if !strings.HasSuffix(dp.Filename, ".gsx") || dp.Line != wantLine || dp.Column != wantCol {
+			t.Errorf("%s: definition at %s:%d:%d, want .gsx %d:%d", tc.name, dp.Filename, dp.Line, dp.Column, wantLine, wantCol)
+		}
+	}
+}
+
+// TestHoverObjectMatrix asserts the ctrl-span hover bridge resolves the object
+// (and its highlight span) for identifiers in CtrlMap-bridged positions — the
+// spans hover previously ignored entirely.
+func TestHoverObjectMatrix(t *testing.T) {
+	src := matrixSrc
+	pkg, path := analyzedLSPPackage(t, src)
+
+	cases := []struct {
+		name   string
+		anchor string
+		delta  int
+		ident  string
+	}{
+		{"cond-attr cond", "{ if disabled {\n\t\t\tdata-x", len("{ if "), "disabled"},
+		{"class guard cond", `"guard": disabled`, len(`"guard": `), "disabled"},
+		{"value-if cond", "if disabled { user", len("if "), "disabled"},
+		{"value-switch tag", "switch n {\n\t\t\tcase", len("switch "), "n"},
+		{"if-markup cond", "{ if disabled { <b>", len("{ if "), "disabled"},
+		{"for-markup clause", "i < n; i++", len("i < "), "n"},
+	}
+	for _, tc := range cases {
+		idx := strings.Index(src, tc.anchor)
+		if idx < 0 {
+			t.Errorf("%s: cursor anchor %q not found", tc.name, tc.anchor)
+			continue
+		}
+		off := idx + tc.delta
+		node, exprPos := exprNodeAtOffset(pkg, path, off)
+		if node == nil {
+			t.Errorf("%s: no node recognized", tc.name)
+			continue
+		}
+		if !isCtrlSpan(node, exprPos) {
+			t.Errorf("%s: matched span of %T is not a ctrl span", tc.name, node)
+			continue
+		}
+		obj, idStart, idLen, ok := ctrlObjectAt(pkg, node, exprPos, off)
+		if !ok {
+			t.Errorf("%s: hover object did not resolve", tc.name)
+			continue
+		}
+		if obj.Name() != tc.ident {
+			t.Errorf("%s: hover object = %q, want %q", tc.name, obj.Name(), tc.ident)
+		}
+		if got := src[idStart : idStart+idLen]; got != tc.ident {
+			t.Errorf("%s: hover range = %q, want %q", tc.name, got, tc.ident)
+		}
+	}
+}
+
+// TestPipedClassPartCondStillCtrl pins the dispatch-order rule: a ClassPart
+// whose EXPR carries a pipeline still resolves its `: cond` guard through the
+// CtrlMap bridge (the pipeline path must not swallow the cond cursor). The
+// GUARDED part's piped seed itself returns no definition — conditional part
+// exprs carry no type harvest, so ExprMap has no entry to walk (a known
+// limitation) — while an UNCONDITIONAL piped part's seed resolves through
+// pipedTarget.
+func TestPipedClassPartCondStillCtrl(t *testing.T) {
+	src := "package page\n\ncomponent Box(user string, cond bool) {\n\t<div class={\n\t\tuser |> trim,\n\t\tuser |> upper: cond,\n\t}>x</div>\n}\n"
+	pkg, path := analyzedLSPPackage(t, src)
+	line := func(off int) int { return strings.Count(src[:off], "\n") + 1 }
+
+	condOff := strings.Index(src, ": cond,") + len(": ")
+	node, exprPos := exprNodeAtOffset(pkg, path, condOff)
+	cp, ok := node.(*gsxast.ClassPart)
+	if !ok {
+		t.Fatalf("cond cursor matched %T, want *ClassPart", node)
+	}
+	if len(cp.Stages) == 0 {
+		t.Fatal("test part lost its pipeline")
+	}
+	if !isCtrlSpan(node, exprPos) {
+		t.Fatal("piped part's cond span not classified as ctrl")
+	}
+	dp, ok := exprDefinitionAt(pkg, path, condOff)
+	if !ok {
+		t.Fatal("no definition for piped part's guard cond")
+	}
+	if want := line(strings.Index(src, "cond bool")); dp.Line != want {
+		t.Errorf("guard cond definition at line %d, want %d", dp.Line, want)
+	}
+
+	// Guarded piped seed: no ExprMap entry → graceful no-result, never a
+	// misaligned jump.
+	if dp, ok := exprDefinitionAt(pkg, path, strings.Index(src, "user |> upper")); ok {
+		t.Errorf("guarded piped seed unexpectedly resolved to %d:%d", dp.Line, dp.Column)
+	}
+
+	// Unconditional piped seed resolves via pipedTarget.
+	dp, ok = exprDefinitionAt(pkg, path, strings.Index(src, "user |> trim"))
+	if !ok {
+		t.Fatal("no definition for unconditional piped part's seed")
+	}
+	if want := line(strings.Index(src, "user string")); dp.Line != want {
+		t.Errorf("piped seed definition at line %d, want %d", dp.Line, want)
+	}
+}

--- a/internal/lsp/definition_test.go
+++ b/internal/lsp/definition_test.go
@@ -70,12 +70,18 @@ func analyzedLSPPackage(t *testing.T, src string) (*Package, string) {
 			})
 		}
 	}
+	ctrl := map[gsxast.Node]CtrlRef{}
+	for n, cr := range pr.CtrlMap {
+		ctrl[n] = CtrlRef{ClauseStart: cr.ClauseStart, Node: cr.Node}
+	}
 	return &Package{
 		GSXFset:  pr.GSXFset,
 		Fset:     pr.Fset,
 		Info:     pr.Info,
 		Types:    pr.Types,
 		Files:    pr.GSXFiles,
+		ExprMap:  pr.ExprMap,
+		CtrlMap:  ctrl,
 		SigTypes: sigTypes,
 	}, gsxPath
 }
@@ -302,6 +308,77 @@ func TestExprNodeAtOffsetControlFlow(t *testing.T) {
 	node, _ := exprNodeAtOffset(pkg, path, off)
 	if _, ok := node.(*gsxast.ForMarkup); !ok {
 		t.Fatalf("exprNodeAtOffset on a for-clause = %T, want *ForMarkup", node)
+	}
+}
+
+// TestExprNodeAtOffsetValueIfCond verifies that exprNodeAtOffset recognizes a
+// ValueIf node when the cursor sits inside the condition of a value-form
+// `if`/`else if` in a composable class list.
+func TestExprNodeAtOffsetValueIfCond(t *testing.T) {
+	src := "package x\n\ncomponent P(disabled bool, busy bool) {\n\t<input class={\n\t\t\"base\",\n\t\tif disabled { \"off\" } else if busy { \"wait\" }\n\t}/>\n}\n"
+	pkg, path := parseOnlyPackage(t, "p.gsx", src)
+
+	off := strings.Index(src, "if disabled") + len("if ")
+	node, exprPos := exprNodeAtOffset(pkg, path, off)
+	vi, ok := node.(*gsxast.ValueIf)
+	if !ok {
+		t.Fatalf("exprNodeAtOffset on a value-form if cond = %T, want *ValueIf", node)
+	}
+	if vi.Cond != "disabled" {
+		t.Fatalf("matched ValueIf cond = %q, want %q", vi.Cond, "disabled")
+	}
+	if !exprPos.IsValid() || exprPos != vi.CondPos {
+		t.Fatalf("exprPos = %v, want CondPos %v", exprPos, vi.CondPos)
+	}
+
+	// The else-if link is its own ValueIf with its own cond span.
+	off2 := strings.Index(src, "if busy") + len("if ")
+	node2, _ := exprNodeAtOffset(pkg, path, off2)
+	vi2, ok := node2.(*gsxast.ValueIf)
+	if !ok {
+		t.Fatalf("exprNodeAtOffset on an else-if cond = %T, want *ValueIf", node2)
+	}
+	if vi2.Cond != "busy" {
+		t.Fatalf("matched else-if ValueIf cond = %q, want %q", vi2.Cond, "busy")
+	}
+}
+
+// TestCtrlDefinitionValueIfCond verifies the full go-to-definition bridge for
+// an identifier inside a value-form if condition in class={...}: the cursor
+// resolves through CtrlMap + innermostIdent to the identifier's declaration in
+// the .gsx (here a {{ }} Go-block local), mirroring IfMarkup cond navigation.
+func TestCtrlDefinitionValueIfCond(t *testing.T) {
+	src := "package page\n\ncomponent Box() {\n\t{{ disabled := true }}\n\t<input class={\n\t\t\"base\",\n\t\tif disabled { \"off\" } else if !disabled { \"on\" }\n\t}/>\n}\n"
+	pkg, path := analyzedLSPPackage(t, src)
+
+	resolve := func(off int) token.Position {
+		t.Helper()
+		node, exprPos := exprNodeAtOffset(pkg, path, off)
+		if _, ok := node.(*gsxast.ValueIf); !ok {
+			t.Fatalf("exprNodeAtOffset at %d = %T, want *ValueIf", off, node)
+		}
+		dp, ok := ctrlDefinitionPos(pkg, node, exprPos, off)
+		if !ok {
+			t.Fatalf("ctrlDefinitionPos found no definition for cond cursor at %d", off)
+		}
+		return dp
+	}
+
+	declOff := strings.Index(src, "disabled :=")
+	wantLine := strings.Count(src[:declOff], "\n") + 1
+	wantCol := declOff - strings.LastIndexByte(src[:declOff], '\n')
+
+	for _, cursor := range []int{
+		strings.Index(src, "if disabled") + len("if "),   // first cond
+		strings.Index(src, "if !disabled") + len("if !"), // else-if cond
+	} {
+		dp := resolve(cursor)
+		if !strings.HasSuffix(dp.Filename, ".gsx") {
+			t.Errorf("cursor %d: definition in %s, want the .gsx", cursor, dp.Filename)
+		}
+		if dp.Line != wantLine || dp.Column != wantCol {
+			t.Errorf("cursor %d: definition at %d:%d, want %d:%d (the {{ disabled := }} local)", cursor, dp.Line, dp.Column, wantLine, wantCol)
+		}
 	}
 }
 

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -69,6 +69,18 @@ func (s *Server) handleHover(f frame) error {
 	if node == nil {
 		return s.reply(f.ID, nil)
 	}
+	// H3: an identifier inside a CtrlMap-bridged span — a for/if/{{ }} clause,
+	// switch tag or case list, in-tag conditional-attribute cond, class guard
+	// cond, or value-form control expression — hovers like the same identifier
+	// in Go. Checked before the pipeline path: a ClassPart's `: cond` guard is
+	// a ctrl span even when the part's expr carries a pipeline.
+	if isCtrlSpan(node, exprPos) {
+		if obj, idStart, idLen, ok := ctrlObjectAt(pkg, node, exprPos, off); ok {
+			rng := rangeForSpan(text, idStart, idStart+idLen, s.enc)
+			return s.reply(f.ID, Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng})
+		}
+		return s.reply(f.ID, nil)
+	}
 	if hasPipeStages(node) {
 		if obj, span, ok := pipedTarget(pkg, node, exprPos, off); ok {
 			rng := rangeForSpan(text, span[0], span[1], s.enc)
@@ -120,13 +132,22 @@ func markdownGo(s string) MarkupContent {
 	return MarkupContent{Kind: "markdown", Value: "```go\n" + s + "\n```"}
 }
 
-// exprText returns the Go-expression source of an Interp / ExprAttr node.
+// exprText returns the Go-expression source of an ExprMap-bridged node — the
+// text whose source bytes start at the node's expr span (see nodeNavSpans).
 func exprText(n gsxast.Node) string {
 	switch e := n.(type) {
 	case *gsxast.Interp:
 		return e.Expr
 	case *gsxast.ExprAttr:
 		return e.Expr
+	case *gsxast.SpreadAttr:
+		return e.Expr
+	case *gsxast.ClassPart:
+		return e.Expr
+	case *gsxast.ValueArm:
+		return e.Expr
+	case *gsxast.OrderedPair:
+		return e.Value
 	}
 	return ""
 }

--- a/internal/lsp/pipe.go
+++ b/internal/lsp/pipe.go
@@ -64,6 +64,12 @@ func pipeStages(node gsxast.Node) []gsxast.PipeStage {
 		return e.Stages
 	case *gsxast.ExprAttr:
 		return e.Stages
+	case *gsxast.SpreadAttr:
+		return e.Stages
+	case *gsxast.ClassPart:
+		return e.Stages
+	case *gsxast.ValueArm:
+		return e.Stages
 	}
 	return nil
 }

--- a/internal/printer/corpus_test.go
+++ b/internal/printer/corpus_test.go
@@ -128,13 +128,37 @@ func zeroSpans(n ast.Node) {
 			case *ast.Element:
 				v.CloseNamePos = 0
 				v.TypeArgsPos = 0
+			case *ast.SpreadAttr:
+				v.ExprPos = 0
+				for i := range v.Stages {
+					v.Stages[i].NamePos = 0
+					v.Stages[i].ArgsPos = 0
+				}
+			case *ast.ClassPart:
+				v.ExprPos = 0
+				v.CondPos = 0
+				for i := range v.Stages {
+					v.Stages[i].NamePos = 0
+					v.Stages[i].ArgsPos = 0
+				}
+			case *ast.CondAttr:
+				v.CondPos = 0
 			case *ast.ForMarkup:
 				v.ClausePos = 0
 			case *ast.IfMarkup:
 				v.CondPos = 0
+			case *ast.SwitchMarkup:
+				v.TagPos = 0
+			case *ast.CaseClause:
+				v.ListPos = 0
 			case *ast.ValueIf:
 				v.CondPos = 0
+			case *ast.ValueSwitch:
+				v.TagPos = 0
+			case *ast.ValueSwitchCase:
+				v.ListPos = 0
 			case *ast.ValueArm:
+				v.ExprPos = 0
 				for i := range v.Stages {
 					v.Stages[i].NamePos = 0
 					v.Stages[i].ArgsPos = 0

--- a/parser/attrs.go
+++ b/parser/attrs.go
@@ -88,18 +88,20 @@ func (p *parser) splitComposed(name, src string, base int) ([]ast.ClassPart, err
 			}
 			partEnd := segEnd
 			var condSrc string
+			condPos := token.NoPos
 			if colon >= 0 {
 				partEnd = colon
 				condSrc = strings.TrimSpace(src[colon+1 : segEnd])
-				condPos := base + colon + 1 + leadingSpaceLen(src[colon+1:segEnd])
+				condOff := base + colon + 1 + leadingSpaceLen(src[colon+1:segEnd])
 				if err := validateGoExpr(condSrc); err != nil {
-					return nil, p.errorf(p.posAt(condPos), "invalid %s condition %q: %v", name, condSrc, err)
+					return nil, p.errorf(p.posAt(condOff), "invalid %s condition %q: %v", name, condSrc, err)
 				}
+				condPos = p.posAt(condOff)
 			}
 			if rest := strings.TrimSpace(src[literalEnd-base : partEnd]); rest != "" {
 				return nil, p.errorf(p.posAt(literalEnd), "unexpected %q after css literal in style={...}", rest)
 			}
-			parts = append(parts, ast.ClassPart{CSSSegments: segments, Cond: condSrc})
+			parts = append(parts, ast.ClassPart{CSSSegments: segments, Cond: condSrc, CondPos: condPos})
 			ast.SetSpan(&parts[len(parts)-1], p.posAt(base+segStart), p.posAt(base+segEnd))
 			continue
 		}
@@ -120,13 +122,15 @@ func (p *parser) splitComposed(name, src string, base int) ([]ast.ClassPart, err
 		if err := validateGoExpr(seed); err != nil {
 			return nil, p.errorf(p.posAt(exprPos), "invalid %s expression %q: %v", name, seed, err)
 		}
+		condPos := token.NoPos
 		if condSrc != "" {
-			condPos := base + colon + 1 + leadingSpaceLen(src[colon+1:segEnd])
+			condOff := base + colon + 1 + leadingSpaceLen(src[colon+1:segEnd])
 			if err := validateGoExpr(condSrc); err != nil {
-				return nil, p.errorf(p.posAt(condPos), "invalid %s condition %q: %v", name, condSrc, err)
+				return nil, p.errorf(p.posAt(condOff), "invalid %s condition %q: %v", name, condSrc, err)
 			}
+			condPos = p.posAt(condOff)
 		}
-		parts = append(parts, ast.ClassPart{Expr: seed, Cond: condSrc, Stages: stages})
+		parts = append(parts, ast.ClassPart{Expr: seed, ExprPos: p.posAt(exprPos), Cond: condSrc, CondPos: condPos, Stages: stages})
 		ast.SetSpan(&parts[len(parts)-1], p.posAt(base+segStart), p.posAt(base+segEnd))
 	}
 	return parts, nil
@@ -189,6 +193,7 @@ func (p *parser) parseSpreadAttr() (ast.Attr, error) {
 		return nil, p.errorf(attrStartPos, "expected `...` trailing spread inside `{ }` attribute")
 	}
 	core := strings.TrimSpace(strings.TrimSuffix(inner, "..."))
+	coreOff := p.i + 1 + leadingSpaceLen(p.src[p.i+1:end])
 	// The spread/splat subject may carry a `|>` pipeline. Its canonical form
 	// parenthesizes the pipeline so the trailing `...` reads unambiguously as the
 	// spread marker on the whole pipeline: `{ (seed |> f)... }`. parsePipe only
@@ -203,15 +208,20 @@ func (p *parser) parseSpreadAttr() (ast.Attr, error) {
 	if perr != nil {
 		return nil, perr
 	}
+	// ExprPos maps the seed back to its source bytes for LSP cursor bridging.
+	// It survives a bare pipeline (the seed is a prefix of the source text) but
+	// not the paren-unwrap below, which rewrites the seed away from the source.
+	exprPos := p.posAt(coreOff)
 	if len(stages) == 0 {
 		if unwrapped, ok := balancedParenUnwrap(core); ok {
 			if s2, st2, err := parsePipe(unwrapped, token.NoPos); err == nil && len(st2) > 0 {
 				seed, stages = s2, st2
+				exprPos = token.NoPos
 			}
 		}
 	}
 	p.i = end + 1
-	sa := &ast.SpreadAttr{Expr: seed, Stages: stages}
+	sa := &ast.SpreadAttr{Expr: seed, ExprPos: exprPos, Stages: stages}
 	ast.SetSpan(sa, attrStartPos, p.posAt(p.i))
 	return sa, nil
 }
@@ -481,12 +491,13 @@ func (p *parser) parseCondAttrTail() (*ast.CondAttr, error) {
 		return nil, p.errorf(p.posAt(p.i), "expected `{` after `if` condition")
 	}
 	cond := strings.TrimSpace(p.src[condStart:braceOff])
+	condPos := p.posAt(condStart + leadingSpaceLen(p.src[condStart:braceOff]))
 	p.i = braceOff + 1 // past body '{'
 	body, err := p.parseAttrsUntilBrace()
 	if err != nil {
 		return nil, err
 	}
-	n := &ast.CondAttr{Cond: cond, Then: body}
+	n := &ast.CondAttr{Cond: cond, CondPos: condPos, Then: body}
 	p.skipSpace()
 	if p.atWord("else") {
 		p.i += len("else")

--- a/parser/markup.go
+++ b/parser/markup.go
@@ -346,6 +346,10 @@ func (p *parser) parseSwitchMarkup() (ast.Markup, error) {
 		return nil, p.errorf(p.posAt(p.i), "expected `{` after `switch`")
 	}
 	tag := strings.TrimSpace(p.src[tagStart:braceOff])
+	tagPos := token.NoPos
+	if tag != "" {
+		tagPos = p.posAt(tagStart + leadingSpaceLen(p.src[tagStart:braceOff]))
+	}
 	p.i = braceOff + 1 // past switch-body '{'
 
 	var cases []*ast.CaseClause
@@ -370,7 +374,7 @@ func (p *parser) parseSwitchMarkup() (ast.Markup, error) {
 		return nil, p.errorf(p.pos(), "expected `}` to close `{ switch … }`")
 	}
 	p.i++ // past outer '}'
-	n := &ast.SwitchMarkup{Tag: tag, Cases: cases}
+	n := &ast.SwitchMarkup{Tag: tag, TagPos: tagPos, Cases: cases}
 	ast.SetSpan(n, startPos, p.posAt(p.i))
 	return n, nil
 }
@@ -389,6 +393,9 @@ func (p *parser) parseCaseClause() (*ast.CaseClause, error) {
 			return nil, p.errorf(p.posAt(p.i), "expected `:` in `case`")
 		}
 		cc.List = strings.TrimSpace(p.src[listStart:colonOff])
+		if cc.List != "" {
+			cc.ListPos = p.posAt(listStart + leadingSpaceLen(p.src[listStart:colonOff]))
+		}
 		p.i = colonOff + 1 // past ':'
 	case p.atWord("default"):
 		p.i += len("default")

--- a/parser/navpos_test.go
+++ b/parser/navpos_test.go
@@ -1,0 +1,147 @@
+package parser
+
+import (
+	"go/token"
+	"testing"
+
+	"github.com/gsxhq/gsx/ast"
+)
+
+// TestNavigationPositionsByteFaithful pins the invariant every LSP bridge
+// relies on: for each recorded expression/clause position, the source bytes at
+// that position spell exactly the stored (trimmed) text.
+func TestNavigationPositionsByteFaithful(t *testing.T) {
+	src := []byte(`package p
+
+component C(user string, cond bool, n int, bag string) {
+	<div
+		class={
+			user,
+			"guard" : cond,
+			if cond { user } else if !cond { "y" },
+			switch n {
+			case 1, 2: user
+			default: "d"
+			}
+		}
+		{ if cond {
+			data-x={user}
+		} else if !cond {
+			data-y={user}
+		} }
+		{ bag... }
+	>
+		{ switch n {
+		case 3:
+			<b>x</b>
+		} }
+	</div>
+}
+`)
+	fset := token.NewFileSet()
+	f, err := ParseFile(fset, "c.gsx", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(what string, pos token.Pos, text string) {
+		t.Helper()
+		if text == "" {
+			return
+		}
+		if !pos.IsValid() {
+			t.Errorf("%s: position not recorded for %q", what, text)
+			return
+		}
+		off := fset.Position(pos).Offset
+		if got := string(src[off : off+len(text)]); got != text {
+			t.Errorf("%s: source at pos = %q, want %q", what, got, text)
+		}
+	}
+
+	seen := map[string]int{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.ClassPart:
+			if v.CF == nil && v.CSSSegments == nil {
+				seen["classpart"]++
+				check("ClassPart.ExprPos", v.ExprPos, v.Expr)
+				check("ClassPart.CondPos", v.CondPos, v.Cond)
+			}
+		case *ast.ValueIf:
+			seen["valueif"]++
+			check("ValueIf.CondPos", v.CondPos, v.Cond)
+		case *ast.ValueArm:
+			seen["valuearm"]++
+			check("ValueArm.ExprPos", v.ExprPos, v.Expr)
+		case *ast.ValueSwitch:
+			seen["valueswitch"]++
+			check("ValueSwitch.TagPos", v.TagPos, v.Tag)
+		case *ast.ValueSwitchCase:
+			seen["valueswitchcase"]++
+			check("ValueSwitchCase.ListPos", v.ListPos, v.List)
+			if v.Default && v.ListPos.IsValid() {
+				t.Error("default value-switch case has a ListPos")
+			}
+		case *ast.CondAttr:
+			seen["condattr"]++
+			check("CondAttr.CondPos", v.CondPos, v.Cond)
+		case *ast.SpreadAttr:
+			seen["spread"]++
+			check("SpreadAttr.ExprPos", v.ExprPos, v.Expr)
+		case *ast.SwitchMarkup:
+			seen["switchmarkup"]++
+			check("SwitchMarkup.TagPos", v.TagPos, v.Tag)
+		case *ast.CaseClause:
+			seen["caseclause"]++
+			check("CaseClause.ListPos", v.ListPos, v.List)
+		}
+		return true
+	})
+	want := map[string]int{
+		"classpart": 2, "valueif": 2, "valuearm": 4, "valueswitch": 1,
+		"valueswitchcase": 2, "condattr": 2, "spread": 1, "switchmarkup": 1,
+		"caseclause": 1,
+	}
+	for k, w := range want {
+		if seen[k] != w {
+			t.Errorf("parsed %d %s nodes, want %d", seen[k], k, w)
+		}
+	}
+}
+
+// TestSpreadPipelineParenUnwrapExprPos pins that a parenthesized spread
+// pipeline — whose seed is rewritten away from the source bytes — records
+// NoPos rather than a misaligned position, while a bare piped spread keeps the
+// seed position.
+func TestSpreadPipelineParenUnwrapExprPos(t *testing.T) {
+	parse := func(body string) *ast.SpreadAttr {
+		t.Helper()
+		src := []byte("package p\n\ncomponent C(bag string) {\n\t<div " + body + ">x</div>\n}\n")
+		fset := token.NewFileSet()
+		f, err := ParseFile(fset, "c.gsx", src, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var sa *ast.SpreadAttr
+		ast.Inspect(f, func(n ast.Node) bool {
+			if s, ok := n.(*ast.SpreadAttr); ok {
+				sa = s
+			}
+			return true
+		})
+		if sa == nil {
+			t.Fatal("no SpreadAttr parsed")
+		}
+		return sa
+	}
+
+	if sa := parse("{ (bag |> trim)... }"); len(sa.Stages) == 0 {
+		t.Error("parenthesized spread pipeline lost its stages")
+	} else if sa.ExprPos.IsValid() {
+		t.Error("paren-unwrapped spread pipeline has an ExprPos; seed no longer matches source bytes")
+	}
+	if sa := parse("{ bag... }"); !sa.ExprPos.IsValid() {
+		t.Error("plain spread has no ExprPos")
+	}
+}

--- a/parser/valueform.go
+++ b/parser/valueform.go
@@ -102,7 +102,7 @@ func (p *parser) parseValueArm(braceOff int) (*ast.ValueArm, token.Pos, error) {
 	if err != nil {
 		return nil, 0, p.pipeErrorf(p.posAt(braceOff), err)
 	}
-	arm := &ast.ValueArm{Expr: seed, Stages: stages}
+	arm := &ast.ValueArm{Expr: seed, ExprPos: p.posAt(braceOff + 1 + lead), Stages: stages}
 	ast.SetSpan(arm, p.posAt(braceOff), p.posAt(closeOff+1))
 	return arm, p.posAt(closeOff + 1), nil
 }
@@ -117,6 +117,9 @@ func (p *parser) parseValueSwitch(at int) (*ast.ValueSwitch, token.Pos, error) {
 		return nil, 0, p.errorf(p.posAt(tagStart), "expected `{` after `switch`")
 	}
 	n := &ast.ValueSwitch{Tag: strings.TrimSpace(p.src[tagStart:braceOff])}
+	if n.Tag != "" {
+		n.TagPos = p.posAt(tagStart + leadingSpaceLen(p.src[tagStart:braceOff]))
+	}
 	i := braceOff + 1 // past switch-body `{`
 	for {
 		r := strings.TrimLeft(p.src[i:], " \t\r\n")
@@ -152,6 +155,9 @@ func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error)
 			return nil, 0, p.errorf(p.posAt(listStart), "expected `:` in `case`")
 		}
 		cc.List = strings.TrimSpace(p.src[listStart:colonOff])
+		if cc.List != "" {
+			cc.ListPos = p.posAt(listStart + leadingSpaceLen(p.src[listStart:colonOff]))
+		}
 		rest := strings.TrimLeft(p.src[colonOff+1:], " \t\r\n")
 		valueAt = colonOff + 1 + (len(p.src[colonOff+1:]) - len(rest))
 	case strings.HasPrefix(r, "default") && (len(r) == 7 || !isIdentByte(r[7])):
@@ -188,7 +194,7 @@ func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error)
 	if err != nil {
 		return nil, 0, err
 	}
-	arm := &ast.ValueArm{Expr: seed, Stages: stages}
+	arm := &ast.ValueArm{Expr: seed, ExprPos: p.posAt(valueAt + lead), Stages: stages}
 	trimmedEnd := end - (len(raw) - len(strings.TrimRight(raw, " \t\r\n")))
 	ast.SetSpan(arm, p.posAt(valueAt+lead), p.posAt(trimmedEnd))
 	cc.Value = arm


### PR DESCRIPTION
## Summary

Closes the LSP navigation gap matrix: identifiers in **all** Go-fragment positions of `.gsx` files now resolve for go-to-definition **and** hover. Previously 10 of 18 cursor positions were dead (empirically probed), and hover never consulted the CtrlMap bridge at all — so even `for`/`if` clauses had gd but no hover.

Reported symptom: gd on `disabled` in `if disabled { "cursor-not-allowed opacity-50" }` (a value-form if cond in `class={…}`) did nothing; likewise `{ if hasCustomModel { … } }` cond-attr conditions.

## The two bridges, completed

- **ExprMap byte-identical expr bridge** — harvest already mapped spreads, ordered-attrs pair values, class plain parts, and value-form arms into the type-checked skeleton; the LSP just never recognized the cursor there. Now dispatched via `nodeNavSpans`.
- **CtrlMap statement-clause bridge** — now also serves markup switch tags + case lists, in-tag conditional-attribute conds `{ if cond { … } }`, class/style `": cond"` guards (incl. css-literal parts), and value-form if conds / switch tags / case lists.

## Changes

- **Parser/AST**: byte-faithful position fields where missing (`CondAttr.CondPos`, `ClassPart.ExprPos/CondPos`, `ValueArm.ExprPos`, `SpreadAttr.ExprPos`, `SwitchMarkup.TagPos`, `CaseClause.ListPos`, `ValueSwitch.TagPos`, `ValueSwitchCase.ListPos`); `parser/navpos_test.go` pins the source-bytes-spell-the-stored-text invariant.
- **Codegen skeleton**: guard conds and cond-attr conds emit as anchored `if cond {}` liveness statements (replacing unmapped `_ = (cond)`); value-form if chains emit per-condition; switch tags/case lists record per-span `ctrlOff` — all with compensated `//line`, so type errors inside those conditions now get exact `.gsx` positions too.
- **LSP**: `nodeNavSpans` + `isCtrlSpan` classify multi-span nodes (a ClassPart's expr resolves via ExprMap while its `: cond` guard is a ctrl span); hover gains an H3 ctrl-span branch sharing `ctrlObjectAt` with definition; `pipeStages`/`exprText`/`hasPipeStages` extended so piped class parts/spreads/arms degrade gracefully via `pipedTarget` instead of byte-bridging misaligned.

## Testing

- `TestDefinitionMatrix` (21 cursor cases) + `TestHoverObjectMatrix` pin the full matrix permanently; `TestPipedClassPartCondStillCtrl` pins the dispatch-order rule; skeleton offset byte-faithfulness pinned in `internal/codegen/controlflow_test.go`.
- Verified live against one-learning-gsx `ds/form/form.gsx` over a real `gsx lsp` stdio session (value-if cond → its `{{ }}` local, cond-attr conds, hover ranges UTF-16-exact).
- Independent adversarial review (live probes: span boundaries, unicode/CRLF, shadowed locals, type-switch tags, A/B diagnostics vs parent commit, e2e stdio session) found **no regressions**; two pre-existing rough edges recorded in ROADMAP.
- `make check` + `make lint` green.

## Known limitations (documented in docs/ROADMAP.md)

The EXPR of a *guarded* class part (`x: cond` — cond navigates, expr doesn't: no type harvest for guarded parts), spread pipeline stage spans, paren-unwrapped spread seeds (`{ (x |> f)... }`), and ctrl spans inside component-tag attributes.

https://claude.ai/code/session_015tYp5dghxdoVJzYqVF3kDz