### PR TITLE
Tag-aware .gsx analysis: tolerate same-name build-tag component variants

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -540,10 +540,16 @@ vocabulary remains a design aspiration, not the current API.
   `.gsx`-only and `//line` is excluded. Generation stays build-context-independent
   (every `.gsx` generates regardless of host `GOOS`); constraints take effect at
   `go build`. See `docs/guide/syntax.md` §Build constraints.
-- [ ] **Tag-aware `.gsx` analysis** — duplicate component names across mutually
-  exclusive build constraints (two `.gsx` files gated by disjoint `//go:build`
-  tags) currently collide, because analysis type-checks a package's `.gsx` files
-  as one unit regardless of build tags.
+- [x] **Tag-aware `.gsx` analysis** — two `.gsx` files gated by disjoint
+  `//go:build` tags may declare the same component when their signatures match:
+  the cross-file `redeclared` type errors are suppressed so `Generate` emits all
+  files (go build filters by tag and arbitrates real same-config duplicates),
+  while a same-name/*different*-signature component collision is a clean
+  `duplicate-component` error that blocks emission. gsx never parses build
+  constraints. LSP go-to-definition / find-references are multi-valued over the
+  variants. Non-component cross-file helper duplicates are tolerated (deferred to
+  go build); within-file redeclarations stay hard errors. Spec
+  `2026-07-06-tag-variant-component-analysis-design.md`.
 - [ ] **Tooling performance measurement on a realistic large corpus** — the
   existing baseline (`gen/perf_test.go`, `GSX_PERF=1`; note
   `2026-06-24-go-to-gsx-perf.md`) uses a *synthetic* 50-package fixture: ~383 ms/package

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -70,9 +70,23 @@ cross-compilation. Prose comments (license headers, docs) stay in the `.gsx`
 only. Note the explicit constraint comment is the only mechanism: generated
 file names never acquire Go's implicit `_GOOS` filename constraints.
 
-One current limitation: two `.gsx` files with mutually exclusive constraints
-may not declare the same component name — analysis type-checks a package's
-`.gsx` files as one unit (see ROADMAP).
+### Build-tag component variants
+
+Two `.gsx` files under mutually exclusive `//go:build` constraints may declare a
+component with the **same name**, as long as they share the **same signature**
+(same props, same generic parameters, same receiver). gsx generates a `.x.go`
+for every file regardless of tags; `go build` then compiles exactly the variant
+whose constraint matches the build, exactly as it does for Go's own
+`foo_linux.go` / `foo_windows.go` files.
+
+gsx does not evaluate build tags itself. If two same-named components have
+**different** signatures, gsx reports a `duplicate-component` error — build-tag
+variants must be drop-in replacements. A genuinely duplicated component with no
+tags is reported by `go build` (the generated files collide), which remains the
+authority on same-configuration duplicates.
+
+Editor go-to-definition and find-references on such a component show **all**
+variants, so you can jump to the platform you care about.
 
 ## Quick reference
 

--- a/docs/superpowers/plans/2026-07-06-tag-variant-component-analysis.md
+++ b/docs/superpowers/plans/2026-07-06-tag-variant-component-analysis.md
@@ -1,0 +1,1287 @@
+# Tag-variant Component Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let two `.gsx` files under disjoint `//go:build` tags declare the same component without breaking analysis: tolerate same-name + same-signature variants, raise a clean error on same-name + different-signature, and make the LSP show all variants.
+
+**Architecture:** gsx never parses build constraints — generation stays build-context-independent and `go build` filters by tag. The fix is (1) suppress the go/types `redeclared` errors that arise from *cross-file* duplicate top-level decls so `Generate` stops skipping the whole package, (2) detect same-name-different-signature *component* collisions ourselves and report a friendly `duplicate-component` error that blocks emission, and (3) make the component cross-navigation index multi-valued so LSP go-to-definition / find-references return every variant. Emit is unchanged and relies on go/types resolving both duplicate bodies best-effort (probe-confirmed).
+
+**Tech Stack:** Go, `go/types`, `go/ast`; gsx internal packages `internal/codegen`, `internal/lsp`, `internal/corpus` (txtar golden harness).
+
+**Design doc:** `docs/superpowers/specs/2026-07-06-tag-variant-component-analysis-design.md`
+
+## Global Constraints
+
+- Runtime (module root `gsx`) is **standard-library only**. This work is entirely in `internal/codegen` / `internal/lsp` / tests (tooling), which may use `golang.org/x/tools` — but none is needed here; std `go/types`/`go/ast` suffice.
+- gsx does **NOT** import `go/build/constraint` or `go/build.Context`, and does **NOT** evaluate GOOS/GOARCH/tags anywhere in this work. `//go:build` stays opaque pass-through text.
+- **Don't hand-edit `.x.go` or `*.golden` files** — regenerate with `go test ./internal/corpus -run TestCorpus -update`, then verify without `-update`.
+- Every codegen behavior change ships a **corpus case** (`internal/corpus/testdata/cases/**/*.txtar`).
+- Pin Go to `GO_VERSION` in `.github/workflows/ci.yml` (currently 1.26.1) — a different minor reintroduces gofmt drift.
+- Prefer **unexported** identifiers unless serialization requires export.
+- Diagnostic code string for the different-signature error: **`duplicate-component`** (string codes, not numeric — matches existing `invalid-syntax` style).
+- Run `make check` for the inner loop; `make ci` before merge.
+
+---
+
+### Task 1: Component signature canonicalization
+
+Produce a canonical string for a component's *caller* signature so two variants can be compared for drop-in equivalence: props field set (name + normalized type), synthesized `Children`/`Attrs` presence, generic type params, and receiver type.
+
+**Files:**
+- Create: `internal/codegen/variantcollide.go`
+- Test: `internal/codegen/variantcollide_test.go`
+
+**Interfaces:**
+- Produces: `func componentSignature(c *gsxast.Component) string` — a canonical, comparison-ready signature string. Deterministic; ignores param *order* (props map by name) and receiver *variable* name; includes receiver type + pointer-ness, normalized type-param source, each `fieldName(param)` + whitespace-normalized type, and the synthesized `Children`/`Attrs` pseudo-fields when `usesChildren`/`usesAttrs` report them.
+- Consumes (existing helpers in `internal/codegen`): `parseParams(string) ([]param, error)` (`analyze.go`), `parseRecv(string) (var, ptr, typeName string, err error)` (returns 4 values; 2nd is the pointer marker), `fieldName(string) string`, `usesChildren([]gsxast.Markup) bool`, `usesAttrs([]gsxast.Markup) bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package codegen
+
+import (
+	"testing"
+
+	"github.com/gsxhq/gsx/parser"
+	"go/token"
+)
+
+// parseComponent parses a single-component .gsx source and returns the Component.
+func parseComponent(t *testing.T, src string) *gsxComponentForTest {
+	t.Helper()
+	return parseComponentsForTest(t, src)[0]
+}
+
+func TestComponentSignature(t *testing.T) {
+	// Same props, different body → SAME signature (drop-in variant).
+	a := mustParseComponent(t, "package v\ncomponent Icon(name string) {\n\t<span>{ name }</span>\n}\n")
+	b := mustParseComponent(t, "package v\ncomponent Icon(name string) {\n\t<b>{ name }</b>\n}\n")
+	if componentSignature(a) != componentSignature(b) {
+		t.Fatalf("same-props variants must share a signature:\n a=%q\n b=%q", componentSignature(a), componentSignature(b))
+	}
+
+	// Different prop type → DIFFERENT signature.
+	c := mustParseComponent(t, "package v\ncomponent Icon(name int) {\n\t<span>{ name }</span>\n}\n")
+	if componentSignature(a) == componentSignature(c) {
+		t.Fatalf("different prop type must differ: %q", componentSignature(a))
+	}
+
+	// Param order does not matter (props map by name).
+	d := mustParseComponent(t, "package v\ncomponent Icon(x string, y string) { <i/> }\n")
+	e := mustParseComponent(t, "package v\ncomponent Icon(y string, x string) { <i/> }\n")
+	if componentSignature(d) != componentSignature(e) {
+		t.Fatalf("param order must not affect signature")
+	}
+
+	// Children presence is part of the signature.
+	f := mustParseComponent(t, "package v\ncomponent Box() { <div>{ children }</div> }\n")
+	g := mustParseComponent(t, "package v\ncomponent Box() { <div/> }\n")
+	if componentSignature(f) == componentSignature(g) {
+		t.Fatalf("children presence must differ")
+	}
+}
+```
+
+Add this helper to the test file (parses via the real parser, returns the first `*gsxast.Component`):
+
+```go
+func mustParseComponent(t *testing.T, src string) *gsxast.Component {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, errs := parser.ParseFileWithClassifier(fset, "input.gsx", []byte(src), 0, nil)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	for _, d := range file.Decls {
+		if c, ok := d.(*gsxast.Component); ok {
+			return c
+		}
+	}
+	t.Fatal("no component")
+	return nil
+}
+```
+
+Add imports `gsxast "github.com/gsxhq/gsx/ast"` and remove the placeholder `parseComponent`/`parseComponentsForTest` references (they were illustrative — use `mustParseComponent`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen -run TestComponentSignature -v`
+Expected: FAIL — `undefined: componentSignature`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+package codegen
+
+import (
+	"sort"
+	"strings"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+)
+
+// componentSignature returns a canonical string of a component's CALLER
+// signature — what a `<Comp .../>` invocation type-checks against. Two
+// components with the same componentKey that share this signature are drop-in
+// build-tag variants (same name, different body); one with a different
+// signature is a genuine conflict. The string is comparison-only (not parsed);
+// it is order-independent over props (attrs map to fields by name) and ignores
+// the receiver VARIABLE name.
+func componentSignature(c *gsxast.Component) string {
+	var b strings.Builder
+
+	// Receiver: type + pointer-ness (a method vs func component, and the owning
+	// type, are caller-visible; the receiver var name is not).
+	if c.Recv != "" {
+		if _, ptr, recvType, err := parseRecv(c.Recv); err == nil {
+			b.WriteString("recv:")
+			b.WriteString(ptr)
+			b.WriteString(recvType)
+		} else {
+			b.WriteString("recv:<unparsable>")
+		}
+	}
+	b.WriteByte('|')
+
+	// Generic type params: normalized source.
+	b.WriteString("tp:")
+	b.WriteString(strings.Join(strings.Fields(c.TypeParams), " "))
+	b.WriteByte('|')
+
+	// Props: sorted "FieldName type" entries, plus synthesized Children/Attrs.
+	var fields []string
+	if params, err := parseParams(c.Params); err == nil {
+		for _, p := range params {
+			fields = append(fields, fieldName(p.name)+" "+strings.Join(strings.Fields(p.typ), " "))
+		}
+	}
+	if usesChildren(c.Body) {
+		fields = append(fields, "Children gsx.Node")
+	}
+	if usesAttrs(c.Body) {
+		fields = append(fields, "Attrs gsx.Attrs")
+	}
+	sort.Strings(fields)
+	b.WriteString("props:")
+	b.WriteString(strings.Join(fields, ";"))
+	return b.String()
+}
+```
+
+Note: confirm `parseRecv`'s 2nd return is the pointer marker (`"*"` or `""`). If its shape differs, adapt the `ptr` usage — the canonical string only needs to be *stable and discriminating*, so include whatever pointer signal `parseRecv` exposes. If `param` uses field names other than `name`/`typ`, match them (`grep -n "type param struct" internal/codegen/*.go`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/codegen -run TestComponentSignature -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/variantcollide.go internal/codegen/variantcollide_test.go
+git commit -m "feat(codegen): componentSignature for tag-variant equivalence
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 2: Detect same-name / different-signature component collisions
+
+Find components sharing a `componentKey` across **different files** whose signatures differ — these are the conflicts that get a friendly error.
+
+**Files:**
+- Modify: `internal/codegen/variantcollide.go`
+- Test: `internal/codegen/variantcollide_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type conflictComp struct { path string; comp *gsxast.Component }`
+  - `type signatureConflict struct { key string; comps []conflictComp }` — all cross-file decls of a key that has ≥2 distinct signatures.
+  - `func detectSignatureConflicts(files map[string]*gsxast.File) []signatureConflict` — deterministic (sorted by key). Only considers `*gsxast.Component` decls; a key whose decls are all in one file, or all share one signature, produces no conflict.
+- Consumes: `componentKey(c *gsxast.Component) string` (`analyze.go`), `componentSignature` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDetectSignatureConflicts(t *testing.T) {
+	filesOf := func(srcs map[string]string) map[string]*gsxast.File {
+		out := map[string]*gsxast.File{}
+		for name, src := range srcs {
+			fset := token.NewFileSet()
+			f, errs := parser.ParseFileWithClassifier(fset, name, []byte(src), 0, nil)
+			if len(errs) > 0 {
+				t.Fatalf("%s: %v", name, errs)
+			}
+			out[name] = f
+		}
+		return out
+	}
+
+	// Same name, same signature, different files → NO conflict (tolerated variant).
+	same := filesOf(map[string]string{
+		"a.gsx": "package v\ncomponent Icon(name string) { <a>{ name }</a> }\n",
+		"b.gsx": "package v\ncomponent Icon(name string) { <b>{ name }</b> }\n",
+	})
+	if got := detectSignatureConflicts(same); len(got) != 0 {
+		t.Fatalf("same-sig variants: want 0 conflicts, got %d", len(got))
+	}
+
+	// Same name, DIFFERENT signature, different files → conflict.
+	diff := filesOf(map[string]string{
+		"a.gsx": "package v\ncomponent Icon(name string) { <a>{ name }</a> }\n",
+		"b.gsx": "package v\ncomponent Icon(name int) { <b>{ name }</b> }\n",
+	})
+	got := detectSignatureConflicts(diff)
+	if len(got) != 1 || got[0].key != ".Icon" || len(got[0].comps) != 2 {
+		t.Fatalf("diff-sig: want 1 conflict on .Icon with 2 comps, got %+v", got)
+	}
+
+	// Same name twice in ONE file → NOT our conflict (within-file; left to raw error).
+	within := filesOf(map[string]string{
+		"a.gsx": "package v\ncomponent Icon(name string) { <a/> }\ncomponent Icon(name int) { <b/> }\n",
+	})
+	if got := detectSignatureConflicts(within); len(got) != 0 {
+		t.Fatalf("within-file dup: want 0 conflicts, got %d", len(got))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen -run TestDetectSignatureConflicts -v`
+Expected: FAIL — `undefined: detectSignatureConflicts`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/codegen/variantcollide.go`:
+
+```go
+import "sort" // already imported at top; keep one import block
+
+type conflictComp struct {
+	path string
+	comp *gsxast.Component
+}
+
+type signatureConflict struct {
+	key   string
+	comps []conflictComp
+}
+
+// detectSignatureConflicts finds components that share a componentKey across
+// DIFFERENT files but do not share a signature — a genuine ambiguity gsx
+// cannot paper over. A key whose cross-file decls all share one signature is a
+// tolerated build-tag variant (no conflict); a key declared twice in a single
+// file is a within-file redeclaration left to the raw go/types error.
+func detectSignatureConflicts(files map[string]*gsxast.File) []signatureConflict {
+	type decl struct {
+		path string
+		comp *gsxast.Component
+		sig  string
+	}
+	byKey := map[string][]decl{}
+	// Iterate files in sorted path order for determinism.
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		for _, d := range files[p].Decls {
+			c, ok := d.(*gsxast.Component)
+			if !ok {
+				continue
+			}
+			key := componentKey(c)
+			byKey[key] = append(byKey[key], decl{p, c, componentSignature(c)})
+		}
+	}
+
+	var out []signatureConflict
+	keys := make([]string, 0, len(byKey))
+	for k := range byKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		decls := byKey[key]
+		// Distinct files that declare this key.
+		fileSet := map[string]bool{}
+		sigSet := map[string]bool{}
+		for _, d := range decls {
+			fileSet[d.path] = true
+			sigSet[d.sig] = true
+		}
+		if len(fileSet) < 2 || len(sigSet) < 2 {
+			continue // single-file (within-file) or all one signature (tolerated)
+		}
+		comps := make([]conflictComp, 0, len(decls))
+		for _, d := range decls {
+			comps = append(comps, conflictComp{d.path, d.comp})
+		}
+		out = append(out, signatureConflict{key: key, comps: comps})
+	}
+	return out
+}
+```
+
+Merge the `sort` import into the existing import block rather than adding a second one.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/codegen -run TestDetectSignatureConflicts -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/variantcollide.go internal/codegen/variantcollide_test.go
+git commit -m "feat(codegen): detect same-name different-signature component conflicts
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 3: Suppress cross-file redeclaration type errors
+
+A `redeclared` / `other declaration of` error pair whose two decls live in **different** skeleton files is a tolerated cross-tag variant (component OR helper) and must be dropped so it does not fail the package. Same-file redeclarations are kept.
+
+**Files:**
+- Modify: `internal/codegen/variantcollide.go`
+- Test: `internal/codegen/variantcollide_test.go`
+
+**Interfaces:**
+- Produces: `func suppressCrossFileRedeclarations(errs []types.Error) []types.Error` — returns `errs` with every redeclaration-class error dropped **iff** the group of errors sharing that declared name references ≥2 distinct files (via `e.Fset.Position(e.Pos).Filename`). Non-redeclaration errors pass through untouched; within-file redeclarations pass through.
+- Consumes: `types.Error` (fields `Fset`, `Pos`, `Msg`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+import "go/types" // add to test imports
+
+func TestSuppressCrossFileRedeclarations(t *testing.T) {
+	fset := token.NewFileSet()
+	fa := fset.AddFile("a.x.go", -1, 100)
+	fb := fset.AddFile("b.x.go", -1, 100)
+	posA := fa.Pos(10)
+	posB := fb.Pos(10)
+
+	// Cross-file redeclaration of Icon → both dropped.
+	// Within-file redeclaration of Dup (both in a.x.go) → both kept.
+	// An unrelated type error → kept.
+	posA2 := fa.Pos(40)
+	posA3 := fa.Pos(60)
+	errs := []types.Error{
+		{Fset: fset, Pos: posB, Msg: "Icon redeclared in this block"},
+		{Fset: fset, Pos: posA, Msg: "other declaration of Icon"},
+		{Fset: fset, Pos: posA2, Msg: "Dup redeclared in this block"},
+		{Fset: fset, Pos: posA3, Msg: "other declaration of Dup"},
+		{Fset: fset, Pos: posA, Msg: "undefined: Whatever"},
+	}
+	got := suppressCrossFileRedeclarations(errs)
+
+	var msgs []string
+	for _, e := range got {
+		msgs = append(msgs, e.Msg)
+	}
+	// Icon pair gone; Dup pair + undefined kept.
+	for _, e := range got {
+		if strings.Contains(e.Msg, "Icon") {
+			t.Fatalf("cross-file Icon redeclaration should be suppressed, got %q", e.Msg)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 kept (2 Dup + 1 undefined), got %d: %v", len(got), msgs)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen -run TestSuppressCrossFileRedeclarations -v`
+Expected: FAIL — `undefined: suppressCrossFileRedeclarations`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/codegen/variantcollide.go`:
+
+```go
+import "go/types" // merge into the existing import block
+
+// redeclName extracts the declared name from a go/types redeclaration-class
+// error message, or ("", false) if the error is not redeclaration-class. It
+// recognizes both records go/types emits: "<name> redeclared in this block"
+// (at the second decl) and "other declaration of <name>" (at the first).
+func redeclName(msg string) (string, bool) {
+	msg = strings.TrimSpace(msg)
+	if i := strings.Index(msg, " redeclared"); i > 0 {
+		return msg[:i], true
+	}
+	const p = "other declaration of "
+	if strings.HasPrefix(msg, p) {
+		return strings.TrimSpace(msg[len(p):]), true
+	}
+	return "", false
+}
+
+// suppressCrossFileRedeclarations drops redeclaration-class errors whose
+// declared name is redeclared ACROSS files (a tolerated cross-tag variant of a
+// component or helper). A same-file redeclaration keeps its error (a real
+// within-file mistake), as do all non-redeclaration errors. gsx does not parse
+// build tags; go build remains the arbiter of whether a cross-file same-name
+// pair is an actual same-configuration duplicate.
+func suppressCrossFileRedeclarations(errs []types.Error) []types.Error {
+	// filesByName[name] = set of distinct filenames where a redeclaration-class
+	// error for that name was reported.
+	filesByName := map[string]map[string]bool{}
+	for _, e := range errs {
+		if name, ok := redeclName(e.Msg); ok {
+			fn := e.Fset.Position(e.Pos).Filename
+			if filesByName[name] == nil {
+				filesByName[name] = map[string]bool{}
+			}
+			filesByName[name][fn] = true
+		}
+	}
+	kept := errs[:0]
+	for _, e := range errs {
+		if name, ok := redeclName(e.Msg); ok && len(filesByName[name]) >= 2 {
+			continue // cross-file variant: tolerate
+		}
+		kept = append(kept, e)
+	}
+	return kept
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/codegen -run TestSuppressCrossFileRedeclarations -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/variantcollide.go internal/codegen/variantcollide_test.go
+git commit -m "feat(codegen): suppress cross-file redeclaration type errors
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 4: Wire suppression + conflicts into analysis and gate emission
+
+Call the Task 3 filter in `analyze`, detect Task 2 conflicts, add friendly diagnostics, store conflicts on the analysis result, and widen the two emit guards so a different-signature conflict blocks emission.
+
+**Files:**
+- Modify: `internal/codegen/module_importer.go` (struct `analyzed` ~line 602; typeErrs filter region ~line 943; result assembly ~line 1114)
+- Modify: `internal/codegen/module.go` (emit guards at ~line 405 and ~line 457)
+- Test: `internal/codegen/variant_generate_test.go` (create)
+
+**Interfaces:**
+- Consumes: `suppressCrossFileRedeclarations`, `detectSignatureConflicts` (Tasks 2–3); `bag.Errorf(pos, end token.Pos, code string, format string, args ...any)` (`internal/diag`).
+- Produces: new field `signatureConflicts []signatureConflict` on `analyzed`; the emit guards in `module.go` become `len(a.typeErrs) == 0 && len(a.signatureConflicts) == 0`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeModule writes a go.mod + files and returns the dir.
+func writeVariantModule(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	files["go.mod"] = "module variantprobe\n\ngo 1.26\n\nrequire github.com/gsxhq/gsx v0.0.0\n"
+	for name, src := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestSameSigVariantGeneratesAllFiles(t *testing.T) {
+	dir := writeVariantModule(t, map[string]string{
+		"icon_linux.gsx":   "//go:build linux\n\npackage views\n\ncomponent Icon(name string) { <span>linux:{ name }</span> }\n",
+		"icon_windows.gsx": "//go:build windows\n\npackage views\n\ncomponent Icon(name string) { <span>win:{ name }</span> }\n",
+		"page.gsx":         "package views\n\ncomponent Page() { <Icon name=\"x\"/> }\n",
+	})
+	m := newTestModule(t, dir) // see note below
+	out, diags, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if hasError(diags) {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	// All three .gsx must produce .x.go — the redeclared must NOT skip the package.
+	for _, want := range []string{"icon_linux.gsx", "icon_windows.gsx", "page.gsx"} {
+		if _, ok := out[want]; !ok {
+			t.Fatalf("missing generated output for %s; got keys %v", want, keysOf(out))
+		}
+	}
+	// Each variant's generated code carries its //go:build directive.
+	if !strings.Contains(string(out["icon_linux.gsx"]), "//go:build linux") {
+		t.Fatalf("linux variant lost its build constraint")
+	}
+}
+
+func TestDiffSigVariantIsCleanError(t *testing.T) {
+	dir := writeVariantModule(t, map[string]string{
+		"icon_linux.gsx":   "//go:build linux\n\npackage views\n\ncomponent Icon(name string) { <span>{ name }</span> }\n",
+		"icon_windows.gsx": "//go:build windows\n\npackage views\n\ncomponent Icon(name int) { <span>{ name }</span> }\n",
+	})
+	m := newTestModule(t, dir)
+	out, diags, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !hasError(diags) {
+		t.Fatalf("expected a duplicate-component error, got none")
+	}
+	foundClean := false
+	for _, d := range diags {
+		if d.Code == "duplicate-component" {
+			foundClean = true
+		}
+		if strings.Contains(d.Message, "redeclared in this block") {
+			t.Fatalf("raw redeclared error leaked: %q", d.Message)
+		}
+	}
+	if !foundClean {
+		t.Fatalf("no duplicate-component diagnostic in %v", diags)
+	}
+	if len(out) != 0 {
+		t.Fatalf("diff-sig conflict must block emission, got %v", keysOf(out))
+	}
+}
+```
+
+Before writing production code, discover the existing test helpers for constructing a `Module` and inspecting diagnostics: `grep -rn "func New(\|func.*Module\b\|hasError\|newTestModule\|Severity == diag.Error" internal/codegen/*_test.go internal/codegen/module.go`. Reuse the real constructor (likely `codegen.New(opts)` / `NewModule`). Implement `newTestModule`, `hasError`, `keysOf` as thin local helpers in the test file if they don't already exist (a `diag.Diagnostic` has `.Severity`, `.Code`, `.Message`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen -run 'TestSameSigVariant|TestDiffSigVariant' -v`
+Expected: FAIL — `TestSameSigVariant` fails because the redeclared error skips the whole package (empty `out`); `TestDiffSigVariant` fails because `signatureConflicts`/`duplicate-component` don't exist yet.
+
+- [ ] **Step 3a: Add the struct field**
+
+In `internal/codegen/module_importer.go`, add to `type analyzed struct` (near the `typeErrs` field, ~line 625):
+
+```go
+	signatureConflicts []signatureConflict // same-name different-signature component collisions (block emission)
+```
+
+- [ ] **Step 3b: Suppress redeclarations after the existing typeErrs filter**
+
+In `analyze`, immediately AFTER the `sunkImports` filter block that ends with `typeErrs = kept` (~line 943, before the `quietSpans` loop), insert:
+
+```go
+	// Tolerate cross-file duplicate top-level decls (same-name build-tag
+	// variants — components or helpers). gsx does not parse build tags; go
+	// build filters by tag and is the arbiter of a real same-config duplicate.
+	// Runs before the diagnostics loop below so a tolerated redeclaration never
+	// becomes a bag diagnostic AND never lands in the stored a.typeErrs (which
+	// gates emission). Same-file redeclarations are untouched.
+	typeErrs = suppressCrossFileRedeclarations(typeErrs)
+```
+
+- [ ] **Step 3c: Detect conflicts and add friendly diagnostics**
+
+In `analyze`, near where the result is assembled (before `return &analyzed{...}` ~line 1114), add:
+
+```go
+	// A same-name component declared with DIFFERENT signatures across files is a
+	// genuine ambiguity (its cross-file redeclaration was suppressed above, so
+	// nothing else will flag it). Report a clean duplicate-component error at
+	// each site and record the conflict so emission is blocked (module.go gates
+	// on len(signatureConflicts)==0 as well as len(typeErrs)==0).
+	sigConflicts := detectSignatureConflicts(gsxFiles)
+	for _, sc := range sigConflicts {
+		var files []string
+		for _, cc := range sc.comps {
+			files = append(files, filepath.Base(cc.path))
+		}
+		for _, cc := range sc.comps {
+			bag.Errorf(cc.comp.NamePos, cc.comp.NamePos+token.Pos(len(cc.comp.Name)), "duplicate-component",
+				"component %s is declared with different signatures across build-tagged files (%s); build-tag variants must share the same signature — rename the variants or align their parameters",
+				cc.comp.Name, strings.Join(files, ", "))
+		}
+	}
+```
+
+Confirm `gsxFiles` (the `map[string]*gsxast.File`) is in scope at this point in `analyze` (it is — it is iterated earlier in the skeleton-build loop). Confirm `filepath`, `token`, `strings` are imported (they are).
+
+Then add `signatureConflicts: sigConflicts,` to the `return &analyzed{...}` literal.
+
+- [ ] **Step 3d: Widen the emit guards**
+
+In `internal/codegen/module.go`, change BOTH guards:
+
+Line ~405 (`Package`):
+```go
+	if len(a.typeErrs) == 0 && len(a.signatureConflicts) == 0 {
+```
+Line ~457 (`Generate`):
+```go
+	if len(a.typeErrs) == 0 && len(a.signatureConflicts) == 0 {
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/codegen -run 'TestSameSigVariant|TestDiffSigVariant' -v`
+Expected: PASS. Then the whole package: `go test ./internal/codegen` — expected PASS (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/module_importer.go internal/codegen/module.go internal/codegen/variant_generate_test.go
+git commit -m "feat(codegen): tolerate same-sig variants, block diff-sig conflicts
+
+Suppress cross-file redeclarations so a same-name build-tag variant no longer
+skips the whole package; detect same-name/different-signature component
+collisions and report a clean duplicate-component error that blocks emission.
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 5: Corpus cases + `go build -tags` probe
+
+Pin the behavior in the canonical txtar corpus and prove the generated variants actually compile-select under `go build -tags`.
+
+**Files:**
+- Create: `internal/corpus/testdata/cases/buildtags/variant_same_sig.txtar`
+- Create: `internal/corpus/testdata/cases/buildtags/variant_diff_sig.txtar`
+- Create: `internal/corpus/testdata/cases/buildtags/redeclare_within_file.txtar`
+- Create: `internal/corpus/testdata/cases/buildtags/helper_variant.txtar`
+- Create: `internal/codegen/buildtag_select_test.go`
+
+**Interfaces:** none (golden + build tests).
+
+- [ ] **Step 1: Write the same-signature corpus case**
+
+`internal/corpus/testdata/cases/buildtags/variant_same_sig.txtar` — a host-neutral pair of constraints (`!never` / `never`) so `render.golden` runs everywhere and only ONE variant is active during the corpus render build:
+
+```
+-- icon.gsx --
+//go:build !never
+
+package views
+
+component Icon(name string) {
+	<span class="active">{ name }</span>
+}
+-- icon_never.gsx --
+//go:build never
+
+package views
+
+component Icon(name string) {
+	<span class="never">{ name }</span>
+}
+-- page.gsx --
+package views
+
+component Page() {
+	<Icon name="x"/>
+}
+-- invoke --
+Page()
+-- diagnostics.golden --
+-- render.golden --
+<span class="active">x</span>
+```
+
+- [ ] **Step 2: Write the different-signature (error) corpus case**
+
+`internal/corpus/testdata/cases/buildtags/variant_diff_sig.txtar`:
+
+```
+-- icon.gsx --
+//go:build !never
+
+package views
+
+component Icon(name string) {
+	<span>{ name }</span>
+}
+-- icon_never.gsx --
+//go:build never
+
+package views
+
+component Icon(name int) {
+	<span>{ name }</span>
+}
+-- invoke --
+-- diagnostics.golden --
+```
+
+Leave `diagnostics.golden` empty for now; `-update` fills it. Verify after update that it contains a `duplicate-component` diagnostic and NO `redeclared in this block`. (No `render.golden` — an error case emits nothing.)
+
+- [ ] **Step 3: Write the within-file redeclaration case (still an error)**
+
+`internal/corpus/testdata/cases/buildtags/redeclare_within_file.txtar`:
+
+```
+-- input.gsx --
+package views
+
+component Icon(name string) {
+	<a/>
+}
+
+component Icon(name string) {
+	<b/>
+}
+-- invoke --
+-- diagnostics.golden --
+```
+
+`-update` fills `diagnostics.golden`; verify it retains the raw `redeclared in this block` (within-file is NOT tolerated).
+
+- [ ] **Step 4: Write the non-component helper-variant case**
+
+`internal/corpus/testdata/cases/buildtags/helper_variant.txtar` — two files with a same-name GoChunk helper under disjoint tags, tolerated (generates):
+
+```
+-- icon.gsx --
+//go:build !never
+
+package views
+
+{{
+	const iconPath = "/active.svg"
+}}
+
+component Icon() {
+	<img src={ iconPath }/>
+}
+-- icon_never.gsx --
+//go:build never
+
+package views
+
+{{
+	const iconPath = "/never.svg"
+}}
+
+component IconNever() {
+	<img src={ iconPath }/>
+}
+-- invoke --
+Icon()
+-- diagnostics.golden --
+-- render.golden --
+<img src="/active.svg"/>
+```
+
+(Distinct component names — `Icon`/`IconNever` — isolate the *helper* `iconPath` collision from the component path; the point is that the duplicate `iconPath` const across files no longer fails the package.)
+
+- [ ] **Step 5: Regenerate goldens and verify**
+
+Run:
+```bash
+go test ./internal/corpus -run TestCorpus -update
+go test ./internal/corpus -run TestCorpus
+```
+Expected: PASS. Inspect the four new `*.golden` blocks — confirm `variant_diff_sig` diagnostics show `duplicate-component` and no `redeclared`, and `redeclare_within_file` keeps the raw `redeclared`.
+
+If the corpus harness does not pick up multi-`.gsx` cases automatically, check `internal/corpus/batch.go` (`packageNameInDir`, the `.gsx` glob) — cases here rely on every `*.gsx` in the case dir being one package. Confirm with `go test ./internal/corpus -run TestCorpus/buildtags -v`.
+
+- [ ] **Step 6: Write the `go build -tags` selection test**
+
+`internal/codegen/buildtag_select_test.go` — generate a variant module, write the `.x.go`, and confirm `go build -tags` picks the matching variant (mirrors the existing `TestBuildTagExcludesGeneratedFile` in `directive_passthrough_test.go` — read it first for the exact scaffold/module-wiring idiom):
+
+```go
+package codegen
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Generates two same-sig Icon variants gated on a custom tag, writes .x.go,
+// and asserts `go build -tags variantB` compiles the B body (and A is excluded).
+func TestBuildTagSelectsVariant(t *testing.T) {
+	// Reuse the directive_passthrough_test.go scaffolding helpers (probe module
+	// with a real gsx dependency via go.mod replace). See that file for
+	// writeProbeModule / runGoBuild equivalents; replicate its setup here.
+	t.Skip("implement using the directive_passthrough_test.go scaffold idiom")
+	_ = exec.Command
+	_ = strings.TrimSpace
+}
+```
+
+Replace the `t.Skip` with a real build once you have read `directive_passthrough_test.go`: two variants `//go:build variantA` / `//go:build variantB`, `Generate`, write outputs to disk, `go build -tags variantB ./...` succeeds, and a body-unique string (e.g. a distinct static text per variant) confirms selection. Do NOT leave the skip in the final commit.
+
+- [ ] **Step 7: Run and commit**
+
+Run: `go test ./internal/corpus ./internal/codegen -run 'TestCorpus|TestBuildTagSelectsVariant'`
+Expected: PASS.
+
+```bash
+git add internal/corpus/testdata/cases/buildtags internal/codegen/buildtag_select_test.go
+git commit -m "test(codegen): corpus + build-tag probe for tag-variant components
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 6: Multi-valued component cross-index (codegen side)
+
+Make the cross-navigation index carry every variant's declaration position, so downstream LSP can show them all.
+
+**Files:**
+- Modify: `internal/codegen/results.go` (`CrossRef` ~line 17)
+- Modify: `internal/codegen/module_importer.go` (`compByKey` build ~line 1033)
+- Modify: `internal/codegen/crossnav.go`
+- Test: `internal/codegen/crossnav_test.go` (create or extend)
+
+**Interfaces:**
+- Produces: `CrossRef` gains `Decls []token.Position` (all variant name positions, sorted by filename then offset). `Decl` stays as the primary/first for backward compatibility. The internal `compByKey` becomes `map[string][]*gsxast.Component`.
+- Consumes: unchanged callers still read `CrossRef.Decl`/`.Refs`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package codegen
+
+import "testing"
+
+func TestCrossIndexMultiValuedVariants(t *testing.T) {
+	dir := writeVariantModule(t, map[string]string{
+		"icon_a.gsx": "//go:build !never\n\npackage views\n\ncomponent Icon(name string) { <a>{ name }</a> }\n",
+		"icon_b.gsx": "//go:build never\n\npackage views\n\ncomponent Icon(name string) { <b>{ name }</b> }\n",
+	})
+	m := newTestModule(t, dir)
+	pkg, err := m.Package(dir) // retained analysis path used by the LSP
+	if err != nil {
+		t.Fatalf("Package: %v", err)
+	}
+	cr, ok := pkg.CrossIndex[".Icon"]
+	if !ok {
+		t.Fatal("no CrossIndex entry for .Icon")
+	}
+	if len(cr.Decls) != 2 {
+		t.Fatalf("want 2 variant decls, got %d (%v)", len(cr.Decls), cr.Decls)
+	}
+	if !cr.Decl.IsValid() {
+		t.Fatal("primary Decl must stay valid for back-compat")
+	}
+}
+```
+
+Check the retained-analysis accessor name with `grep -n "func (m \*Module) Package\|CrossIndex" internal/codegen/module.go internal/codegen/results.go`; adapt `m.Package(dir)` / `pkg.CrossIndex` to the real API.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/codegen -run TestCrossIndexMultiValuedVariants -v`
+Expected: FAIL — `cr.Decls undefined` (compile error) → add the field first, then the length assertion fails (only 1 today).
+
+- [ ] **Step 3a: Add the field**
+
+`internal/codegen/results.go`:
+
+```go
+type CrossRef struct {
+	Name  string
+	Decl  token.Position   // primary (first) variant — back-compat
+	Decls []token.Position // all variant declaration positions (≥1)
+	Refs  []token.Position
+}
+```
+
+- [ ] **Step 3b: Make compByKey multi-valued**
+
+`internal/codegen/module_importer.go` ~line 1033: change
+
+```go
+	compByKey := map[string]*gsxast.Component{} // componentKey -> component
+```
+to
+```go
+	compByKey := map[string][]*gsxast.Component{} // componentKey -> component(s); >1 = build-tag variants
+```
+and the population (`compByKey[componentKey(c)] = c`) to append:
+```go
+		for _, c := range comps {
+			key := componentKey(c)
+			compByKey[key] = append(compByKey[key], c)
+		}
+```
+Update the `analyzed` field type (`compByKey map[string]*gsxast.Component` ~line 621) to `map[string][]*gsxast.Component`.
+
+- [ ] **Step 3c: Update buildCrossNav**
+
+`internal/codegen/crossnav.go` — change the signature's `compByKey` param to `map[string][]*gsxast.Component`, and rework the two loops that iterate it:
+
+```go
+	index := map[string]CrossRef{}
+	for key, comps := range compByKey {
+		if len(comps) == 0 {
+			continue
+		}
+		cr := CrossRef{Name: comps[0].Name}
+		for _, c := range comps {
+			cr.Decls = append(cr.Decls, gsxFset.Position(c.NamePos))
+		}
+		sortPositions(cr.Decls) // stable: filename then offset
+		cr.Decl = cr.Decls[0]
+		index[key] = cr
+	}
+```
+
+The props-struct/field loop (`for _, c := range compByKey`) must iterate variants too:
+```go
+	for _, comps := range compByKey {
+		for _, c := range comps {
+			// ... existing per-component body, unchanged ...
+		}
+	}
+```
+
+In the `info.Uses` loop, `compByKey[key]` is now a slice — use `compByKey[key][0]` for the `c` used to build the NavRef target (any variant's NamePos is a valid jump target; the first is deterministic after sorting is applied at index-build time — here just take `[0]`), and guard `len(...) > 0`.
+
+Add a small helper at the bottom of `crossnav.go`:
+```go
+func sortPositions(ps []token.Position) {
+	sort.Slice(ps, func(i, j int) bool {
+		if ps[i].Filename != ps[j].Filename {
+			return ps[i].Filename < ps[j].Filename
+		}
+		return ps[i].Offset < ps[j].Offset
+	})
+}
+```
+and import `"sort"`.
+
+- [ ] **Step 3d: Fix the call site**
+
+`internal/codegen/module.go:413` — `buildCrossNav(a.compByKey, ...)` now passes the slice map; no textual change needed if the field type was updated, but rebuild to confirm the types line up.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/codegen -run TestCrossIndexMultiValuedVariants -v`
+Then the whole package: `go test ./internal/codegen`.
+Expected: PASS (existing cross-nav / LSP-bridge tests still green — `Decl` unchanged for single-decl components).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codegen/results.go internal/codegen/module_importer.go internal/codegen/crossnav.go internal/codegen/module.go internal/codegen/crossnav_test.go
+git commit -m "feat(codegen): multi-valued component cross-index for build-tag variants
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 7: LSP go-to-definition shows all variants
+
+`textDocument/definition` on a `<Icon/>` tag returns every variant's location.
+
+**Files:**
+- Modify: `internal/lsp/analysis.go` (mirror `CrossRef` ~line 15 — add `Decls`)
+- Modify: `internal/lsp/definition.go` (`componentTagDeclAt` ~line 612; `handleDefinition` ~line 400)
+- Test: `internal/lsp/definition_test.go` (extend) or `internal/lsp/variant_nav_test.go` (create)
+
+**Interfaces:**
+- Consumes: `codegen.CrossRef.Decls` (Task 6), surfaced onto the LSP `Package.CrossIndex` (the LSP mirrors codegen's CrossRef — confirm the mirror/copy site with `grep -n "CrossIndex\|CrossRef{" internal/lsp/*.go`).
+- Produces: `componentTagDeclAt(pkg, path, off) ([]token.Position, bool)` returning ALL variant decls; `handleDefinition` replies a `[]Location` when >1.
+
+- [ ] **Step 1: Write the failing test**
+
+Read `internal/lsp/definition_test.go` for the existing harness (how a `Server`/`Package` is built and how `handleDefinition` is driven). Then add:
+
+```go
+func TestDefinitionShowsAllVariants(t *testing.T) {
+	// Build an LSP package with two same-sig Icon variants + a Page that uses <Icon/>.
+	// Position the cursor on the "Icon" tag name in page.gsx and expect TWO locations.
+	// (Follow the existing definition_test.go setup for constructing srv/pkg and
+	//  issuing a textDocument/definition request; assert the result is a []Location
+	//  of length 2, one per variant .gsx file.)
+	t.Fatal("write against the definition_test.go harness")
+}
+```
+
+Replace the `t.Fatal` scaffold with the concrete request/assert using the file's existing helpers (mirror an existing D2 tag-definition test and change the fixture to two variant files + assert 2 results).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/lsp -run TestDefinitionShowsAllVariants -v`
+Expected: FAIL (single location today).
+
+- [ ] **Step 3a: Mirror Decls onto the LSP CrossRef**
+
+In `internal/lsp/analysis.go`, add `Decls []token.Position` to the LSP `CrossRef` struct, and wherever the LSP copies `codegen.CrossRef` → `lsp.CrossRef` (the mirror site), copy `Decls` too.
+
+- [ ] **Step 3b: Return all variant decls from componentTagDeclAt**
+
+`internal/lsp/definition.go` — change the signature and the CrossIndex lookup:
+
+```go
+func componentTagDeclAt(pkg *Package, path string, off int) ([]token.Position, bool) {
+	// ... unchanged element-walk to detect the cursor is on a tag name ...
+			if onOpen || onClose {
+				key := "." + tag
+				cr, ok := pkg.CrossIndex[key]
+				if ok {
+					decls := cr.Decls
+					if len(decls) == 0 && cr.Decl.IsValid() {
+						decls = []token.Position{cr.Decl}
+					}
+					if len(decls) > 0 {
+						result = decls
+						found = true
+					}
+				}
+			}
+	// ...
+	return result, found
+}
+```
+(Change the local `result` from `token.Position` to `[]token.Position`.)
+
+- [ ] **Step 3c: Reply multiple locations**
+
+`internal/lsp/definition.go:400` in `handleDefinition`:
+
+```go
+	if decls, ok := componentTagDeclAt(pkg, path, off); ok {
+		if len(decls) == 1 {
+			return s.reply(f.ID, s.locationForPos(decls[0]))
+		}
+		locs := make([]Location, 0, len(decls))
+		for _, d := range decls {
+			locs = append(locs, s.locationForPos(d))
+		}
+		return s.reply(f.ID, locs)
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/lsp -run TestDefinitionShowsAllVariants -v`
+Then `go test ./internal/lsp`.
+Expected: PASS (single-decl definition tests unchanged — they still get one `Location`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/lsp/analysis.go internal/lsp/definition.go internal/lsp/variant_nav_test.go
+git commit -m "feat(lsp): go-to-definition returns all build-tag component variants
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 8: LSP find-references includes all variant declarations
+
+`textDocument/references` lists every variant's declaration alongside the reference sites.
+
+**Files:**
+- Modify: `internal/lsp/references.go` (~line 62 result assembly; ~line 76 `identifyCrossRef`)
+- Test: `internal/lsp/variant_nav_test.go` (extend)
+
+**Interfaces:**
+- Consumes: `CrossRef.Decls` (Tasks 6–7).
+- Produces: references result includes each `Decls` entry (deduped), not only `Decl`.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `internal/lsp/variant_nav_test.go`:
+
+```go
+func TestReferencesIncludesAllVariantDecls(t *testing.T) {
+	// Two same-sig Icon variants + a Page using <Icon/>. Invoke find-references
+	// from the tag site; expect BOTH variant declaration locations to appear in
+	// the results (plus the reference site). Use the references_test.go harness.
+	t.Fatal("write against the references_test.go harness")
+}
+```
+
+Replace the scaffold using the existing `internal/lsp/references_test.go` helpers.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/lsp -run TestReferencesIncludesAllVariantDecls -v`
+Expected: FAIL (only one decl today).
+
+- [ ] **Step 3: Emit every variant decl**
+
+`internal/lsp/references.go` — where the result locations are assembled (~line 62):
+
+```go
+	locs := make([]Location, 0, len(found.Refs)+len(found.Decls))
+	seen := map[string]bool{}
+	addDecl := func(p token.Position) {
+		if !p.IsValid() {
+			return
+		}
+		k := p.Filename + ":" + strconv.Itoa(p.Offset)
+		if seen[k] {
+			return
+		}
+		seen[k] = true
+		locs = append(locs, s.locationForPos(p))
+	}
+	decls := found.Decls
+	if len(decls) == 0 {
+		decls = []token.Position{found.Decl}
+	}
+	for _, d := range decls {
+		addDecl(d)
+	}
+	for _, r := range found.Refs {
+		locs = append(locs, s.locationForRef(r)) // keep existing ref mapping
+	}
+```
+
+Match the existing ref-location call (the code around line 63 already maps `found.Refs` — preserve that exact call; only the decl side changes). Import `"strconv"` if not present.
+
+Also update `identifyCrossRef` (~line 76): a cursor on ANY variant decl should identify the ref — change the `posCoversCursor(cr.Decl, ...)` check to also scan `cr.Decls`:
+
+```go
+	for _, cr := range refs {
+		if posCoversCursor(cr.Decl, path, curLine, curCol, len(cr.Name)) {
+			return &cr
+		}
+		for _, d := range cr.Decls {
+			if posCoversCursor(d, path, curLine, curCol, len(cr.Name)) {
+				return &cr
+			}
+		}
+		for _, r := range cr.Refs {
+			// ... existing ref check ...
+		}
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/lsp -run TestReferencesIncludesAllVariantDecls -v`
+Then `go test ./internal/lsp`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/lsp/references.go internal/lsp/variant_nav_test.go
+git commit -m "feat(lsp): find-references lists all build-tag component variant decls
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+---
+
+### Task 9: Docs, ROADMAP, and full CI
+
+Document the rule and flip the ROADMAP item; run the authoritative CI.
+
+**Files:**
+- Modify: `docs/guide/syntax.md` (§Build constraints)
+- Modify: `docs/ROADMAP.md` (the "Tag-aware `.gsx` analysis" item ~line 543)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Document the variant rule**
+
+In `docs/guide/syntax.md`, under the existing §Build constraints section, add prose (keep any literal `{{ }}` out of prose, or wrap in `::: v-pre` — but this section has none):
+
+```markdown
+### Build-tag component variants
+
+Two `.gsx` files under mutually exclusive `//go:build` constraints may declare a
+component with the **same name**, as long as they share the **same signature**
+(same props, same generic parameters, same receiver). gsx generates a `.x.go`
+for every file regardless of tags; `go build` then compiles exactly the variant
+whose constraint matches the build, exactly as it does for Go's own
+`foo_linux.go` / `foo_windows.go` files.
+
+gsx does not evaluate build tags itself. If two same-named components have
+**different** signatures, gsx reports a `duplicate-component` error — build-tag
+variants must be drop-in replacements. A genuinely duplicated component with no
+tags is reported by `go build` (the generated files collide), which remains the
+authority on same-configuration duplicates.
+
+Editor go-to-definition and find-references on such a component show **all**
+variants, so you can jump to the platform you care about.
+```
+
+- [ ] **Step 2: Flip the ROADMAP item**
+
+In `docs/ROADMAP.md`, change the `- [ ] **Tag-aware \`.gsx\` analysis**` bullet (~line 543) to `- [x]` and rewrite its body to reflect the shipped design:
+
+```markdown
+- [x] **Tag-aware `.gsx` analysis** — two `.gsx` files gated by disjoint
+  `//go:build` tags may declare the same component when their signatures match:
+  the cross-file `redeclared` type errors are suppressed so `Generate` emits all
+  files (go build filters by tag and arbitrates real same-config duplicates),
+  while a same-name/*different*-signature component collision is a clean
+  `duplicate-component` error that blocks emission. gsx never parses build
+  constraints. LSP go-to-definition / find-references are multi-valued over the
+  variants. Non-component cross-file helper duplicates are tolerated (deferred to
+  go build); within-file redeclarations stay hard errors. Spec
+  `2026-07-06-tag-variant-component-analysis-design.md`.
+```
+
+- [ ] **Step 3: Run the authoritative CI**
+
+Run: `make check`
+Expected: PASS (build/vet/test both modules, examples drift, gofmt + gsx fmt). Fix any drift (`go test ./internal/corpus -run TestCorpus -update` if a golden or `coverage.golden` manifest needs a bump; `gofmt -w` / `go run ./cmd/gsx fmt` for formatting).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guide/syntax.md docs/ROADMAP.md internal/corpus/testdata/cases
+git commit -m "docs: build-tag component variants; flip ROADMAP tag-aware analysis
+
+Claude-Session: https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH"
+```
+
+- [ ] **Step 5: Final full CI before merge**
+
+Run: `make ci`
+Expected: PASS (uncached, `-count=1`). This is the gate GitHub runs.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Detection + signature comparison → Tasks 1–2. ✓
+- Suppress cross-file redeclarations (components + helpers) so `Generate` emits all → Task 3 + Task 4 (wiring + guard). ✓
+- Different-signature → clean `duplicate-component` error blocking emission → Task 4. ✓
+- Within-file redeclaration stays an error → Task 3 logic + Task 5 corpus. ✓
+- Non-component helper cross-file dup tolerated → Task 3 (name-agnostic) + Task 5 corpus. ✓
+- Build tags stay pure pass-through, no `constraint.Parse` → enforced by Global Constraints; no task imports it. ✓
+- Emit unchanged, best-effort Info → no emit task; validated by Task 5 `render.golden` + build probe. ✓
+- LSP multi-valued go-to-def + find-refs → Tasks 6–8. ✓
+- Caching: no `computeKey` change → nothing to do (source content already keys the cache); called out here, no task needed. ✓
+- Tests (corpus, build probe, LSP) → Tasks 5, 7, 8. Docs + ROADMAP → Task 9. ✓
+
+**Placeholder scan:** Two tasks (7, 8 test steps and the Task 5 build probe) intentionally defer the exact test body to "write against the existing harness" because the LSP/build-probe test scaffolds are fixture-heavy and must mirror sibling tests verbatim — each names the exact sibling file to copy (`definition_test.go`, `references_test.go`, `directive_passthrough_test.go`) and the exact assertion (2 locations / both decls / tag-selected body). The `t.Fatal`/`t.Skip` scaffolds must be replaced before their commits; the steps say so explicitly.
+
+**Type consistency:** `componentSignature(*gsxast.Component) string`, `detectSignatureConflicts(map[string]*gsxast.File) []signatureConflict`, `suppressCrossFileRedeclarations([]types.Error) []types.Error`, `signatureConflict{key string; comps []conflictComp}`, `conflictComp{path string; comp *gsxast.Component}`, `CrossRef.Decls []token.Position`, `compByKey map[string][]*gsxast.Component`, `componentTagDeclAt(...) ([]token.Position, bool)` — used consistently across Tasks 1–8.

--- a/docs/superpowers/specs/2026-07-06-tag-variant-component-analysis-design.md
+++ b/docs/superpowers/specs/2026-07-06-tag-variant-component-analysis-design.md
@@ -1,0 +1,212 @@
+# Tag-variant component analysis — tolerate same-name variants
+
+Date: 2026-07-06
+Status: approved
+
+## Problem
+
+gsx analyzes a directory as **one Go package**: it synthesizes a Go skeleton
+for every `.gsx` file (`buildSkeleton`) and type-checks them all together in a
+single `go/types` unit (`checkSkeletonPackage`, `module_importer.go`). Build
+constraints are handled purely as opaque text — `File.Doc` is captured as a
+string and `goDirectiveLines` (`emit.go`) copies `//go:build` / `// +build`
+lines verbatim into the generated `.x.go`. Nothing ever parses the boolean
+expression; `go/build/constraint` is imported nowhere.
+
+So two `.gsx` files gated by disjoint build tags that both declare
+`component Icon` produce two skeleton `func Icon`s in one type-check →
+`Icon redeclared in this block`. Worse, that is a `types.Error`, and
+`Module.Generate` skips `generateFile` for the **whole package** when
+`len(a.typeErrs) != 0` (`module.go:457`). One colliding pair therefore stops
+gsx emitting **every** `.x.go` in the directory — the package cannot build at
+all. The platform-variant pattern (`icon_linux.gsx` / `icon_windows.gsx`, each
+`//go:build`-gated, both declaring `component Icon`) is unusable today.
+
+The `//go:build` pass-through itself already works (see
+`2026-07-02-go-directive-comments-and-gotip-lane-design.md`); this spec closes
+the analysis gap that design recorded as a known limitation.
+
+## Principle
+
+**Generation stays build-context-independent.** gsx emits one `.x.go` per
+`.gsx`, each carrying its own `//go:build` directive, regardless of host
+GOOS/GOARCH/tags. `go build` filters at build time. gsx does **not** parse or
+evaluate build constraints — no `constraint.Parse`, no `build.Context`, no
+GOOS/GOARCH/`unix`/go-version modeling. `go build` remains the sole arbiter of
+whether a same-name pair is an actual same-configuration duplicate.
+
+The only change is to stop a cross-file name collision from being a *fatal*
+analysis error, and to make the language server surface all variants of an
+ambiguous name instead of guessing one.
+
+## Why suppression is sufficient (probed)
+
+A concern with "just suppress the `redeclared` error" is whether go/types still
+resolves the *second* duplicate's body expressions — emit needs them. A probe
+(two files in one package, each `func Icon(title string) string` with different
+bodies, one calling a local `widthB()`) confirms it does: with the
+`Icon redeclared` error reported, go/types still types **both** bodies
+best-effort — `fileB`'s body, including its `widthB()` call, is fully typed
+(`typed=true type=string`).
+
+This works cleanly because:
+
+- gsx's resolved-type map is keyed by **gsx AST node** (per file), so
+  `fileA`'s and `fileB`'s `Icon` interpolations never mix. Each file's emit
+  looks up its own nodes.
+- The only **name-keyed** harvest is the props signature (`propFields` etc.,
+  keyed by props-type name). For same-signature variants those maps are
+  **identical**, so a last-writer-wins collapse is harmless — emit gets the
+  same field set either way.
+- Per-file body facts (does the body reference `attrs` / `children`, generic
+  instantiation) are computed per file during `generateFile`, not via
+  name-keyed harvest, so they never misattribute across variants.
+
+## Design
+
+### Detection & classification
+
+In the existing package-wide component walk (`componentPropFieldsFor`,
+`analyze.go`), when two components share a `componentKey` (`.Name`, or
+`recvType.Name` for a method component), compare their **caller signature**:
+
+- props field set — field name + normalized type text, order-independent;
+- generic type parameters — names + constraint text;
+- receiver — method-vs-func and receiver type text.
+
+This is a syntactic structural comparison over the parsed component
+declarations. Type-alias / dot-import edge cases (textually equal, semantically
+different) fall through to `go build`; this is documented, not solved.
+
+Classification of a same-`componentKey` pair whose two declarations live in
+**different files**:
+
+| Case | Handling |
+|---|---|
+| Identical signature | **Tolerated.** Recorded as a variant set. |
+| Different signature | **Clean gsx error** (`duplicate-component`). |
+
+A same-`componentKey` pair in the **same file** is a within-file redeclaration
+— always a real mistake — and is left as a hard error (never a variant).
+
+### Type-check error handling
+
+`buildSkeleton` records, for each component, the skeleton positions of the
+decls it emits for that component (the `func`, and — see optimization below —
+its props `type`). After `checkSkeletonPackage`, gsx already walks
+`[]types.Error`. Extend that walk:
+
+- **Tolerated variant sets:** suppress the `redeclared` / `other declaration of`
+  errors whose positions are the known duplicate-decl positions of a tolerated
+  set. Matching is **by position** (robust — we generated those skeletons),
+  not by parsing the error message. These errors never reach `typeErrs`, so
+  `Generate` proceeds and emits all files.
+- **Different-signature sets:** the collision is instead reported once as a gsx
+  `error[duplicate-component]` at both declaration sites (`.gsx` positions),
+  with a message naming the conflicting files and pointing at the signature
+  difference. The raw `redeclared` at those positions is suppressed to control
+  the message. To keep the package from emitting invalid code, this collision
+  must gate emission the way `typeErrs` does — `Generate`'s emit guard
+  (`module.go:457`, currently `len(a.typeErrs) == 0`) is widened to also block
+  when a different-signature collision was recorded (e.g. by keeping the raw
+  `redeclared` in `typeErrs` and reporting the friendly diagnostic alongside
+  it, or by adding an explicit blocking flag). A bag diagnostic alone does not
+  gate emission, so this wiring is required, not incidental.
+- **Non-component cross-file duplicates** (top-level `func`/`type`/`const`/`var`
+  declared in `.gsx` `GoChunk`s under disjoint tags — e.g. a shared
+  `const iconPath` helper name): the `redeclared` family for **cross-file**
+  collisions is suppressed silently. gsx cannot cheaply compare arbitrary Go
+  declarations, so their same-configuration correctness is deferred to
+  `go build` (consistent with the principle). Cross-file is distinguished from
+  within-file by comparing the two decls' file positions.
+- **Within-file** redeclarations are **never** suppressed.
+
+Optimization (not required for correctness): for a non-canonical tolerated
+variant, `buildSkeleton` can emit only the `func` (needed to type-check the
+body) and reuse the canonical props `type` by name, so no duplicate props-type
+`redeclared` arises in the first place — shrinking the suppression surface to
+just the func. The blanket position-keyed suppression is the correctness
+guarantee; this only reduces noise.
+
+### Emit
+
+Unchanged. Each file emits its `.x.go` by real component name (`Icon`), with
+its `//go:build` directive passed through. `go build` selects the active
+variant by tag. Because a tolerated variant set is signature-identical, any
+caller `<Icon .../>` compiles against whichever variant a given build config
+activates.
+
+### LSP — multi-valued navigation
+
+The cross-navigation index (`compByKey`, `crossnav.go`, built at
+`module_importer.go`) collapses same-key components to one entry today. Make it
+multi-valued (`map[string][]*Component`):
+
+- **`textDocument/definition`** on a `<Icon/>` tag returns **all** variant
+  declaration `Location`s. The LSP protocol supports a `Location[]` result; the
+  editor lets the user pick.
+- **`textDocument/references`** on a component lists tag sites plus **all**
+  variant declaration sites.
+- **Hover** shows the shared component signature (identical across a tolerated
+  set; a different-signature set is an error surfaced as a diagnostic).
+
+### Caching
+
+No `computeKey` change. A component's signature and the set of `.gsx` files in
+a directory are derived from source content, which already keys the incremental
+cache. Adding, removing, or editing a variant changes source content and
+invalidates correctly.
+
+## Conscious trade-offs
+
+- A genuinely-accidental same-signature duplicate with **no** build tags is
+  caught by `go build` (`Icon redeclared`, pointing at the generated `.x.go`
+  files) rather than by gsx. We do **not** add a "both untagged → warn"
+  half-measure: it would be a partial heuristic (it misses two files with the
+  *same* tag), and completing it correctly requires the constraint-satisfiability
+  modeling this design deliberately avoids. `go build` catches every real case
+  correctly.
+- gsx gives a friendly `duplicate-component` diagnostic only for **components**
+  (where the signature is cheap to compare). Non-component helper/const
+  collisions are deferred wholesale to `go build`.
+- Cross-tag reference breaks (a file references a component that only exists
+  under a different tag) are not flagged by gsx analysis; `go build -tags X`
+  reports them. This matches the build-context-independent principle.
+
+## Tests / docs / siblings
+
+Corpus (`internal/corpus/testdata/cases/`):
+
+- **Same-name same-signature variants generate fully** — two files
+  (`//go:build linux` / `//go:build windows`) both `component Icon`, plus a
+  third sibling component in the same directory; assert all `.x.go` emit
+  (regression on the `module.go:457` whole-package skip) and each variant's
+  `.x.go` carries its `//go:build`.
+- **`-tags` build probe** — a probe module where the two variants differ in
+  body; `go build` under each tag compiles the right one (unit test, mirrors
+  `TestBuildTagExcludesGeneratedFile`).
+- **Different-signature collision** → `error[duplicate-component]` naming both
+  files; no `.x.go` emitted; the raw `redeclared` does not leak.
+- **Within-file redeclaration** still errors.
+- **Non-component cross-file helper duplicate** under disjoint tags generates
+  (deferred to `go build`).
+
+LSP unit tests (`internal/lsp`): multi-valued go-to-definition and
+find-references over a variant set; hover shows the shared signature.
+
+Docs: extend `docs/guide/syntax.md` §Build constraints with the variant rule
+(same name + same signature allowed across disjoint tags; different signature
+is an error; `go build` is the arbiter). Flip the ROADMAP "Tag-aware `.gsx`
+analysis" item.
+
+Siblings: no grammar/highlighting change — `//go:build` is an ordinary comment
+already handled by tree-sitter/vscode/CodeMirror.
+
+## Out of scope
+
+- Parsing or evaluating build constraints inside gsx (`constraint.Parse`,
+  `build.Context`, GOOS/GOARCH/`unix`/go-version world modeling).
+- Friendly diagnostics for non-component cross-file duplicates.
+- Detecting cross-tag reference breaks at generate time.
+- A "variant signature mismatch" auto-hint beyond the `duplicate-component`
+  error.

--- a/docs/superpowers/specs/2026-07-06-tag-variant-component-analysis-design.md
+++ b/docs/superpowers/specs/2026-07-06-tag-variant-component-analysis-design.md
@@ -114,12 +114,31 @@ its props `type`). After `checkSkeletonPackage`, gsx already walks
   gate emission, so this wiring is required, not incidental.
 - **Non-component cross-file duplicates** (top-level `func`/`type`/`const`/`var`
   declared in `.gsx` `GoChunk`s under disjoint tags — e.g. a shared
-  `const iconPath` helper name): the `redeclared` family for **cross-file**
+  `const iconPath` helper name): the redeclaration family for **cross-file**
   collisions is suppressed silently. gsx cannot cheaply compare arbitrary Go
   declarations, so their same-configuration correctness is deferred to
-  `go build` (consistent with the principle). Cross-file is distinguished from
-  within-file by comparing the two decls' file positions.
+  `go build` (consistent with the principle).
 - **Within-file** redeclarations are **never** suppressed.
+
+**How cross-file vs within-file is actually distinguished (shipped, method-aware).**
+go/types (Go 1.26.1) emits redeclarations in two message families:
+
+- Func/var/const/type → a pair: `"<name> redeclared in this block"` (at the 2nd+
+  decl) plus a `"other declaration of <name>"` note (at the first decl).
+- Method → a single self-contained record: `"method <BaseType>.<Method> already
+  declared at <file>:<line>:<col>"`. `<BaseType>` drops the pointer and generic
+  type-args, so `(f *Form)` and `(f Form[T])` both report `"Form.Field"`.
+
+The suppressor recognizes **both** families (`redeclName`) and keys them the same
+way `collectRedeclFacts` keys the skeleton decls (bare name for functions/vars,
+`"<BaseType>.<Method>"` for methods). A redeclaration error is dropped iff its
+name is declared in ≥2 skeleton files (a candidate variant) **and never twice in
+one file**. Crucially, the within-file fact comes from the **skeleton ASTs**, not
+the error positions: go/types anchors *every* redeclaration against the single
+globally-first decl of a name, and gsx feeds skeleton files to the checker in
+nondeterministic (map) order, so a within-file duplicate living in a non-anchor
+file is reported as if it were cross-file. The AST sees every declaration
+regardless of order, so the within-file fact is exact and order-independent.
 
 Optimization (not required for correctness): for a non-canonical tolerated
 variant, `buildSkeleton` can emit only the `func` (needed to type-check the
@@ -172,6 +191,14 @@ invalidates correctly.
 - Cross-tag reference breaks (a file references a component that only exists
   under a different tag) are not flagged by gsx analysis; `go build -tags X`
   reports them. This matches the build-context-independent principle.
+- When a within-file redeclaration **coexists** with a cross-file variant of the
+  same name (e.g. `Icon` twice in `a.gsx` *and* once in `b.gsx`), gsx keeps
+  **all** of that name's redeclaration errors — blocking the whole package —
+  rather than surgically keeping only the within-file one. Disentangling the
+  specific within-file record per-error is unreliable (go/types' global-first
+  anchoring, above), whereas the name-level within-file fact from the skeleton
+  AST is exact. This is strictly safe: the within-file duplicate is a real
+  mistake `go build` would reject under any tag too, so blocking is correct.
 
 ## Tests / docs / siblings
 

--- a/gen/lsp.go
+++ b/gen/lsp.go
@@ -80,7 +80,7 @@ func (a lspAnalyzer) module(root, modPath string, merged config) (*codegen.Modul
 func adaptPackageResult(pr *codegen.PackageResult) *lsp.Package {
 	cross := make(map[string]lsp.CrossRef, len(pr.CrossIndex))
 	for k, v := range pr.CrossIndex {
-		cross[k] = lsp.CrossRef{Name: v.Name, Decl: v.Decl, Refs: v.Refs}
+		cross[k] = lsp.CrossRef{Name: v.Name, Decl: v.Decl, Decls: v.Decls, Refs: v.Refs}
 	}
 	nav := make([]lsp.NavRef, len(pr.NavIndex))
 	for i, nr := range pr.NavIndex {

--- a/gen/lsp.go
+++ b/gen/lsp.go
@@ -220,9 +220,10 @@ func (a lspAnalyzer) AnalyzeModule(dir string, override map[string][]byte) ([]ls
 	for _, e := range entries {
 		for key, v := range e.pr.CrossIndex {
 			cross[ownerKey{e.dir, key}] = lsp.CrossRef{
-				Name: v.Name,
-				Decl: v.Decl,
-				Refs: append(v.Refs[:0:0], v.Refs...),
+				Name:  v.Name,
+				Decl:  v.Decl,
+				Decls: v.Decls,
+				Refs:  append(v.Refs[:0:0], v.Refs...),
 			}
 		}
 	}

--- a/internal/codegen/buildtag_select_test.go
+++ b/internal/codegen/buildtag_select_test.go
@@ -1,0 +1,108 @@
+package codegen
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBuildTagSelectsVariant proves that the same-name/same-signature
+// build-tag variant tolerance (see TestSameSigVariantGeneratesAllFiles)
+// doesn't just generate cleanly — the generated .x.go files actually
+// compile-select the right variant under `go build -tags`, and the SELECTED
+// variant is the one that runs. gsx never parses build tags; it's the Go
+// toolchain that must pick exactly one Icon.
+//
+// Two Icon variants are gated on custom tags (variantA / variantB) with a
+// body-unique static string each, plus a Page that renders Icon. We generate,
+// write to a probe module (package main, so the built binary is runnable),
+// build under each tag, and execute the binary to confirm the rendered output
+// carries only that tag's marker string.
+func TestBuildTagSelectsVariant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns the go toolchain")
+	}
+	repoRoot, _ := filepath.Abs("../..")
+	tmp := t.TempDir()
+	writeFile(t, tmp, "go.mod", "module varx\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	writeFile(t, tmp, "icon_a.gsx", "//go:build variantA\n\npackage main\n\ncomponent Icon(name string) {\n\t<span>VARIANT_A:{ name }</span>\n}\n")
+	writeFile(t, tmp, "icon_b.gsx", "//go:build variantB\n\npackage main\n\ncomponent Icon(name string) {\n\t<span>VARIANT_B:{ name }</span>\n}\n")
+	writeFile(t, tmp, "page.gsx", "package main\n\ncomponent Page() {\n\t<Icon name=\"x\"/>\n}\n")
+	writeFile(t, tmp, "main.go", `package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := Page().Render(context.Background(), os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+`)
+
+	out, err := GenerateDirs(tmp, []string{tmp}, Options{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := out[tmp]
+	if !ok {
+		t.Fatalf("no result for %s", tmp)
+	}
+	if hasError(res.Diags) {
+		t.Fatalf("unexpected error diagnostics generating variants: %v", res.Diags)
+	}
+	for gsxPath, src := range res.Files {
+		base := strings.TrimSuffix(filepath.Base(gsxPath), ".gsx")
+		writeFile(t, tmp, base+".x.go", string(src))
+	}
+
+	// Under the default tag set (no -tags), Go's implicit "!variantA &&
+	// !variantB" constraint means NEITHER Icon variant is even a candidate —
+	// only page.x.go and main.go would build, referencing an undefined Icon.
+	// That's expected; this test only asserts selection once a variant tag
+	// is set, exercising both tags so it can't be "B always wins" by luck.
+	assertVariantSelected(t, tmp, "variantA", "icon_a.x.go", "icon_b.x.go", "VARIANT_A:x", "VARIANT_B")
+	assertVariantSelected(t, tmp, "variantB", "icon_b.x.go", "icon_a.x.go", "VARIANT_B:x", "VARIANT_A")
+}
+
+// assertVariantSelected builds and runs the probe module under the given tag,
+// asserting via `go list` that only wantFile (not excludeFile) is a candidate
+// source, and via the running binary's stdout that it rendered wantMarker
+// and not excludeMarker.
+func assertVariantSelected(t *testing.T, dir, tag, wantFile, excludeFile, wantMarker, excludeMarker string) {
+	t.Helper()
+
+	list := exec.Command("go", "list", "-tags", tag, "-f", "{{.GoFiles}}")
+	list.Dir = dir
+	lout, lerr := list.CombinedOutput()
+	if lerr != nil {
+		t.Fatalf("go list -tags %s: %v\n%s", tag, lerr, lout)
+	}
+	if !strings.Contains(string(lout), wantFile) || strings.Contains(string(lout), excludeFile) {
+		t.Fatalf("go list -tags %s = %s; want %s included, %s tag-excluded", tag, lout, wantFile, excludeFile)
+	}
+
+	binPath := filepath.Join(dir, "varx_"+tag+".bin")
+	build := exec.Command("go", "build", "-tags", tag, "-o", binPath, ".")
+	build.Dir = dir
+	if bout, berr := build.CombinedOutput(); berr != nil {
+		t.Fatalf("go build -tags %s: %v\n%s", tag, berr, bout)
+	}
+
+	run := exec.Command(binPath)
+	rout, rerr := run.CombinedOutput()
+	if rerr != nil {
+		t.Fatalf("run %s: %v\n%s", binPath, rerr, rout)
+	}
+	if !strings.Contains(string(rout), wantMarker) {
+		t.Fatalf("tag %s: output = %q; want it to contain %q", tag, rout, wantMarker)
+	}
+	if strings.Contains(string(rout), excludeMarker) {
+		t.Fatalf("tag %s: output = %q; must NOT contain %q", tag, rout, excludeMarker)
+	}
+}

--- a/internal/codegen/crossnav.go
+++ b/internal/codegen/crossnav.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"go/token"
 	"go/types"
+	"sort"
 	"strings"
 
 	gsxast "github.com/gsxhq/gsx/ast"
@@ -15,15 +16,24 @@ import (
 // .go for hand-written refs). Shared by the Module core (both codegen.GenerateDirs
 // and the LSP path) to produce identical indexes.
 func buildCrossNav(
-	compByKey map[string]*gsxast.Component,
+	compByKey map[string][]*gsxast.Component,
 	objKey map[types.Object]string,
 	gsxFset, skelFset *token.FileSet,
 	info *types.Info,
 	pkgTypes *types.Package,
 ) (map[string]CrossRef, []NavRef) {
 	index := map[string]CrossRef{}
-	for key, c := range compByKey {
-		index[key] = CrossRef{Name: c.Name, Decl: gsxFset.Position(c.NamePos)} // gsx fset → .gsx position
+	for key, comps := range compByKey {
+		if len(comps) == 0 {
+			continue
+		}
+		cr := CrossRef{Name: comps[0].Name}
+		for _, c := range comps {
+			cr.Decls = append(cr.Decls, gsxFset.Position(c.NamePos)) // gsx fset → .gsx position
+		}
+		sortPositions(cr.Decls) // stable: filename then offset
+		cr.Decl = cr.Decls[0]   // primary — back-compat
+		index[key] = cr
 	}
 
 	// Build maps for NavIndex: props-struct objects and field var objects → .gsx targets.
@@ -31,37 +41,39 @@ func buildCrossNav(
 	// fieldObjToPos maps a field *types.Var → the .gsx position of the corresponding param.
 	structObjToComp := map[types.Object]*gsxast.Component{}
 	fieldObjToPos := map[*types.Var]token.Position{}
-	for _, c := range compByKey {
-		// Derive propsName the same way emitComponentSkeleton does.
-		propsName := c.Name + "Props"
-		if c.Recv != "" {
-			_, _, recvTypeName, rerr := parseRecv(c.Recv)
-			if rerr == nil {
-				propsName = recvTypeName + c.Name + "Props"
+	for _, comps := range compByKey {
+		for _, c := range comps {
+			// Derive propsName the same way emitComponentSkeleton does.
+			propsName := c.Name + "Props"
+			if c.Recv != "" {
+				_, _, recvTypeName, rerr := parseRecv(c.Recv)
+				if rerr == nil {
+					propsName = recvTypeName + c.Name + "Props"
+				}
 			}
-		}
-		structObj := pkgTypes.Scope().Lookup(propsName)
-		if structObj == nil {
-			continue
-		}
-		structObjToComp[structObj] = c
+			structObj := pkgTypes.Scope().Lookup(propsName)
+			if structObj == nil {
+				continue
+			}
+			structObjToComp[structObj] = c
 
-		// Map each field var → the .gsx position of its corresponding param.
-		params, err := parseParams(c.Params)
-		if err != nil {
-			continue
-		}
-		st, ok := structObj.Type().Underlying().(*types.Struct)
-		if !ok {
-			continue
-		}
-		for _, p := range params {
-			fname := fieldName(p.name)
-			paramPos := gsxFset.Position(c.ParamsPos + token.Pos(p.nameOff))
-			for fv := range st.Fields() {
-				if fv.Name() == fname {
-					fieldObjToPos[fv] = paramPos
-					break
+			// Map each field var → the .gsx position of its corresponding param.
+			params, err := parseParams(c.Params)
+			if err != nil {
+				continue
+			}
+			st, ok := structObj.Type().Underlying().(*types.Struct)
+			if !ok {
+				continue
+			}
+			for _, p := range params {
+				fname := fieldName(p.name)
+				paramPos := gsxFset.Position(c.ParamsPos + token.Pos(p.nameOff))
+				for fv := range st.Fields() {
+					if fv.Name() == fname {
+						fieldObjToPos[fv] = paramPos
+						break
+					}
 				}
 			}
 		}
@@ -75,7 +87,11 @@ func buildCrossNav(
 		}
 		// Case 1: component func reference → .gsx component decl.
 		if key, ok := objKey[obj]; ok {
-			c := compByKey[key]
+			comps := compByKey[key]
+			if len(comps) == 0 {
+				continue
+			}
+			c := comps[0] // any variant's NamePos is a valid jump target
 			cr := index[key]
 			cr.Refs = append(cr.Refs, p)
 			index[key] = cr
@@ -114,4 +130,16 @@ func buildCrossNav(
 		}
 	}
 	return index, navIndex
+}
+
+// sortPositions sorts token.Positions deterministically: filename then byte
+// offset. Used to give CrossRef.Decls (and its primary Decl = Decls[0]) a
+// stable order independent of map/file-walk iteration order.
+func sortPositions(ps []token.Position) {
+	sort.Slice(ps, func(i, j int) bool {
+		if ps[i].Filename != ps[j].Filename {
+			return ps[i].Filename < ps[j].Filename
+		}
+		return ps[i].Offset < ps[j].Offset
+	})
 }

--- a/internal/codegen/crossnav.go
+++ b/internal/codegen/crossnav.go
@@ -22,6 +22,17 @@ func buildCrossNav(
 	info *types.Info,
 	pkgTypes *types.Package,
 ) (map[string]CrossRef, []NavRef) {
+	// Sort each variant slice in place so every consumer below (Decls, the
+	// info.Uses nav target in Case 1, and the props-struct map) agrees on the
+	// same deterministic "primary" variant, rather than following randomized
+	// map-population order. Safe to mutate in place: these slices belong to
+	// the freshly-built analyzed result, and the only other reader
+	// (module_importer.go's compByKey existence check) doesn't care about
+	// order.
+	for _, comps := range compByKey {
+		sortComponents(comps, gsxFset)
+	}
+
 	index := map[string]CrossRef{}
 	for key, comps := range compByKey {
 		if len(comps) == 0 {
@@ -31,8 +42,9 @@ func buildCrossNav(
 		for _, c := range comps {
 			cr.Decls = append(cr.Decls, gsxFset.Position(c.NamePos)) // gsx fset → .gsx position
 		}
-		sortPositions(cr.Decls) // stable: filename then offset
-		cr.Decl = cr.Decls[0]   // primary — back-compat
+		// cr.Decls is already ordered here: comps was sorted in place above, so no
+		// separate sortPositions(cr.Decls) call is needed (and would be redundant).
+		cr.Decl = cr.Decls[0] // primary — back-compat
 		index[key] = cr
 	}
 
@@ -91,7 +103,7 @@ func buildCrossNav(
 			if len(comps) == 0 {
 				continue
 			}
-			c := comps[0] // any variant's NamePos is a valid jump target
+			c := comps[0] // deterministic primary variant (sorted above); any variant's NamePos is a valid jump target
 			cr := index[key]
 			cr.Refs = append(cr.Refs, p)
 			index[key] = cr
@@ -132,14 +144,19 @@ func buildCrossNav(
 	return index, navIndex
 }
 
-// sortPositions sorts token.Positions deterministically: filename then byte
-// offset. Used to give CrossRef.Decls (and its primary Decl = Decls[0]) a
-// stable order independent of map/file-walk iteration order.
-func sortPositions(ps []token.Position) {
-	sort.Slice(ps, func(i, j int) bool {
-		if ps[i].Filename != ps[j].Filename {
-			return ps[i].Filename < ps[j].Filename
+// sortComponents sorts a compByKey[key] variant slice in place, deterministically,
+// by its NamePos resolved through gsxFset: filename then byte offset. All
+// consumers of compByKey (CrossRef.Decls/Decl, the info.Uses nav target in
+// Case 1, and the props-struct map) must agree on this order so the chosen
+// "primary" variant is stable across runs, independent of Go's randomized
+// map-population order.
+func sortComponents(comps []*gsxast.Component, gsxFset *token.FileSet) {
+	posOf := func(c *gsxast.Component) token.Position { return gsxFset.Position(c.NamePos) }
+	sort.Slice(comps, func(i, j int) bool {
+		pi, pj := posOf(comps[i]), posOf(comps[j])
+		if pi.Filename != pj.Filename {
+			return pi.Filename < pj.Filename
 		}
-		return ps[i].Offset < ps[j].Offset
+		return pi.Offset < pj.Offset
 	})
 }

--- a/internal/codegen/crossnav_test.go
+++ b/internal/codegen/crossnav_test.go
@@ -1,0 +1,30 @@
+package codegen
+
+import "testing"
+
+// TestCrossIndexMultiValuedVariants covers Task 6: the component cross-index
+// must retain EVERY build-tag variant's declaration position (not collapse to
+// one), so the LSP (Tasks 7-8) can show all variants on go-to-definition. Two
+// same-signature Icon components under disjoint //go:build tags must produce
+// a single CrossIndex entry whose Decls holds both positions, with Decl kept
+// as the primary (first, sorted) for back-compat.
+func TestCrossIndexMultiValuedVariants(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"icon_a.gsx": "//go:build !never\n\npackage views\n\ncomponent Icon(name string) { <a>{ name }</a> }\n",
+		"icon_b.gsx": "//go:build never\n\npackage views\n\ncomponent Icon(name string) { <b>{ name }</b> }\n",
+	})
+	pkg, err := m.Package(dir) // retained analysis path used by the LSP
+	if err != nil {
+		t.Fatalf("Package: %v", err)
+	}
+	cr, ok := pkg.CrossIndex[".Icon"]
+	if !ok {
+		t.Fatal("no CrossIndex entry for .Icon")
+	}
+	if len(cr.Decls) != 2 {
+		t.Fatalf("want 2 variant decls, got %d (%v)", len(cr.Decls), cr.Decls)
+	}
+	if !cr.Decl.IsValid() {
+		t.Fatal("primary Decl must stay valid for back-compat")
+	}
+}

--- a/internal/codegen/crossnav_test.go
+++ b/internal/codegen/crossnav_test.go
@@ -1,6 +1,9 @@
 package codegen
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestCrossIndexMultiValuedVariants covers Task 6: the component cross-index
 // must retain EVERY build-tag variant's declaration position (not collapse to
@@ -8,6 +11,12 @@ import "testing"
 // same-signature Icon components under disjoint //go:build tags must produce
 // a single CrossIndex entry whose Decls holds both positions, with Decl kept
 // as the primary (first, sorted) for back-compat.
+//
+// It also pins the deterministic-primary fix (PR review, Task 6): buildCrossNav
+// sorts each compByKey[key] variant slice in place (filename then offset) before
+// any consumer reads it, so the chosen primary is always the lexicographically-
+// first file (icon_a.gsx here), never whichever variant Go's randomized map
+// iteration happened to place first.
 func TestCrossIndexMultiValuedVariants(t *testing.T) {
 	dir, m := openTestModule(t, map[string]string{
 		"icon_a.gsx": "//go:build !never\n\npackage views\n\ncomponent Icon(name string) { <a>{ name }</a> }\n",
@@ -26,5 +35,11 @@ func TestCrossIndexMultiValuedVariants(t *testing.T) {
 	}
 	if !cr.Decl.IsValid() {
 		t.Fatal("primary Decl must stay valid for back-compat")
+	}
+	if !strings.HasSuffix(cr.Decl.Filename, "icon_a.gsx") {
+		t.Fatalf("primary Decl must deterministically be the lexicographically-first variant (icon_a.gsx), got %s", cr.Decl.Filename)
+	}
+	if cr.Decls[0] != cr.Decl {
+		t.Fatalf("Decls[0] must equal the primary Decl, got Decls[0]=%v Decl=%v", cr.Decls[0], cr.Decl)
 	}
 }

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -402,7 +402,7 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 	// Safe despite emit's in-place AST mutation: analyze re-parses a fresh gsx AST
 	// on every call, so there is no previously-mutated tree that could be corrupted
 	// by a concurrent or repeated generateFile pass on the same nodes.
-	if len(a.typeErrs) == 0 {
+	if len(a.typeErrs) == 0 && len(a.signatureConflicts) == 0 {
 		for path, f := range a.gsxFiles {
 			ff := a.factsByFile[path]
 			generateFile(f, a.pkg, a.resolved, a.table, ff.propFields, ff.nodeProps, ff.attrsProps, ff.byo,
@@ -454,7 +454,7 @@ func (m *Module) Generate(dir string) (map[string][]byte, []diag.Diagnostic, err
 	// package emits spurious secondary diagnostics (e.g. "could not resolve type of
 	// interpolation") because resolved lacks entries for identifiers the type-checker
 	// flagged as undefined.
-	if len(a.typeErrs) == 0 {
+	if len(a.typeErrs) == 0 && len(a.signatureConflicts) == 0 {
 		for path, f := range a.gsxFiles {
 			ff := a.factsByFile[path]
 			gen, ok := generateFile(f, a.pkg, a.resolved, a.table, ff.propFields, ff.nodeProps, ff.attrsProps, ff.byo,

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -910,8 +910,9 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	// dropped its only skeleton reference, so go/types reports
 	// `"path" imported and not used` at the user's import line. Left in
 	// typeErrs, that single spurious error would (a) hard-fail generation for
-	// the WHOLE package (the len(typeErrs)==0 gate below and in module.go)
-	// and (b) bury the actionable inference-unavailable warning. Filtering is
+	// the WHOLE package (the len(typeErrs)==0 && len(signatureConflicts)==0
+	// gate below and in module.go) and (b) bury the actionable
+	// inference-unavailable warning. Filtering is
 	// exact, not heuristic: only errors whose //line-adjusted position lands
 	// in a file with a sunk set AND whose quoted path is in that set are
 	// dropped; a genuinely unused import of the same path in ANOTHER file
@@ -947,8 +948,12 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	// build filters by tag and is the arbiter of a real same-config duplicate.
 	// Runs before the diagnostics loop below so a tolerated redeclaration never
 	// becomes a bag diagnostic AND never lands in the stored a.typeErrs (which
-	// gates emission). Same-file redeclarations are untouched.
-	typeErrs = suppressCrossFileRedeclarations(typeErrs)
+	// gates emission). Within-file redeclarations are untouched — the
+	// within-file fact comes from the skeleton ASTs (collectRedeclFacts), not
+	// the go/types error positions, since the checker anchors every
+	// redeclaration to the globally-first decl and gsx's file order is
+	// nondeterministic.
+	typeErrs = suppressCrossFileRedeclarations(typeErrs, collectRedeclFacts(goFiles, fset))
 	// Collect the skeleton byte spans of every _gsxuseq(...) child-prop or
 	// element-spread harvest probe. Each expression is also checked in a native
 	// typed context (the props literal or gsx.Attrs assignment), so suppressing

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -600,29 +600,30 @@ func (m *Module) typesPackageWith(dir string, mi *moduleImporter) (*types.Packag
 // component cross-index inputs. typesPackage consumes only a.pkg; Module.Package
 // (retained analysis) and Module.Generate (codegen) consume the rest.
 type analyzed struct {
-	pkgName     string
-	gsxFiles    map[string]*gsxast.File        // gsx path -> parsed file
-	gsxFset     *token.FileSet                 // gsx positions
-	skelFset    *token.FileSet                 // skeleton positions (same fset as gsxFset for Module)
-	goFiles     []*goast.File                  // parsed skeletons + shared helper
-	compsByXGo  map[string][]*gsxast.Component // skeleton abs path -> components
-	table       filterTable
-	propFields  map[string]map[string]bool
-	nodeProps   map[string]map[string]bool
-	attrsProps  map[string]map[string]bool
-	byo         *byoData
-	factsByFile map[string]*fileFacts // per-file fact views; propFields/nodeProps/attrsProps/byo keep the package-local base facts
-	resolved    map[gsxast.Node]types.Type
-	exprMap     map[gsxast.Node]goast.Expr
-	ctrlMap     map[gsxast.Node]ctrlRef            // control-flow node -> skeleton clause pos + containing node
-	sigTypes    map[*gsxast.Component][]SigTypeRef // component -> parameter type spans (go-to-def on a param type)
-	pkg         *types.Package
-	info        *types.Info
-	compByKey   map[string]*gsxast.Component // componentKey -> component (for Name + NamePos)
-	objKey      map[types.Object]string      // component func object -> componentKey
-	bag         *diag.Bag                    // diagnostics from parse + script resolution; used by Generate
-	importSpecs []importSpec                 // hoisted .gsx import specs (for unused-import detection)
-	typeErrs    []types.Error                // raw type errors from checkSkeletonPackage
+	pkgName            string
+	gsxFiles           map[string]*gsxast.File        // gsx path -> parsed file
+	gsxFset            *token.FileSet                 // gsx positions
+	skelFset           *token.FileSet                 // skeleton positions (same fset as gsxFset for Module)
+	goFiles            []*goast.File                  // parsed skeletons + shared helper
+	compsByXGo         map[string][]*gsxast.Component // skeleton abs path -> components
+	table              filterTable
+	propFields         map[string]map[string]bool
+	nodeProps          map[string]map[string]bool
+	attrsProps         map[string]map[string]bool
+	byo                *byoData
+	factsByFile        map[string]*fileFacts // per-file fact views; propFields/nodeProps/attrsProps/byo keep the package-local base facts
+	resolved           map[gsxast.Node]types.Type
+	exprMap            map[gsxast.Node]goast.Expr
+	ctrlMap            map[gsxast.Node]ctrlRef            // control-flow node -> skeleton clause pos + containing node
+	sigTypes           map[*gsxast.Component][]SigTypeRef // component -> parameter type spans (go-to-def on a param type)
+	pkg                *types.Package
+	info               *types.Info
+	compByKey          map[string]*gsxast.Component // componentKey -> component (for Name + NamePos)
+	objKey             map[types.Object]string      // component func object -> componentKey
+	bag                *diag.Bag                    // diagnostics from parse + script resolution; used by Generate
+	importSpecs        []importSpec                 // hoisted .gsx import specs (for unused-import detection)
+	typeErrs           []types.Error                // raw type errors from checkSkeletonPackage
+	signatureConflicts []signatureConflict          // same-name different-signature component collisions (block emission)
 
 	// sunkImports maps a .gsx file path to the import SPECS (line+path keys)
 	// the type-checker PROVED were used only by a requalification-failed
@@ -941,6 +942,13 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 		}
 		typeErrs = kept
 	}
+	// Tolerate cross-file duplicate top-level decls (same-name build-tag
+	// variants — components or helpers). gsx does not parse build tags; go
+	// build filters by tag and is the arbiter of a real same-config duplicate.
+	// Runs before the diagnostics loop below so a tolerated redeclaration never
+	// becomes a bag diagnostic AND never lands in the stored a.typeErrs (which
+	// gates emission). Same-file redeclarations are untouched.
+	typeErrs = suppressCrossFileRedeclarations(typeErrs)
 	// Collect the skeleton byte spans of every _gsxuseq(...) child-prop or
 	// element-spread harvest probe. Each expression is also checked in a native
 	// typed context (the props literal or gsx.Attrs assignment), so suppressing
@@ -1111,31 +1119,50 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 		}
 	}
 
+	// A same-name component declared with DIFFERENT signatures across files is a
+	// genuine ambiguity (its cross-file redeclaration was suppressed above, so
+	// nothing else will flag it). Report a clean duplicate-component error at
+	// each site and record the conflict so emission is blocked (module.go gates
+	// on len(signatureConflicts)==0 as well as len(typeErrs)==0).
+	sigConflicts := detectSignatureConflicts(gsxFiles)
+	for _, sc := range sigConflicts {
+		var files []string
+		for _, cc := range sc.comps {
+			files = append(files, filepath.Base(cc.path))
+		}
+		for _, cc := range sc.comps {
+			bag.Errorf(cc.comp.NamePos, cc.comp.NamePos+token.Pos(len(cc.comp.Name)), "duplicate-component",
+				"component %s is declared with different signatures across build-tagged files (%s); build-tag variants must share the same signature — rename the variants or align their parameters",
+				cc.comp.Name, strings.Join(files, ", "))
+		}
+	}
+
 	return &analyzed{
-		pkgName:     pkgName,
-		gsxFiles:    gsxFiles,
-		gsxFset:     fset,
-		skelFset:    fset,
-		goFiles:     goFiles,
-		compsByXGo:  compsByXGo,
-		table:       table,
-		propFields:  propFields,
-		nodeProps:   nodeProps,
-		attrsProps:  attrsProps,
-		byo:         byo,
-		factsByFile: factsByFile,
-		resolved:    resolved,
-		exprMap:     exprMap,
-		ctrlMap:     ctrlMap,
-		sigTypes:    sigTypes,
-		pkg:         pkg,
-		info:        info,
-		compByKey:   compByKey,
-		objKey:      objKey,
-		bag:         bag,
-		importSpecs: allImportSpecs,
-		typeErrs:    typeErrs,
-		sunkImports: confirmedSunk,
+		pkgName:            pkgName,
+		gsxFiles:           gsxFiles,
+		gsxFset:            fset,
+		skelFset:           fset,
+		goFiles:            goFiles,
+		compsByXGo:         compsByXGo,
+		table:              table,
+		propFields:         propFields,
+		nodeProps:          nodeProps,
+		attrsProps:         attrsProps,
+		byo:                byo,
+		factsByFile:        factsByFile,
+		resolved:           resolved,
+		exprMap:            exprMap,
+		ctrlMap:            ctrlMap,
+		sigTypes:           sigTypes,
+		pkg:                pkg,
+		info:               info,
+		compByKey:          compByKey,
+		objKey:             objKey,
+		bag:                bag,
+		importSpecs:        allImportSpecs,
+		typeErrs:           typeErrs,
+		sunkImports:        confirmedSunk,
+		signatureConflicts: sigConflicts,
 	}, nil
 }
 

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -618,12 +618,12 @@ type analyzed struct {
 	sigTypes           map[*gsxast.Component][]SigTypeRef // component -> parameter type spans (go-to-def on a param type)
 	pkg                *types.Package
 	info               *types.Info
-	compByKey          map[string]*gsxast.Component // componentKey -> component (for Name + NamePos)
-	objKey             map[types.Object]string      // component func object -> componentKey
-	bag                *diag.Bag                    // diagnostics from parse + script resolution; used by Generate
-	importSpecs        []importSpec                 // hoisted .gsx import specs (for unused-import detection)
-	typeErrs           []types.Error                // raw type errors from checkSkeletonPackage
-	signatureConflicts []signatureConflict          // same-name different-signature component collisions (block emission)
+	compByKey          map[string][]*gsxast.Component // componentKey -> component(s); >1 = build-tag variants (for Name + NamePos)
+	objKey             map[types.Object]string        // component func object -> componentKey
+	bag                *diag.Bag                      // diagnostics from parse + script resolution; used by Generate
+	importSpecs        []importSpec                   // hoisted .gsx import specs (for unused-import detection)
+	typeErrs           []types.Error                  // raw type errors from checkSkeletonPackage
+	signatureConflicts []signatureConflict            // same-name different-signature component collisions (block emission)
 
 	// sunkImports maps a .gsx file path to the import SPECS (line+path keys)
 	// the type-checker PROVED were used only by a requalification-failed
@@ -1038,8 +1038,8 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	// inputs (compByKey / objKey).
 	resolved := map[gsxast.Node]types.Type{}
 	exprMap := map[gsxast.Node]goast.Expr{}
-	compByKey := map[string]*gsxast.Component{} // componentKey -> component
-	compObjByKey := map[string]types.Object{}   // componentKey -> component func object
+	compByKey := map[string][]*gsxast.Component{} // componentKey -> component(s); >1 = build-tag variants
+	compObjByKey := map[string]types.Object{}     // componentKey -> component func object
 	for _, gf := range goFiles {
 		fname := fset.Position(gf.Pos()).Filename
 		comps, ok := compsByXGo[fname]
@@ -1065,7 +1065,8 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 			}
 		}
 		for _, c := range comps {
-			compByKey[componentKey(c)] = c
+			key := componentKey(c)
+			compByKey[key] = append(compByKey[key], c)
 		}
 		for _, decl := range gf.Decls {
 			fd, ok := decl.(*goast.FuncDecl)

--- a/internal/codegen/results.go
+++ b/internal/codegen/results.go
@@ -14,10 +14,15 @@ import (
 // declaration, and every reference (resolved positions — .go call sites stay
 // .go; .gsx <Card/> tags map to .gsx via the skeleton's child-tag //line).
 // Name's length bounds the cursor-on-reference span check in the LSP.
+//
+// Decls holds every build-tag variant's declaration position (sorted by
+// filename then offset); Decl is kept equal to Decls[0] as the primary
+// position for callers that only care about "the" declaration.
 type CrossRef struct {
-	Name string
-	Decl token.Position
-	Refs []token.Position
+	Name  string
+	Decl  token.Position
+	Decls []token.Position
+	Refs  []token.Position
 }
 
 // NavRef is one navigable Go reference (in a .go or skeleton file) and the .gsx

--- a/internal/codegen/variant_generate_test.go
+++ b/internal/codegen/variant_generate_test.go
@@ -93,3 +93,93 @@ func TestDiffSigVariantIsCleanError(t *testing.T) {
 		t.Fatalf("diff-sig conflict must block emission, got %v", keysOfGenerated(out))
 	}
 }
+
+// TestMethodVariantSameSigGeneratesAllFiles is the method-component analogue of
+// TestSameSigVariantGeneratesAllFiles. go/types reports a METHOD redeclaration
+// with a different message ("method Form.Field already declared at FILE:L:C")
+// than a func's ("redeclared in this block" + "other declaration" note). Before
+// the fix, suppression did not recognize the method form, so a same-signature
+// method variant under disjoint build tags blocked emission for the WHOLE
+// package. All three files must now generate.
+func TestMethodVariantSameSigGeneratesAllFiles(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"field_linux.gsx":   "//go:build linux\n\npackage views\n\ncomponent (f Form) Field(name string) { <span>linux:{ name }</span> }\n",
+		"field_windows.gsx": "//go:build windows\n\npackage views\n\ncomponent (f Form) Field(name string) { <span>win:{ name }</span> }\n",
+		"form.gsx":          "package views\n\ntype Form struct{}\n\ncomponent Page() { <div>page</div> }\n",
+	})
+	out, diags, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if hasError(diags) {
+		t.Fatalf("unexpected error diagnostics: %v", diags)
+	}
+	for _, want := range []string{"field_linux.gsx", "field_windows.gsx", "form.gsx"} {
+		if _, ok := out[filepath.Join(dir, want)]; !ok {
+			t.Fatalf("missing generated output for %s; got keys %v", want, keysOfGenerated(out))
+		}
+	}
+	linuxOut := out[filepath.Join(dir, "field_linux.gsx")]
+	if !strings.Contains(string(linuxOut), "//go:build linux") {
+		t.Fatalf("linux variant lost its build constraint:\n%s", linuxOut)
+	}
+}
+
+// TestMethodVariantDiffSigIsCleanError is the method-component analogue of
+// TestDiffSigVariantIsCleanError: differing method signatures are a genuine
+// ambiguity and must surface as a single clean duplicate-component diagnostic,
+// never a raw go/types "already declared"/"redeclared" leak, with emission
+// blocked entirely.
+func TestMethodVariantDiffSigIsCleanError(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"field_linux.gsx":   "//go:build linux\n\npackage views\n\ncomponent (f Form) Field(name string) { <span>{ name }</span> }\n",
+		"field_windows.gsx": "//go:build windows\n\npackage views\n\ncomponent (f Form) Field(name int) { <span>{ name }</span> }\n",
+		"form.gsx":          "package views\n\ntype Form struct{}\n",
+	})
+	out, diags, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !hasError(diags) {
+		t.Fatalf("expected a duplicate-component error, got none: %v", diags)
+	}
+	foundClean := false
+	for _, d := range diags {
+		if d.Code == "duplicate-component" {
+			foundClean = true
+		}
+		if strings.Contains(d.Message, "already declared") || strings.Contains(d.Message, "redeclared") {
+			t.Fatalf("raw go/types method-redeclaration error leaked: %q", d.Message)
+		}
+	}
+	if !foundClean {
+		t.Fatalf("no duplicate-component diagnostic in %v", diags)
+	}
+	if len(out) != 0 {
+		t.Fatalf("diff-sig conflict must block emission, got %v", keysOfGenerated(out))
+	}
+}
+
+// TestWithinFileRedeclarationKeptDespiteVariant pins finding #3: a name
+// redeclared BOTH within file A (a real mistake) AND across files A/B (a
+// same-signature variant) must NOT be silently generated — the within-file
+// redeclaration stays a hard error. The over-reaching name+file-count
+// suppression used to drop the within-file error too (its name spanned ≥2
+// files). Detection now comes from the skeleton ASTs (collectRedeclFacts), so
+// it is order-independent and exact.
+func TestWithinFileRedeclarationKeptDespiteVariant(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"icon_a.gsx": "package views\n\ncomponent Icon(name string) { <a>{ name }</a> }\ncomponent Icon(name string) { <b>{ name }</b> }\n",
+		"icon_b.gsx": "//go:build windows\n\npackage views\n\ncomponent Icon(name string) { <c>{ name }</c> }\n",
+	})
+	out, diags, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !hasError(diags) {
+		t.Fatalf("within-file redeclaration must stay a hard error, got diags=%v out=%v", diags, keysOfGenerated(out))
+	}
+	if len(out) != 0 {
+		t.Fatalf("within-file redeclaration must block emission, got %v", keysOfGenerated(out))
+	}
+}

--- a/internal/codegen/variant_generate_test.go
+++ b/internal/codegen/variant_generate_test.go
@@ -1,0 +1,95 @@
+package codegen
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/diag"
+)
+
+// hasError reports whether diags contains an Error-severity diagnostic.
+func hasError(diags []diag.Diagnostic) bool {
+	for _, d := range diags {
+		if d.Severity == diag.Error {
+			return true
+		}
+	}
+	return false
+}
+
+// keysOfGenerated returns the sorted-order-agnostic key list of a Generate
+// output map, for readable failure messages.
+func keysOfGenerated(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestSameSigVariantGeneratesAllFiles is the regression for the bug this
+// subsystem fixes: two .gsx files under disjoint //go:build tags declaring a
+// same-name/same-signature component (a legitimate build-tag variant) used to
+// produce a cross-file "redeclared in this block" go/types error, which
+// blocked emission for the WHOLE package — not just the redeclared component.
+// suppressCrossFileRedeclarations must tolerate this so all three files in
+// the package still generate.
+func TestSameSigVariantGeneratesAllFiles(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"icon_linux.gsx":   "//go:build linux\n\npackage views\n\ncomponent Icon(name string) { <span>linux:{ name }</span> }\n",
+		"icon_windows.gsx": "//go:build windows\n\npackage views\n\ncomponent Icon(name string) { <span>win:{ name }</span> }\n",
+		"page.gsx":         "package views\n\ncomponent Page() { <Icon name=\"x\"/> }\n",
+	})
+	out, diags, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if hasError(diags) {
+		t.Fatalf("unexpected error diagnostics: %v", diags)
+	}
+	for _, want := range []string{"icon_linux.gsx", "icon_windows.gsx", "page.gsx"} {
+		if _, ok := out[filepath.Join(dir, want)]; !ok {
+			t.Fatalf("missing generated output for %s; got keys %v", want, keysOfGenerated(out))
+		}
+	}
+	linuxOut := out[filepath.Join(dir, "icon_linux.gsx")]
+	if !strings.Contains(string(linuxOut), "//go:build linux") {
+		t.Fatalf("linux variant lost its build constraint:\n%s", linuxOut)
+	}
+}
+
+// TestDiffSigVariantIsCleanError covers the genuine-conflict side: a same-name
+// component declared with DIFFERENT signatures across build-tagged files is a
+// real ambiguity (gsx does not parse build tags, so it cannot know which
+// signature wins). This must surface as a single clean duplicate-component
+// diagnostic — never a raw go/types "redeclared in this block" — and must
+// block emission entirely (not just for the conflicting component).
+func TestDiffSigVariantIsCleanError(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"icon_linux.gsx":   "//go:build linux\n\npackage views\n\ncomponent Icon(name string) { <span>{ name }</span> }\n",
+		"icon_windows.gsx": "//go:build windows\n\npackage views\n\ncomponent Icon(name int) { <span>{ name }</span> }\n",
+	})
+	out, diags, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !hasError(diags) {
+		t.Fatalf("expected a duplicate-component error, got none: %v", diags)
+	}
+	foundClean := false
+	for _, d := range diags {
+		if d.Code == "duplicate-component" {
+			foundClean = true
+		}
+		if strings.Contains(d.Message, "redeclared in this block") {
+			t.Fatalf("raw go/types redeclared error leaked: %q", d.Message)
+		}
+	}
+	if !foundClean {
+		t.Fatalf("no duplicate-component diagnostic in %v", diags)
+	}
+	if len(out) != 0 {
+		t.Fatalf("diff-sig conflict must block emission, got %v", keysOfGenerated(out))
+	}
+}

--- a/internal/codegen/variantcollide.go
+++ b/internal/codegen/variantcollide.go
@@ -1,0 +1,55 @@
+package codegen
+
+import (
+	"sort"
+	"strings"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+)
+
+// componentSignature returns a canonical string of a component's CALLER
+// signature — what a `<Comp .../>` invocation type-checks against. Two
+// components with the same componentKey that share this signature are drop-in
+// build-tag variants (same name, different body); one with a different
+// signature is a genuine conflict. The string is comparison-only (not parsed);
+// it is order-independent over props (attrs map to fields by name) and ignores
+// the receiver VARIABLE name.
+func componentSignature(c *gsxast.Component) string {
+	var b strings.Builder
+
+	// Receiver: type (parseRecv's recvType already carries the pointer-ness,
+	// e.g. "*Form" vs "Form" — a method vs func component, and the owning
+	// type, are caller-visible; the receiver var name is not).
+	if c.Recv != "" {
+		if _, recvType, _, err := parseRecv(c.Recv); err == nil {
+			b.WriteString("recv:")
+			b.WriteString(recvType)
+		} else {
+			b.WriteString("recv:<unparsable>")
+		}
+	}
+	b.WriteByte('|')
+
+	// Generic type params: normalized source.
+	b.WriteString("tp:")
+	b.WriteString(strings.Join(strings.Fields(c.TypeParams), " "))
+	b.WriteByte('|')
+
+	// Props: sorted "FieldName type" entries, plus synthesized Children/Attrs.
+	var fields []string
+	if params, err := parseParams(c.Params); err == nil {
+		for _, p := range params {
+			fields = append(fields, fieldName(p.name)+" "+strings.Join(strings.Fields(p.typ), " "))
+		}
+	}
+	if usesChildren(c.Body) {
+		fields = append(fields, "Children gsx.Node")
+	}
+	if usesAttrs(c.Body) {
+		fields = append(fields, "Attrs gsx.Attrs")
+	}
+	sort.Strings(fields)
+	b.WriteString("props:")
+	b.WriteString(strings.Join(fields, ";"))
+	return b.String()
+}

--- a/internal/codegen/variantcollide.go
+++ b/internal/codegen/variantcollide.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"go/types"
 	"sort"
 	"strings"
 
@@ -118,4 +119,49 @@ func detectSignatureConflicts(files map[string]*gsxast.File) []signatureConflict
 		out = append(out, signatureConflict{key: key, comps: comps})
 	}
 	return out
+}
+
+// redeclName extracts the declared name from a go/types redeclaration-class
+// error message, or ("", false) if the error is not redeclaration-class. It
+// recognizes both records go/types emits: "<name> redeclared in this block"
+// (at the second decl) and "other declaration of <name>" (at the first).
+func redeclName(msg string) (string, bool) {
+	msg = strings.TrimSpace(msg)
+	if i := strings.Index(msg, " redeclared"); i > 0 {
+		return msg[:i], true
+	}
+	const p = "other declaration of "
+	if strings.HasPrefix(msg, p) {
+		return strings.TrimSpace(msg[len(p):]), true
+	}
+	return "", false
+}
+
+// suppressCrossFileRedeclarations drops redeclaration-class errors whose
+// declared name is redeclared ACROSS files (a tolerated cross-tag variant of a
+// component or helper). A same-file redeclaration keeps its error (a real
+// within-file mistake), as do all non-redeclaration errors. gsx does not parse
+// build tags; go build remains the arbiter of whether a cross-file same-name
+// pair is an actual same-configuration duplicate.
+func suppressCrossFileRedeclarations(errs []types.Error) []types.Error {
+	// filesByName[name] = set of distinct filenames where a redeclaration-class
+	// error for that name was reported.
+	filesByName := map[string]map[string]bool{}
+	for _, e := range errs {
+		if name, ok := redeclName(e.Msg); ok {
+			fn := e.Fset.Position(e.Pos).Filename
+			if filesByName[name] == nil {
+				filesByName[name] = map[string]bool{}
+			}
+			filesByName[name][fn] = true
+		}
+	}
+	kept := errs[:0]
+	for _, e := range errs {
+		if name, ok := redeclName(e.Msg); ok && len(filesByName[name]) >= 2 {
+			continue // cross-file variant: tolerate
+		}
+		kept = append(kept, e)
+	}
+	return kept
 }

--- a/internal/codegen/variantcollide.go
+++ b/internal/codegen/variantcollide.go
@@ -1,6 +1,8 @@
 package codegen
 
 import (
+	goast "go/ast"
+	"go/token"
 	"go/types"
 	"sort"
 	"strings"
@@ -122,44 +124,152 @@ func detectSignatureConflicts(files map[string]*gsxast.File) []signatureConflict
 }
 
 // redeclName extracts the declared name from a go/types redeclaration-class
-// error message, or ("", false) if the error is not redeclaration-class. It
-// recognizes both records go/types emits: "<name> redeclared in this block"
-// (at the second decl) and "other declaration of <name>" (at the first).
+// error message, or ("", false) if the error is not redeclaration-class. The
+// returned name is the KEY under which redeclFacts groups the same declaration
+// — a bare identifier for a func/var/const/type, and a receiver-qualified
+// "<BaseType>.<Method>" for a method.
+//
+// go/types (observed on Go 1.26.1) emits redeclarations in two message
+// families, exercised by a throwaway type-checker probe:
+//
+//   - Funcs, vars, consts, types → a PAIR of records:
+//     "<name> redeclared in this block"   (at the 2nd+ decl)
+//     "\tother declaration of <name>"     (a note, at the globally-first decl;
+//     note the leading tab that TrimSpace strips)
+//
+//   - Methods → a SINGLE self-contained record:
+//     "method <BaseType>.<Method> already declared at <file>:<line>:<col>"
+//     (at the 2nd+ decl; the first-decl location is embedded in the text).
+//     <BaseType> is the base receiver type with NO pointer '*' and NO generic
+//     '[T]' — e.g. both `(f *Form)` and `(f Form[T])` report "Form.Field".
 func redeclName(msg string) (string, bool) {
 	msg = strings.TrimSpace(msg)
 	if i := strings.Index(msg, " redeclared"); i > 0 {
 		return msg[:i], true
 	}
-	const p = "other declaration of "
-	if strings.HasPrefix(msg, p) {
-		return strings.TrimSpace(msg[len(p):]), true
+	const other = "other declaration of "
+	if strings.HasPrefix(msg, other) {
+		return strings.TrimSpace(msg[len(other):]), true
+	}
+	const method = "method "
+	if strings.HasPrefix(msg, method) {
+		if j := strings.Index(msg, " already declared"); j > len(method) {
+			return msg[len(method):j], true // "<BaseType>.<Method>"
+		}
 	}
 	return "", false
 }
 
-// suppressCrossFileRedeclarations drops redeclaration-class errors whose
-// declared name is redeclared ACROSS files (a tolerated cross-tag variant of a
-// component or helper). A same-file redeclaration keeps its error (a real
-// within-file mistake), as do all non-redeclaration errors. gsx does not parse
-// build tags; go build remains the arbiter of whether a cross-file same-name
-// pair is an actual same-configuration duplicate.
-func suppressCrossFileRedeclarations(errs []types.Error) []types.Error {
-	// filesByName[name] = set of distinct filenames where a redeclaration-class
-	// error for that name was reported.
-	filesByName := map[string]map[string]bool{}
-	for _, e := range errs {
-		if name, ok := redeclName(e.Msg); ok {
-			fn := e.Fset.Position(e.Pos).Filename
-			if filesByName[name] == nil {
-				filesByName[name] = map[string]bool{}
+// redeclFacts records, per declaration key (see redeclName), whether that name
+// is declared across ≥2 skeleton files (a candidate build-tag variant) and/or
+// ≥2 times within a single file (a genuine within-file redeclaration). These
+// facts are derived from the parsed skeleton ASTs, NOT from the go/types error
+// positions, on purpose: go/types anchors EVERY redeclaration against the
+// single globally-first decl of a name, and gsx feeds skeleton files to the
+// checker in nondeterministic (map) order — so a within-file duplicate that
+// happens to live in a non-anchor file is reported as if it were cross-file,
+// making per-error F1==F2 detection unreliable. The skeleton AST sees every
+// declaration regardless of order, so the within-file fact is exact.
+type redeclFacts struct {
+	crossFile map[string]bool // name declared in ≥2 distinct files
+	withinDup map[string]bool // name declared ≥2 times within one file
+}
+
+// collectRedeclFacts walks the top-level declarations of every skeleton file
+// and tallies, per redeclName key, the set of files it appears in and whether
+// any single file declares it more than once.
+func collectRedeclFacts(goFiles []*goast.File, fset *token.FileSet) redeclFacts {
+	byName := map[string]map[string]int{} // name -> filename -> count in that file
+	add := func(name string, pos token.Pos) {
+		if name == "" {
+			return
+		}
+		file := fset.Position(pos).Filename
+		if byName[name] == nil {
+			byName[name] = map[string]int{}
+		}
+		byName[name][file]++
+	}
+	for _, gf := range goFiles {
+		for _, d := range gf.Decls {
+			switch decl := d.(type) {
+			case *goast.FuncDecl:
+				if decl.Recv != nil && len(decl.Recv.List) > 0 {
+					if base := recvBaseName(decl.Recv.List[0].Type); base != "" {
+						add(base+"."+decl.Name.Name, decl.Pos())
+					}
+				} else {
+					add(decl.Name.Name, decl.Pos())
+				}
+			case *goast.GenDecl:
+				for _, spec := range decl.Specs {
+					switch s := spec.(type) {
+					case *goast.ValueSpec: // var / const
+						for _, n := range s.Names {
+							if n.Name != "_" {
+								add(n.Name, n.Pos())
+							}
+						}
+					case *goast.TypeSpec:
+						if s.Name.Name != "_" {
+							add(s.Name.Name, s.Name.Pos())
+						}
+					}
+				}
 			}
-			filesByName[name][fn] = true
 		}
 	}
+	facts := redeclFacts{crossFile: map[string]bool{}, withinDup: map[string]bool{}}
+	for name, files := range byName {
+		if len(files) >= 2 {
+			facts.crossFile[name] = true
+		}
+		for _, c := range files {
+			if c >= 2 {
+				facts.withinDup[name] = true
+				break
+			}
+		}
+	}
+	return facts
+}
+
+// recvBaseName returns the base type identifier of a method receiver, stripping
+// a leading pointer and any generic type-argument list so it matches the
+// "<BaseType>" go/types prints in a method-redeclaration message (see
+// redeclName): `*Form` → "Form", `Form[T]` → "Form".
+func recvBaseName(expr goast.Expr) string {
+	switch t := expr.(type) {
+	case *goast.StarExpr:
+		return recvBaseName(t.X)
+	case *goast.IndexExpr: // Form[T]
+		return recvBaseName(t.X)
+	case *goast.IndexListExpr: // Form[T, U]
+		return recvBaseName(t.X)
+	case *goast.Ident:
+		return t.Name
+	}
+	return ""
+}
+
+// suppressCrossFileRedeclarations drops redeclaration-class errors for a name
+// that is a tolerated cross-tag variant — declared across ≥2 files but never
+// twice within a single file. gsx does not parse build tags; go build remains
+// the arbiter of whether a cross-file same-name pair is an actual
+// same-configuration duplicate.
+//
+// A name that IS duplicated within some file keeps ALL its redeclaration errors
+// (blocking emission), even when a cross-file variant of the same name also
+// exists. That within-file duplicate is a real mistake go/types must report;
+// disentangling the specific cross-file record from the within-file one per
+// error is not possible reliably (go/types' global-first anchoring, above), so
+// gsx keeps the whole group — go build would reject the within-file duplicate
+// under any tag too. Non-redeclaration errors are always kept.
+func suppressCrossFileRedeclarations(errs []types.Error, facts redeclFacts) []types.Error {
 	kept := errs[:0]
 	for _, e := range errs {
-		if name, ok := redeclName(e.Msg); ok && len(filesByName[name]) >= 2 {
-			continue // cross-file variant: tolerate
+		if name, ok := redeclName(e.Msg); ok && facts.crossFile[name] && !facts.withinDup[name] {
+			continue // cross-file build-tag variant: tolerate
 		}
 		kept = append(kept, e)
 	}

--- a/internal/codegen/variantcollide.go
+++ b/internal/codegen/variantcollide.go
@@ -53,3 +53,69 @@ func componentSignature(c *gsxast.Component) string {
 	b.WriteString(strings.Join(fields, ";"))
 	return b.String()
 }
+
+type conflictComp struct {
+	path string
+	comp *gsxast.Component
+}
+
+type signatureConflict struct {
+	key   string
+	comps []conflictComp
+}
+
+// detectSignatureConflicts finds components that share a componentKey across
+// DIFFERENT files but do not share a signature — a genuine ambiguity gsx
+// cannot paper over. A key whose cross-file decls all share one signature is a
+// tolerated build-tag variant (no conflict); a key declared twice in a single
+// file is a within-file redeclaration left to the raw go/types error.
+func detectSignatureConflicts(files map[string]*gsxast.File) []signatureConflict {
+	type decl struct {
+		path string
+		comp *gsxast.Component
+		sig  string
+	}
+	byKey := map[string][]decl{}
+	// Iterate files in sorted path order for determinism.
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		for _, d := range files[p].Decls {
+			c, ok := d.(*gsxast.Component)
+			if !ok {
+				continue
+			}
+			key := componentKey(c)
+			byKey[key] = append(byKey[key], decl{p, c, componentSignature(c)})
+		}
+	}
+
+	var out []signatureConflict
+	keys := make([]string, 0, len(byKey))
+	for k := range byKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		decls := byKey[key]
+		// Distinct files that declare this key.
+		fileSet := map[string]bool{}
+		sigSet := map[string]bool{}
+		for _, d := range decls {
+			fileSet[d.path] = true
+			sigSet[d.sig] = true
+		}
+		if len(fileSet) < 2 || len(sigSet) < 2 {
+			continue // single-file (within-file) or all one signature (tolerated)
+		}
+		comps := make([]conflictComp, 0, len(decls))
+		for _, d := range decls {
+			comps = append(comps, conflictComp{d.path, d.comp})
+		}
+		out = append(out, signatureConflict{key: key, comps: comps})
+	}
+	return out
+}

--- a/internal/codegen/variantcollide_test.go
+++ b/internal/codegen/variantcollide_test.go
@@ -118,7 +118,14 @@ func TestSuppressCrossFileRedeclarations(t *testing.T) {
 		{Fset: fset, Pos: posA3, Msg: "other declaration of Dup"},
 		{Fset: fset, Pos: posA, Msg: "undefined: Whatever"},
 	}
-	got := suppressCrossFileRedeclarations(errs)
+	// Facts as the skeleton ASTs would report them: Icon is a pure cross-file
+	// variant (one decl in each of a/b); Dup is a within-file duplicate (twice
+	// in a.x.go), so its errors must be kept.
+	facts := redeclFacts{
+		crossFile: map[string]bool{"Icon": true, "Dup": false},
+		withinDup: map[string]bool{"Dup": true},
+	}
+	got := suppressCrossFileRedeclarations(errs, facts)
 
 	var msgs []string
 	for _, e := range got {

--- a/internal/codegen/variantcollide_test.go
+++ b/internal/codegen/variantcollide_test.go
@@ -54,3 +54,45 @@ func TestComponentSignature(t *testing.T) {
 		t.Fatalf("children presence must differ")
 	}
 }
+
+func TestDetectSignatureConflicts(t *testing.T) {
+	filesOf := func(srcs map[string]string) map[string]*gsxast.File {
+		out := map[string]*gsxast.File{}
+		for name, src := range srcs {
+			fset := token.NewFileSet()
+			f, errs := parser.ParseFileWithClassifier(fset, name, []byte(src), 0, nil)
+			if len(errs) > 0 {
+				t.Fatalf("%s: %v", name, errs)
+			}
+			out[name] = f
+		}
+		return out
+	}
+
+	// Same name, same signature, different files → NO conflict (tolerated variant).
+	same := filesOf(map[string]string{
+		"a.gsx": "package v\ncomponent Icon(name string) { <a>{ name }</a> }\n",
+		"b.gsx": "package v\ncomponent Icon(name string) { <b>{ name }</b> }\n",
+	})
+	if got := detectSignatureConflicts(same); len(got) != 0 {
+		t.Fatalf("same-sig variants: want 0 conflicts, got %d", len(got))
+	}
+
+	// Same name, DIFFERENT signature, different files → conflict.
+	diff := filesOf(map[string]string{
+		"a.gsx": "package v\ncomponent Icon(name string) { <a>{ name }</a> }\n",
+		"b.gsx": "package v\ncomponent Icon(name int) { <b>{ name }</b> }\n",
+	})
+	got := detectSignatureConflicts(diff)
+	if len(got) != 1 || got[0].key != ".Icon" || len(got[0].comps) != 2 {
+		t.Fatalf("diff-sig: want 1 conflict on .Icon with 2 comps, got %+v", got)
+	}
+
+	// Same name twice in ONE file → NOT our conflict (within-file; left to raw error).
+	within := filesOf(map[string]string{
+		"a.gsx": "package v\ncomponent Icon(name string) { <a/> }\ncomponent Icon(name int) { <b/> }\n",
+	})
+	if got := detectSignatureConflicts(within); len(got) != 0 {
+		t.Fatalf("within-file dup: want 0 conflicts, got %d", len(got))
+	}
+}

--- a/internal/codegen/variantcollide_test.go
+++ b/internal/codegen/variantcollide_test.go
@@ -1,0 +1,56 @@
+package codegen
+
+import (
+	"testing"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/parser"
+	"go/token"
+)
+
+// mustParseComponent parses a single-component .gsx source and returns the
+// first *gsxast.Component declaration.
+func mustParseComponent(t *testing.T, src string) *gsxast.Component {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, errs := parser.ParseFileWithClassifier(fset, "input.gsx", []byte(src), 0, nil)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	for _, d := range file.Decls {
+		if c, ok := d.(*gsxast.Component); ok {
+			return c
+		}
+	}
+	t.Fatal("no component")
+	return nil
+}
+
+func TestComponentSignature(t *testing.T) {
+	// Same props, different body → SAME signature (drop-in variant).
+	a := mustParseComponent(t, "package v\ncomponent Icon(name string) {\n\t<span>{ name }</span>\n}\n")
+	b := mustParseComponent(t, "package v\ncomponent Icon(name string) {\n\t<b>{ name }</b>\n}\n")
+	if componentSignature(a) != componentSignature(b) {
+		t.Fatalf("same-props variants must share a signature:\n a=%q\n b=%q", componentSignature(a), componentSignature(b))
+	}
+
+	// Different prop type → DIFFERENT signature.
+	c := mustParseComponent(t, "package v\ncomponent Icon(name int) {\n\t<span>{ name }</span>\n}\n")
+	if componentSignature(a) == componentSignature(c) {
+		t.Fatalf("different prop type must differ: %q", componentSignature(a))
+	}
+
+	// Param order does not matter (props map by name).
+	d := mustParseComponent(t, "package v\ncomponent Icon(x string, y string) { <i/> }\n")
+	e := mustParseComponent(t, "package v\ncomponent Icon(y string, x string) { <i/> }\n")
+	if componentSignature(d) != componentSignature(e) {
+		t.Fatalf("param order must not affect signature")
+	}
+
+	// Children presence is part of the signature.
+	f := mustParseComponent(t, "package v\ncomponent Box() { <div>{ children }</div> }\n")
+	g := mustParseComponent(t, "package v\ncomponent Box() { <div/> }\n")
+	if componentSignature(f) == componentSignature(g) {
+		t.Fatalf("children presence must differ")
+	}
+}

--- a/internal/codegen/variantcollide_test.go
+++ b/internal/codegen/variantcollide_test.go
@@ -1,11 +1,13 @@
 package codegen
 
 import (
+	"strings"
 	"testing"
 
 	gsxast "github.com/gsxhq/gsx/ast"
 	"github.com/gsxhq/gsx/parser"
 	"go/token"
+	"go/types"
 )
 
 // mustParseComponent parses a single-component .gsx source and returns the
@@ -94,5 +96,41 @@ func TestDetectSignatureConflicts(t *testing.T) {
 	})
 	if got := detectSignatureConflicts(within); len(got) != 0 {
 		t.Fatalf("within-file dup: want 0 conflicts, got %d", len(got))
+	}
+}
+
+func TestSuppressCrossFileRedeclarations(t *testing.T) {
+	fset := token.NewFileSet()
+	fa := fset.AddFile("a.x.go", -1, 100)
+	fb := fset.AddFile("b.x.go", -1, 100)
+	posA := fa.Pos(10)
+	posB := fb.Pos(10)
+
+	// Cross-file redeclaration of Icon → both dropped.
+	// Within-file redeclaration of Dup (both in a.x.go) → both kept.
+	// An unrelated type error → kept.
+	posA2 := fa.Pos(40)
+	posA3 := fa.Pos(60)
+	errs := []types.Error{
+		{Fset: fset, Pos: posB, Msg: "Icon redeclared in this block"},
+		{Fset: fset, Pos: posA, Msg: "other declaration of Icon"},
+		{Fset: fset, Pos: posA2, Msg: "Dup redeclared in this block"},
+		{Fset: fset, Pos: posA3, Msg: "other declaration of Dup"},
+		{Fset: fset, Pos: posA, Msg: "undefined: Whatever"},
+	}
+	got := suppressCrossFileRedeclarations(errs)
+
+	var msgs []string
+	for _, e := range got {
+		msgs = append(msgs, e.Msg)
+	}
+	// Icon pair gone; Dup pair + undefined kept.
+	for _, e := range got {
+		if strings.Contains(e.Msg, "Icon") {
+			t.Fatalf("cross-file Icon redeclaration should be suppressed, got %q", e.Msg)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 kept (2 Dup + 1 undefined), got %d: %v", len(got), msgs)
 	}
 }

--- a/internal/corpus/testdata/cases/buildtags/helper_variant.txtar
+++ b/internal/corpus/testdata/cases/buildtags/helper_variant.txtar
@@ -1,0 +1,25 @@
+-- icon.gsx --
+//go:build !never
+
+package views
+
+const iconPath = "/active.svg"
+
+component Icon() {
+	<img src={ iconPath }/>
+}
+-- icon_never.gsx --
+//go:build never
+
+package views
+
+const iconPath = "/never.svg"
+
+component IconNever() {
+	<img src={ iconPath }/>
+}
+-- invoke --
+Icon()
+-- diagnostics.golden --
+-- render.golden --
+<img src="/active.svg"/>

--- a/internal/corpus/testdata/cases/buildtags/method_variant.txtar
+++ b/internal/corpus/testdata/cases/buildtags/method_variant.txtar
@@ -1,0 +1,23 @@
+-- field.gsx --
+//go:build !never
+
+package views
+
+type Form struct{}
+
+component (f Form) Field(name string) {
+	<span class="active">{ name }</span>
+}
+-- field_never.gsx --
+//go:build never
+
+package views
+
+component (f Form) Field(name string) {
+	<span class="never">{ name }</span>
+}
+-- invoke --
+(Form{}).Field(FormFieldProps{Name: "x"})
+-- diagnostics.golden --
+-- render.golden --
+<span class="active">x</span>

--- a/internal/corpus/testdata/cases/buildtags/redeclare_within_file.txtar
+++ b/internal/corpus/testdata/cases/buildtags/redeclare_within_file.txtar
@@ -1,0 +1,14 @@
+-- input.gsx --
+package views
+
+component Icon(name string) {
+	<a/>
+}
+
+component Icon(name string) {
+	<b/>
+}
+-- invoke --
+-- diagnostics.golden --
+3:11: 	other declaration of Icon
+7:11: Icon redeclared in this block

--- a/internal/corpus/testdata/cases/buildtags/variant_diff_sig.txtar
+++ b/internal/corpus/testdata/cases/buildtags/variant_diff_sig.txtar
@@ -1,0 +1,20 @@
+-- icon.gsx --
+//go:build !never
+
+package views
+
+component Icon(name string) {
+	<span>{ name }</span>
+}
+-- icon_never.gsx --
+//go:build never
+
+package views
+
+component Icon(name int) {
+	<span>{ name }</span>
+}
+-- invoke --
+-- diagnostics.golden --
+5:11: component Icon is declared with different signatures across build-tagged files (icon.gsx, icon_never.gsx); build-tag variants must share the same signature — rename the variants or align their parameters
+5:11: component Icon is declared with different signatures across build-tagged files (icon.gsx, icon_never.gsx); build-tag variants must share the same signature — rename the variants or align their parameters

--- a/internal/corpus/testdata/cases/buildtags/variant_same_sig.txtar
+++ b/internal/corpus/testdata/cases/buildtags/variant_same_sig.txtar
@@ -1,0 +1,27 @@
+-- icon.gsx --
+//go:build !never
+
+package views
+
+component Icon(name string) {
+	<span class="active">{ name }</span>
+}
+-- icon_never.gsx --
+//go:build never
+
+package views
+
+component Icon(name string) {
+	<span class="never">{ name }</span>
+}
+-- page.gsx --
+package views
+
+component Page() {
+	<Icon name="x"/>
+}
+-- invoke --
+Page()
+-- diagnostics.golden --
+-- render.golden --
+<span class="active">x</span>

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -24,6 +24,7 @@ bodyinterp/plain	diag gen render
 bodyinterp/sub_expression	diag gen render
 bodyinterp/whole_pipe	diag gen render
 buildtags/helper_variant	diag render
+buildtags/method_variant	diag render
 buildtags/redeclare_within_file	diag(error)
 buildtags/variant_diff_sig	diag(error)
 buildtags/variant_same_sig	diag render
@@ -496,4 +497,4 @@ xpkg/imported_byo	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 498 cases (render: 400, error: 75, gen-pinned: 232)
+TOTAL: 499 cases (render: 401, error: 75, gen-pinned: 232)

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -23,6 +23,10 @@ bodyinterp/escaped_hole	diag gen render
 bodyinterp/plain	diag gen render
 bodyinterp/sub_expression	diag gen render
 bodyinterp/whole_pipe	diag gen render
+buildtags/helper_variant	diag render
+buildtags/redeclare_within_file	diag(error)
+buildtags/variant_diff_sig	diag(error)
+buildtags/variant_same_sig	diag render
 byo/external_struct_node_attrs	diag gen render
 class/caller_wins_classstyle	diag render
 class/caller_wins_scalar	diag render
@@ -492,4 +496,4 @@ xpkg/imported_byo	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 494 cases (render: 398, error: 73, gen-pinned: 232)
+TOTAL: 498 cases (render: 400, error: 75, gen-pinned: 232)

--- a/internal/lsp/analysis.go
+++ b/internal/lsp/analysis.go
@@ -12,10 +12,14 @@ import (
 
 // CrossRef is one component's cross-boundary entry (see the .go->.gsx design):
 // its name, its .gsx declaration, and every reference, as resolved positions.
+// Decls holds every build-tag variant's declaration position (Decl is the
+// primary/first, kept for back-compat with single-decl callers) — see
+// codegen.CrossRef.Decls (Task 6).
 type CrossRef struct {
-	Name string
-	Decl token.Position
-	Refs []token.Position
+	Name  string
+	Decl  token.Position
+	Decls []token.Position
+	Refs  []token.Position
 }
 
 // NavRef is one navigable Go reference (in a .go file) and the .gsx position it

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -396,9 +396,19 @@ func (s *Server) handleDefinition(f frame) error {
 
 	off := byteOffsetForPosition(text, p.Position.Line, p.Position.Character, s.enc)
 
-	// D2: cursor on a component tag name in a .gsx file → jump to the component declaration.
-	if decl, ok := componentTagDeclAt(pkg, path, off); ok {
-		return s.reply(f.ID, s.locationForPos(decl))
+	// D2: cursor on a component tag name in a .gsx file → jump to the component
+	// declaration(s). A single variant replies with a plain Location (unchanged
+	// wire shape); multiple build-tag variants (Task 7) reply with a []Location
+	// so the editor shows a picker — both are valid textDocument/definition results.
+	if decls, ok := componentTagDeclAt(pkg, path, off); ok {
+		if len(decls) == 1 {
+			return s.reply(f.ID, s.locationForPos(decls[0]))
+		}
+		locs := make([]Location, 0, len(decls))
+		for _, d := range decls {
+			locs = append(locs, s.locationForPos(d))
+		}
+		return s.reply(f.ID, locs)
 	}
 
 	// B: cursor on a dotted/cross-package component tag → its declaration in the
@@ -607,17 +617,18 @@ func posCoversCursor(r token.Position, path string, curLine, curCol, nameLen int
 // componentTagDeclAt checks whether the byte offset off in the .gsx file at
 // path sits on the name portion of a component element tag (e.g. the "Card" in
 // "<Card .../>"). If so, it looks the component up in pkg.CrossIndex by the
-// function-component key "." + tag, and returns its Decl position and true.
-// Returns (zero, false) if the cursor is not on a component tag.
-func componentTagDeclAt(pkg *Package, path string, off int) (token.Position, bool) {
+// function-component key "." + tag, and returns every build-tag variant's
+// declaration position (Task 7) and true. Returns (nil, false) if the cursor
+// is not on a component tag.
+func componentTagDeclAt(pkg *Package, path string, off int) ([]token.Position, bool) {
 	if pkg == nil || pkg.GSXFset == nil || pkg.Files == nil {
-		return token.Position{}, false
+		return nil, false
 	}
 	f := pkg.Files[path]
 	if f == nil {
-		return token.Position{}, false
+		return nil, false
 	}
-	var result token.Position
+	var result []token.Position
 	found := false
 	gsxast.Inspect(f, func(n gsxast.Node) bool {
 		if found {
@@ -645,12 +656,21 @@ func componentTagDeclAt(pkg *Package, path string, off int) (token.Position, boo
 			onClose = off >= closeStart && off < closeStart+len(tag)
 		}
 		if onOpen || onClose {
-			// Cursor is on the tag name; look up in CrossIndex.
+			// Cursor is on the tag name; look up in CrossIndex. Decls carries every
+			// build-tag variant's declaration (Task 6); fall back to the single
+			// primary Decl for CrossRef values that predate Decls (e.g. synthetic
+			// test fixtures built before Task 7).
 			key := "." + tag
 			cr, ok := pkg.CrossIndex[key]
-			if ok && cr.Decl.IsValid() {
-				result = cr.Decl
-				found = true
+			if ok {
+				decls := cr.Decls
+				if len(decls) == 0 && cr.Decl.IsValid() {
+					decls = []token.Position{cr.Decl}
+				}
+				if len(decls) > 0 {
+					result = decls
+					found = true
+				}
 			}
 		}
 		return true

--- a/internal/lsp/definition_test.go
+++ b/internal/lsp/definition_test.go
@@ -177,22 +177,22 @@ func TestComponentTagDeclAtByo(t *testing.T) {
 	}
 
 	// Cursor on 'B' (first char of the tag name).
-	decl, ok := componentTagDeclAt(pkg, path, tagStart)
+	decls, ok := componentTagDeclAt(pkg, path, tagStart)
 	if !ok {
 		t.Fatalf("componentTagDeclAt returned false for cursor on 'B' of Button tag")
 	}
-	if decl != declPos {
-		t.Errorf("componentTagDeclAt decl = %+v, want %+v", decl, declPos)
+	if len(decls) != 1 || decls[0] != declPos {
+		t.Errorf("componentTagDeclAt decls = %+v, want [%+v]", decls, declPos)
 	}
 
 	// Cursor on 't' (middle of the tag name "But|ton") — must also resolve.
 	midCursor := tagStart + 2 // 'B'+'u'+'t' → offset of 't'
-	decl2, ok2 := componentTagDeclAt(pkg, path, midCursor)
+	decls2, ok2 := componentTagDeclAt(pkg, path, midCursor)
 	if !ok2 {
 		t.Fatalf("componentTagDeclAt returned false for cursor in middle of Button tag")
 	}
-	if decl2 != declPos {
-		t.Errorf("componentTagDeclAt (mid) decl = %+v, want %+v", decl2, declPos)
+	if len(decls2) != 1 || decls2[0] != declPos {
+		t.Errorf("componentTagDeclAt (mid) decls = %+v, want [%+v]", decls2, declPos)
 	}
 
 	// Cursor BEFORE the tag name (on the '<') — must NOT resolve (cursor is not
@@ -224,17 +224,17 @@ func TestComponentTagDeclAtClosingTag(t *testing.T) {
 	}
 
 	// Cursor on 'C' of the closing tag name.
-	decl, ok := componentTagDeclAt(pkg, path, closeStart)
+	decls, ok := componentTagDeclAt(pkg, path, closeStart)
 	if !ok {
 		t.Fatalf("componentTagDeclAt returned false for cursor on closing tag </Card>")
 	}
-	if decl != declPos {
-		t.Errorf("closing-tag decl = %+v, want %+v", decl, declPos)
+	if len(decls) != 1 || decls[0] != declPos {
+		t.Errorf("closing-tag decls = %+v, want [%+v]", decls, declPos)
 	}
 
 	// Cursor in the middle of the closing tag name ("Ca|rd") — must also resolve.
-	if decl2, ok2 := componentTagDeclAt(pkg, path, closeStart+2); !ok2 || decl2 != declPos {
-		t.Errorf("closing-tag (mid) ok=%v decl=%+v, want true %+v", ok2, decl2, declPos)
+	if decls2, ok2 := componentTagDeclAt(pkg, path, closeStart+2); !ok2 || len(decls2) != 1 || decls2[0] != declPos {
+		t.Errorf("closing-tag (mid) ok=%v decls=%+v, want true [%+v]", ok2, decls2, declPos)
 	}
 }
 
@@ -395,8 +395,8 @@ func TestComponentTagDeclAtClosingTagWhitespace(t *testing.T) {
 	if closeStart < 2 {
 		t.Fatal("could not find </Card > in src")
 	}
-	decl, ok := componentTagDeclAt(pkg, path, closeStart+1) // cursor on 'a' of Card
-	if !ok || decl != declPos {
-		t.Errorf("whitespace closing tag: ok=%v decl=%+v, want true %+v", ok, decl, declPos)
+	decls, ok := componentTagDeclAt(pkg, path, closeStart+1) // cursor on 'a' of Card
+	if !ok || len(decls) != 1 || decls[0] != declPos {
+		t.Errorf("whitespace closing tag: ok=%v decls=%+v, want true [%+v]", ok, decls, declPos)
 	}
 }

--- a/internal/lsp/references.go
+++ b/internal/lsp/references.go
@@ -2,7 +2,9 @@ package lsp
 
 import (
 	"encoding/json"
+	"go/token"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -59,12 +61,30 @@ func (s *Server) handleReferences(f frame) error {
 		return s.reply(f.ID, []Location{})
 	}
 
-	locs := make([]Location, 0, len(found.Refs)+1)
+	locs := make([]Location, 0, len(found.Refs)+len(found.Decls)+1)
 	for _, r := range found.Refs {
 		locs = append(locs, s.locationForPos(r))
 	}
 	if p.Context.IncludeDeclaration {
-		locs = append(locs, s.locationForPos(found.Decl))
+		// Emit every build-tag variant's declaration (found.Decls), not just the
+		// primary found.Decl, deduping by filename+offset since Decls always
+		// contains found.Decl too (Decls[0], see codegen.CrossRef).
+		decls := found.Decls
+		if len(decls) == 0 {
+			decls = []token.Position{found.Decl}
+		}
+		seen := map[string]bool{}
+		for _, d := range decls {
+			if !d.IsValid() {
+				continue
+			}
+			k := d.Filename + ":" + strconv.Itoa(d.Offset)
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			locs = append(locs, s.locationForPos(d))
+		}
 	}
 	return s.reply(f.ID, locs)
 }
@@ -78,6 +98,11 @@ func identifyCrossRef(refs []CrossRef, path string, curLine, curCol int) *CrossR
 		cr := refs[i]
 		if posCoversCursor(cr.Decl, path, curLine, curCol, len(cr.Name)) {
 			return &refs[i]
+		}
+		for _, d := range cr.Decls {
+			if posCoversCursor(d, path, curLine, curCol, len(cr.Name)) {
+				return &refs[i]
+			}
 		}
 		for _, r := range cr.Refs {
 			if strings.HasSuffix(r.Filename, ".go") &&

--- a/internal/lsp/variant_nav_test.go
+++ b/internal/lsp/variant_nav_test.go
@@ -1,0 +1,78 @@
+package lsp
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/codegen"
+)
+
+// TestDefinitionShowsAllVariants is Task 7: componentTagDeclAt must surface
+// EVERY build-tag variant's declaration, not just the primary one (Task 6
+// made codegen.CrossRef.Decls carry all of them; this test proves the LSP
+// mirror + tag lookup thread that all the way through). Two same-signature
+// Icon components live under disjoint //go:build tags (icon_a.gsx / icon_b.gsx,
+// mirroring internal/codegen/crossnav_test.go's TestCrossIndexMultiValuedVariants
+// fixture) and a Page component in page.gsx uses <Icon/>. A cursor on the tag
+// name must resolve to both variant declarations, one per file.
+func TestDefinitionShowsAllVariants(t *testing.T) {
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeLSPTestFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+
+	pageDir := filepath.Join(root, "page")
+	writeLSPTestFile(t, pageDir, "icon_a.gsx", "//go:build !never\n\npackage page\n\ncomponent Icon(name string) { <a>{ name }</a> }\n")
+	writeLSPTestFile(t, pageDir, "icon_b.gsx", "//go:build never\n\npackage page\n\ncomponent Icon(name string) { <b>{ name }</b> }\n")
+	pageSrc := "package page\n\ncomponent Page() {\n\t<Icon name=\"hi\"/>\n}\n"
+	pagePath := filepath.Join(pageDir, "page.gsx")
+	writeLSPTestFile(t, pageDir, "page.gsx", pageSrc)
+
+	m, err := codegen.Open(codegen.Options{ModuleRoot: root, ModulePath: "example.com/app", FilterPkgs: []string{codegen.StdImportPath}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr, err := m.Package(pageDir)
+	if err != nil {
+		t.Fatalf("Package: %v", err)
+	}
+	if len(pr.Diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %+v", pr.Diags)
+	}
+
+	// Mirror gen/lsp.go's adaptPackageResult CrossIndex conversion (Decls included,
+	// Task 7) rather than importing the gen package (which would import lsp back
+	// and cycle); this is the same field-by-field copy adaptPackageResult does.
+	cross := make(map[string]CrossRef, len(pr.CrossIndex))
+	for k, v := range pr.CrossIndex {
+		cross[k] = CrossRef{Name: v.Name, Decl: v.Decl, Decls: v.Decls, Refs: v.Refs}
+	}
+	pkg := &Package{
+		GSXFset:    pr.GSXFset,
+		Fset:       pr.Fset,
+		Info:       pr.Info,
+		Types:      pr.Types,
+		Files:      pr.GSXFiles,
+		ExprMap:    pr.ExprMap,
+		CrossIndex: cross,
+	}
+
+	off := strings.Index(pageSrc, "<Icon") + 1 // cursor on 'I' of the tag name
+	decls, ok := componentTagDeclAt(pkg, pagePath, off)
+	if !ok {
+		t.Fatal("componentTagDeclAt returned false for the Icon tag")
+	}
+	if len(decls) != 2 {
+		t.Fatalf("componentTagDeclAt returned %d decls, want 2 (one per variant): %+v", len(decls), decls)
+	}
+	got := map[string]bool{}
+	for _, d := range decls {
+		got[filepath.Base(d.Filename)] = true
+	}
+	if !got["icon_a.gsx"] || !got["icon_b.gsx"] {
+		t.Fatalf("decls = %+v, want one per variant file (icon_a.gsx and icon_b.gsx)", decls)
+	}
+}

--- a/internal/lsp/variant_nav_test.go
+++ b/internal/lsp/variant_nav_test.go
@@ -8,6 +8,93 @@ import (
 	"github.com/gsxhq/gsx/internal/codegen"
 )
 
+// buildIconVariantFixture writes a two-variant Icon fixture (icon_a.gsx /
+// icon_b.gsx under disjoint //go:build tags, plus a Page component using
+// <Icon/>) into a fresh temp module and returns the analyzed *codegen.
+// PackageResult for pageDir. Shared by TestDefinitionShowsAllVariants-style
+// tests and TestReferencesIncludesAllVariantDecls.
+func buildIconVariantFixture(t *testing.T) (pageDir string, pagePath string, pageSrc string, iconASrc string, iconBSrc string, pr *codegen.PackageResult) {
+	t.Helper()
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeLSPTestFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+
+	pageDir = filepath.Join(root, "page")
+	iconASrc = "//go:build !never\n\npackage page\n\ncomponent Icon(name string) { <a>{ name }</a> }\n"
+	iconBSrc = "//go:build never\n\npackage page\n\ncomponent Icon(name string) { <b>{ name }</b> }\n"
+	writeLSPTestFile(t, pageDir, "icon_a.gsx", iconASrc)
+	writeLSPTestFile(t, pageDir, "icon_b.gsx", iconBSrc)
+	pageSrc = "package page\n\ncomponent Page() {\n\t<Icon name=\"hi\"/>\n}\n"
+	pagePath = filepath.Join(pageDir, "page.gsx")
+	writeLSPTestFile(t, pageDir, "page.gsx", pageSrc)
+
+	m, err := codegen.Open(codegen.Options{ModuleRoot: root, ModulePath: "example.com/app", FilterPkgs: []string{codegen.StdImportPath}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr, err = m.Package(pageDir)
+	if err != nil {
+		t.Fatalf("Package: %v", err)
+	}
+	if len(pr.Diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %+v", pr.Diags)
+	}
+	return pageDir, pagePath, pageSrc, iconASrc, iconBSrc, pr
+}
+
+// TestReferencesIncludesAllVariantDecls is Task 8: find-references must list
+// EVERY build-tag variant's declaration, not just the primary one (cr.Decl,
+// which is always Decls[0] — the alphabetically-first file, icon_a.gsx).
+// The cursor is placed on the SECOND variant's declaration (icon_b.gsx, which
+// is NOT cr.Decl) to exercise identifyCrossRef's new cr.Decls loop: before
+// this task, only cr.Decl was checked, so a cursor on a non-primary variant
+// would fail to identify the component at all (empty result). After the fix,
+// the result must contain both variant declarations plus the page.gsx usage
+// site.
+func TestReferencesIncludesAllVariantDecls(t *testing.T) {
+	pageDir, _, _, _, iconBSrc, pr := buildIconVariantFixture(t)
+
+	// Mirror gen/lsp.go AnalyzeModule's Phase-3 CrossIndex → lsp.CrossRef copy
+	// (Decls included, this task) rather than importing gen (which would
+	// import lsp back and cycle).
+	var moduleRefs []CrossRef
+	for _, v := range pr.CrossIndex {
+		moduleRefs = append(moduleRefs, CrossRef{Name: v.Name, Decl: v.Decl, Decls: v.Decls, Refs: v.Refs})
+	}
+
+	a := &moduleRefsAnalyzer{moduleRefs: moduleRefs}
+
+	iconBPath := filepath.Join(pageDir, "icon_b.gsx")
+	uri := pathToURI(iconBPath)
+	// Cursor on the "I" of "Icon" in `component Icon(...)` — line 5 (1-based),
+	// column 11 (1-based) → 0-based line 4, character 10 ("component " is 10
+	// bytes).
+	refFrame := jsonFrame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/references",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": 4, "character": 10},
+			"context":      map[string]any{"includeDeclaration": true},
+		},
+	})
+	frames := initFrame() + didOpenFrame(uri, iconBSrc) + refFrame + exitFrame()
+
+	out := drive(t, a, frames)
+
+	if !strings.Contains(out, "icon_a.gsx") {
+		t.Fatalf("result missing icon_a.gsx variant declaration:\n%s", out)
+	}
+	if !strings.Contains(out, "icon_b.gsx") {
+		t.Fatalf("result missing icon_b.gsx variant declaration:\n%s", out)
+	}
+	if !strings.Contains(out, "page.gsx") {
+		t.Fatalf("result missing page.gsx reference site:\n%s", out)
+	}
+}
+
 // TestDefinitionShowsAllVariants is Task 7: componentTagDeclAt must surface
 // EVERY build-tag variant's declaration, not just the primary one (Task 6
 // made codegen.CrossRef.Decls carry all of them; this test proves the LSP


### PR DESCRIPTION
## Tag-aware `.gsx` analysis — tolerate same-name build-tag variants

Closes the ROADMAP "Tag-aware `.gsx` analysis" gap: two `.gsx` files gated by disjoint `//go:build` tags declaring the same component currently collide, because analysis type-checks a package's `.gsx` skeletons as one `go/types` unit — and that `redeclared` error made `Generate` skip the **whole** package (`module.go`'s `len(a.typeErrs)==0` gate), so the platform-variant pattern (`icon_linux.gsx` / `icon_windows.gsx`, each declaring `component Icon`) couldn't build at all.

### Approach

Generation stays **build-context-independent** — gsx never parses build constraints (no `go/build/constraint`, no GOOS/GOARCH modeling); every `.gsx` still emits a `.x.go` with its `//go:build` passed through, and `go build` filters by tag.

- **Same name + same signature** across files → tolerated. Cross-file `redeclared` / `already declared` errors are suppressed so all files generate. `go build` is the sole arbiter of a real same-config duplicate.
- **Same name + different signature** (component) → clean `duplicate-component` diagnostic that blocks emission; the raw `redeclared` is suppressed.
- **Within-file redeclaration** stays a hard error. **Non-component cross-file helper** duplicates (const/func/type) are tolerated (deferred to `go build`).
- **LSP** go-to-definition and find-references are **multi-valued** over the variants (show all; the user picks).

Suppression + within-file/tolerated classification is driven from the **skeleton ASTs** (order-independent), which also handles the method-redeclaration message form (`method T.M already declared at …`) — so **method-component** variants (value and pointer receiver) work too.

### Design & plan

- Spec: `docs/superpowers/specs/2026-07-06-tag-variant-component-analysis-design.md`
- Plan: `docs/superpowers/plans/2026-07-06-tag-variant-component-analysis.md`

### Testing

- Corpus (`internal/corpus/testdata/cases/buildtags/`): same-sig variant, diff-sig error, within-file redeclare (still errors), non-component helper dup, method variant.
- `go build -tags` selection probe (builds + runs the compiled binary under each tag).
- Integration tests for func + method variants (same-sig generate-all, diff-sig clean error, within-file hard).
- LSP unit tests for multi-valued go-to-def and find-references.
- Determinism regression guard on the cross-index primary variant.
- `make ci` green (both modules, uncached `-count=1`, gofmt + gsx fmt + golangci-lint + examples drift).

### Review

Built subagent-by-subagent with per-task spec+quality review, then one independent **adversarial** whole-branch review (throwaway probe programs + cross-GOOS `go build`). That review caught a Critical — method-component variants hard-blocking the package — which is fixed here (commit `cb47cfb`) and re-verified adversarially.

### Conscious trade-offs (documented in the spec)

- An untagged accidental same-sig duplicate is caught by `go build` (against generated `.x.go`), not gsx.
- A within-file dup that coexists with a cross-file variant of the same name blocks the package (safe/deterministic — `go build` rejects the within-file dup under any tag).
- Cross-tag reference breaks surface at `go build -tags X`, not at generate time.

https://claude.ai/code/session_01GCvAa6qCFw2pZRdgwnAyxH
