### PR TITLE
perf(fmt): syntactic unused-import detection (goimports-style), 5.3× faster

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -505,9 +505,23 @@ vocabulary remains a design aspiration, not the current API.
   `2026-06-24-go-to-gsx-perf.md`) uses a *synthetic* 50-package fixture: ~383 ms/package
   `Analyze` (dominated by `go/packages.Load`), ~24.7 MiB/package retained. Plan:
   measure a realistic corpus (blog example, then a larger real project) to gauge
-  `Analyze`/codegen latency, retained memory, GC pressure. Also measure `gsx fmt`
-  default (module-loading, for unused-import removal) vs `-no-imports` at scale.
-  Likely mitigations: LSP retained-package LRU cap; slim the `.gsx`-side full-`Info`.
+  `Analyze`/codegen latency, retained memory, GC pressure. Likely mitigations:
+  LSP retained-package LRU cap; slim the `.gsx`-side full-`Info`.
+  **`gsx fmt` unused-import removal — done:** detection was rearchitected off
+  full type-checking onto a syntactic skeleton scan (`internal/codegen/unused_imports_syntactic.go`,
+  `Module.UnusedImports` — parses each file's lowered skeleton, classifies
+  imports by referenced qualifier name, resolving only ambiguous default-import
+  candidates via a cheap `go/packages` `NeedName`-only load; no importer, no
+  dependency type-checking). Measured on a real 91-file/8-package project
+  (`one-learning-gsx`): `fmt -l` over the whole tree dropped from ~16s to ~3s.
+  Behavior change vs the old type-check-gated path: unused imports are now
+  removed even when the package has an unrelated type error, matching
+  gofmt/goimports parity. (The LSP's `textDocument/formatting` handler, noted
+  above, is a separate path and still sources its unused-import list from the
+  full type-checked analysis it already performs for diagnostics — untouched by
+  this change.) Remaining cost on large directories is dominated by genuine
+  skeleton-build compute and per-directory BYO external-struct `go/packages`
+  loads (`internal/codegen/byo.go`), not by this detector.
 
 ## Documentation backlog
 

--- a/docs/superpowers/plans/2026-07-05-fmt-syntactic-unused-imports.md
+++ b/docs/superpowers/plans/2026-07-05-fmt-syntactic-unused-imports.md
@@ -98,8 +98,8 @@ func TestClassifyUnusedImports(t *testing.T) {
 		{name: ".", path: "math"},           // dot → never removed
 	}
 	unused, candidates := classifyUnusedImports(used, imps, nil, fset)
-	if len(unused) != 1 || unused[0].Path != "os" || unused[0].Name != " al" {
-		t.Errorf("unused=%+v, want only { al os}", unused)
+	if len(unused) != 1 || unused[0].Path != "os" || unused[0].Name != "al" {
+		t.Errorf("unused=%+v, want only {al os}", unused)
 	}
 	if len(candidates) != 1 || candidates[0].path != "bytes" {
 		t.Errorf("candidates=%+v, want only bytes", candidates)

--- a/docs/superpowers/plans/2026-07-05-fmt-syntactic-unused-imports.md
+++ b/docs/superpowers/plans/2026-07-05-fmt-syntactic-unused-imports.md
@@ -1,0 +1,812 @@
+# `gsx fmt` Syntactic Unused-Import Detection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `gsx fmt`'s unused-import detection ~30× faster by replacing the full-dependency-graph type-check with a syntactic scan of the already-built skeleton AST (goimports' technique), correctly handling default-import name mismatches.
+
+**Architecture:** Add an importer-free `Module.UnusedImports(dir)` that reuses the existing skeleton-lowering helpers (`buildSkeleton` et al.) but stops before `checkSkeletonPackage`, then scans each skeleton file's selector qualifiers to decide which hoisted imports are unused. Default imports whose path base is not referenced get their real package name resolved via a cheap `NeedName` load. `gen/fmt.go` opens one `Module` per module (not per directory) and calls the new method. `generate`, the cache, and `computeKey` are untouched.
+
+**Tech Stack:** Go, `go/ast`, `golang.org/x/tools/go/packages` (NeedName only), the existing `internal/codegen` skeleton pipeline.
+
+## Global Constraints
+
+- Runtime root package stays standard-library only; `internal/codegen` and `gen` are tooling and may use `golang.org/x/tools` (verbatim from CLAUDE.md).
+- No "simple heuristics" in core logic — real implementations only. Import-usage is determined the way the Go frontend defines it (name referenced as a selector qualifier); default-import real names are *resolved*, never guessed when a guess would drive removal.
+- Pin Go to `GO_VERSION` in `.github/workflows/ci.yml` (currently 1.26.1) to avoid gofmt drift.
+- Don't hand-edit `.x.go` or golden files — regenerate.
+- `generate`, the on-disk cache, and `computeKey` MUST remain byte-for-byte unchanged (no cache-key or generated-output change).
+
+---
+
+## File Structure
+
+- **Create** `internal/codegen/unused_imports_syntactic.go` — the new detector: `Module.UnusedImports`, `buildPackageSkeletons`, `skeletonUsedNames`, `classifyUnusedImports`, `importBaseName`, `resolvePackageNames`, and the `packageSkeletons`/`fileSkeleton` types.
+- **Create** `internal/codegen/unused_imports_syntactic_test.go` — unit + equivalence-oracle tests.
+- **Modify** `gen/fmt.go` — rewrite `analyzeUnusedImports` to group by module, open one `Module` per module, and call `m.UnusedImports`.
+- **Modify** `gen/main.go` (`fmt` case, ~line 211-217) — best-effort `resolveConfig`, pass a `codegen.Options` to `runFmt`.
+- **Modify** `gen/fmt_test.go` — fmt integration coverage (per-context keep/remove, malformed config, one-load-per-module).
+- **Modify** `docs/ROADMAP.md` and `changelog/` — record the change.
+
+The existing type-check detector (`detectUnusedImports` in `internal/codegen/results.go`) stays: `generate`/`Module.Package` still use it, and the equivalence test uses it as an oracle.
+
+---
+
+### Task 1: Pure detector functions (`skeletonUsedNames`, `classifyUnusedImports`)
+
+**Files:**
+- Create: `internal/codegen/unused_imports_syntactic.go`
+- Test: `internal/codegen/unused_imports_syntactic_test.go`
+
+**Interfaces:**
+- Consumes: `importSpec` (`{name, path string; srcOff int; pos token.Pos}`, `analyze.go:3049`), `UnusedImport` (`{Name, Path string}`, `results.go:72`), `sunkImportKey` (`{line int; path string}`, `module_importer.go:436`).
+- Produces:
+  - `func skeletonUsedNames(f *goast.File) map[string]bool`
+  - `func importBaseName(path string) string`
+  - `func classifyUnusedImports(used map[string]bool, imps []importSpec, sunk map[sunkImportKey]bool, gsxFset *token.FileSet) (unused []UnusedImport, candidates []importSpec)`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package codegen
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestSkeletonUsedNames(t *testing.T) {
+	const src = `package p
+import "strings"
+func f() { _ = strings.TrimSpace("x"); _ = a.b.c }
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "s.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	used := skeletonUsedNames(f)
+	if !used["strings"] {
+		t.Errorf("want strings used")
+	}
+	if !used["a"] { // inner selector a.b of a.b.c
+		t.Errorf("want a used")
+	}
+}
+
+func TestImportBaseName(t *testing.T) {
+	for path, want := range map[string]string{
+		"strings":            "strings",
+		"gopkg.in/yaml.v3":   "yaml.v3", // base is NOT the package name → forces candidate resolution
+		"github.com/x/go-fo": "go-fo",
+	} {
+		if got := importBaseName(path); got != want {
+			t.Errorf("importBaseName(%q)=%q want %q", path, got, want)
+		}
+	}
+}
+
+func TestClassifyUnusedImports(t *testing.T) {
+	fset := token.NewFileSet()
+	used := map[string]bool{"strings": true, "sx": true}
+	imps := []importSpec{
+		{name: "", path: "strings"},         // default, base used → kept
+		{name: "", path: "bytes"},           // default, base unused → candidate
+		{name: "sx", path: "text/scanner"},  // aliased, alias used → kept
+		{name: "al", path: "os"},            // aliased, alias unused → unused
+		{name: "_", path: "embed"},          // blank → never removed
+		{name: ".", path: "math"},           // dot → never removed
+	}
+	unused, candidates := classifyUnusedImports(used, imps, nil, fset)
+	if len(unused) != 1 || unused[0].Path != "os" || unused[0].Name != " al" {
+		t.Errorf("unused=%+v, want only { al os}", unused)
+	}
+	if len(candidates) != 1 || candidates[0].path != "bytes" {
+		t.Errorf("candidates=%+v, want only bytes", candidates)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen/ -run 'TestSkeletonUsedNames|TestImportBaseName|TestClassifyUnusedImports' -count=1`
+Expected: FAIL — `undefined: skeletonUsedNames` (etc.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/codegen/unused_imports_syntactic.go`:
+
+```go
+package codegen
+
+import (
+	goast "go/ast"
+	"go/token"
+	"strings"
+)
+
+// skeletonUsedNames returns the set of identifiers used as the qualifier X in
+// any selector expression X.Sel within f. An imported package name can only be
+// referenced this way (or via a dot/blank import, handled separately), so this
+// set is exactly "which import local-names are referenced" for a valid Go file.
+func skeletonUsedNames(f *goast.File) map[string]bool {
+	used := map[string]bool{}
+	goast.Inspect(f, func(n goast.Node) bool {
+		if sel, ok := n.(*goast.SelectorExpr); ok {
+			if id, ok := sel.X.(*goast.Ident); ok {
+				used[id.Name] = true
+			}
+		}
+		return true
+	})
+	return used
+}
+
+// importBaseName is the last path segment — the CONVENTIONAL default local name,
+// which for some packages (e.g. gopkg.in/yaml.v3 → "yaml") is NOT the real
+// package name. It is used only as a fast "definitely used" check; a base that
+// is not referenced makes the import a removal CANDIDATE whose real name must be
+// resolved before removal.
+func importBaseName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// classifyUnusedImports splits a file's hoisted import specs into definitely-unused
+// imports and removal candidates, given the set of referenced qualifier names.
+//
+//   - `_` / `.` imports are never removed (always "used").
+//   - An import whose only skeleton reference was dropped by a requalification-
+//     failed generic tag (sunk) is never removed — it IS used in the .gsx source.
+//   - An aliased import's explicit name is authoritative: unused iff its alias is
+//     not referenced.
+//   - A default import is kept when its path base is referenced; otherwise it is a
+//     CANDIDATE (its real package name may differ from the base and still be used).
+func classifyUnusedImports(used map[string]bool, imps []importSpec, sunk map[sunkImportKey]bool, gsxFset *token.FileSet) (unused []UnusedImport, candidates []importSpec) {
+	for _, imp := range imps {
+		if imp.name == "_" || imp.name == "." {
+			continue
+		}
+		if sunk != nil && imp.pos.IsValid() {
+			k := sunkImportKey{line: gsxFset.Position(imp.pos).Line, path: imp.path}
+			if sunk[k] {
+				continue
+			}
+		}
+		if imp.name != "" {
+			if !used[imp.name] {
+				unused = append(unused, UnusedImport{Name: imp.name, Path: imp.path})
+			}
+			continue
+		}
+		if used[importBaseName(imp.path)] {
+			continue
+		}
+		candidates = append(candidates, imp)
+	}
+	return unused, candidates
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/codegen/ -run 'TestSkeletonUsedNames|TestImportBaseName|TestClassifyUnusedImports' -count=1`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/unused_imports_syntactic.go internal/codegen/unused_imports_syntactic_test.go
+git commit -m "feat(codegen): pure syntactic unused-import classifier"
+```
+
+---
+
+### Task 2: `buildPackageSkeletons` — importer-free skeleton build
+
+**Files:**
+- Modify: `internal/codegen/unused_imports_syntactic.go`
+- Test: `internal/codegen/unused_imports_syntactic_test.go`
+
+**Interfaces:**
+- Consumes: `Module` lifecycle + helpers — `m.fset`, `m.maybeRebuildFset()`, `m.applyDirty()`, `m.analysisMu`, `m.parsePackageWithFset(dir, fset)` (`module_importer.go:1288`), `m.cachedFilterTable()` (`module.go:295`), `componentPropFieldsFor(dir, gsxFiles)` (`analyze.go:69`), `genericSigsFor(gsxFiles, byo)` (`analyze.go:547`), `newInferNameAllocator()`, `m.fileScopedFacts(...)` (`module_importer.go:476`), `buildSkeleton(...)` (`analyze.go:335`), `m.externalLoads()` (`module.go:276`), `jsx.ResolveScripts`. This mirrors `analyze`'s per-file loop (`module_importer.go:769-819`) using the SAME lowering, but keeps only import-detection state and never calls `checkSkeletonPackage`.
+- Produces:
+  - `type fileSkeleton struct { skel *goast.File; imps []importSpec; sunk map[sunkImportKey]bool }`
+  - `type packageSkeletons struct { gsxFset *token.FileSet; byGsx map[string]fileSkeleton }`
+  - `func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/codegen/unused_imports_syntactic_test.go`. Reuse the Module-construction pattern from `internal/codegen/unused_imports_test.go` (a helper that writes .gsx into a temp module and calls `Open`). If that test file has an existing helper (e.g. `openModuleWithFiles`), call it; otherwise inline the same steps.
+
+```go
+func TestBuildPackageSkeletonsNoExternalLoad(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"page.gsx": "{ import \"strings\" }\ncomp Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n",
+	})
+	ps, err := m.buildPackageSkeletons(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs, ok := ps.byGsx[filepath.Join(dir, "page.gsx")]
+	if !ok {
+		t.Fatalf("no skeleton for page.gsx; got %v", ps.byGsx)
+	}
+	if len(fs.imps) != 1 || fs.imps[0].path != "strings" {
+		t.Errorf("imps=%+v, want [strings]", fs.imps)
+	}
+	used := skeletonUsedNames(fs.skel)
+	if !used["strings"] {
+		t.Errorf("expected strings referenced in skeleton; used=%v", used)
+	}
+	if n := m.externalLoads(); n != 0 {
+		t.Errorf("buildPackageSkeletons did %d external loads, want 0 (importer-free)", n)
+	}
+}
+```
+
+`openTestModule(t, files)` returns `(absDir, *Module)`: write a `go.mod` (`module testmod\n\ngo 1.26\n`) and the `.gsx` files into `t.TempDir()`, then `Open(Options{ModuleRoot: root, ModulePath: "testmod", Classifier: attrclass.Builtin()})` and return the package dir. Model it on the existing `unused_imports_test.go` setup; add it as a shared test helper if none exists.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen/ -run TestBuildPackageSkeletonsNoExternalLoad -count=1`
+Expected: FAIL — `m.buildPackageSkeletons undefined`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/codegen/unused_imports_syntactic.go` (add imports: `goparser "go/parser"`, `"path/filepath"`, `"github.com/gsxhq/gsx/internal/diag"`, `"github.com/gsxhq/gsx/internal/jsx"`):
+
+```go
+type fileSkeleton struct {
+	skel *goast.File
+	imps []importSpec
+	sunk map[sunkImportKey]bool
+}
+
+type packageSkeletons struct {
+	gsxFset *token.FileSet
+	byGsx   map[string]fileSkeleton // .gsx abs path -> skeleton + import specs + sunk set
+}
+
+// buildPackageSkeletons lowers every .gsx file in dir to its skeleton AST WITHOUT
+// type-checking (no importer, no dependency resolution) and returns, per file,
+// the parsed skeleton, its hoisted import specs, and its sunk-import set. It
+// mirrors analyze's per-file loop (module_importer.go:769-819) using the same
+// buildSkeleton lowering, but keeps only what unused-import detection needs. A
+// file whose skeleton fails to build (parse/attr error) is simply omitted, so
+// the caller keeps all of that file's imports.
+func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
+	m.analysisMu.Lock()
+	defer m.analysisMu.Unlock()
+	m.maybeRebuildFset()
+	m.applyDirty()
+	fset := m.fset
+	bag := diag.NewBag(fset)
+	gsxFiles, _, err := m.parsePackageWithFset(dir, fset)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range gsxFiles {
+		jsx.ResolveScripts(f, bag) // best-effort; failure just means we may skip that file below
+	}
+	table, err := m.cachedFilterTable()
+	if err != nil {
+		return nil, err
+	}
+	propFields, nodeProps, attrsProps, byo, err := componentPropFieldsFor(dir, gsxFiles)
+	if err != nil {
+		return nil, err
+	}
+	genericSigs := genericSigsFor(gsxFiles, byo)
+	inferNames := newInferNameAllocator()
+	out := &packageSkeletons{gsxFset: fset, byGsx: map[string]fileSkeleton{}}
+	for path, f := range gsxFiles {
+		ff := m.fileScopedFacts(dir, f, propFields, nodeProps, attrsProps, byo, bag, fset)
+		skel, _, imps, _, infReg, berr := buildSkeleton(f, table, ff.propFields, ff.nodeProps, ff.attrsProps,
+			genericSigs, ff.genericSigs, ff.byo, m.opts.FieldMatcher, fset, bag, inferNames)
+		if berr != nil {
+			continue // unbuildable → keep all imports (no entry)
+		}
+		base := strings.TrimSuffix(filepath.Base(path), ".gsx")
+		absXpath := filepath.Join(dir, base+".x.go")
+		gf, perr := goparser.ParseFile(fset, absXpath, skel, goparser.SkipObjectResolution)
+		if perr != nil {
+			continue
+		}
+		sunk := map[sunkImportKey]bool{}
+		if len(infReg.failedAliases) > 0 && ff.depAliasSpecs != nil {
+			for alias := range infReg.failedAliases {
+				if spec, ok := ff.depAliasSpecs[alias]; ok && spec.pos.IsValid() {
+					sunk[sunkImportKey{line: fset.Position(spec.pos).Line, path: spec.path}] = true
+				}
+			}
+		}
+		out.byGsx[path] = fileSkeleton{skel: gf, imps: imps, sunk: sunk}
+	}
+	return out, nil
+}
+```
+
+Note: confirm the `fileFacts` field names against `m.fileScopedFacts`'s return (`propFields`, `nodeProps`, `attrsProps`, `genericSigs`, `byo`, `depAliasSpecs`) — they are exactly the fields the analyze loop reads at `module_importer.go:770-808`. If a name differs, match the analyze loop verbatim.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/codegen/ -run TestBuildPackageSkeletonsNoExternalLoad -count=1`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/unused_imports_syntactic.go internal/codegen/unused_imports_syntactic_test.go
+git commit -m "feat(codegen): importer-free per-package skeleton build for import detection"
+```
+
+---
+
+### Task 3: `resolvePackageNames` + `Module.UnusedImports`
+
+**Files:**
+- Modify: `internal/codegen/unused_imports_syntactic.go`
+- Test: `internal/codegen/unused_imports_syntactic_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 + Task 2 functions; `golang.org/x/tools/go/packages`; `m.opts.ModuleRoot`.
+- Produces:
+  - `func (m *Module) resolvePackageNames(paths []string) map[string]string`
+  - `func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, error)` — keyed by .gsx abs path.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestUnusedImportsSyntactic(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"page.gsx": "{ import (\n\t\"strings\"\n\t\"bytes\"\n) }\n" +
+			"comp Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n",
+	})
+	got, err := m.UnusedImports(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unused := got[filepath.Join(dir, "page.gsx")]
+	if len(unused) != 1 || unused[0].Path != "bytes" {
+		t.Errorf("unused=%+v, want [bytes]; strings is used and must be kept", unused)
+	}
+}
+
+func TestUnusedImportsDefaultNameMismatchKept(t *testing.T) {
+	// gopkg.in/yaml.v3's package name is "yaml", not its base "yaml.v3".
+	// A base-only scan would wrongly drop it; real-name resolution must keep it.
+	dir, m := openTestModuleWithGoMod(t,
+		"module testmod\n\ngo 1.26\n\nrequire gopkg.in/yaml.v3 v3.0.1\n",
+		map[string]string{
+			"page.gsx": "{ import \"gopkg.in/yaml.v3\" }\n" +
+				"comp Page() {\n\t<div>{string(mustYAML())}</div>\n}\n" +
+				"{ func mustYAML() []byte { b, _ := yaml.Marshal(1); return b } }\n",
+		})
+	got, err := m.UnusedImports(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u := got[filepath.Join(dir, "page.gsx")]; len(u) != 0 {
+		t.Errorf("yaml is used (yaml.Marshal) and must be kept; got unused=%+v", u)
+	}
+}
+```
+
+`openTestModuleWithGoMod` is `openTestModule` with a caller-supplied `go.mod`; both share one helper. The yaml test needs the module resolvable — run `go mod tidy` (or vendor `gopkg.in/yaml.v3`) inside the temp module as part of the helper, or skip via `testing.Short()` when offline. Prefer materializing yaml.v3 into the temp module's `go.sum` by copying from this repo's own module cache if available; otherwise `t.Skip` when `go list gopkg.in/yaml.v3` fails, and note the skip.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen/ -run 'TestUnusedImportsSyntactic|TestUnusedImportsDefaultNameMismatchKept' -count=1`
+Expected: FAIL — `m.UnusedImports undefined`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append (add import `"golang.org/x/tools/go/packages"`):
+
+```go
+// resolvePackageNames returns the real package name for each import path, via a
+// NeedName-only load (no type-checking, no dependency resolution). Unresolvable
+// paths are simply absent from the result, so the caller keeps those imports.
+func (m *Module) resolvePackageNames(paths []string) map[string]string {
+	out := map[string]string{}
+	if len(paths) == 0 {
+		return out
+	}
+	cfg := &packages.Config{Mode: packages.NeedName, Dir: m.opts.ModuleRoot}
+	pkgs, err := packages.Load(cfg, paths...)
+	if err != nil {
+		return out
+	}
+	for _, p := range pkgs {
+		if p.PkgPath != "" && p.Name != "" {
+			out[p.PkgPath] = p.Name
+		}
+	}
+	return out
+}
+
+// UnusedImports returns, per .gsx file (abs path) in dir, the imports the file
+// declares but never references — determined syntactically from the skeleton,
+// with NO type-checking and NO dependency resolution. Default imports whose path
+// base is not referenced have their real package name resolved via a single
+// cheap NeedName load before removal, so a package whose name differs from its
+// path base (e.g. gopkg.in/yaml.v3 → "yaml") is handled correctly.
+func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, error) {
+	ps, err := m.buildPackageSkeletons(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string][]UnusedImport{}
+	usedByFile := map[string]map[string]bool{}
+	type pending struct {
+		gsxPath string
+		imp     importSpec
+	}
+	var candidates []pending
+	candPaths := map[string]bool{}
+	for gsxPath, fs := range ps.byGsx {
+		used := skeletonUsedNames(fs.skel)
+		usedByFile[gsxPath] = used
+		unused, cands := classifyUnusedImports(used, fs.imps, fs.sunk, ps.gsxFset)
+		if len(unused) > 0 {
+			out[gsxPath] = unused
+		}
+		for _, c := range cands {
+			candidates = append(candidates, pending{gsxPath, c})
+			candPaths[c.path] = true
+		}
+	}
+	if len(candPaths) > 0 {
+		paths := make([]string, 0, len(candPaths))
+		for p := range candPaths {
+			paths = append(paths, p)
+		}
+		names := m.resolvePackageNames(paths)
+		for _, p := range candidates {
+			realName, ok := names[p.imp.path]
+			if !ok {
+				continue // unresolvable → conservative keep
+			}
+			if !usedByFile[p.gsxPath][realName] {
+				out[p.gsxPath] = append(out[p.gsxPath], UnusedImport{Name: p.imp.name, Path: p.imp.path})
+			}
+		}
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/codegen/ -run 'TestUnusedImportsSyntactic|TestUnusedImportsDefaultNameMismatchKept' -count=1`
+Expected: PASS (yaml test may `Skip` when offline)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/unused_imports_syntactic.go internal/codegen/unused_imports_syntactic_test.go
+git commit -m "feat(codegen): Module.UnusedImports syntactic detector with real-name resolution"
+```
+
+---
+
+### Task 4: Rewire `gen/fmt.go` to one `Module` per module
+
+**Files:**
+- Modify: `gen/fmt.go` (`analyzeUnusedImports`, ~line 165-204; and its call site in `runFmt`, ~line 74-77 + signature ~line 45)
+- Modify: `gen/main.go` (`fmt` case, ~line 211-217)
+- Test: `gen/fmt_test.go`
+
+**Interfaces:**
+- Consumes: `Module.UnusedImports` (Task 3), `groupByModule(dirs)` (`gen/modroot.go:28`, returns `groups []moduleGroup` with `.root`, `.modPath`, `.dirs`), `codegen.Open`, `codegen.Options`, `resolveConfig`.
+- Produces: `analyzeUnusedImports(files []string, opts codegen.Options) map[string][]gsxfmt.ImportRef`; `runFmt(..., opts codegen.Options, ...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `gen/fmt_test.go`. Follow the existing fmt-test harness in that file (write .gsx into a temp module, call `runFmt`). Assert per-context removal:
+
+```go
+func TestFmtRemovesUnusedKeepsUsed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module fmtmod\n\ngo 1.26\n")
+	src := "{ import (\n\t\"strings\"\n\t\"bytes\"\n) }\n" +
+		"comp Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n"
+	page := filepath.Join(dir, "page.gsx")
+	writeFile(t, page, src)
+
+	var out, errBuf bytes.Buffer
+	code := runFmt(&out, &errBuf, []string{"-w", page}, nil, nil, codegen.Options{Classifier: attrclass.Builtin()}, dir)
+	if code != 0 {
+		t.Fatalf("runFmt code=%d stderr=%s", code, errBuf.String())
+	}
+	got := readFile(t, page)
+	if strings.Contains(got, `"bytes"`) {
+		t.Errorf("unused bytes import should be removed:\n%s", got)
+	}
+	if !strings.Contains(got, `"strings"`) {
+		t.Errorf("used strings import must be kept:\n%s", got)
+	}
+}
+
+func TestFmtToleratesMalformedConfig(t *testing.T) {
+	// A malformed gsx.toml must not break fmt: with builtin Options, formatting
+	// still succeeds (imports simply may be conservatively kept).
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module fmtmod\n\ngo 1.26\n")
+	page := filepath.Join(dir, "page.gsx")
+	writeFile(t, page, "comp Page() {\n\t<div>hi</div>\n}\n")
+
+	var out, errBuf bytes.Buffer
+	code := runFmt(&out, &errBuf, []string{"-l", page}, nil, nil, codegen.Options{Classifier: attrclass.Builtin()}, dir)
+	if code != 0 { // already canonical → no diff → 0
+		t.Fatalf("runFmt code=%d stderr=%s", code, errBuf.String())
+	}
+}
+```
+
+Use whatever `writeFile`/`readFile` helpers `gen/fmt_test.go` already has; add minimal ones if absent.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./gen/ -run 'TestFmtRemovesUnusedKeepsUsed|TestFmtToleratesMalformedConfig' -count=1`
+Expected: FAIL — `runFmt` signature mismatch (no `opts` param) / compile error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `gen/fmt.go`, change `runFmt`'s signature to accept `opts codegen.Options` and pass it to `analyzeUnusedImports`:
+
+```go
+func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Formatter, opts codegen.Options, workDir string) int {
+```
+
+At the analysis call (currently `unusedByPath = analyzeUnusedImports(files)`):
+
+```go
+	var unusedByPath map[string][]gsxfmt.ImportRef
+	if !noImports {
+		unusedByPath = analyzeUnusedImports(files, opts)
+	}
+```
+
+Replace the whole `analyzeUnusedImports` body with the grouped, one-Module-per-module form:
+
+```go
+// analyzeUnusedImports computes, per absolute .gsx path, the imports the file
+// declares but does not use — syntactically, via the skeleton (no type-check).
+// It opens ONE codegen.Module per module (not per directory) and reuses it across
+// that module's directories. Directories not in a module, or that fail to open,
+// are skipped (those files are then formatted without import removal). opts
+// carries the resolved codegen config so skeletons match what `generate` emits;
+// a zero/builtin opts still works (buildSkeleton tolerates unknown filters).
+func analyzeUnusedImports(files []string, opts codegen.Options) map[string][]gsxfmt.ImportRef {
+	out := map[string][]gsxfmt.ImportRef{}
+	dirSet := map[string]bool{}
+	for _, f := range files {
+		dirSet[filepath.Dir(f)] = true
+	}
+	dirs := make([]string, 0, len(dirSet))
+	for d := range dirSet {
+		dirs = append(dirs, d)
+	}
+	groups, _ := groupByModule(dirs)
+	for _, g := range groups {
+		o := opts
+		o.ModuleRoot = g.root
+		o.ModulePath = g.modPath
+		m, err := codegen.Open(o)
+		if err != nil {
+			continue // not loadable → syntactic-only fallback (no removal)
+		}
+		for _, dir := range g.dirs {
+			absDir, err := filepath.Abs(dir)
+			if err != nil {
+				continue
+			}
+			byPath, err := m.UnusedImports(absDir)
+			if err != nil {
+				continue
+			}
+			for gsxPath, imps := range byPath {
+				absPath, err := filepath.Abs(gsxPath)
+				if err != nil {
+					continue
+				}
+				refs := make([]gsxfmt.ImportRef, len(imps))
+				for i, u := range imps {
+					refs[i] = gsxfmt.ImportRef{Name: u.Name, Path: u.Path}
+				}
+				out[absPath] = refs
+			}
+		}
+	}
+	return out
+}
+```
+
+Delete the now-unused `codegen`/`attrclass` imports only if they become unused (they are still used via `codegen.Open`/`codegen.Options`; `attrclass` may no longer be referenced here — run goimports/`gsx fmt` discipline: remove if unused).
+
+In `gen/main.go`, the `fmt` case: best-effort resolve config and pass Options (Classifier, FieldMatcher, Aliases, FilterPkgs — the knobs that affect skeleton import references; omit ClassMerger/minify, which are emit-only, to avoid an extra package load):
+
+```go
+	case "fmt":
+		// fmt tolerates a malformed config: resolveConfig is best-effort and only
+		// feeds the syntactic import analysis. On failure we fall back to the builtin
+		// classifier (files using named filters still skeletonize — buildSkeleton
+		// tolerates unknown filters). CSS/JS formatter overrides remain programmatic.
+		fmtOpts := codegen.Options{Classifier: attrclass.Builtin()}
+		if merged, _, cerr := resolveConfig(cfg, workDir); cerr == nil {
+			fmtOpts = codegen.Options{
+				Classifier:   merged.classifier(),
+				FieldMatcher: merged.fieldMatcher,
+				Aliases:      merged.aliases,
+				FilterPkgs:   merged.filterPkgs,
+			}
+		}
+		return runFmt(stdout, stderr, cmdArgs, cfg.cssFmt, cfg.jsFmt, fmtOpts, workDir)
+```
+
+Also update any other `runFmt(` call sites (search: `rg 'runFmt\('`) — e.g. `formatGsx`/`Format` helpers do NOT call runFmt, but confirm none break.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./gen/ -run 'TestFmtRemovesUnusedKeepsUsed|TestFmtToleratesMalformedConfig' -count=1`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gen/fmt.go gen/main.go gen/fmt_test.go
+git commit -m "perf(fmt): syntactic unused-import detection, one module load per module"
+```
+
+---
+
+### Task 5: Equivalence oracle test + fmt context coverage + single-load assertion
+
+**Files:**
+- Modify: `internal/codegen/unused_imports_syntactic_test.go`
+- Modify: `gen/fmt_test.go`
+
+**Interfaces:**
+- Consumes: `Module.UnusedImports` (Task 3), `Module.Package(dir)` → `pr.UnusedImports` (the type-check oracle), `pr.Diags`.
+
+- [ ] **Step 1: Write the failing/what-if test — equivalence oracle**
+
+The oracle: on a package that type-checks cleanly (no error-severity diagnostics), the syntactic removal set MUST equal the type-check removal set. Skip packages with unrelated type errors (documented divergence — syntactic still removes, oracle returns nothing).
+
+```go
+func TestSyntacticMatchesTypecheckOracle(t *testing.T) {
+	cases := map[string]map[string]string{
+		"interp":    {"a.gsx": "{ import (\n\t\"strings\"\n\t\"bytes\"\n) }\ncomp A(){<p>{strings.ToUpper(\"x\")}</p>}\n"},
+		"attr":      {"b.gsx": "{ import \"strings\" }\ncomp B(){<p id={strings.ToLower(\"X\")}>hi</p>}\n"},
+		"tag":       {"c.gsx": "{ import \"bytes\" }\ncomp C(){<div>{bytes.NewBufferString(\"x\").String()}</div>}\n"},
+		"allunused": {"d.gsx": "{ import (\n\t\"strings\"\n\t\"bytes\"\n) }\ncomp D(){<p>hi</p>}\n"},
+		"aliased":   {"e.gsx": "{ import sx \"strings\" }\ncomp E(){<p>{sx.ToUpper(\"x\")}</p>}\n"},
+	}
+	for name, files := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir, m := openTestModule(t, files)
+			syn, err := m.UnusedImports(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pr, err := m.Package(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if anyErrorDiagCodegen(pr.Diags) {
+				t.Skipf("package has type errors; oracle returns nothing by design")
+			}
+			assertSameRemovalSet(t, dir, syn, pr.UnusedImports)
+		})
+	}
+}
+```
+
+`assertSameRemovalSet` compares the two `map[gsxPath][]UnusedImport` as sets of `(Name,Path)` per file (order-independent). `anyErrorDiagCodegen` reports whether any diagnostic is error-severity (mirror `gen`'s `anyErrorDiag`). Note `m.Package`'s `UnusedImports` keys are file paths as recorded by `detectUnusedImports` (the `.gsx` filename via `//line`); normalize both sides to abs `.gsx` paths before comparing.
+
+- [ ] **Step 2: Run test to verify current behavior**
+
+Run: `go test ./internal/codegen/ -run TestSyntacticMatchesTypecheckOracle -count=1`
+Expected: PASS (this validates parity; if a case diverges, it exposes a real scan gap to fix before shipping).
+
+- [ ] **Step 3: Add the single-load assertion (fmt integration)**
+
+Add to `gen/fmt_test.go` — a two-directory module must load once, proving we don't re-open per directory. Since `analyzeUnusedImports` opens the `Module` internally, assert indirectly via wall-clock-independent means: expose the per-module load by checking that formatting a 2-dir module calls `codegen.Open` once. Simplest robust form: unit-test `analyzeUnusedImports` directly and assert both dirs' results come back in a single call, and add a `codegen` test that `buildPackageSkeletons` across N dirs on ONE module keeps `m.externalLoads()==0` (already covered in Task 2) — plus a `Module`-level test that calling `UnusedImports` on two dirs of one module resolves names in one `resolvePackageNames` batch is out of scope; the meaningful guarantee (one `Open` per module) is structural in the Task 4 code. Add:
+
+```go
+func TestFmtTwoDirsOneModule(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module fmtmod\n\ngo 1.26\n")
+	writeFile(t, filepath.Join(dir, "a", "a.gsx"), "{ import \"bytes\" }\ncomp A(){<p>hi</p>}\n")
+	writeFile(t, filepath.Join(dir, "b", "b.gsx"), "{ import \"strings\" }\ncomp B(){<p>{strings.ToUpper(\"x\")}</p>}\n")
+	refs := analyzeUnusedImports(
+		[]string{filepath.Join(dir, "a", "a.gsx"), filepath.Join(dir, "b", "b.gsx")},
+		codegen.Options{Classifier: attrclass.Builtin()},
+	)
+	aAbs, _ := filepath.Abs(filepath.Join(dir, "a", "a.gsx"))
+	bAbs, _ := filepath.Abs(filepath.Join(dir, "b", "b.gsx"))
+	if len(refs[aAbs]) != 1 || refs[aAbs][0].Path != "bytes" {
+		t.Errorf("a: want bytes unused, got %+v", refs[aAbs])
+	}
+	if len(refs[bAbs]) != 0 {
+		t.Errorf("b: strings is used, want none unused, got %+v", refs[bAbs])
+	}
+}
+```
+
+- [ ] **Step 4: Run all new tests**
+
+Run: `go test ./internal/codegen/ ./gen/ -run 'Unused|Fmt|Oracle|Skeleton' -count=1`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/unused_imports_syntactic_test.go gen/fmt_test.go
+git commit -m "test(fmt): syntactic/typecheck equivalence oracle + fmt context coverage"
+```
+
+---
+
+### Task 6: Full verification, docs, changelog, real-world timing
+
+**Files:**
+- Modify: `docs/ROADMAP.md`, `changelog/` (follow the existing changelog format in that dir)
+
+- [ ] **Step 1: Run the full check suite**
+
+Run: `make check`
+Expected: PASS (build/vet/test both modules, examples drift, gofmt + gsx fmt). Fix any fallout.
+
+- [ ] **Step 2: Confirm the real-world speedup**
+
+Build and time against `one-learning-gsx` (the reproduction case):
+
+```bash
+go build -o /tmp/gsx-bench ./cmd/gsx
+cd ~/work/one-learning-gsx && time /tmp/gsx-bench fmt -l >/dev/null
+```
+Expected: sub-second wall time (down from ~16s), and `fmt -l` still lists the same files as `fmt -l -no-imports` plus any with genuinely-unused imports. Spot-check `fmt -d` on a file with a known unused import shows the import removed.
+
+- [ ] **Step 3: Verify idempotence and no generated-output change**
+
+```bash
+cd ~/work/one-learning-gsx && /tmp/gsx-bench fmt -w . && /tmp/gsx-bench fmt -l .
+```
+Expected: second `fmt -l` prints nothing (idempotent). Run `git diff --stat` in that repo — only import removals, no unrelated reformatting. Confirm `gsx generate` output is byte-identical (`git diff` on `.x.go` empty).
+
+- [ ] **Step 4: Update docs + changelog**
+
+Add a `changelog/` entry: "`gsx fmt` unused-import detection is now syntactic (skeleton scan), ~30× faster on large trees; removes unused imports even when the package has an unrelated type error (gofmt/goimports parity)." Update `docs/ROADMAP.md` if it tracks fmt performance.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ROADMAP.md changelog/
+git commit -m "docs: record syntactic fmt unused-import detection"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Importer-free detector on the skeleton → Tasks 1-3. ✓
+- One `Module` per module (not per directory) → Task 4. ✓
+- Best-effort config / malformed-config tolerance → Task 4 (`gen/main.go` + `TestFmtToleratesMalformedConfig`). ✓
+- `sunkImports` preserved, `_`/`.` never removed, aliased-by-local-name, file-scoped → Task 1 `classifyUnusedImports` + Task 2 sunk wiring + Task 5 aliased case. ✓
+- Default-import real-name resolution (the correctness gap the spec's syntactic story must close) → Task 3 `resolvePackageNames` + `TestUnusedImportsDefaultNameMismatchKept`. ✓
+- Behavior change (removes amid unrelated errors) → documented in Task 5 oracle skip + Task 6 changelog. ✓
+- Equivalence oracle → Task 5. ✓
+- `generate`/cache/`computeKey` untouched → no task modifies them; Task 6 Step 3 verifies byte-identical output. ✓
+- Filter/merger-load optimization (§4) → intentionally out of scope (Task 4 omits ClassMerger; the filter-table skip is deferred).
+
+**Placeholder scan:** No TBD/TODO; every code step carries full code. The only conditional is the yaml.v3 test's offline `Skip`, which is explicit.
+
+**Type consistency:** `UnusedImports` returns `map[string][]UnusedImport` (Task 3) consumed by `analyzeUnusedImports` (Task 4) which maps to `gsxfmt.ImportRef{Name,Path}`. `classifyUnusedImports` signature identical across Tasks 1/3. `buildPackageSkeletons`→`packageSkeletons{gsxFset,byGsx}`→`fileSkeleton{skel,imps,sunk}` consistent Tasks 2/3. `runFmt` gains `opts codegen.Options` in both signature and call site (Task 4). ✓
+
+**Open risk to watch during execution:** `fileFacts` field names read in Task 2 (`ff.propFields/nodeProps/attrsProps/genericSigs/byo/depAliasSpecs`) must match `m.fileScopedFacts`'s actual struct; verify against the analyze loop at `module_importer.go:770-808` before finalizing Task 2.

--- a/docs/superpowers/specs/2026-07-05-fmt-syntactic-unused-imports-design.md
+++ b/docs/superpowers/specs/2026-07-05-fmt-syntactic-unused-imports-design.md
@@ -1,0 +1,209 @@
+# `gsx fmt` — syntactic unused-import detection (goimports-style)
+
+**Status:** design
+**Date:** 2026-07-05
+
+## Problem
+
+`gsx fmt` is ~300× slower than it should be. On `one-learning-gsx` (91 `.gsx`
+files, 8 packages, one module):
+
+| Command | Wall | User CPU |
+|---|---|---|
+| `generate` (cached, warm) | 0.45s | 0.74s |
+| `fmt -l` | 16.3s | 103s |
+| `fmt -l -no-imports` | **0.05s** | 0.06s |
+
+The formatting itself (parse → whitespace-normalize → print) of the whole tree is
+~50ms. **~99.7% of `fmt -l`'s time is unused-import analysis**
+(`analyzeUnusedImports`, `gen/fmt.go`).
+
+### Why it is slow
+
+Two stacked causes, both rooted in the same wrong tool:
+
+1. **Per-directory module `Open`.** `analyzeUnusedImports` calls
+   `codegen.Open(...)` *inside* its per-directory loop (`gen/fmt.go:171-184`).
+   Each `Open`, on first analysis, drives a full `go/packages.Load` of the entire
+   external dependency graph (temporal, clickhouse, prometheus, …). For 8
+   directories in one module that is **8 complete dependency loads** — which is
+   why `fmt` (16s) is even slower than a *cold* full `generate` (6.1s, which does
+   that heavy load once via a single batched `GenerateDirs`).
+
+2. **Type-checking at all.** Detection is driven by `go/types` "imported and not
+   used" errors: `detectUnusedImports` (`internal/codegen/results.go:99`)
+   correlates the raw type errors from `checkSkeletonPackage`
+   (`internal/codegen/module_importer.go:57`) with the hoisted import specs. To
+   produce those errors, `checkSkeletonPackage` must resolve *every* dependency
+   (recursively for project gsx packages, `packages.Load` for external ones).
+   That dependency resolution is the entire cost.
+
+### How goimports is fast
+
+Unused-import detection is a **local, syntactic** fact: an import is unused iff
+its local package name is never referenced in the file. goimports walks the
+file's AST (`astutil.UsesImport`) and never resolves a single dependency, never
+type-checks. That is why it runs in milliseconds.
+
+## Approach
+
+Do what goimports does, on the artifact we already build.
+
+We already lower each `.gsx` file to a **skeleton** — valid Go where every gsx
+import usage (interpolations, attribute expressions, pipelines, and
+`<pkg.Comp>` component/element tags) becomes a plain Go reference, and the
+hoisted user imports are emitted as a normal import block. Building the skeleton
+is **importer-free** (`buildSkeleton`, `analyze.go:335`); the dependency
+resolution only happens later, in `checkSkeletonPackage`.
+
+So instead of type-checking the skeleton to read off "imported and not used"
+errors, **scan the skeleton AST syntactically** for import usage — pure
+`go/ast`, zero dependency loads. This is the canonical, real implementation of
+import-usage (it is how the Go frontend itself defines it), not a heuristic, and
+it reuses our own lowering, so it cannot drift from what `generate` emits.
+
+Fixing detection this way **subsumes both slow causes**: with no type-check there
+is no external load to duplicate and nothing per-directory to redo. `fmt` with
+imports becomes ~as fast as `fmt -no-imports`.
+
+### Validation (spike, `one-learning-gsx` `ui/`, warm caches)
+
+| Load | Time | Note |
+|---|---|---|
+| Full `NeedTypes` `./ui/...` (933 pkgs incl deps) | 1.1s | the per-dir cost, ×8 + skeleton checks ≈ 16s — **eliminated** |
+| Filter+merger packages only | 344ms | residual, once per module (see optimization) |
+| `NeedSyntax` only `./ui/...` | 290ms | parse-only reference |
+
+Confirmed: the 16s is type-checking the graph eight times. Syntactic detection
+removes all of it; the only residual is a one-time ~344ms filter/merger load the
+skeleton prerequisites currently perform.
+
+## Design
+
+### 1. Importer-free detector in `codegen`
+
+Add a skeleton-only analysis path that runs `analyze`'s front half — parse →
+prerequisites (`cachedFilterTable`, `componentPropFieldsFor`, `genericSigsFor`) →
+`buildSkeleton` per file, collecting `goFiles` (parsed skeleton `*goast.File`s),
+`allImportSpecs`, and `sunkImports` — and **stops before `checkSkeletonPackage`**.
+`analyze` already produces all three before the type-check
+(`module_importer.go:769-820`), so the split is at an existing boundary.
+
+Expose it as a `Module` method, e.g.:
+
+```go
+// UnusedImports returns, per .gsx file in dir, the imports the file declares but
+// never references — determined syntactically from the skeleton, with NO
+// type-checking and NO dependency resolution.
+func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, []diag.Diagnostic, error)
+```
+
+The syntactic detector, per skeleton file `gf` and that file's import specs:
+
+- An import is **unused** iff its effective local name is never referenced in
+  `gf` (walk for selector-qualifier identifiers; equivalently
+  `astutil.UsesImport(gf, path)` — the skeleton emits the user imports so
+  `gf.Imports` is populated).
+- **Never** remove `_` (blank) or `.` (dot) imports.
+- **Never** remove an import in that file's `sunkImports` set — a
+  requalification-failed generic tag can drop a real reference from the skeleton
+  (`module_importer.go:788-808`); the `sunkImports` signal is computed
+  importer-free during `buildSkeleton`, so the scan consults it directly.
+- Aliased imports (`f "foo"`) are keyed by their **local** name.
+- Imports are **file-scoped**: an import used only in a sibling file of the same
+  package is still unused in this file (matches Go and goimports).
+- If a file's (or the package's) skeleton fails to build (parse error,
+  `attrError`) → **remove nothing** for it (keep all imports). Matches today's
+  skip-on-error posture.
+
+`generate` is **untouched** — it still type-checks (it needs full type info for
+emit). Only `fmt`'s detection path changes.
+
+### 2. `gen/fmt.go` — one module `Open`, not one per directory
+
+Replace `analyzeUnusedImports`'s per-directory `codegen.Open` loop with:
+
+- Group the target files by directory, then group directories by module (reuse
+  `groupByModule`).
+- **`Open` one `Module` per module root**, then iterate its directories calling
+  `m.UnusedImports(dir)`, reusing the warm module across directories.
+
+### 3. Config for a faithful skeleton
+
+To build a skeleton that matches what `generate` emits, the `Module` needs the
+real `Options` — the configured filter table (`gsx.toml [filters]`), class
+merger, classifier, and field matcher. `fmt` today builds with
+`attrclass.Builtin()` only, which is a latent inconsistency. `fmt` will resolve
+config **best-effort** (the same `resolveConfig` path): on success it uses the
+real config; on failure (malformed `gsx.toml`) it falls back to
+builtin/empty config, and any file whose skeleton fails to build under that
+fallback keeps all its imports (no removal). This preserves fmt's existing
+"tolerates a malformed config" property while staying fast.
+
+### 4. Optimization (deferred, measured before adopting)
+
+The skeleton **tolerates unknown filters** — an unresolved named filter falls
+back to the bare seed (`analyze.go:1553`). Because named filters (`url`, …)
+resolve to *config-injected* imports (structpages, ds/filters), not the file's
+own hoisted imports, a degraded (config-only, signature-less) filter table
+should still capture every **user** import reference. If verified equivalent for
+user-import detection, `fmt` can skip the ~344ms filter/merger load entirely and
+land in the tens-of-milliseconds range. Baseline design uses the real config
+(correct-by-construction, sub-second); this optimization is a follow-up gated on
+an equivalence check.
+
+## Behavior change
+
+Today's detector is ultra-conservative: `detectUnusedImports` returns **nothing**
+if the package has *any* non-import type error ("analysis unreliable, remove
+nothing"). The syntactic scan removes unused imports **regardless** of unrelated
+errors — exactly like `gofmt`/`goimports`. For a formatter this is more correct
+(you can clean imports in a file that has an unrelated error elsewhere), but it
+is a real behavior change and is called out here deliberately.
+
+## What this replaces
+
+The previously-considered "reuse `generate`'s warm on-disk cache for fmt" plan is
+**dropped**. Caching a slow computation is strictly worse than making it fast;
+with syntactic detection at sub-second there is nothing worth caching. No change
+to the cache format, `computeKey`, or `generate`.
+
+## Testing
+
+Detection lives in `codegen`, so its tests do too. The txtar corpus is unchanged
+(fmt output for already-clean files is identical; this is detection behavior, not
+codegen output).
+
+**`internal/codegen` — syntactic detector (one case per usage context, per the
+project's per-context discipline):**
+- Unused user import → removed.
+- Used import kept when referenced via: interpolation `{pkg.X}`, attribute
+  expression, pipeline-qualified filter `{x |> pkg.Fn}`, component tag
+  `<pkg.Comp>`, and generic type argument.
+- `_` and `.` imports never removed.
+- Aliased import (`f "foo"`) detected by local name.
+- Multi-file: import used only in a sibling file is still unused here.
+- Sunk generic-tag import kept (reuse an existing generic-tag scenario).
+- Skeleton build failure (parse error) → no removal.
+- **Equivalence oracle:** for a set of real packages, assert the syntactic
+  removal set equals a full type-check `detectUnusedImports` run — except the
+  documented "unrelated error" divergence. This is the safety net proving the
+  scan matches `go/types` on real files and guards against future skeleton/scan
+  drift.
+
+**`gen` — fmt integration:**
+- `fmt -l` / `fmt -w` on a fixture with unused imports removes exactly the right
+  ones; a used import (each context) is preserved.
+- Malformed `gsx.toml` → fmt still formats and tolerates it (fallback path).
+- One `Module` opened per module (not per directory): the skeleton
+  prerequisites (filter table etc.) are cached on the `Module`, so a
+  multi-directory module must load them **once**, not once per directory. Assert
+  the per-module load count is 1 (e.g. via the module's load counter,
+  `module.go:273`) for a multi-directory fixture.
+
+## Scope boundaries
+
+- `generate`, the cache, and `computeKey` are untouched.
+- No new syntax; no corpus golden changes.
+- The filter/merger-skip optimization (§4) is out of scope for the first cut;
+  ship the correct-by-construction version, then measure.

--- a/gen/fmt.go
+++ b/gen/fmt.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gsxhq/gsx/internal/attrclass"
 	"github.com/gsxhq/gsx/internal/codegen"
 	"github.com/gsxhq/gsx/internal/gsxfmt"
 	"github.com/gsxhq/gsx/internal/rawfmt"
@@ -42,7 +41,7 @@ import (
 //
 // All logic lives here (runFmt returns an int) so tests can drive it without
 // os.Exit.
-func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Formatter, workDir string) int {
+func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Formatter, opts codegen.Options, workDir string) int {
 	fs := flag.NewFlagSet("gsx fmt", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
@@ -73,7 +72,7 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 
 	var unusedByPath map[string][]gsxfmt.ImportRef
 	if !noImports {
-		unusedByPath = analyzeUnusedImports(files)
+		unusedByPath = analyzeUnusedImports(files, opts)
 	}
 
 	exit := 0
@@ -158,46 +157,52 @@ func printWidthFor(dir string) int {
 	return cfg.effectivePrintWidth()
 }
 
-// analyzeUnusedImports best-effort computes, per absolute .gsx path, the imports
-// the file declares but does not use, by analyzing each containing directory's
-// package. Directories not in a module, or that fail to load, are skipped — the
-// caller then formats those files syntactically (no removal). Keys are absolute.
-func analyzeUnusedImports(files []string) map[string][]gsxfmt.ImportRef {
+// analyzeUnusedImports computes, per absolute .gsx path, the imports the file
+// declares but does not use — syntactically, via the skeleton (no type-check).
+// It opens ONE codegen.Module per module (not per directory) and reuses it across
+// that module's directories. Directories not in a module, or that fail to open,
+// are skipped (those files are then formatted without import removal). opts
+// carries the resolved codegen config so skeletons match what `generate` emits;
+// a zero/builtin opts still works (buildSkeleton tolerates unknown filters).
+func analyzeUnusedImports(files []string, opts codegen.Options) map[string][]gsxfmt.ImportRef {
 	out := map[string][]gsxfmt.ImportRef{}
-	dirs := map[string]bool{}
+	dirSet := map[string]bool{}
 	for _, f := range files {
-		dirs[filepath.Dir(f)] = true
+		dirSet[filepath.Dir(f)] = true
 	}
-	for dir := range dirs {
-		root, modPath, err := moduleRoot(dir)
+	dirs := make([]string, 0, len(dirSet))
+	for d := range dirSet {
+		dirs = append(dirs, d)
+	}
+	groups, _ := groupByModule(dirs)
+	for _, g := range groups {
+		o := opts
+		o.ModuleRoot = g.root
+		o.ModulePath = g.modPath
+		m, err := codegen.Open(o)
 		if err != nil {
-			continue // not in a module → syntactic fallback
+			continue // not loadable → syntactic-only fallback (no removal)
 		}
-		absDir, err := filepath.Abs(dir)
-		if err != nil {
-			continue
-		}
-		m, err := codegen.Open(codegen.Options{ModuleRoot: root, ModulePath: modPath, Classifier: attrclass.Builtin()})
-		if err != nil {
-			continue
-		}
-		pr, err := m.Package(absDir)
-		if err != nil {
-			continue
-		}
-		if pr == nil {
-			continue
-		}
-		for gsxPath, imps := range pr.UnusedImports {
-			absPath, err := filepath.Abs(gsxPath)
+		for _, dir := range g.dirs {
+			absDir, err := filepath.Abs(dir)
 			if err != nil {
 				continue
 			}
-			refs := make([]gsxfmt.ImportRef, len(imps))
-			for i, u := range imps {
-				refs[i] = gsxfmt.ImportRef{Name: u.Name, Path: u.Path}
+			byPath, err := m.UnusedImports(absDir)
+			if err != nil {
+				continue
 			}
-			out[absPath] = refs
+			for gsxPath, imps := range byPath {
+				absPath, err := filepath.Abs(gsxPath)
+				if err != nil {
+					continue
+				}
+				refs := make([]gsxfmt.ImportRef, len(imps))
+				for i, u := range imps {
+					refs[i] = gsxfmt.ImportRef{Name: u.Name, Path: u.Path}
+				}
+				out[absPath] = refs
+			}
 		}
 	}
 	return out

--- a/gen/fmt_test.go
+++ b/gen/fmt_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gsxhq/gsx/internal/attrclass"
+	"github.com/gsxhq/gsx/internal/codegen"
 )
 
 // fmtCapture drives runFmt with captured stdout/stderr and returns code+output.
@@ -13,7 +16,7 @@ func fmtCapture(t *testing.T, args []string) (int, string, string) {
 	t.Helper()
 	var out, errb bytes.Buffer
 	wd, _ := os.Getwd()
-	code := runFmt(&out, &errb, args, nil, nil, wd)
+	code := runFmt(&out, &errb, args, nil, nil, codegen.Options{Classifier: attrclass.Builtin()}, wd)
 	return code, out.String(), errb.String()
 }
 
@@ -301,5 +304,50 @@ func TestFmtOutsideModuleFallsBack(t *testing.T) {
 	}
 	if strings.Contains(string(after), "import   \"strings\"") {
 		t.Fatalf("file was not syntactically formatted:\n%s", after)
+	}
+}
+
+// TestFmtRemovesUnusedKeepsUsed proves the rewired analyzeUnusedImports (one
+// codegen.Module per module, via groupByModule) still removes an unused import
+// while keeping a used one, for a module containing a single directory.
+func TestFmtRemovesUnusedKeepsUsed(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newModule(t, "fmtmod")
+	src := "package fmtmod\n\nimport (\n\t\"strings\"\n\t\"bytes\"\n)\n\ncomponent Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n"
+	page := writeFile(t, dir, "page.gsx", src)
+
+	code, _, errb := fmtCapture(t, []string{"-w", page})
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, errb)
+	}
+	got, err := os.ReadFile(page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), `"bytes"`) {
+		t.Errorf("unused bytes import should be removed:\n%s", got)
+	}
+	if !strings.Contains(string(got), `"strings"`) {
+		t.Errorf("used strings import must be kept:\n%s", got)
+	}
+}
+
+// TestFmtToleratesMalformedConfig proves that with a builtin-only
+// codegen.Options (the fallback gen/main.go's `fmt` case uses when
+// resolveConfig fails on a malformed gsx.toml), formatting still succeeds.
+func TestFmtToleratesMalformedConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newModule(t, "fmtmod")
+	page := writeFile(t, dir, "page.gsx", "package fmtmod\n\ncomponent Page() {\n\t<div>hi</div>\n}\n")
+
+	code, _, errb := fmtCapture(t, []string{"-l", page})
+	if code != 0 { // already canonical → no diff → 0
+		t.Fatalf("exit=%d stderr=%s", code, errb)
 	}
 }

--- a/gen/fmt_test.go
+++ b/gen/fmt_test.go
@@ -335,6 +335,38 @@ func TestFmtRemovesUnusedKeepsUsed(t *testing.T) {
 	}
 }
 
+// TestFmtTwoDirsOneModule proves analyzeUnusedImports (the grouped
+// one-codegen.Module-per-module path, via groupByModule) returns correct,
+// independent results for two DIFFERENT directories of the SAME module in a
+// single call: a's unused bytes import is reported, b's used strings import is
+// not — confirming the shared Module correctly resolves each directory's own
+// package rather than conflating them.
+func TestFmtTwoDirsOneModule(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newModule(t, "fmtmod")
+	aSrc := "package a\n\nimport \"bytes\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n"
+	bSrc := "package b\n\nimport \"strings\"\n\ncomponent B() {\n\t<p>{strings.ToUpper(\"x\")}</p>\n}\n"
+	aPath := writeFile(t, filepath.Join(dir, "a"), "a.gsx", aSrc)
+	bPath := writeFile(t, filepath.Join(dir, "b"), "b.gsx", bSrc)
+
+	refs := analyzeUnusedImports(
+		[]string{aPath, bPath},
+		codegen.Options{Classifier: attrclass.Builtin()},
+	)
+
+	aAbs, _ := filepath.Abs(aPath)
+	bAbs, _ := filepath.Abs(bPath)
+	if len(refs[aAbs]) != 1 || refs[aAbs][0].Path != "bytes" {
+		t.Errorf("a: want bytes unused, got %+v", refs[aAbs])
+	}
+	if len(refs[bAbs]) != 0 {
+		t.Errorf("b: strings is used, want none unused, got %+v", refs[bAbs])
+	}
+}
+
 // TestFmtToleratesMalformedConfig proves that with a builtin-only
 // codegen.Options (the fallback gen/main.go's `fmt` case uses when
 // resolveConfig fails on a malformed gsx.toml), formatting still succeeds.

--- a/gen/main.go
+++ b/gen/main.go
@@ -214,7 +214,24 @@ func runConfig(args []string, stdout, stderr io.Writer, cfg config) int {
 		// overrides are programmatic options (no gsx.toml entry), so they come
 		// from cfg directly — not resolveConfig (which would hard-fail on a bad
 		// config).
-		return runFmt(stdout, stderr, cmdArgs, cfg.cssFmt, cfg.jsFmt, workDir)
+		//
+		// The syntactic unused-import analysis is best-effort: resolveConfig
+		// only feeds it (Classifier/FieldMatcher/Aliases/FilterPkgs — the knobs
+		// that affect skeleton import references). ClassMerger and minify are
+		// emit-only and are deliberately omitted, to avoid an unwanted extra
+		// package load. On a malformed config we fall back to the builtin
+		// classifier; files using named filters still skeletonize fine
+		// (buildSkeleton tolerates unknown filters).
+		fmtOpts := codegen.Options{Classifier: attrclass.Builtin()}
+		if merged, _, cerr := resolveConfig(cfg, workDir); cerr == nil {
+			fmtOpts = codegen.Options{
+				Classifier:   merged.classifier(),
+				FieldMatcher: merged.fieldMatcher,
+				Aliases:      merged.aliases,
+				FilterPkgs:   merged.filterPkgs,
+			}
+		}
+		return runFmt(stdout, stderr, cmdArgs, cfg.cssFmt, cfg.jsFmt, fmtOpts, workDir)
 	case "init":
 		return runInit(cmdArgs, os.Stdin, stdout, stderr, workDir)
 	case "lsp":

--- a/internal/codegen/codegen_test.go
+++ b/internal/codegen/codegen_test.go
@@ -31,7 +31,11 @@ func TestLineDirectives(t *testing.T) {
 
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+	full := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gsxhq/gsx/internal/diag"
 	"github.com/gsxhq/gsx/internal/jsx"
+	"golang.org/x/tools/go/packages"
 )
 
 // skeletonUsedNames returns the set of identifiers used as the qualifier X in
@@ -149,6 +150,77 @@ func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
 			}
 		}
 		out.byGsx[path] = fileSkeleton{skel: gf, imps: imps, sunk: sunk}
+	}
+	return out, nil
+}
+
+// resolvePackageNames returns the real package name for each import path, via a
+// NeedName-only load (no type-checking, no dependency resolution). Unresolvable
+// paths are simply absent from the result, so the caller keeps those imports.
+func (m *Module) resolvePackageNames(paths []string) map[string]string {
+	out := map[string]string{}
+	if len(paths) == 0 {
+		return out
+	}
+	cfg := &packages.Config{Mode: packages.NeedName, Dir: m.opts.ModuleRoot}
+	pkgs, err := packages.Load(cfg, paths...)
+	if err != nil {
+		return out
+	}
+	for _, p := range pkgs {
+		if p.PkgPath != "" && p.Name != "" {
+			out[p.PkgPath] = p.Name
+		}
+	}
+	return out
+}
+
+// UnusedImports returns, per .gsx file (abs path) in dir, the imports the file
+// declares but never references — determined syntactically from the skeleton,
+// with NO type-checking and NO dependency resolution. Default imports whose path
+// base is not referenced have their real package name resolved via a single
+// cheap NeedName load before removal, so a package whose name differs from its
+// path base (e.g. gopkg.in/yaml.v3 → "yaml") is handled correctly.
+func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, error) {
+	ps, err := m.buildPackageSkeletons(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string][]UnusedImport{}
+	usedByFile := map[string]map[string]bool{}
+	type pending struct {
+		gsxPath string
+		imp     importSpec
+	}
+	var candidates []pending
+	candPaths := map[string]bool{}
+	for gsxPath, fs := range ps.byGsx {
+		used := skeletonUsedNames(fs.skel)
+		usedByFile[gsxPath] = used
+		unused, cands := classifyUnusedImports(used, fs.imps, fs.sunk, ps.gsxFset)
+		if len(unused) > 0 {
+			out[gsxPath] = unused
+		}
+		for _, c := range cands {
+			candidates = append(candidates, pending{gsxPath, c})
+			candPaths[c.path] = true
+		}
+	}
+	if len(candPaths) > 0 {
+		paths := make([]string, 0, len(candPaths))
+		for p := range candPaths {
+			paths = append(paths, p)
+		}
+		names := m.resolvePackageNames(paths)
+		for _, p := range candidates {
+			realName, ok := names[p.imp.path]
+			if !ok {
+				continue // unresolvable → conservative keep
+			}
+			if !usedByFile[p.gsxPath][realName] {
+				out[p.gsxPath] = append(out[p.gsxPath], UnusedImport{Name: p.imp.name, Path: p.imp.path})
+			}
+		}
 	}
 	return out, nil
 }

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -1,0 +1,71 @@
+package codegen
+
+import (
+	goast "go/ast"
+	"go/token"
+	"strings"
+)
+
+// skeletonUsedNames returns the set of identifiers used as the qualifier X in
+// any selector expression X.Sel within f. An imported package name can only be
+// referenced this way (or via a dot/blank import, handled separately), so this
+// set is exactly "which import local-names are referenced" for a valid Go file.
+func skeletonUsedNames(f *goast.File) map[string]bool {
+	used := map[string]bool{}
+	goast.Inspect(f, func(n goast.Node) bool {
+		if sel, ok := n.(*goast.SelectorExpr); ok {
+			if id, ok := sel.X.(*goast.Ident); ok {
+				used[id.Name] = true
+			}
+		}
+		return true
+	})
+	return used
+}
+
+// importBaseName is the last path segment — the CONVENTIONAL default local name,
+// which for some packages (e.g. gopkg.in/yaml.v3 → "yaml") is NOT the real
+// package name. It is used only as a fast "definitely used" check; a base that
+// is not referenced makes the import a removal CANDIDATE whose real name must be
+// resolved before removal.
+func importBaseName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// classifyUnusedImports splits a file's hoisted import specs into definitely-unused
+// imports and removal candidates, given the set of referenced qualifier names.
+//
+//   - `_` / `.` imports are never removed (always "used").
+//   - An import whose only skeleton reference was dropped by a requalification-
+//     failed generic tag (sunk) is never removed — it IS used in the .gsx source.
+//   - An aliased import's explicit name is authoritative: unused iff its alias is
+//     not referenced.
+//   - A default import is kept when its path base is referenced; otherwise it is a
+//     CANDIDATE (its real package name may differ from the base and still be used).
+func classifyUnusedImports(used map[string]bool, imps []importSpec, sunk map[sunkImportKey]bool, gsxFset *token.FileSet) (unused []UnusedImport, candidates []importSpec) {
+	for _, imp := range imps {
+		if imp.name == "_" || imp.name == "." {
+			continue
+		}
+		if sunk != nil && imp.pos.IsValid() {
+			k := sunkImportKey{line: gsxFset.Position(imp.pos).Line, path: imp.path}
+			if sunk[k] {
+				continue
+			}
+		}
+		if imp.name != "" {
+			if !used[imp.name] {
+				unused = append(unused, UnusedImport{Name: imp.name, Path: imp.path})
+			}
+			continue
+		}
+		if used[importBaseName(imp.path)] {
+			continue
+		}
+		candidates = append(candidates, imp)
+	}
+	return unused, candidates
+}

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -103,6 +103,14 @@ type packageSkeletons struct {
 // buildSkeleton lowering, but keeps only what unused-import detection needs. A
 // file whose skeleton fails to build (parse/attr error) is simply omitted, so
 // the caller keeps all of that file's imports.
+//
+// Two deliberate divergences from analyze, both safe because unused-import
+// detection is strictly per-file: (1) the ResolveScripts return is ignored
+// (analyze skips the whole package on a script-resolution error) — a resolution
+// failure only preserves references, so it can never cause a false removal; and
+// (2) any buildSkeleton error skips only that file (analyze distinguishes a
+// per-file attrError from a package-aborting error), because skipping one file
+// and still scanning its siblings can only remove genuinely-unused imports.
 func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
 	m.analysisMu.Lock()
 	defer m.analysisMu.Unlock()

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -2,8 +2,13 @@ package codegen
 
 import (
 	goast "go/ast"
+	goparser "go/parser"
 	"go/token"
+	"path/filepath"
 	"strings"
+
+	"github.com/gsxhq/gsx/internal/diag"
+	"github.com/gsxhq/gsx/internal/jsx"
 )
 
 // skeletonUsedNames returns the set of identifiers used as the qualifier X in
@@ -68,4 +73,82 @@ func classifyUnusedImports(used map[string]bool, imps []importSpec, sunk map[sun
 		candidates = append(candidates, imp)
 	}
 	return unused, candidates
+}
+
+// fileSkeleton is one .gsx file's lowered skeleton AST plus the import
+// metadata buildPackageSkeletons harvests alongside it: the file's hoisted
+// import specs (imps) and the set of specs sunk by a requalification-failed
+// generic tag (sunk) — see analyze's sunkImports doc for why a sunk import is
+// never a removal candidate even when the skeleton drops its only reference.
+type fileSkeleton struct {
+	skel *goast.File
+	imps []importSpec
+	sunk map[sunkImportKey]bool
+}
+
+// packageSkeletons is the per-package result of buildPackageSkeletons: every
+// buildable .gsx file's skeleton, keyed by its absolute .gsx path, plus the
+// FileSet those skeletons (and the .gsx positions in their import specs)
+// resolve against.
+type packageSkeletons struct {
+	gsxFset *token.FileSet
+	byGsx   map[string]fileSkeleton // .gsx abs path -> skeleton + import specs + sunk set
+}
+
+// buildPackageSkeletons lowers every .gsx file in dir to its skeleton AST WITHOUT
+// type-checking (no importer, no dependency resolution) and returns, per file,
+// the parsed skeleton, its hoisted import specs, and its sunk-import set. It
+// mirrors analyze's per-file loop (module_importer.go:769-819) using the same
+// buildSkeleton lowering, but keeps only what unused-import detection needs. A
+// file whose skeleton fails to build (parse/attr error) is simply omitted, so
+// the caller keeps all of that file's imports.
+func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
+	m.analysisMu.Lock()
+	defer m.analysisMu.Unlock()
+	m.maybeRebuildFset()
+	m.applyDirty()
+	fset := m.fset
+	bag := diag.NewBag(fset)
+	gsxFiles, _, err := m.parsePackageWithFset(dir, fset)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range gsxFiles {
+		jsx.ResolveScripts(f, bag) // best-effort; failure just means we may skip that file below
+	}
+	table, err := m.cachedFilterTable()
+	if err != nil {
+		return nil, err
+	}
+	propFields, nodeProps, attrsProps, byo, err := componentPropFieldsFor(dir, gsxFiles)
+	if err != nil {
+		return nil, err
+	}
+	genericSigs := genericSigsFor(gsxFiles, byo)
+	inferNames := newInferNameAllocator()
+	out := &packageSkeletons{gsxFset: fset, byGsx: map[string]fileSkeleton{}}
+	for path, f := range gsxFiles {
+		ff := m.fileScopedFacts(dir, f, propFields, nodeProps, attrsProps, byo, bag, fset)
+		skel, _, imps, _, infReg, berr := buildSkeleton(f, table, ff.propFields, ff.nodeProps, ff.attrsProps,
+			genericSigs, ff.genericSigs, ff.byo, m.opts.FieldMatcher, fset, bag, inferNames)
+		if berr != nil {
+			continue // unbuildable → keep all imports (no entry)
+		}
+		base := strings.TrimSuffix(filepath.Base(path), ".gsx")
+		absXpath := filepath.Join(dir, base+".x.go")
+		gf, perr := goparser.ParseFile(fset, absXpath, skel, goparser.SkipObjectResolution)
+		if perr != nil {
+			continue
+		}
+		sunk := map[sunkImportKey]bool{}
+		if len(infReg.failedAliases) > 0 && ff.depAliasSpecs != nil {
+			for alias := range infReg.failedAliases {
+				if spec, ok := ff.depAliasSpecs[alias]; ok && spec.pos.IsValid() {
+					sunk[sunkImportKey{line: fset.Position(spec.pos).Line, path: spec.path}] = true
+				}
+			}
+		}
+		out.byGsx[path] = fileSkeleton{skel: gf, imps: imps, sunk: sunk}
+	}
+	return out, nil
 }

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -3,8 +3,49 @@ package codegen
 import (
 	"go/parser"
 	"go/token"
+	"path/filepath"
 	"testing"
+
+	"github.com/gsxhq/gsx/internal/attrclass"
 )
+
+// openTestModule writes a minimal go.mod plus the given .gsx files (keyed by
+// filename) into a fresh temp module root, opens a Module over it, and
+// returns the package dir (== the module root, since files are written
+// directly into it) and the Module. Shared by the syntactic-unused-import
+// tests (Tasks 2, 3, 5).
+//
+// The go.mod carries a require+replace for github.com/gsxhq/gsx (mirroring
+// unused_imports_test.go's pattern) pointed at this checkout: even a
+// buildPackageSkeletons-only test exercises cachedFilterTable, which always
+// resolves the built-in "github.com/gsxhq/gsx/std" filter package (dedupFilterPkgs
+// defaults to it when Options.FilterPkgs is empty) — without the replace, that
+// packages.Load fails outright since "github.com/gsxhq/gsx" is not a real
+// dependency of the ephemeral "testmod" module. This filter-table load is
+// counted separately (m.filterTableLoads()), not by m.externalLoads(), so it
+// does not contradict the importer-free claim buildPackageSkeletons makes.
+// The go directive must match the real module's (currently 1.26.1, see
+// ci.yml's GO_VERSION) — "go 1.26" alone makes the replaced module's higher
+// go directive trip "go: updates to go.mod needed; to update it: go mod tidy"
+// during the filter-table's packages.Load.
+func openTestModule(t *testing.T, files map[string]string) (string, *Module) {
+	t.Helper()
+	dir := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "go.mod",
+		"module testmod\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	for name, src := range files {
+		writeFile(t, dir, name, src)
+	}
+	m, err := Open(Options{ModuleRoot: dir, ModulePath: "testmod", Classifier: attrclass.Builtin()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, m
+}
 
 func TestSkeletonUsedNames(t *testing.T) {
 	const src = `package p
@@ -81,5 +122,34 @@ func TestClassifyUnusedImportsSkipsSunk(t *testing.T) {
 	unused, candidates = classifyUnusedImports(map[string]bool{}, imps, sunk, fset)
 	if len(unused) != 0 || len(candidates) != 0 {
 		t.Errorf("with sunk: unused=%+v candidates=%+v, want both empty", unused, candidates)
+	}
+}
+
+// TestBuildPackageSkeletonsNoExternalLoad proves buildPackageSkeletons is
+// importer-free: it lowers page.gsx to its skeleton AST and reports the
+// hoisted "strings" import as referenced in the skeleton, all WITHOUT
+// triggering a single external packages.Load (m.externalLoads() stays 0) —
+// the whole point of scanning the skeleton instead of type-checking.
+func TestBuildPackageSkeletonsNoExternalLoad(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"page.gsx": "package testmod\n\nimport \"strings\"\n\ncomponent Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n",
+	})
+	ps, err := m.buildPackageSkeletons(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs, ok := ps.byGsx[filepath.Join(dir, "page.gsx")]
+	if !ok {
+		t.Fatalf("no skeleton for page.gsx; got %v", ps.byGsx)
+	}
+	if len(fs.imps) != 1 || fs.imps[0].path != "strings" {
+		t.Errorf("imps=%+v, want [strings]", fs.imps)
+	}
+	used := skeletonUsedNames(fs.skel)
+	if !used["strings"] {
+		t.Errorf("expected strings referenced in skeleton; used=%v", used)
+	}
+	if n := m.externalLoads(); n != 0 {
+		t.Errorf("buildPackageSkeletons did %d external loads, want 0 (importer-free)", n)
 	}
 }

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -56,3 +56,30 @@ func TestClassifyUnusedImports(t *testing.T) {
 		t.Errorf("candidates=%+v, want only bytes", candidates)
 	}
 }
+
+func TestClassifyUnusedImportsSkipsSunk(t *testing.T) {
+	fset := token.NewFileSet()
+	tf := fset.AddFile("page.gsx", -1, 1000)
+	pos := tf.Pos(0) // offset 0 → line 1
+
+	// A default import whose base name is not referenced: without a sunk entry
+	// it would be a removal candidate.
+	imps := []importSpec{
+		{name: "", path: "github.com/foo/sunk", pos: pos},
+	}
+
+	// Contrast/sanity: with no sunk map it IS a candidate, proving the sunk map
+	// (not something else) is what excludes it below.
+	unused, candidates := classifyUnusedImports(map[string]bool{}, imps, nil, fset)
+	if len(unused) != 0 || len(candidates) != 1 {
+		t.Fatalf("without sunk: unused=%+v candidates=%+v, want 0 unused / 1 candidate", unused, candidates)
+	}
+
+	// With a matching sunk entry the import is used in the .gsx source, so it must
+	// be excluded from BOTH unused and candidates.
+	sunk := map[sunkImportKey]bool{{line: 1, path: "github.com/foo/sunk"}: true}
+	unused, candidates = classifyUnusedImports(map[string]bool{}, imps, sunk, fset)
+	if len(unused) != 0 || len(candidates) != 0 {
+		t.Errorf("with sunk: unused=%+v candidates=%+v, want both empty", unused, candidates)
+	}
+}

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -125,6 +125,42 @@ func TestClassifyUnusedImportsSkipsSunk(t *testing.T) {
 	}
 }
 
+// TestUnusedImportsSyntactic exercises Module.UnusedImports end to end: strings
+// is referenced (via strings.ToUpper) and must be kept, bytes is never
+// referenced and must be reported unused.
+func TestUnusedImportsSyntactic(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"page.gsx": "package testmod\n\nimport (\n\t\"strings\"\n\t\"bytes\"\n)\n\ncomponent Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n",
+	})
+	got, err := m.UnusedImports(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unused := got[filepath.Join(dir, "page.gsx")]
+	if len(unused) != 1 || unused[0].Path != "bytes" {
+		t.Errorf("unused=%+v, want [bytes]; strings is used and must be kept", unused)
+	}
+}
+
+// TestUnusedImportsDefaultNameMismatchKept covers the real-name resolution
+// path: renamedpkg/lib.go declares "package renamed", so the import path's
+// base ("renamedpkg") is never referenced, but the real package name
+// ("renamed") is. A base-only scan would wrongly flag testmod/renamedpkg as
+// unused; resolvePackageNames must resolve it to "renamed" so it is kept.
+func TestUnusedImportsDefaultNameMismatchKept(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"renamedpkg/lib.go": "package renamed\n\nfunc Hello() string { return \"hi\" }\n",
+		"page.gsx":          "package testmod\n\nimport \"testmod/renamedpkg\"\n\ncomponent Page() {\n\t<div>{renamed.Hello()}</div>\n}\n",
+	})
+	got, err := m.UnusedImports(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u := got[filepath.Join(dir, "page.gsx")]; len(u) != 0 {
+		t.Errorf("testmod/renamedpkg is used (renamed.Hello) and must be kept; got unused=%+v", u)
+	}
+}
+
 // TestBuildPackageSkeletonsNoExternalLoad proves buildPackageSkeletons is
 // importer-free: it lowers page.gsx to its skeleton AST and reports the
 // hoisted "strings" import as referenced in the skeleton, all WITHOUT

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -1,0 +1,58 @@
+package codegen
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestSkeletonUsedNames(t *testing.T) {
+	const src = `package p
+import "strings"
+func f() { _ = strings.TrimSpace("x"); _ = a.b.c }
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "s.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	used := skeletonUsedNames(f)
+	if !used["strings"] {
+		t.Errorf("want strings used")
+	}
+	if !used["a"] { // inner selector a.b of a.b.c
+		t.Errorf("want a used")
+	}
+}
+
+func TestImportBaseName(t *testing.T) {
+	for path, want := range map[string]string{
+		"strings":            "strings",
+		"gopkg.in/yaml.v3":   "yaml.v3", // base is NOT the package name → forces candidate resolution
+		"github.com/x/go-fo": "go-fo",
+	} {
+		if got := importBaseName(path); got != want {
+			t.Errorf("importBaseName(%q)=%q want %q", path, got, want)
+		}
+	}
+}
+
+func TestClassifyUnusedImports(t *testing.T) {
+	fset := token.NewFileSet()
+	used := map[string]bool{"strings": true, "sx": true}
+	imps := []importSpec{
+		{name: "", path: "strings"},        // default, base used → kept
+		{name: "", path: "bytes"},          // default, base unused → candidate
+		{name: "sx", path: "text/scanner"}, // aliased, alias used → kept
+		{name: "al", path: "os"},           // aliased, alias unused → unused
+		{name: "_", path: "embed"},         // blank → never removed
+		{name: ".", path: "math"},          // dot → never removed
+	}
+	unused, candidates := classifyUnusedImports(used, imps, nil, fset)
+	if len(unused) != 1 || unused[0].Path != "os" || unused[0].Name != "al" {
+		t.Errorf("unused=%+v, want only {al os}", unused)
+	}
+	if len(candidates) != 1 || candidates[0].path != "bytes" {
+		t.Errorf("candidates=%+v, want only bytes", candidates)
+	}
+}

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -4,9 +4,11 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gsxhq/gsx/internal/attrclass"
+	"github.com/gsxhq/gsx/internal/diag"
 )
 
 // openTestModule writes a minimal go.mod plus the given .gsx files (keyed by
@@ -187,5 +189,161 @@ func TestBuildPackageSkeletonsNoExternalLoad(t *testing.T) {
 	}
 	if n := m.externalLoads(); n != 0 {
 		t.Errorf("buildPackageSkeletons did %d external loads, want 0 (importer-free)", n)
+	}
+}
+
+// anyErrorDiagCodegen reports whether diags contains an error-severity
+// diagnostic that is NOT a clean "imported and not used" error.
+//
+// This is deliberately NOT a blind mirror of gen's anyErrorDiag (severity ==
+// Error, full stop): an unused import is ITSELF surfaced as a go/types
+// "<path>" imported and not used error (verified empirically — see
+// module_importer.go's analyze loop, which adds every type error to the bag
+// as diag.Error with no special-casing for this message). detectUnusedImports
+// (results.go) treats that EXACT class of error as the safe, expected case —
+// it returns the populated map when EVERY type error matches "imported and
+// not used"; it returns nil (removes nothing) only when some OTHER error is
+// present. The old type-check-based analyzeUnusedImports (pre-Task-1, see
+// commit 56c4787) read pr.UnusedImports directly with no Diags gate at all,
+// confirming this: the "unused import" diagnostic was never meant to block
+// removal. So the oracle's documented divergence is specifically "some
+// unrelated (non-unused-import) error exists, ⇒ oracle removes nothing" —
+// gating on ANY error diagnostic (including the unused-import ones the two
+// detectors are supposed to agree on) would skip the interp/allunused cases
+// this test exists to exercise. Matching on the message substring mirrors
+// detectUnusedImports' own criterion exactly (results.go:120).
+func anyErrorDiagCodegen(diags []diag.Diagnostic) bool {
+	for _, d := range diags {
+		if d.Severity == diag.Error && !strings.Contains(d.Message, "imported and not used") {
+			return true
+		}
+	}
+	return false
+}
+
+// impKey is the (Name,Path) identity of one UnusedImport, order-independent.
+type impKey struct{ name, path string }
+
+// keyedByAbsPath re-keys a per-.gsx-path UnusedImport map by absolute path (so
+// syn's keys, already abs since openTestModule's dir is a t.TempDir(), compare
+// equal to the oracle's keys, which come from the gsx fset's recorded
+// filename — abs in practice here too, but normalized defensively since the
+// brief calls out //line-mapped paths as the general case), collapsing each
+// file's imports into a set of impKey.
+func keyedByAbsPath(t *testing.T, m map[string][]UnusedImport) map[string]map[impKey]bool {
+	t.Helper()
+	out := map[string]map[impKey]bool{}
+	for path, imps := range m {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			t.Fatalf("filepath.Abs(%q): %v", path, err)
+		}
+		set := out[abs]
+		if set == nil {
+			set = map[impKey]bool{}
+			out[abs] = set
+		}
+		for _, u := range imps {
+			set[impKey{u.Name, u.Path}] = true
+		}
+	}
+	return out
+}
+
+// assertSameRemovalSet asserts syn and oracle report the identical set of
+// (Name,Path) unused imports per file, order-independent. dir is included in
+// failure messages only.
+func assertSameRemovalSet(t *testing.T, dir string, syn, oracle map[string][]UnusedImport) {
+	t.Helper()
+	synSet := keyedByAbsPath(t, syn)
+	oracleSet := keyedByAbsPath(t, oracle)
+	allFiles := map[string]bool{}
+	for f := range synSet {
+		allFiles[f] = true
+	}
+	for f := range oracleSet {
+		allFiles[f] = true
+	}
+	for f := range allFiles {
+		a, b := synSet[f], oracleSet[f]
+		if len(a) != len(b) || !supersetOf(a, b) {
+			t.Errorf("dir %s, file %s: syntactic=%v oracle=%v (removal sets differ)", dir, f, a, b)
+			continue
+		}
+	}
+}
+
+// supersetOf reports whether every key in b is present in a (used alongside a
+// length check in assertSameRemovalSet to establish set equality).
+func supersetOf(a, b map[impKey]bool) bool {
+	for k := range b {
+		if !a[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSyntacticMatchesTypecheckOracle proves the syntactic detector
+// (Module.UnusedImports) agrees with the type-check detector (Module.Package's
+// pr.UnusedImports, the pre-existing oracle) on packages that type-check
+// cleanly (no unrelated errors). Each case is its own module (openTestModule),
+// so per-case files never collide.
+func TestSyntacticMatchesTypecheckOracle(t *testing.T) {
+	cases := map[string]map[string]string{
+		// strings is referenced via a plain interpolation call; bytes is never
+		// referenced and must be reported unused by both detectors.
+		"interp": {
+			"a.gsx": "package testmod\n\nimport (\n\t\"strings\"\n\t\"bytes\"\n)\n\ncomponent A() {\n\t<p>{strings.ToUpper(\"x\")}</p>\n}\n",
+		},
+		// strings is referenced only from inside an expr attribute (name={expr}),
+		// not a text interpolation — a different skeleton context.
+		"attr": {
+			"b.gsx": "package testmod\n\nimport \"strings\"\n\ncomponent B() {\n\t<p id={strings.ToLower(\"X\")}>hi</p>\n}\n",
+		},
+		// strings is referenced only from inside a pipe stage's ARGS (a raw string
+		// spliced verbatim into the lowered call, per lowerPipe) — proving the
+		// skeleton captures identifier usage buried in pipeline argument text, not
+		// just the stage name/seed. truncate(s string, n int) is the std filter.
+		"pipeline": {
+			"f.gsx": "package testmod\n\nimport \"strings\"\n\ncomponent F(s string) {\n\t<p>{ s |> truncate(strings.Count(s, \"a\")) }</p>\n}\n",
+		},
+		// two imports, neither referenced anywhere: both detectors must remove both.
+		"allunused": {
+			"d.gsx": "package testmod\n\nimport (\n\t\"strings\"\n\t\"bytes\"\n)\n\ncomponent D() {\n\t<p>hi</p>\n}\n",
+		},
+		// an aliased import (import sx "strings") used via its alias, not the
+		// package's real name.
+		"aliased": {
+			"e.gsx": "package testmod\n\nimport sx \"strings\"\n\ncomponent E() {\n\t<p>{sx.ToUpper(\"x\")}</p>\n}\n",
+		},
+		// tag-position import usage: main.gsx imports a sibling gsx package (foo)
+		// and uses it only as a component tag (<foo.Box/>), never as a plain Go
+		// selector expression — proving tag usage counts as a reference and the
+		// import must be KEPT (an all-context-blind base-name scan would still see
+		// "foo" referenced here since the tag identifier IS "foo", but this pins
+		// the cross-package-component case explicitly, matching the sibling
+		// module_test.go/depfacts_test.go pattern for real cross-package tags).
+		"tag": {
+			"foo/box.gsx": "package foo\n\ncomponent Box() {\n\t<div>box</div>\n}\n",
+			"main.gsx":    "package testmod\n\nimport \"testmod/foo\"\n\ncomponent Main() {\n\t<foo.Box/>\n}\n",
+		},
+	}
+	for name, files := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir, m := openTestModule(t, files)
+			syn, err := m.UnusedImports(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pr, err := m.Package(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if anyErrorDiagCodegen(pr.Diags) {
+				t.Skipf("package has an unrelated type error; oracle removes nothing by design (documented divergence); diags=%+v", pr.Diags)
+			}
+			assertSameRemovalSet(t, dir, syn, pr.UnusedImports)
+		})
 	}
 }

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -252,7 +252,10 @@ func keyedByAbsPath(t *testing.T, m map[string][]UnusedImport) map[string]map[im
 
 // assertSameRemovalSet asserts syn and oracle report the identical set of
 // (Name,Path) unused imports per file, order-independent. dir is included in
-// failure messages only.
+// failure messages only. A file with nothing unused is represented by an ABSENT
+// key on both sides (not a present-but-empty slice), so a case where every
+// import is used asserts via absence-of-disagreement: any false positive on
+// either side injects an asymmetric key that the union loop catches.
 func assertSameRemovalSet(t *testing.T, dir string, syn, oracle map[string][]UnusedImport) {
 	t.Helper()
 	synSet := keyedByAbsPath(t, syn)


### PR DESCRIPTION
## Summary

`gsx fmt`'s unused-import analysis was the dominant cost of `fmt` — ~16s on the one-learning tree (91 `.gsx` files, 8 packages), vs ~0.05s for `fmt -no-imports`. It opened a fresh `codegen.Module` **per directory** and type-checked the whole dependency graph via `go/packages` just to read `go/types` "imported and not used" errors.

This replaces that with a **goimports-style syntactic scan of the already-built skeleton AST** — importer-free, one `Module` per module. The skeleton already lowers every gsx import usage (interpolations, attrs, pipelines, `<pkg.Comp>` tags) to a plain Go reference, so detecting unused imports is a local `go/ast` walk, no dependency resolution.

**Result: ~16s → ~3.0s (5.3×)** on one-learning; `fmt -no-imports` unchanged.

## How it works

- `Module.buildPackageSkeletons(dir)` — reuses the existing `buildSkeleton` lowering (argument-identical to `analyze`'s loop) but stops before `checkSkeletonPackage`. Importer-free (verified: `externalLoads()==0`).
- `Module.UnusedImports(dir)` — per-file scan of selector qualifiers → classify → for default imports whose path base isn't referenced, resolve the **real** package name via a cheap `packages.NeedName` load (only for removal candidates) so name-mismatched packages (`gopkg.in/yaml.v3`→`yaml`) are handled correctly — resolved, never guessed.
- `gen/fmt.go` opens one `Module` per module group (via `groupByModule`) instead of one per directory.
- `gen/main.go` threads best-effort config (malformed `gsx.toml` → builtin fallback, still formats).
- Preserves `sunkImports` (generic-tag) handling; never removes `_`/`.` imports.

`generate`, the on-disk cache, and `computeKey` are **untouched**.

## Behavior change

Detection now removes unused imports even when the package has an **unrelated** type error (gofmt/goimports parity). Previously it removed nothing in that case.

## Testing

- `TestSyntacticMatchesTypecheckOracle` — equivalence oracle pinning the syntactic removal set against the old type-check detector across 6 contexts (interp, attr, pipeline, aliased, all-unused, cross-package component tag).
- Unit coverage for the classifier (incl. sunk-import skip), importer-free skeleton build, default-name-mismatch resolution, and the one-Module-per-module fmt path.
- `make ci` clean; whole-branch adversarial review passed (4 probe programs stressed the wrong-removal failure mode — all kept used imports correctly).

## Known follow-up (not in this PR)

Sub-second wasn't reached: the residual ~3s is a **pre-existing per-directory `packages.Load`** in `internal/codegen/byo.go` (BYO struct-field enumeration, `loadExternalStructFields` / `packageNullaryFuncs`) that skeleton-building depends on. Optimizing it (batch/cache per module, or skip when no BYO components) would also speed up `generate`'s cold path — worth its own change.

Design + plan: `docs/superpowers/specs/2026-07-05-fmt-syntactic-unused-imports-design.md`, `docs/superpowers/plans/2026-07-05-fmt-syntactic-unused-imports.md`.

https://claude.ai/code/session_01WQUBymbXcdjAkom6cAMbqV