### PR TITLE
docs(patterns): add Patterns section + render-once (templ OnceHandle port)

### DIFF
--- a/docs/guide/patterns.md
+++ b/docs/guide/patterns.md
@@ -1,0 +1,22 @@
+# Patterns
+
+Reusable recipes for things gsx doesn't build in — singletons, integrations with
+other libraries, and idioms that fall out of gsx being *plain Go*. Each pattern is
+self-contained: copy the code into your project and adapt it.
+
+Unlike the [Syntax reference](./syntax), these pages are not language features. They
+are conventions built on top of the language, kept here so you don't have to
+rediscover them.
+
+## Available patterns
+
+- **[Render once](./patterns/render-once)** — emit a per-request singleton (a dialog
+  container, a dev-mode asset preamble, a one-time inline `<style>`/`<script>`)
+  exactly once even when its component is invoked from many call sites. A userland
+  port of templ's `OnceHandle`.
+
+## Planned
+
+More patterns will land here as they stabilise — HTMX partial rendering and
+[structpages](https://github.com/jackielii/structpages) routing integration are the
+next candidates. If you have a pattern worth documenting, open an issue.

--- a/docs/guide/patterns/render-once.md
+++ b/docs/guide/patterns/render-once.md
@@ -1,0 +1,149 @@
+# Render once
+
+Some markup must appear **exactly once per page**, no matter how many times the
+component that owns it is invoked. A modal dialog needs a single container element;
+a widget that ships an inline `<style>` block should emit it once, not once per
+instance; a dev-mode asset preamble belongs at the top of the page a single time.
+
+gsx has no built-in render-once primitive. This page shows the recommended userland
+pattern: a small handle type plus an `<Once>` component that renders its children
+only the first time a given handle is seen in a request.
+
+::: tip Ported from templ
+This is a faithful port of templ's [`OnceHandle`](https://github.com/a-h/templ/blob/main/once.go)
+(`templ.NewOnceHandle`). The one difference is setup — see [Why the middleware is
+required](#why-the-middleware-is-required) below.
+:::
+
+## The recipe
+
+### 1. The handle and per-request state
+
+The handle is an opaque token you declare once per singleton. Rendering is keyed by
+the handle's pointer identity, and a per-request set records which handles have
+already rendered.
+
+```go
+package app
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// OnceHandle dedups a render within a single request: the first render of a
+// handle renders; every later render of the same handle is skipped.
+type OnceHandle struct{ id int64 }
+
+var onceIndex int64
+
+// NewOnce creates an OnceHandle. Declare one at package level per singleton.
+func NewOnce() *OnceHandle { return &OnceHandle{id: atomic.AddInt64(&onceIndex, 1)} }
+
+// onceState holds the set of handles already rendered this request. Rendering is
+// single-goroutine per request, so the map needs no mutex.
+type onceState struct{ seen map[*OnceHandle]struct{} }
+
+type onceKeyT struct{}
+
+// firstRender reports whether h is rendering for the first time this request,
+// marking it seen. With no scope installed it degrades to "always render" — dedup
+// is lost but nothing crashes.
+func (h *OnceHandle) firstRender(ctx context.Context) bool {
+	st, _ := ctx.Value(onceKeyT{}).(*onceState)
+	if st == nil {
+		return true
+	}
+	if _, done := st.seen[h]; done {
+		return false
+	}
+	st.seen[h] = struct{}{}
+	return true
+}
+```
+
+::: warning The `id` field is load-bearing
+The seen-set is keyed by `*OnceHandle`, and Go may place two **zero-size** structs
+at the same address — which would make distinct handles collide. The non-empty `id`
+field guarantees distinct handles get distinct addresses. Don't remove it.
+:::
+
+### 2. Install the per-request scope with middleware
+
+The seen-set lives in the request `context`. Install it once per request with a
+standard `net/http` middleware, before any page renders (same package as above; add
+`net/http` to the imports):
+
+```go
+// withOnceScope installs the per-request dedup state; idempotent.
+func withOnceScope(ctx context.Context) context.Context {
+	if ctx.Value(onceKeyT{}) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, onceKeyT{}, &onceState{seen: map[*OnceHandle]struct{}{}})
+}
+
+// OnceScopeMiddleware installs the scope that <Once> relies on. Wrap your handler
+// (or router) with it once.
+func OnceScopeMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(withOnceScope(r.Context())))
+	})
+}
+```
+
+Wire it in wherever your app installs middleware:
+
+```go
+handler := OnceScopeMiddleware(mux)
+```
+
+### 3. The `<Once>` component
+
+A tiny gsx component guards its children behind `firstRender`:
+
+```gsx
+component Once(handle *OnceHandle) {
+	{ if handle.firstRender(ctx) { { children } } }
+}
+```
+
+`firstRender` both reports and records first-render, so the guard renders children
+on the first pass and skips every later one.
+
+## Using it
+
+Declare a handle at package level, then invoke your singleton through `<Once>`.
+Duplicate invocations anywhere on the page collapse to a single render:
+
+```gsx
+var dialogContainerOnce = NewOnce()
+
+component DialogContainer() {
+	<Once handle={dialogContainerOnce}>
+		<div id="dialog-root"></div>
+	</Once>
+}
+```
+
+Now `<DialogContainer/>` can appear next to every dialog trigger in your tree, and
+`#dialog-root` is emitted exactly once.
+
+## Why the middleware is required
+
+templ's generated `Render` calls `InitializeContext` at the root of every render,
+which is where templ installs its own once-state — so `templ.Once` works with no
+setup. gsx generates no such call: a gsx component's `Render` does nothing but write
+your markup. That keeps generated code minimal and predictable, but it means the
+per-request scope is **your** responsibility. `OnceScopeMiddleware` is what gives you
+back what templ installed for free.
+
+If you forget the middleware, `firstRender` finds no scope and returns `true` every
+time — so the singleton renders on every invocation instead of once. It never panics;
+the failure mode is duplicate output, not a crash.
+
+## Scope note
+
+The dedup is **per request**, keyed by handle pointer. A package-level handle is
+shared across all requests, but the seen-set is fresh per request (installed by the
+middleware), so one request's renders never affect another's.

--- a/docs/superpowers/specs/2026-07-06-docs-patterns-render-once-design.md
+++ b/docs/superpowers/specs/2026-07-06-docs-patterns-render-once-design.md
@@ -1,0 +1,87 @@
+# Patterns docs section — Render once
+
+**Date:** 2026-07-06
+**Status:** Approved, executing
+
+## Goal
+
+Introduce a new top-level **Patterns** area in the guide for reusable tricks &
+integrations (once-handle, htmx, structpages, …), seeded with the **Render once**
+pattern. The pattern is a faithful userland port of templ's `OnceHandle` —
+gsx ships no built-in render-once primitive, so this documents the recommended
+recipe and pins it with a corpus case so it can't rot.
+
+Source of the recipe: `~/work/one-learning-gsx/ui/once.gsx` (structpages middleware
+stripped; net/http-only per the decision below).
+
+## Decisions
+
+1. **IA placement** — a *new top-level* sidebar group **"Patterns"**, not a fill-in
+   of the pre-existing dead `Render once` link under "Interop and Gaps". That dead
+   link is removed.
+2. **Middleware framing** — **plain `net/http` only** (`func(http.Handler) http.Handler`).
+   No structpages on this page; a structpages integration gets its own future
+   Patterns page.
+3. **Verification** — ship a **corpus case** proving the recipe generates, renders,
+   and dedups (second render of the same handle is empty). Docs snippets are lifted
+   from the verified case.
+
+## Scope
+
+### gsx repo (`docs/guide/`)
+
+- **`patterns.md`** — Patterns overview: what the section is, a short list of current
+  (Render once) + planned (htmx, structpages) patterns.
+- **`patterns/render-once.md`** — the Once pattern:
+  - Problem: emit a per-request singleton (dialog container, dev-mode asset
+    preamble, one-time CSS/JS block) exactly once even when its owning component is
+    invoked from many call sites.
+  - Attribution: faithful port of **templ's `OnceHandle`** (`a-h/templ`, `once.go` /
+    `templ.Once`). Explicit callout of the one gsx difference — templ auto-runs
+    `InitializeContext` at the root of every generated `Render`; gsx does not, so the
+    app installs a per-request scope itself via middleware.
+  - Recipe (verified, lifted from the corpus case): `OnceHandle` + load-bearing `id`
+    note, `NewOnce`, the `onceState`/context-key/`withOnceScope`/`firstRender`
+    machinery, a plain `net/http` scope-install middleware, the `<Once>` component,
+    and a usage snippet. Note the graceful degrade (no scope installed → always
+    render, never crash).
+  - No structpages here (deferred).
+
+### gsx repo (`internal/corpus/testdata/cases/patterns/render_once.txtar`)
+
+- `input.gsx`: the `OnceHandle`/`withOnceScope`/`firstRender`/`NewOnce` Go, the
+  `<Once>` component, and a `Demo` component doing `{{ ctx := withOnceScope(ctx) }}`
+  then rendering `<Once handle={demoOnce}>…</Once>` **twice**.
+- Pins `generated.x.go.golden` + `render.golden` (second render empty). Regenerate
+  `coverage.golden` + manifest.
+- Feasibility confirmed by `docs/guide/syntax/raw-go.md:18`: a GoBlock-assigned
+  variable is available to all subsequent children in the same scope, so the
+  `ctx :=` rebind reaches both `<Once>` children. The corpus has no HTTP layer, so
+  this GoBlock is how it simulates the middleware's scope install.
+
+### website repo (`gsxhq.github.io/.vitepress/config.mts`)
+
+- Add top-level sidebar group **"Patterns"** (after **Tooling**): Overview →
+  `/guide/patterns`, Render once → `/guide/patterns/render-once`.
+- Remove the dead `Render once` entry under **"Interop and Gaps"**.
+
+### Conditional
+
+- `docs/guide/status.md` — if it frames "no render-once primitive" as a known gap,
+  point it at the new pattern; otherwise leave it.
+
+## Non-goals (YAGNI)
+
+- No structpages middleware variant on this page.
+- No htmx page yet.
+- No new runtime primitive in the gsx core — the Once machinery stays userland,
+  exactly as in `once.gsx`.
+- tree-sitter-gsx / vscode-gsx untouched (no new syntax).
+
+## Verification
+
+- `go test ./internal/corpus -run TestCorpus -update`, then re-run **without**
+  `-update`.
+- `make check` (build/vet/test/gofmt/gsx fmt).
+- `{{ }}` shown in *prose* (outside code fences) must be wrapped in `::: v-pre`;
+  GoBlock examples stay inside ```gsx fences and need no wrapping.

--- a/internal/corpus/testdata/cases/patterns/render_once.txtar
+++ b/internal/corpus/testdata/cases/patterns/render_once.txtar
@@ -1,0 +1,67 @@
+# COVERAGE: the userland "render once" pattern (a port of templ's OnceHandle).
+# A per-request scope (onceState in ctx) plus a *OnceHandle-keyed seen-set lets
+# the <Once> component render its children only the first time a handle is seen.
+# Demo installs the scope via a `{{ ctx = withOnceScope(ctx) }}` GoBlock (the
+# corpus has no HTTP layer, so this stands in for the net/http middleware) then
+# renders the same handle twice; the golden pins that the second render is empty.
+-- once.go --
+package views
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// OnceHandle dedups a render within a single request. The id field is load
+// bearing: the seen-set is keyed by *OnceHandle and Go may place two zero-size
+// structs at the same address, which would collide distinct handles.
+type OnceHandle struct{ id int64 }
+
+var onceIndex int64
+
+func NewOnce() *OnceHandle { return &OnceHandle{id: atomic.AddInt64(&onceIndex, 1)} }
+
+type onceState struct{ seen map[*OnceHandle]struct{} }
+
+type onceKeyT struct{}
+
+// withOnceScope installs the per-request dedup state; idempotent.
+func withOnceScope(ctx context.Context) context.Context {
+	if ctx.Value(onceKeyT{}) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, onceKeyT{}, &onceState{seen: map[*OnceHandle]struct{}{}})
+}
+
+// firstRender reports whether h is rendering for the first time this request,
+// marking it seen. With no scope installed it degrades to "always render".
+func (h *OnceHandle) firstRender(ctx context.Context) bool {
+	st, _ := ctx.Value(onceKeyT{}).(*onceState)
+	if st == nil {
+		return true
+	}
+	if _, done := st.seen[h]; done {
+		return false
+	}
+	st.seen[h] = struct{}{}
+	return true
+}
+-- input.gsx --
+package views
+
+var demoOnce = NewOnce()
+
+component Once(handle *OnceHandle) {
+	{ if handle.firstRender(ctx) { { children } } }
+}
+
+component Demo() {
+	{{ ctx = withOnceScope(ctx) }}
+	<Once handle={demoOnce}><span>x</span></Once>
+	<Once handle={demoOnce}><span>x</span></Once>
+}
+-- invoke --
+Demo()
+-- diagnostics.golden --
+-- render.golden --
+<span>x</span>

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -311,6 +311,7 @@ parser/e04_nonspread_brace	ast diag(error)
 parser/e05_empty_pipe_stage	ast diag(error)
 parser/recover_broken_then_valid	diag(error)
 parser/recover_two_broken_components	diag(error)
+patterns/render_once	diag render
 pipeerr/attr_mid_stage	diag gen render
 pipeerr/child_prop_mid_stage	diag gen render
 pipeerr/class_cf_arm_mid_stage	diag gen render
@@ -482,4 +483,4 @@ xpkg/imported_byo	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 484 cases (render: 390, error: 71, gen-pinned: 228)
+TOTAL: 485 cases (render: 391, error: 71, gen-pinned: 228)


### PR DESCRIPTION
## What

Adds a new top-level **Patterns** area to the guide — reusable userland recipes for things gsx doesn't build in — seeded with the **Render once** pattern.

- `docs/guide/patterns.md` — Patterns overview (htmx / structpages flagged as planned).
- `docs/guide/patterns/render-once.md` — a faithful userland port of templ's [`OnceHandle`](https://github.com/a-h/templ/blob/main/once.go). gsx ships no built-in render-once primitive (it generates no `InitializeContext`), so the recipe installs a per-request scope via plain `net/http` middleware and guards `<Once>` children behind a `*OnceHandle`-keyed seen-set. Includes the load-bearing `id`-field note and a *"Why the middleware is required"* section explaining the one gsx↔templ difference.

## Verification

- New corpus case `internal/corpus/testdata/cases/patterns/render_once.txtar` pins the recipe: renders the same handle twice under a `{ ctx = withOnceScope(ctx) }` GoBlock; `render.golden` proves the second render is empty (dedup).
- `make check` green; corpus green with `-count=1`; VitePress builds both pages cleanly (no `{{ }}`/Vue parse errors).

## Sibling repo

Sidebar wiring lives in `gsxhq.github.io` (`.vitepress/config.mts`) — separate PR: gsxhq/gsxhq.github.io#docs/patterns-sidebar. No new syntax, so tree-sitter-gsx / vscode-gsx are untouched.

https://claude.ai/code/session_01L1m6kX2zAJ8pQVgDNUoeSS