### PR TITLE
fmt: preserve author line breaks in control-flow bodies and element children

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -169,6 +169,10 @@ type Element struct {
 	// (which have no closing tag). Tooling (LSP go-to-definition) uses it so a
 	// cursor on the closing tag resolves like the opening tag.
 	CloseNamePos token.Pos
+	// ChildrenMultiline records that the source placed a line break immediately
+	// after the opening tag's `>`; the formatter preserves that vertical layout,
+	// keeping inline-only children block-formatted instead of collapsing them.
+	ChildrenMultiline bool
 }
 
 func (*Element) markupNode() {}
@@ -177,6 +181,9 @@ func (*Element) markupNode() {}
 type Fragment struct {
 	span
 	Children []Markup
+	// ChildrenMultiline records that the source placed a line break immediately
+	// after the `<>`; the formatter preserves that vertical layout.
+	ChildrenMultiline bool
 }
 
 func (*Fragment) markupNode() {}
@@ -374,6 +381,13 @@ type IfMarkup struct {
 	CondPos token.Pos // first char of Cond text in source (NoPos if unavailable)
 	Then    []Markup
 	Else    []Markup
+	// ThenMultiline/ElseMultiline record that the source placed a line break
+	// immediately after the then/else body's opening `{`. The formatter preserves
+	// that vertical layout (keeping an inline-only body block-formatted) instead of
+	// collapsing it to one line. ElseMultiline is meaningful only for a plain
+	// `else { … }`; an `else if` is a nested IfMarkup carrying its own ThenMultiline.
+	ThenMultiline bool
+	ElseMultiline bool
 }
 
 func (*IfMarkup) markupNode() {}
@@ -384,6 +398,9 @@ type ForMarkup struct {
 	Clause    string
 	ClausePos token.Pos // first char of Clause text in source (NoPos if unavailable)
 	Body      []Markup
+	// BodyMultiline records that the source placed a line break immediately after
+	// the body's opening `{`; the formatter preserves that vertical layout.
+	BodyMultiline bool
 }
 
 func (*ForMarkup) markupNode() {}

--- a/docs/examples.json
+++ b/docs/examples.json
@@ -98,7 +98,7 @@
   {
     "name": "Props heuristic",
     "category": "Components",
-    "source": "package views\n\ntype Props struct {\n\tTitle string\n}\n\ncomponent Greeting(name string) {\n\t<p>Hi { name }</p>\n}\n\ncomponent Card(title string, n int) {\n\t<div>{ title }: { n }</div>\n}\n\ncomponent Panel(p Props) {\n\t<section>{ p.Title }</section>\n}\n\ncomponent Page() {\n\t<><Greeting name=\"Ann\"/><Card title=\"T\" n={2}/><Panel title=\"P\"/></>\n}\n",
+    "source": "package views\n\ntype Props struct {\n\tTitle string\n}\n\ncomponent Greeting(name string) {\n\t<p>Hi { name }</p>\n}\n\ncomponent Card(title string, n int) {\n\t<div>{ title }: { n }</div>\n}\n\ncomponent Panel(p Props) {\n\t<section>{ p.Title }</section>\n}\n\ncomponent Page() {\n\t<>\n\t\t<Greeting name=\"Ann\"/>\n\t\t<Card title=\"T\" n={2}/>\n\t\t<Panel title=\"P\"/>\n\t</>\n}\n",
     "invoke": "Page()"
   },
   {
@@ -242,7 +242,7 @@
   {
     "name": "Composable class",
     "category": "Styling",
-    "source": "package views\n\ncomponent Tag(label string, active bool) {\n\t<span class={ \"tag\", \"tag--active\": active }>{ label }</span>\n}\n",
+    "source": "package views\n\ncomponent Tag(label string, active bool) {\n\t<span class={ \"tag\", \"tag--active\": active }>\n\t\t{ label }\n\t</span>\n}\n",
     "invoke": "Tag(TagProps{Label: \"stable\", Active: true})"
   },
   {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -248,6 +248,14 @@ formats `.` recursively.
 in `gsx.toml` to change it. The language server reads the same setting, so
 `gsx fmt` and format-on-save always agree.
 
+**Your line breaks are preserved.** When you place a line break immediately
+after a control-flow body's opening `{` (`{ if … {`, `else {`, `{ for … {`) or
+an element's opening `>` (or a fragment's `<>`), the formatter keeps that body
+block-formatted instead of collapsing it onto one line — even when it would fit
+the print width. Write it inline and it stays inline; write it multi-line and it
+stays multi-line. (A block-level child, e.g. a nested element, still forces the
+enclosing body to break regardless, so the document hierarchy stays visible.)
+
 **Unused imports.** Like `goimports`, `gsx fmt` **removes unused imports** from a
 `.gsx` file's pass-through Go by default — detected via the type-checker, so it
 runs a module analysis (`go list` + type-check). Pass `-no-imports` to format

--- a/docs/guide/syntax/_generated/props/020-props-heuristic.md
+++ b/docs/guide/syntax/_generated/props/020-props-heuristic.md
@@ -20,7 +20,11 @@ component Panel(p Props) {
 }
 
 component Page() {
-	<><Greeting name="Ann"/><Card title="T" n={2}/><Panel title="P"/></>
+	<>
+		<Greeting name="Ann"/>
+		<Card title="T" n={2}/>
+		<Panel title="P"/>
+	</>
 }
 ```
 
@@ -30,4 +34,4 @@ Renders:
 <p>Hi Ann</p><div>T: 2</div><section>P</section>
 ```
 
-[▶ Open in Playground](/playground#try=eyJzIjoicGFja2FnZSB2aWV3c1xuXG50eXBlIFByb3BzIHN0cnVjdCB7XG5cdFRpdGxlIHN0cmluZ1xufVxuXG5jb21wb25lbnQgR3JlZXRpbmcobmFtZSBzdHJpbmcpIHtcblx0XHUwMDNjcFx1MDAzZUhpIHsgbmFtZSB9XHUwMDNjL3BcdTAwM2Vcbn1cblxuY29tcG9uZW50IENhcmQodGl0bGUgc3RyaW5nLCBuIGludCkge1xuXHRcdTAwM2NkaXZcdTAwM2V7IHRpdGxlIH06IHsgbiB9XHUwMDNjL2Rpdlx1MDAzZVxufVxuXG5jb21wb25lbnQgUGFuZWwocCBQcm9wcykge1xuXHRcdTAwM2NzZWN0aW9uXHUwMDNleyBwLlRpdGxlIH1cdTAwM2Mvc2VjdGlvblx1MDAzZVxufVxuXG5jb21wb25lbnQgUGFnZSgpIHtcblx0XHUwMDNjXHUwMDNlXHUwMDNjR3JlZXRpbmcgbmFtZT1cIkFublwiL1x1MDAzZVx1MDAzY0NhcmQgdGl0bGU9XCJUXCIgbj17Mn0vXHUwMDNlXHUwMDNjUGFuZWwgdGl0bGU9XCJQXCIvXHUwMDNlXHUwMDNjL1x1MDAzZVxufVxuIiwiaSI6IlBhZ2UoKSJ9)
+[▶ Open in Playground](/playground#try=eyJzIjoicGFja2FnZSB2aWV3c1xuXG50eXBlIFByb3BzIHN0cnVjdCB7XG5cdFRpdGxlIHN0cmluZ1xufVxuXG5jb21wb25lbnQgR3JlZXRpbmcobmFtZSBzdHJpbmcpIHtcblx0XHUwMDNjcFx1MDAzZUhpIHsgbmFtZSB9XHUwMDNjL3BcdTAwM2Vcbn1cblxuY29tcG9uZW50IENhcmQodGl0bGUgc3RyaW5nLCBuIGludCkge1xuXHRcdTAwM2NkaXZcdTAwM2V7IHRpdGxlIH06IHsgbiB9XHUwMDNjL2Rpdlx1MDAzZVxufVxuXG5jb21wb25lbnQgUGFuZWwocCBQcm9wcykge1xuXHRcdTAwM2NzZWN0aW9uXHUwMDNleyBwLlRpdGxlIH1cdTAwM2Mvc2VjdGlvblx1MDAzZVxufVxuXG5jb21wb25lbnQgUGFnZSgpIHtcblx0XHUwMDNjXHUwMDNlXG5cdFx0XHUwMDNjR3JlZXRpbmcgbmFtZT1cIkFublwiL1x1MDAzZVxuXHRcdFx1MDAzY0NhcmQgdGl0bGU9XCJUXCIgbj17Mn0vXHUwMDNlXG5cdFx0XHUwMDNjUGFuZWwgdGl0bGU9XCJQXCIvXHUwMDNlXG5cdFx1MDAzYy9cdTAwM2Vcbn1cbiIsImkiOiJQYWdlKCkifQ==)

--- a/docs/guide/syntax/_generated/styling/010-composable-class.md
+++ b/docs/guide/syntax/_generated/styling/010-composable-class.md
@@ -4,7 +4,9 @@
 package views
 
 component Tag(label string, active bool) {
-	<span class={ "tag", "tag--active": active }>{ label }</span>
+	<span class={ "tag", "tag--active": active }>
+		{ label }
+	</span>
 }
 ```
 
@@ -14,4 +16,4 @@ Renders:
 <span class="tag tag--active">stable</span>
 ```
 
-[▶ Open in Playground](/playground#try=eyJzIjoicGFja2FnZSB2aWV3c1xuXG5jb21wb25lbnQgVGFnKGxhYmVsIHN0cmluZywgYWN0aXZlIGJvb2wpIHtcblx0XHUwMDNjc3BhbiBjbGFzcz17IFwidGFnXCIsIFwidGFnLS1hY3RpdmVcIjogYWN0aXZlIH1cdTAwM2V7IGxhYmVsIH1cdTAwM2Mvc3Bhblx1MDAzZVxufVxuIiwiaSI6IlRhZyhUYWdQcm9wc3tMYWJlbDogXCJzdGFibGVcIiwgQWN0aXZlOiB0cnVlfSkifQ==)
+[▶ Open in Playground](/playground#try=eyJzIjoicGFja2FnZSB2aWV3c1xuXG5jb21wb25lbnQgVGFnKGxhYmVsIHN0cmluZywgYWN0aXZlIGJvb2wpIHtcblx0XHUwMDNjc3BhbiBjbGFzcz17IFwidGFnXCIsIFwidGFnLS1hY3RpdmVcIjogYWN0aXZlIH1cdTAwM2Vcblx0XHR7IGxhYmVsIH1cblx0XHUwMDNjL3NwYW5cdTAwM2Vcbn1cbiIsImkiOiJUYWcoVGFnUHJvcHN7TGFiZWw6IFwic3RhYmxlXCIsIEFjdGl2ZTogdHJ1ZX0pIn0=)

--- a/docs/superpowers/specs/2026-07-06-fmt-preserve-author-line-breaks-design.md
+++ b/docs/superpowers/specs/2026-07-06-fmt-preserve-author-line-breaks-design.md
@@ -1,0 +1,145 @@
+# gsx fmt: preserve author line breaks in control-flow bodies and element children
+
+Status: design → implementation
+Date: 2026-07-06
+
+## Problem
+
+`gsx fmt` collapses a control-flow body (or element children) onto one line
+whenever the body is *inline-only* (text/interp) and fits the print width — even
+when the author deliberately wrote it across multiple lines. Example:
+
+```gsx
+{ if props.viewing != nil {
+	{ *props.viewing }
+} }
+```
+
+is reformatted to
+
+```gsx
+{ if props.viewing != nil { { *props.viewing } } }
+```
+
+Users expect the formatter to keep the vertical layout they chose, the same way
+`gofmt` keeps a composite literal multi-line when its first element sits on a
+line below the opening `{`.
+
+## Root cause
+
+`internal/printer/printer.go` decides a children list's layout purely from
+*content*:
+
+- `cfBody` (control-flow bodies) and `element` force a break only when the body
+  has a **block-level child** (`hasBlockChild`). An inline-only body stays on one
+  line and breaks only on width overflow.
+
+The printer never consults the *source layout*. There is no signal recording
+that the author put a line break after the opening delimiter.
+
+## Rule (what we add)
+
+Preserve the author's vertical layout: **if the source places a line break
+immediately after the container's opening delimiter, the body stays
+block-formatted (each segment on its own line), regardless of width.**
+
+Opening delimiters, by container:
+
+| Container                         | Delimiter        |
+|-----------------------------------|------------------|
+| `{ if COND {` … `}` (then body)   | the body `{`     |
+| `… else {` … `}` (plain else)     | the else `{`     |
+| `{ for CLAUSE {` … `}`            | the body `{`     |
+| `<tag …>` … `</tag>` (children)   | the opening `>`  |
+| `<>` … `</>` (fragment children)  | the `>` of `<>`  |
+
+Out of scope (unchanged): `switch` (already always breaks), `component` body
+(already always breaks), raw-text `<script>`/`<style>`/`pre`/`textarea` bodies
+(verbatim), and attributes (always inline). `else if` is a nested `IfMarkup` and
+carries its own then-flag.
+
+"Line break immediately after the delimiter" = the contiguous whitespace run
+following the delimiter contains a `\n`/`\r` before the next non-whitespace byte.
+This is checked against the **whitespace run**, not the first child's start line,
+because a leading text child's `Pos()` begins *at* the newline (the newline is
+part of the text), so a line-number comparison would miss it.
+
+## Design
+
+Record the fact at parse time; consume it in the printer. This mirrors the
+existing precedent where the printer preserves author whitespace intent from
+AST-carried source facts (`GoChunk.Src` → `endsWithBlankLine` for blank lines
+between declarations).
+
+### AST (`ast/ast.go`) — new exported bool fields
+
+- `IfMarkup.ThenMultiline bool` — a line break follows the then-body `{`.
+- `IfMarkup.ElseMultiline bool` — a line break follows a plain-else `{` (unused
+  for `else if`).
+- `ForMarkup.BodyMultiline bool` — a line break follows the for-body `{`.
+- `Element.ChildrenMultiline bool` — a line break follows the opening tag `>`.
+- `Fragment.ChildrenMultiline bool` — a line break follows the `<>` `>`.
+
+Exported because `internal/printer` (a different package) reads them; consistent
+with existing exported position fields (`CondPos`, `CloseNamePos`).
+
+### Parser (`parser/markup.go`)
+
+Helper: `newlineFollows(src string, off int) bool` — true iff the whitespace run
+starting at `off` contains a line break before the next non-whitespace byte.
+
+Set each flag at the point the parser advances past the delimiter (all offsets
+already known: `braceOff+1` for `if`/`for` bodies, `p.i` after `p.i++` past the
+else `{`, the fragment `>`, and the element `>`).
+
+### Printer (`internal/printer/printer.go`)
+
+OR the new flag into the existing force-break condition, **after** the
+edge-safety guards (so a body that leads/trails a significant space still stays
+inline for correctness — the flag is ignored there):
+
+- `cfBody`: `if hasBlockChild(nodes) || multiline { … BreakParent … }`
+  (pass `multiline` in from `ifChain`/`forMarkup`).
+- `element`: `if hasBlockChild(e.Children) || e.ChildrenMultiline { force = BreakParent }`.
+- `fragment`: force-break when `f.ChildrenMultiline` (fragment currently has no
+  block-child force-break; add the author-newline one).
+
+### wsnorm
+
+No change: `Normalize` mutates nodes in place (same pointers), so the new bools
+survive. It may drop a leading all-whitespace text child, but the flag was
+computed from raw source pre-normalization and is unaffected.
+
+## Idempotency
+
+`format(format(x)) == format(x)` holds:
+
+- Author newline → flag true → printer breaks → output has a newline after the
+  delimiter → re-parse sets flag true → stays broken.
+- No author newline → flag false, fits width → inline → re-parse flag false →
+  stays inline.
+- Author newline but body is edge-unsafe → printer keeps inline (correctness) →
+  output has no post-delimiter newline → re-parse flag false → stable inline.
+
+The force-break only fires in already-edge-safe branches, so no cosmetic newline
+ever absorbs a significant space.
+
+## Tests
+
+Corpus cases (per context) under `internal/corpus/testdata/cases/`:
+
+- `control_flow/if_multiline_preserved` — inline-only then body, author-broken → stays multi-line.
+- `control_flow/if_inline_preserved` — inline-only then body, author-inline → stays inline.
+- `control_flow/if_else_multiline_preserved` — else body author-broken.
+- `control_flow/for_multiline_preserved` — for body author-broken.
+- `elements/children_multiline_preserved` — element children author-broken, inline-only.
+- `elements/fragment_multiline_preserved` — fragment children author-broken.
+
+Printer unit tests (`internal/printer/printer_test.go`): idempotency +
+edge-unsafe-stays-inline for the new cases. Parser unit test for
+`newlineFollows` / flag wiring.
+
+## Siblings
+
+No syntax change — grammar is identical. tree-sitter-gsx / vscode-gsx /
+website need no update.

--- a/internal/printer/corpus_test.go
+++ b/internal/printer/corpus_test.go
@@ -128,6 +128,9 @@ func zeroSpans(n ast.Node) {
 			case *ast.Element:
 				v.CloseNamePos = 0
 				v.TypeArgsPos = 0
+				v.ChildrenMultiline = false
+			case *ast.Fragment:
+				v.ChildrenMultiline = false
 			case *ast.SpreadAttr:
 				v.ExprPos = 0
 				for i := range v.Stages {
@@ -145,8 +148,11 @@ func zeroSpans(n ast.Node) {
 				v.CondPos = 0
 			case *ast.ForMarkup:
 				v.ClausePos = 0
+				v.BodyMultiline = false
 			case *ast.IfMarkup:
 				v.CondPos = 0
+				v.ThenMultiline = false
+				v.ElseMultiline = false
 			case *ast.SwitchMarkup:
 				v.TagPos = 0
 			case *ast.CaseClause:

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -259,7 +259,7 @@ func (p *printer) element(e *ast.Element) pretty.Doc {
 	// independently, so short attributes stay inline even when children break,
 	// and a CondAttr's BreakParent inside the tag also forces the children open.
 	force := pretty.Text("")
-	if hasBlockChild(e.Children) {
+	if hasBlockChild(e.Children) || e.ChildrenMultiline {
 		force = pretty.BreakParent
 	}
 	return pretty.Group(pretty.Concat(
@@ -468,8 +468,14 @@ func (p *printer) fragment(f *ast.Fragment) pretty.Doc {
 	if !breakable {
 		return pretty.Concat(pretty.Text("<>"), inner, pretty.Text("</>"))
 	}
+	// An author line break after `<>` is preserved (force the group open);
+	// otherwise the fragment breaks only on width overflow.
+	force := pretty.Text("")
+	if f.ChildrenMultiline {
+		force = pretty.BreakParent
+	}
 	body := pretty.Concat(pretty.Indent(pretty.Concat(pretty.SoftLine, inner)), pretty.SoftLine)
-	return pretty.Group(pretty.Concat(pretty.Text("<>"), body, pretty.Text("</>")))
+	return pretty.Group(pretty.Concat(pretty.Text("<>"), force, body, pretty.Text("</>")))
 }
 
 func (p *printer) interp(i *ast.Interp) pretty.Doc {
@@ -515,7 +521,7 @@ func (p *printer) ifMarkup(i *ast.IfMarkup) pretty.Doc {
 }
 
 func (p *printer) ifChain(i *ast.IfMarkup) pretty.Doc {
-	parts := []pretty.Doc{pretty.Text("if "), multiline(fmtExpr(i.Cond)), pretty.Text(" {"), p.cfBody(i.Then), pretty.Text("}")}
+	parts := []pretty.Doc{pretty.Text("if "), multiline(fmtExpr(i.Cond)), pretty.Text(" {"), p.cfBody(i.Then, i.ThenMultiline), pretty.Text("}")}
 	if len(i.Else) == 0 {
 		return pretty.Concat(parts...)
 	}
@@ -525,13 +531,13 @@ func (p *printer) ifChain(i *ast.IfMarkup) pretty.Doc {
 			return pretty.Concat(parts...)
 		}
 	}
-	parts = append(parts, pretty.Text(" else {"), p.cfBody(i.Else), pretty.Text("}"))
+	parts = append(parts, pretty.Text(" else {"), p.cfBody(i.Else, i.ElseMultiline), pretty.Text("}"))
 	return pretty.Concat(parts...)
 }
 
 func (p *printer) forMarkup(f *ast.ForMarkup) pretty.Doc {
 	return pretty.Group(pretty.Concat(
-		pretty.Text("{ for "), pretty.Text(fmtClause(f.Clause)), pretty.Text(" {"), p.cfBody(f.Body), pretty.Text("} }")))
+		pretty.Text("{ for "), pretty.Text(fmtClause(f.Clause)), pretty.Text(" {"), p.cfBody(f.Body, f.BodyMultiline), pretty.Text("} }")))
 }
 
 // cfBody renders a control-flow body between an already-emitted `{` and a
@@ -540,8 +546,10 @@ func (p *printer) forMarkup(f *ast.ForMarkup) pretty.Doc {
 // `{ … }` (Line renders as " "); break mode → newline-indented. This is
 // correct for both short bodies (Group fits → collapses) and long bodies (Group
 // doesn't fit → breaks). Indent is always applied so break-mode content is one
-// tab deeper than the surrounding `{`/`}`.
-func (p *printer) cfBody(nodes []ast.Markup) pretty.Doc {
+// tab deeper than the surrounding `{`/`}`. multiline is true when the source
+// placed a line break after the body's opening `{` (ast.*Multiline), in which
+// case the vertical layout is preserved even for an inline-only body that fits.
+func (p *printer) cfBody(nodes []ast.Markup, multiline bool) pretty.Doc {
 	if len(nodes) == 0 {
 		return pretty.Text("")
 	}
@@ -557,9 +565,10 @@ func (p *printer) cfBody(nodes []ast.Markup) pretty.Doc {
 	body := pretty.Concat(pretty.Indent(pretty.Concat(pretty.Line, inner)), pretty.Line)
 	// Structural rule: a control-flow body containing a block-level child always
 	// breaks (the BreakParent forces the enclosing if/for group open), so e.g.
-	// `{ for … { <Card/> } }` shows its hierarchy. An inline-only body stays on
+	// `{ for … { <Card/> } }` shows its hierarchy. An author line break after `{`
+	// is likewise preserved. An inline-only body the author kept inline stays on
 	// one line and breaks only if it overflows the width.
-	if hasBlockChild(nodes) {
+	if hasBlockChild(nodes) || multiline {
 		return pretty.Concat(pretty.BreakParent, body)
 	}
 	return body

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -554,13 +554,32 @@ component C() {
 }
 
 func TestFragment(t *testing.T) {
-	// Two short paragraph children fit on one line: fragment Group collapses.
+	// The author wrote the fragment children on their own lines; that vertical
+	// layout is preserved (the line break after `<>` forces the group open).
 	src := `package p
 component C() {
 	<>
 		<p>a</p>
 		<p>b</p>
 	</>
+}`
+	want := `package p
+
+component C() {
+	<>
+		<p>a</p>
+		<p>b</p>
+	</>
+}
+`
+	checkFormat(t, src, want)
+}
+
+func TestFragmentInlineStaysInline(t *testing.T) {
+	// Authored on one line and fits: the fragment stays collapsed.
+	src := `package p
+component C() {
+	<><p>a</p><p>b</p></>
 }`
 	want := `package p
 
@@ -1424,4 +1443,64 @@ func TestFmtCommentsIdempotentMixed(t *testing.T) {
 		!strings.Contains(once, "/* c */") || !strings.Contains(once, "{/* d */}") {
 		t.Fatalf("a comment was dropped:\n%s", once)
 	}
+}
+
+// --- author line-break preservation (control-flow bodies + element children) ---
+// When the source places a line break immediately after the opening delimiter,
+// the body stays block-formatted even though it is inline-only and would fit.
+
+func TestIfInlineBodyPreservesAuthorLineBreak(t *testing.T) {
+	src := "package p\ncomponent C(viewing *int) {\n\t<div>\n\t\t{ if viewing != nil {\n\t\t\t{ *viewing }\n\t\t} }\n\t</div>\n}\n"
+	want := "package p\n\ncomponent C(viewing *int) {\n\t<div>\n\t\t{ if viewing != nil {\n\t\t\t{ *viewing }\n\t\t} }\n\t</div>\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestIfInlineBodyStaysInlineWhenAuthorInline(t *testing.T) {
+	// The <div> still breaks structurally (the `if` is a block child), but the
+	// author-inline if body is NOT expanded — only author line breaks are honored.
+	src := "package p\ncomponent C(viewing *int) {\n\t<div>{ if viewing != nil { { *viewing } } }</div>\n}\n"
+	want := "package p\n\ncomponent C(viewing *int) {\n\t<div>\n\t\t{ if viewing != nil { { *viewing } } }\n\t</div>\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestIfElseInlineBodyPreservesAuthorLineBreak(t *testing.T) {
+	src := "package p\ncomponent C(x int) {\n\t<div>\n\t\t{ if x > 0 {\n\t\t\t{ x }\n\t\t} else {\n\t\t\t{ -x }\n\t\t} }\n\t</div>\n}\n"
+	want := "package p\n\ncomponent C(x int) {\n\t<div>\n\t\t{ if x > 0 {\n\t\t\t{ x }\n\t\t} else {\n\t\t\t{ -x }\n\t\t} }\n\t</div>\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestForInlineBodyPreservesAuthorLineBreak(t *testing.T) {
+	src := "package p\ncomponent C(items []string) {\n\t<ul>\n\t\t{ for _, it := range items {\n\t\t\t{ it }\n\t\t} }\n\t</ul>\n}\n"
+	want := "package p\n\ncomponent C(items []string) {\n\t<ul>\n\t\t{ for _, it := range items {\n\t\t\t{ it }\n\t\t} }\n\t</ul>\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestElementInlineChildrenPreserveAuthorLineBreak(t *testing.T) {
+	src := "package p\ncomponent C(name string) {\n\t<span>\n\t\t{ name }\n\t</span>\n}\n"
+	want := "package p\n\ncomponent C(name string) {\n\t<span>\n\t\t{ name }\n\t</span>\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestElementInlineChildrenStayInlineWhenAuthorInline(t *testing.T) {
+	src := "package p\ncomponent C(name string) {\n\t<span>{ name }</span>\n}\n"
+	want := "package p\n\ncomponent C(name string) {\n\t<span>{ name }</span>\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestCfBodyAuthorNewlineButEdgeUnsafeStaysInline(t *testing.T) {
+	// Author broke the line after `{`, but the body's Text trails a significant
+	// space (edge-unsafe). The edge guard MUST win over the author-newline flag:
+	// breaking would absorb the trailing space and change the normalized AST.
+	src := "package p\ncomponent C(x bool) {\n\t<p>a{ if x {\n\ttext  } }b</p>\n}\n"
+	want := "package p\n\ncomponent C(x bool) {\n\t<p>\n\t\ta\n\t\t{ if x { text  } }\n\t\tb\n\t</p>\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestFragmentInlineChildrenPreserveAuthorLineBreak(t *testing.T) {
+	// Once the author line break after `<>` forces the fragment open, its two
+	// adjacent interps (safe-boundary segments) each take their own line — the
+	// normal layout of any broken children list.
+	src := "package p\ncomponent C(a, b string) {\n\t<>\n\t\t{ a }{ b }\n\t</>\n}\n"
+	want := "package p\n\ncomponent C(a, b string) {\n\t<>\n\t\t{ a }\n\t\t{ b }\n\t</>\n}\n"
+	checkFormat(t, src, want)
 }

--- a/parser/markup.go
+++ b/parser/markup.go
@@ -291,6 +291,7 @@ func (p *parser) parseForMarkup() (ast.Markup, error) {
 	clausePos := p.posAt(clauseStart + lead)
 	clause := strings.TrimSpace(rawClause)
 	p.i = braceOff + 1 // past body '{'
+	bodyMultiline := newlineFollows(p.src, p.i)
 	body, err := p.parseControlBody()
 	if err != nil {
 		return nil, err
@@ -300,7 +301,7 @@ func (p *parser) parseForMarkup() (ast.Markup, error) {
 		return nil, p.errorf(p.pos(), "expected `}` to close `{ for … }`")
 	}
 	p.i++ // past outer '}'
-	n := &ast.ForMarkup{Clause: clause, ClausePos: clausePos, Body: body}
+	n := &ast.ForMarkup{Clause: clause, ClausePos: clausePos, Body: body, BodyMultiline: bodyMultiline}
 	ast.SetSpan(n, startPos, p.posAt(p.i))
 	return n, nil
 }
@@ -340,11 +341,12 @@ func (p *parser) parseIfTail() (*ast.IfMarkup, error) {
 	condPos := p.posAt(condStart + lead)
 	cond := strings.TrimSpace(rawCond)
 	p.i = braceOff + 1 // past body '{'
+	thenMultiline := newlineFollows(p.src, p.i)
 	body, err := p.parseControlBody()
 	if err != nil {
 		return nil, err
 	}
-	n := &ast.IfMarkup{Cond: cond, CondPos: condPos, Then: body}
+	n := &ast.IfMarkup{Cond: cond, CondPos: condPos, Then: body, ThenMultiline: thenMultiline}
 	p.skipSpace()
 	if p.atWord("else") {
 		p.i += len("else")
@@ -352,6 +354,7 @@ func (p *parser) parseIfTail() (*ast.IfMarkup, error) {
 		switch {
 		case p.peek() == '{':
 			p.i++ // past '{'
+			n.ElseMultiline = newlineFollows(p.src, p.i)
 			elseBody, err := p.parseControlBody()
 			if err != nil {
 				return nil, err
@@ -698,11 +701,12 @@ func (p *parser) parseElement() (ast.Markup, error) {
 	// Fragment: <>…</>
 	if p.peek() == '>' {
 		p.i++ // past '>'
+		childrenMultiline := newlineFollows(p.src, p.i)
 		children, _, err := p.parseChildren("")
 		if err != nil {
 			return nil, err
 		}
-		fr := &ast.Fragment{Children: children}
+		fr := &ast.Fragment{Children: children, ChildrenMultiline: childrenMultiline}
 		ast.SetSpan(fr, startPos, p.posAt(p.i))
 		return fr, nil
 	}
@@ -750,6 +754,7 @@ func (p *parser) parseElement() (ast.Markup, error) {
 		return nil, p.errorf(p.pos(), "expected '>' or '/>' in <%s>", tag)
 	}
 	p.i++ // past '>'
+	childrenMultiline := newlineFollows(p.src, p.i)
 
 	// Raw-text elements (<script>, <style>): content is verbatim until the
 	// matching case-insensitive close tag. No markup/interpolation inside.
@@ -767,7 +772,7 @@ func (p *parser) parseElement() (ast.Markup, error) {
 	if err != nil {
 		return nil, err
 	}
-	el := &ast.Element{Tag: tag, TypeArgs: typeArgs, TypeArgsPos: typeArgsPos, Attrs: attrs, Children: children, CloseNamePos: closeNamePos}
+	el := &ast.Element{Tag: tag, TypeArgs: typeArgs, TypeArgsPos: typeArgsPos, Attrs: attrs, Children: children, CloseNamePos: closeNamePos, ChildrenMultiline: childrenMultiline}
 	ast.SetSpan(el, startPos, p.posAt(p.i))
 	return el, nil
 }

--- a/parser/markup_test.go
+++ b/parser/markup_test.go
@@ -1509,3 +1509,75 @@ func TestEmptyTypeArgsRejected(t *testing.T) {
 		t.Fatalf("anchored at line %d, want 4", p.Line)
 	}
 }
+
+// TestAuthorLineBreakFlags checks that the parser records a line break placed
+// immediately after a control-flow body / element-children opening delimiter
+// (the *Multiline flags the formatter uses to preserve vertical layout).
+func TestAuthorLineBreakFlags(t *testing.T) {
+	firstOf := func(f *ast.File, want func(ast.Node) bool) ast.Node {
+		var found ast.Node
+		for _, d := range f.Decls {
+			if found != nil {
+				break
+			}
+			c, ok := d.(*ast.Component)
+			if !ok {
+				continue
+			}
+			for _, m := range c.Body {
+				ast.Inspect(m, func(n ast.Node) bool {
+					if found == nil && n != nil && want(n) {
+						found = n
+					}
+					return found == nil
+				})
+			}
+		}
+		return found
+	}
+	ifNode := func(src string) *ast.IfMarkup {
+		n := firstOf(parseStringT(t, src), func(n ast.Node) bool { _, ok := n.(*ast.IfMarkup); return ok })
+		if n == nil {
+			t.Fatalf("no IfMarkup in:\n%s", src)
+		}
+		return n.(*ast.IfMarkup)
+	}
+	elemNode := func(src, tag string) *ast.Element {
+		n := firstOf(parseStringT(t, src), func(n ast.Node) bool {
+			e, ok := n.(*ast.Element)
+			return ok && e.Tag == tag
+		})
+		if n == nil {
+			t.Fatalf("no <%s> in:\n%s", tag, src)
+		}
+		return n.(*ast.Element)
+	}
+
+	// then-body broken vs inline
+	if got := ifNode("package p\ncomponent C(x bool) {\n\t<div>{ if x {\n\t{ x }\n\t} }</div>\n}\n"); !got.ThenMultiline {
+		t.Error("ThenMultiline: want true for author-broken then body")
+	}
+	if got := ifNode("package p\ncomponent C(x bool) {\n\t<div>{ if x { { x } } }</div>\n}\n"); got.ThenMultiline {
+		t.Error("ThenMultiline: want false for inline then body")
+	}
+	// CRLF line break after `{` still counts.
+	if got := ifNode("package p\r\ncomponent C(x bool) {\r\n\t<div>{ if x {\r\n\t{ x }\r\n\t} }</div>\r\n}\r\n"); !got.ThenMultiline {
+		t.Error("ThenMultiline: want true for CRLF-broken then body")
+	}
+	// plain else broken.
+	if got := ifNode("package p\ncomponent C(x bool) {\n\t<div>{ if x { { x } } else {\n\t{ x }\n\t} }</div>\n}\n"); !got.ElseMultiline {
+		t.Error("ElseMultiline: want true for author-broken else body")
+	}
+	// else-if must NOT set ElseMultiline (Else is a nested IfMarkup).
+	elseIf := ifNode("package p\ncomponent C(x bool) {\n\t<div>{ if x { { x } } else if !x {\n\t{ x }\n\t} }</div>\n}\n")
+	if elseIf.ElseMultiline {
+		t.Error("ElseMultiline: want false for else-if chain")
+	}
+	// element children broken vs inline.
+	if got := elemNode("package p\ncomponent C(s string) {\n\t<span>\n\t{ s }\n\t</span>\n}\n", "span"); !got.ChildrenMultiline {
+		t.Error("ChildrenMultiline: want true for author-broken children")
+	}
+	if got := elemNode("package p\ncomponent C(s string) {\n\t<span>{ s }</span>\n}\n", "span"); got.ChildrenMultiline {
+		t.Error("ChildrenMultiline: want false for inline children")
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -77,6 +77,24 @@ func (p *parser) skipSpace() {
 	}
 }
 
+// newlineFollows reports whether the whitespace run in src starting at off
+// contains a line break before the next non-whitespace byte — i.e. the author
+// placed the following content on its own line. The formatter uses this to keep
+// a body block-formatted when the source did (see ast.*Multiline fields).
+func newlineFollows(src string, off int) bool {
+	for off < len(src) {
+		switch src[off] {
+		case '\n', '\r':
+			return true
+		case ' ', '\t':
+			off++
+		default:
+			return false
+		}
+	}
+	return false
+}
+
 // pos returns the token.Pos of the current cursor position.
 func (p *parser) pos() token.Pos {
 	return p.file.Pos(p.base + p.i)

--- a/playground/server/examples.json
+++ b/playground/server/examples.json
@@ -98,7 +98,7 @@
   {
     "name": "Props heuristic",
     "category": "Components",
-    "source": "package views\n\ntype Props struct {\n\tTitle string\n}\n\ncomponent Greeting(name string) {\n\t<p>Hi { name }</p>\n}\n\ncomponent Card(title string, n int) {\n\t<div>{ title }: { n }</div>\n}\n\ncomponent Panel(p Props) {\n\t<section>{ p.Title }</section>\n}\n\ncomponent Page() {\n\t<><Greeting name=\"Ann\"/><Card title=\"T\" n={2}/><Panel title=\"P\"/></>\n}\n",
+    "source": "package views\n\ntype Props struct {\n\tTitle string\n}\n\ncomponent Greeting(name string) {\n\t<p>Hi { name }</p>\n}\n\ncomponent Card(title string, n int) {\n\t<div>{ title }: { n }</div>\n}\n\ncomponent Panel(p Props) {\n\t<section>{ p.Title }</section>\n}\n\ncomponent Page() {\n\t<>\n\t\t<Greeting name=\"Ann\"/>\n\t\t<Card title=\"T\" n={2}/>\n\t\t<Panel title=\"P\"/>\n\t</>\n}\n",
     "invoke": "Page()"
   },
   {
@@ -242,7 +242,7 @@
   {
     "name": "Composable class",
     "category": "Styling",
-    "source": "package views\n\ncomponent Tag(label string, active bool) {\n\t<span class={ \"tag\", \"tag--active\": active }>{ label }</span>\n}\n",
+    "source": "package views\n\ncomponent Tag(label string, active bool) {\n\t<span class={ \"tag\", \"tag--active\": active }>\n\t\t{ label }\n\t</span>\n}\n",
     "invoke": "Tag(TagProps{Label: \"stable\", Active: true})"
   },
   {


### PR DESCRIPTION
## Problem

`gsx fmt` collapsed an inline-only control-flow body (or element/fragment children) onto one line whenever it fit the print width, discarding the vertical layout the author wrote:

```gsx
{ if props.viewing != nil {
	{ *props.viewing }
} }
```

was reformatted to `{ if props.viewing != nil { { *props.viewing } } }`. The printer decided layout purely from content (`hasBlockChild`) and never consulted the source.

## Fix

Record the author's intent at parse time and honor it in the printer — the same way `gofmt` keeps a composite literal multi-line when its first element sits below the opening brace:

- **ast** — new bool fields: `IfMarkup.ThenMultiline`/`ElseMultiline`, `ForMarkup.BodyMultiline`, `Element.ChildrenMultiline`, `Fragment.ChildrenMultiline`.
- **parser** — `newlineFollows()` sets each flag when a line break immediately follows the body's opening `{` / element's `>` / fragment's `<>`.
- **printer** — ORs the flag into the existing force-break, **after** the edge-safety guard, so a significant-space body still stays inline for correctness.

Written inline stays inline; written multi-line stays multi-line. A block-level child still forces the enclosing body to break regardless. `switch`/`component` bodies already always break; raw-text/`pre`/`textarea` are untouched. **No syntax change**, so no sibling grammar updates.

## Verification

- Full corpus **idempotence + faithfulness** pass uncached; `gsx fmt -l .` shows zero repo-wide drift; `make lint` green.
- Subtle boundary covered: author newline **but** a trailing significant space correctly stays inline (edge guard wins).
- 10 printer layout tests + a parser flag test (inline/broken/CRLF/else-if). `TestFragment` updated (it encoded the old collapse behavior).
- Non-semantic layout bools are cleared in `TestCorpusFaithfulness`'s `zeroSpans`.

Two docs examples whose `.gsx` sources are authored multi-line now render multi-line (regenerated via `make examples`).

Spec: `docs/superpowers/specs/2026-07-06-fmt-preserve-author-line-breaks-design.md`. Behavior documented in `docs/guide/cli.md`.

https://claude.ai/code/session_01L1m6kX2zAJ8pQVgDNUoeSS