### PR TITLE
feat(dev): [dev].host + honor VITE_DEV_URL host for the front door

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -25,6 +25,19 @@ log = "tmp/dev.log"
 shell. If `build` changes the output path, update `run` to match it. `log` is
 optional and off by default; a configured path may write into the working tree.
 
+`host` sets the hostname in the generated `VITE_DEV_URL` (default `localhost`),
+for when the dev server must be reachable under a specific name:
+
+```toml
+[dev]
+host = "mstudio"   # → VITE_DEV_URL=http://mstudio:<port>
+```
+
+When `host` is unset, `gsx dev` takes the hostname from an existing
+`VITE_DEV_URL` in the environment (typically a gitignored `.env`), so a
+per-machine dev hostname needs no committed config. Only the host is taken —
+the port still comes from `VITE_PORT` or the auto-picker.
+
 Set `no_web = true` when another process manages Vite:
 
 ```toml

--- a/gen/configfile.go
+++ b/gen/configfile.go
@@ -54,6 +54,10 @@ type tomlDev struct {
 	Run   []string `toml:"run"`
 	Log   string   `toml:"log"`
 	NoWeb bool     `toml:"no_web"`
+	// Host is the hostname used to build VITE_DEV_URL (default "localhost"). Set
+	// it when the dev server must be reachable under a specific hostname —
+	// e.g. host = "mstudio" yields VITE_DEV_URL=http://mstudio:<port>.
+	Host string `toml:"host"`
 }
 
 // tomlMinify is the [minify] table: per-asset level spellings. A nil pointer

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -44,7 +44,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 
 	// --- env + ports ---
 	env := append(os.Environ(), loadDotEnv(workDir)...)
-	env, viteURL, err := resolveViteDevEnv(env)
+	env, viteURL, err := resolveViteDevEnv(env, dc.host)
 	if err != nil {
 		fmt.Fprintf(stderr, "gsx dev: %v\n", err)
 		return 1
@@ -207,7 +207,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				envDirty = false
 				env = append(os.Environ(), loadDotEnv(workDir)...)
 				var envErr error
-				env, viteURL, envErr = resolveViteDevEnv(env)
+				env, viteURL, envErr = resolveViteDevEnv(env, dc.host)
 				if envErr != nil {
 					fmt.Fprintf(stderr, "gsx dev: %v\n", envErr)
 					overlayUp = true

--- a/gen/devconfig.go
+++ b/gen/devconfig.go
@@ -14,6 +14,7 @@ type devConfig struct {
 	build   []string
 	run     []string
 	logPath string
+	host    string // hostname for VITE_DEV_URL; "" means localhost
 }
 
 // devFlags carries the CLI-flag layer for resolveDevConfig. A nil command slice
@@ -74,6 +75,9 @@ func resolveDevConfig(workDir string, td *tomlDev, fl devFlags) devConfig {
 		}
 		if td.Log != "" {
 			dc.logPath = td.Log
+		}
+		if td.Host != "" {
+			dc.host = td.Host
 		}
 	}
 

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,7 +95,18 @@ func envLookup(env []string, key string) (string, bool) {
 // envValue is envPort by another name for non-port keys (VITE_DEV_URL).
 func envValue(env []string, key, def string) string { return envPort(env, key, def) }
 
-func resolveViteDevEnv(env []string) ([]string, string, error) {
+func resolveViteDevEnv(env []string, host string) ([]string, string, error) {
+	// When [dev].host is unset, honor the hostname from an existing VITE_DEV_URL
+	// (typically a gitignored .env) so a per-machine dev hostname needs no
+	// committed config. Only the host is taken — the port still comes from
+	// VITE_PORT or the auto-picker, so a stale URL never pins a busy port.
+	if host == "" {
+		if raw := envValue(env, "VITE_DEV_URL", ""); raw != "" {
+			if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+				host = u.Hostname()
+			}
+		}
+	}
 	port, ok := envLookup(env, "VITE_PORT")
 	var err error
 	if ok {
@@ -110,7 +122,10 @@ func resolveViteDevEnv(env []string) ([]string, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	viteURL := "http://localhost:" + port
+	if host == "" {
+		host = "localhost"
+	}
+	viteURL := "http://" + host + ":" + port
 	env = setEnvValue(env, "VITE_PORT", port)
 	env = setEnvValue(env, "VITE_DEV_URL", viteURL)
 	return env, viteURL, nil

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -78,7 +78,7 @@ func TestResolveViteDevEnvSkipsBoundDefaultPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"})
+	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,6 +94,42 @@ func TestResolveViteDevEnvSkipsBoundDefaultPort(t *testing.T) {
 	}
 }
 
+func TestResolveViteDevEnvHost(t *testing.T) {
+	env, viteURL, err := resolveViteDevEnv([]string{"VITE_PORT=0", "PATH=/bin"}, "mstudio")
+	if err != nil {
+		// port 0 is "available" (ephemeral); if the platform rejects it, fall back.
+		env, viteURL, err = resolveViteDevEnv([]string{"PATH=/bin"}, "mstudio")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(viteURL, "http://mstudio:") {
+		t.Fatalf("viteURL = %q, want http://mstudio:<port>", viteURL)
+	}
+	if got := envValue(env, "VITE_DEV_URL", ""); got != viteURL {
+		t.Fatalf("VITE_DEV_URL = %q, want %q", got, viteURL)
+	}
+}
+
+func TestResolveViteDevEnvHostFromDevURL(t *testing.T) {
+	// With no [dev].host, the hostname comes from VITE_DEV_URL in the env.
+	_, viteURL, err := resolveViteDevEnv([]string{"VITE_DEV_URL=http://mstudio:4000", "PATH=/bin"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(viteURL, "http://mstudio:") {
+		t.Fatalf("viteURL = %q, want host mstudio from VITE_DEV_URL", viteURL)
+	}
+	// An explicit [dev].host wins over VITE_DEV_URL.
+	_, viteURL2, err := resolveViteDevEnv([]string{"VITE_DEV_URL=http://mstudio:4000", "PATH=/bin"}, "override")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(viteURL2, "http://override:") {
+		t.Fatalf("viteURL = %q, want [dev].host override to win", viteURL2)
+	}
+}
+
 func TestResolveViteDevEnvSkipsIPv6BoundDefaultPort(t *testing.T) {
 	l, err := net.Listen("tcp", "[::1]:5173")
 	if err != nil {
@@ -105,7 +141,7 @@ func TestResolveViteDevEnvSkipsIPv6BoundDefaultPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"})
+	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +161,7 @@ func TestResolveViteDevEnvRejectsBoundExplicitVitePort(t *testing.T) {
 	}
 	defer l.Close()
 
-	_, _, err = resolveViteDevEnv([]string{"VITE_PORT=5173"})
+	_, _, err = resolveViteDevEnv([]string{"VITE_PORT=5173"}, "")
 	if err == nil {
 		t.Fatal("expected bound explicit VITE_PORT to fail")
 	}


### PR DESCRIPTION
`gsx dev` hardcoded http://localhost:<port> for VITE_DEV_URL, so it could not
serve under a custom hostname. Add a `host` knob to the [dev] table, and — when
it is unset — take the hostname from an existing VITE_DEV_URL in the environment
(typically a gitignored .env), so a per-machine dev hostname needs no committed
config. Only the host is derived; the port still comes from VITE_PORT or the
auto-picker, so a stale URL never pins a busy port.

Threads host through resolveViteDevEnv at both call sites (initial + .env-change
restart). Adds tests for the [dev].host override and VITE_DEV_URL derivation;
documents both in config.md.

Claude-Session: https://claude.ai/code/session_01HVcVd1BtzEdH7hcZpBxrBd
