### PR TITLE
fix(fmt): gofmt Go text around element literals; hang multi-line literals off their opening tag

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -297,7 +297,22 @@ render goldens.
     `element-literals/*` (var, call-arg, component-tag, return, struct-field,
     outer-scope interpolation capture, plus an apostrophe/prose-scanning
     regression and a formatter round-trip case). Docs: `syntax/elements.md`
-    §Elements as values, `syntax/raw-go.md` cross-reference. **Deferred:**
+    §Elements as values, `syntax/raw-go.md` cross-reference.
+    **`gsx fmt` follow-up - done:** an element literal turned its whole
+    surrounding Go region into an `ast.GoWithElements`, whose Go text the printer
+    relayed verbatim - so one `var x = <p/>` left every declaration in the region
+    unformatted, and `fmt -l` called the file clean. The printer now substitutes a
+    placeholder identifier per embedded gsx value (an identifier is a valid Go
+    operand in every position such a value can occupy), hands the resulting
+    ordinary Go to `go/format`, and re-splits the output at the placeholders. Each
+    placeholder is exactly as many runes wide as the value it stands for, so
+    gofmt's end-of-line comment columns are computed against the element rather
+    than the placeholder. gsx still never parses Go - it hands Go something Go can
+    parse, the same claim-what-Go-leaves-free move as `|>`, so this needed no
+    merged Go+gsx grammar. Separately, a multi-line element literal now hangs off
+    its opening tag (`pretty.Align`) instead of breaking to column 0: children
+    indent one level deeper than `<`, the closing tag lines up under it. Trade-off:
+    renaming the variable re-indents the element. **Deferred:**
     component values (`type Component = func(...gsx.Attr) gsx.Node` collapse) -
     parked; a baked element literal already covers the driving nav-icon use
     case since its class is constant there, and component values only earn

--- a/internal/pretty/align_test.go
+++ b/internal/pretty/align_test.go
@@ -1,0 +1,59 @@
+package pretty
+
+import "testing"
+
+// Align pins hard-line breaks inside d to the column where d began, rather than
+// to the enclosing tab-indent level. The prefix reproduces the current line's
+// leading whitespace VERBATIM and pads the rest with spaces, so the alignment
+// holds at any tab width the reader has configured.
+
+func TestAlignHangingIndentAtColumn(t *testing.T) {
+	// "\tn := " then an aligned doc that breaks: continuation lines land under
+	// the doc's start column -> one tab (verbatim) + 5 spaces for "n := ".
+	d := Concat(
+		Text("\tn := "),
+		Align(Concat(Text("<div>"), Indent(Concat(HardLine, Text("<p/>"))), HardLine, Text("</div>"))),
+	)
+	got := Print(d, 80)
+	want := "\tn := <div>\n\t     \t<p/>\n\t     </div>"
+	if got != want {
+		t.Errorf("Align mismatch:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestAlignAtColumnZeroMatchesPlainIndent(t *testing.T) {
+	// With no preceding text, Align must be a no-op: the prefix is empty, so
+	// output is identical to the same doc without Align.
+	inner := Concat(Text("<div>"), Indent(Concat(HardLine, Text("<p/>"))), HardLine, Text("</div>"))
+	if got, want := Print(Align(inner), 80), Print(inner, 80); got != want {
+		t.Errorf("Align at column 0 changed output:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestAlignAfterTabIndentOnly(t *testing.T) {
+	// Leading whitespace only: the prefix is the tabs themselves, no spaces.
+	d := Concat(Text("\t\t"), Align(Concat(Text("a"), HardLine, Text("b"))))
+	if got, want := Print(d, 80), "\t\ta\n\t\tb"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestAlignForcesEnclosingGroupToBreak(t *testing.T) {
+	// A hard break inside an Align must still propagate to the enclosing Group,
+	// or the group would render flat and swallow the newline.
+	d := Group(Concat(Text("x"), Align(Concat(Text("a"), HardLine, Text("b")))))
+	if got, want := Print(d, 80), "xa\n b"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestAlignNestedIndentStacksTabsAfterPrefix(t *testing.T) {
+	d := Concat(
+		Text("  x="),
+		Align(Concat(Text("a"), Indent(Concat(HardLine, Text("b"), Indent(Concat(HardLine, Text("c"))))))),
+	)
+	// line is "  x=" -> prefix is "  " (verbatim lead) + "  " (2 spaces for "x=").
+	if got, want := Print(d, 80), "  x=a\n    \tb\n    \t\tc"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}

--- a/internal/pretty/doc.go
+++ b/internal/pretty/doc.go
@@ -14,6 +14,7 @@ const (
 	kindText kind = iota
 	kindConcat
 	kindIndent
+	kindAlign       // breaks inside indent to the column where the child began
 	kindLine        // a soft/space/hard break candidate (see flat, hard)
 	kindGroup       // flat if it fits, else broken
 	kindFill        // greedy per-element wrap (Task 2)
@@ -43,6 +44,19 @@ func Concat(ds ...Doc) Doc { return Doc{kind: kindConcat, parts: ds} }
 
 // Indent renders d with the break-indent increased by one tab level.
 func Indent(d Doc) Doc { return Doc{kind: kindIndent, parts: []Doc{d}} }
+
+// Align renders d as a hanging indent: every break inside d returns to the
+// COLUMN at which d began, instead of to the enclosing tab-indent level. Indent
+// levels inside d stack tabs on top of that column.
+//
+// Use it for a document that starts partway along a line whose earlier text is
+// not part of the document — a gsx element sitting in Go-expression position
+// (`n := <div>`), whose closing tag should line up under its opening tag.
+//
+// The break prefix reproduces the current line's leading whitespace verbatim and
+// pads the remainder with one space per rune, so the alignment holds however the
+// reader's editor renders a tab. Align at column zero is a no-op.
+func Align(d Doc) Doc { return Doc{kind: kindAlign, parts: []Doc{d}} }
 
 // Group renders d flat if it fits the remaining width on the current line,
 // else broken. A group containing any hard break (HardLine/BreakParent, at any
@@ -83,7 +97,7 @@ func containsForcedBreak(d Doc) bool {
 		return true
 	case kindGroup:
 		return d.forced
-	case kindIndent:
+	case kindIndent, kindAlign:
 		return containsForcedBreak(d.parts[0])
 	case kindConcat, kindFill:
 		return slices.ContainsFunc(d.parts, containsForcedBreak)

--- a/internal/pretty/print.go
+++ b/internal/pretty/print.go
@@ -21,16 +21,35 @@ type cmd struct {
 	indent int
 	mode   mode
 	doc    Doc
+	// align is the hanging-indent prefix written after each break inside this
+	// command's subtree, before its indent tabs (see Align). Empty at top level,
+	// where breaks are indented with tabs alone.
+	align string
+	// alignCol is the column align occupies, so pos stays accurate after a break.
+	alignCol int
+}
+
+// alignPrefix returns the break prefix that reproduces line's width: its leading
+// whitespace verbatim (so the reader's tab width is honored), then one space per
+// remaining rune. Together they place a break at the column line ends on.
+func alignPrefix(line []byte) string {
+	i := 0
+	for i < len(line) && (line[i] == '\t' || line[i] == ' ') {
+		i++
+	}
+	return string(line[:i]) + strings.Repeat(" ", utf8.RuneCount(line[i:]))
 }
 
 // Print renders d at the given right margin (columns). width <= 0 uses 80.
 // Indentation is emitted as tabs; each tab counts as tabWidth columns when
-// measuring fit.
+// measuring fit. Align subtrees additionally carry a per-line prefix (tabs then
+// spaces) placing their breaks at the column where the subtree began.
 func Print(d Doc, width int) string {
 	if width <= 0 {
 		width = defaultWidth
 	}
-	var b strings.Builder
+	var b []byte
+	lineStart := 0 // index in b of the current line's first byte
 	pos := 0
 	stack := []cmd{{indent: 0, mode: modeBreak, doc: d}}
 	for len(stack) > 0 {
@@ -38,47 +57,57 @@ func Print(d Doc, width int) string {
 		stack = stack[:len(stack)-1]
 		switch c.doc.kind {
 		case kindText:
-			b.WriteString(c.doc.text)
+			b = append(b, c.doc.text...)
+			if i := strings.LastIndexByte(c.doc.text, '\n'); i >= 0 {
+				lineStart = len(b) - (len(c.doc.text) - i - 1)
+			}
 			pos = advance(pos, c.doc.text)
 		case kindConcat:
 			for i := len(c.doc.parts) - 1; i >= 0; i-- {
-				stack = append(stack, cmd{c.indent, c.mode, c.doc.parts[i]})
+				stack = append(stack, cmd{c.indent, c.mode, c.doc.parts[i], c.align, c.alignCol})
 			}
 		case kindFill:
 			stack = fillStep(stack, c, width-pos)
 		case kindIndent:
-			stack = append(stack, cmd{c.indent + 1, c.mode, c.doc.parts[0]})
+			stack = append(stack, cmd{c.indent + 1, c.mode, c.doc.parts[0], c.align, c.alignCol})
+		case kindAlign:
+			// Breaks inside the child return to the column reached right here.
+			// Indent levels within the child stack tabs after that prefix, so the
+			// child's own indent restarts at zero.
+			stack = append(stack, cmd{0, c.mode, c.doc.parts[0], alignPrefix(b[lineStart:]), pos})
 		case kindLine:
 			if c.doc.hard || c.mode == modeBreak {
-				b.WriteByte('\n')
+				b = append(b, '\n')
+				lineStart = len(b)
+				b = append(b, c.align...)
 				for i := 0; i < c.indent; i++ {
-					b.WriteByte('\t')
+					b = append(b, '\t')
 				}
-				pos = c.indent * tabWidth
+				pos = c.alignCol + c.indent*tabWidth
 			} else {
-				b.WriteString(c.doc.text)
+				b = append(b, c.doc.text...)
 				pos += utf8.RuneCountInString(c.doc.text)
 			}
 		case kindGroup:
 			child := c.doc.parts[0]
 			if c.doc.forced {
-				stack = append(stack, cmd{c.indent, modeBreak, child})
-			} else if fits(width-pos, cmd{c.indent, modeFlat, child}, stack) {
-				stack = append(stack, cmd{c.indent, modeFlat, child})
+				stack = append(stack, cmd{c.indent, modeBreak, child, c.align, c.alignCol})
+			} else if fits(width-pos, cmd{c.indent, modeFlat, child, c.align, c.alignCol}, stack) {
+				stack = append(stack, cmd{c.indent, modeFlat, child, c.align, c.alignCol})
 			} else {
-				stack = append(stack, cmd{c.indent, modeBreak, child})
+				stack = append(stack, cmd{c.indent, modeBreak, child, c.align, c.alignCol})
 			}
 		case kindIfBreak:
 			if c.mode == modeBreak {
-				stack = append(stack, cmd{c.indent, c.mode, c.doc.parts[0]})
+				stack = append(stack, cmd{c.indent, c.mode, c.doc.parts[0], c.align, c.alignCol})
 			} else {
-				stack = append(stack, cmd{c.indent, c.mode, c.doc.parts[1]})
+				stack = append(stack, cmd{c.indent, c.mode, c.doc.parts[1], c.align, c.alignCol})
 			}
 		case kindBreakParent:
 			// no output; its effect is via the forced flag on enclosing groups.
 		}
 	}
-	return b.String()
+	return string(b)
 }
 
 // fillStep implements one step of the greedy Fill layout, pushing onto stack
@@ -88,39 +117,39 @@ func fillStep(stack []cmd, c cmd, remaining int) []cmd {
 	if len(parts) == 0 {
 		return stack
 	}
-	content := cmd{c.indent, modeFlat, parts[0]}
+	content := cmd{c.indent, modeFlat, parts[0], c.align, c.alignCol}
 	contentFits := fits(remaining, content, nil)
 	if len(parts) == 1 {
 		m := modeBreak
 		if contentFits {
 			m = modeFlat
 		}
-		return append(stack, cmd{c.indent, m, parts[0]})
+		return append(stack, cmd{c.indent, m, parts[0], c.align, c.alignCol})
 	}
 	sep := parts[1]
 	if len(parts) == 2 {
 		if contentFits {
-			stack = append(stack, cmd{c.indent, modeFlat, sep})
-			return append(stack, cmd{c.indent, modeFlat, parts[0]})
+			stack = append(stack, cmd{c.indent, modeFlat, sep, c.align, c.alignCol})
+			return append(stack, cmd{c.indent, modeFlat, parts[0], c.align, c.alignCol})
 		}
-		stack = append(stack, cmd{c.indent, modeBreak, sep})
-		return append(stack, cmd{c.indent, modeBreak, parts[0]})
+		stack = append(stack, cmd{c.indent, modeBreak, sep, c.align, c.alignCol})
+		return append(stack, cmd{c.indent, modeBreak, parts[0], c.align, c.alignCol})
 	}
-	rest := cmd{c.indent, c.mode, Doc{kind: kindFill, parts: parts[2:]}}
-	pair := cmd{c.indent, modeFlat, Concat(parts[0], sep, parts[2])}
+	rest := cmd{c.indent, c.mode, Doc{kind: kindFill, parts: parts[2:]}, c.align, c.alignCol}
+	pair := cmd{c.indent, modeFlat, Concat(parts[0], sep, parts[2]), c.align, c.alignCol}
 	pairFits := fits(remaining, pair, nil)
 	// Push in reverse so content is processed first, then separator, then rest.
 	stack = append(stack, rest)
 	switch {
 	case pairFits:
-		stack = append(stack, cmd{c.indent, modeFlat, sep})
-		stack = append(stack, cmd{c.indent, modeFlat, parts[0]})
+		stack = append(stack, cmd{c.indent, modeFlat, sep, c.align, c.alignCol})
+		stack = append(stack, cmd{c.indent, modeFlat, parts[0], c.align, c.alignCol})
 	case contentFits:
-		stack = append(stack, cmd{c.indent, modeBreak, sep})
-		stack = append(stack, cmd{c.indent, modeFlat, parts[0]})
+		stack = append(stack, cmd{c.indent, modeBreak, sep, c.align, c.alignCol})
+		stack = append(stack, cmd{c.indent, modeFlat, parts[0], c.align, c.alignCol})
 	default:
-		stack = append(stack, cmd{c.indent, modeBreak, sep})
-		stack = append(stack, cmd{c.indent, modeBreak, parts[0]})
+		stack = append(stack, cmd{c.indent, modeBreak, sep, c.align, c.alignCol})
+		stack = append(stack, cmd{c.indent, modeBreak, parts[0], c.align, c.alignCol})
 	}
 	return stack
 }
@@ -164,16 +193,20 @@ func fits(remaining int, next cmd, rest []cmd) bool {
 			}
 		case kindConcat, kindFill:
 			for i := len(c.doc.parts) - 1; i >= 0; i-- {
-				local = append(local, cmd{c.indent, c.mode, c.doc.parts[i]})
+				local = append(local, cmd{c.indent, c.mode, c.doc.parts[i], c.align, c.alignCol})
 			}
 		case kindIndent:
-			local = append(local, cmd{c.indent + 1, c.mode, c.doc.parts[0]})
+			local = append(local, cmd{c.indent + 1, c.mode, c.doc.parts[0], c.align, c.alignCol})
+		case kindAlign:
+			// Only flat layout is measured here, and a flat subtree emits no break,
+			// so the hanging prefix never materializes: width is unaffected.
+			local = append(local, cmd{0, c.mode, c.doc.parts[0], c.align, c.alignCol})
 		case kindGroup:
 			gm := c.mode
 			if c.doc.forced {
 				gm = modeBreak
 			}
-			local = append(local, cmd{c.indent, gm, c.doc.parts[0]})
+			local = append(local, cmd{c.indent, gm, c.doc.parts[0], c.align, c.alignCol})
 		case kindLine:
 			if c.doc.hard || c.mode == modeBreak {
 				return true
@@ -184,9 +217,9 @@ func fits(remaining int, next cmd, rest []cmd) bool {
 			}
 		case kindIfBreak:
 			if c.mode == modeBreak {
-				local = append(local, cmd{c.indent, c.mode, c.doc.parts[0]})
+				local = append(local, cmd{c.indent, c.mode, c.doc.parts[0], c.align, c.alignCol})
 			} else {
-				local = append(local, cmd{c.indent, c.mode, c.doc.parts[1]})
+				local = append(local, cmd{c.indent, c.mode, c.doc.parts[1], c.align, c.alignCol})
 			}
 		case kindBreakParent:
 			// ignored in fits; propagation handled by the forced flag.

--- a/internal/printer/goexpr_test.go
+++ b/internal/printer/goexpr_test.go
@@ -1,0 +1,123 @@
+package printer
+
+import "testing"
+
+// A GoWithElements decl's Go text is real, complete Go once each embedded
+// element literal is stood in for by an ordinary Go operand. These tests pin
+// that it is gofmt'd like any other top-level Go, rather than relayed verbatim
+// because one part of it happens to be a gsx element.
+
+// TestGoWithElementsVarGroupFormatted is the reported bug: an element literal
+// inside a `var (…)` group left the whole group — including the sibling
+// declaration `hello` — unindented, and `gsx fmt -l` called the file clean.
+func TestGoWithElementsVarGroupFormatted(t *testing.T) {
+	src := "package main\n\nvar (\nhello = \"Hello, World!\"\n\nxx = <p>{ hello }</p>\n)\n"
+	want := "package main\n\nvar (\n\thello = \"Hello, World!\"\n\n\txx = <p>{ hello }</p>\n)\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsSiblingDeclsFormatted pins that complete declarations on
+// either side of an element literal are gofmt'd. Before the fix a single
+// element literal anywhere in the file's Go region relayed the entire region
+// — both funcs here — byte-for-byte.
+func TestGoWithElementsSiblingDeclsFormatted(t *testing.T) {
+	src := "package main\n\nfunc a() {\nx := 1\n_ = x\n}\n\nvar xx = <p>hi</p>\n\nfunc b() {\ny := 2\n_ = y\n}\n"
+	want := "package main\n\nfunc a() {\n\tx := 1\n\t_ = x\n}\n\nvar xx = <p>hi</p>\n\nfunc b() {\n\ty := 2\n\t_ = y\n}\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsEqAlignment pins that gofmt's `=` alignment (which keys on
+// name width) is applied across a group containing an element literal.
+func TestGoWithElementsEqAlignment(t *testing.T) {
+	src := "package main\n\nvar (\na = 1\nxx = <p/>\n)\n"
+	want := "package main\n\nvar (\n\ta  = 1\n\txx = <p/>\n)\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsMultipleElements pins that a decl holding two element
+// literals still formats, and that each element's own printer output is
+// spliced back in source order.
+func TestGoWithElementsMultipleElements(t *testing.T) {
+	src := "package main\n\nvar ns = []any{<a/>,<b/>}\n"
+	want := "package main\n\nvar ns = []any{<a/>, <b/>}\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsInsideFuncBody pins an element literal in a short var decl
+// inside a func body: the body's statements gofmt around it.
+func TestGoWithElementsInsideFuncBody(t *testing.T) {
+	src := "package main\n\nfunc f() {\nn := <p>hi</p>\n_ = n\n}\n"
+	want := "package main\n\nfunc f() {\n\tn := <p>hi</p>\n\t_ = n\n}\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsTrailingCommentAlignment pins that gofmt's end-of-line
+// comment columns — which it computes from each value's rendered width — are
+// correct across a group holding an element literal. This only holds because the
+// placeholder handed to gofmt is exactly as many runes wide as the element it
+// stands for; a fixed-width placeholder aligns `// one`/`// three` to itself and
+// leaves `// two` stranded.
+func TestGoWithElementsTrailingCommentAlignment(t *testing.T) {
+	src := "package main\n\nvar (\na = 1 // one\nxx = <p>{ hello }</p> // two\nb = 3 // three\n)\n"
+	want := "package main\n\nvar (\n\ta  = 1                // one\n\txx = <p>{ hello }</p> // two\n\tb  = 3                // three\n)\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsNarrowElementCommentAlignment pins the same for an element
+// narrower than any `_gsx`-prefixed placeholder name could be (4 runes), which
+// is why the placeholder is a repeated rune rather than a prefixed identifier.
+func TestGoWithElementsNarrowElementCommentAlignment(t *testing.T) {
+	src := "package main\n\nvar (\na = 1 // one\nxx = <a/> // two\n)\n"
+	want := "package main\n\nvar (\n\ta  = 1    // one\n\txx = <a/> // two\n)\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsMultilineElementStillFormats pins that a value with a forced
+// break (a block element, which has no single rendered width) does not stop the
+// surrounding Go from being formatted: indentation and `=` alignment do not
+// depend on value width.
+func TestGoWithElementsMultilineElementStillFormats(t *testing.T) {
+	src := "package main\n\nfunc f() {\nx := 1\nn := <div>\n<p>hi</p>\n</div>\n_, _ = x, n\n}\n"
+	got := fmtSource(t, src)
+	if !contains(got, "\tx := 1\n") {
+		t.Errorf("surrounding Go not formatted:\n%s", got)
+	}
+	again := fmtSource(t, got)
+	if again != got {
+		t.Errorf("not idempotent:\n--- 1 ---\n%s\n--- 2 ---\n%s", got, again)
+	}
+}
+
+// TestGoWithElementsHoleRuneInSourceFallsBack pins that a source legitimately
+// containing the first placeholder rune does not corrupt the re-split: another
+// candidate rune is chosen, and the Go still formats.
+func TestGoWithElementsHoleRuneInSourceFallsBack(t *testing.T) {
+	src := "package main\n\nvar (\ns = \"ᴳ\"\nxx = <p/>\n)\n"
+	want := "package main\n\nvar (\n\ts  = \"ᴳ\"\n\txx = <p/>\n)\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsInvalidGoLeftVerbatim pins the graceful degrade: Go that
+// gsx parsed but go/format rejects must fall back to the verbatim relay rather
+// than dropping source on the floor.
+func TestGoWithElementsInvalidGoLeftVerbatim(t *testing.T) {
+	// `func f() {` never closes at the gap's end -> format.Source errors.
+	src := "package main\n\nfunc f( {\nn := <p>hi</p>\n}\n"
+	got := fmtSource(t, src)
+	if !contains(got, "<p>hi</p>") || !contains(got, "func f( {") {
+		t.Errorf("invalid Go should relay verbatim, got:\n%s", got)
+	}
+}
+
+func contains(hay, needle string) bool {
+	return len(hay) >= len(needle) && indexOf(hay, needle) >= 0
+}
+
+func indexOf(hay, needle string) int {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/printer/goexpr_test.go
+++ b/internal/printer/goexpr_test.go
@@ -1,6 +1,51 @@
 package printer
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// A multi-line element literal in Go-expression position hangs off its opening
+// tag: children indent one level deeper than `<`, and the closing tag lines up
+// under it. The prefix is the line's leading whitespace verbatim plus spaces, so
+// the alignment survives any tab width.
+
+func TestGoExprElementHangsOffOpeningTag(t *testing.T) {
+	// "\tsomeLongName := " -> prefix is one tab then 16 spaces.
+	pfx := "\t" + strings.Repeat(" ", len("someLongName := "))
+	src := "package main\n\nfunc f() {\nsomeLongName := <div>\n<p>hi</p>\n</div>\n_ = someLongName\n}\n"
+	want := "package main\n\nfunc f() {\n" +
+		"\tsomeLongName := <div>\n" +
+		pfx + "\t<p>hi</p>\n" +
+		pfx + "</div>\n" +
+		"\t_ = someLongName\n}\n"
+	checkFormat(t, src, want)
+}
+
+func TestGoExprElementHangsOffOpeningTagAtTopLevel(t *testing.T) {
+	// "var n = " has no leading whitespace -> prefix is 8 spaces.
+	pfx := strings.Repeat(" ", len("var n = "))
+	src := "package main\n\nvar n = <div>\n<p>hi</p>\n</div>\n"
+	want := "package main\n\nvar n = <div>\n" + pfx + "\t<p>hi</p>\n" + pfx + "</div>\n"
+	checkFormat(t, src, want)
+}
+
+func TestGoExprElementHangsOffOpeningTagInVarGroup(t *testing.T) {
+	// "\tn = " -> one tab (verbatim) then 4 spaces.
+	pfx := "\t" + strings.Repeat(" ", len("n = "))
+	src := "package main\n\nvar (\nn = <div>\n<p>hi</p>\n</div>\n)\n"
+	want := "package main\n\nvar (\n\tn = <div>\n" + pfx + "\t<p>hi</p>\n" + pfx + "</div>\n)\n"
+	checkFormat(t, src, want)
+}
+
+// Renaming the variable re-indents the element, since the hanging indent is
+// anchored to the opening tag's column. Pinned so the trade-off is explicit.
+func TestGoExprElementRenameShiftsHangingIndent(t *testing.T) {
+	pfx := "\t" + strings.Repeat(" ", len("n := "))
+	src := "package main\n\nfunc f() {\nn := <div>\n<p>hi</p>\n</div>\n_ = n\n}\n"
+	want := "package main\n\nfunc f() {\n\tn := <div>\n" + pfx + "\t<p>hi</p>\n" + pfx + "</div>\n\t_ = n\n}\n"
+	checkFormat(t, src, want)
+}
 
 // A GoWithElements decl's Go text is real, complete Go once each embedded
 // element literal is stood in for by an ordinary Go operand. These tests pin

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/gsxhq/gsx/ast"
 	"github.com/gsxhq/gsx/internal/cssfmt"
@@ -144,50 +145,46 @@ func (p *printer) decl(d ast.Decl) pretty.Doc {
 // function requires a syntactically complete compilation unit, and a bare
 // "var help = " isn't one.
 //
-// Instead each GoText part is printed verbatim via multiline (which lays out
+// The parts are NOT relayed verbatim, though. fmtGoExprParts first restores
+// syntactic completeness — standing a placeholder identifier in for each gsx
+// value — so go/format can lay the Go text out exactly as it would any other
+// top-level Go; the formatted text comes back re-split into GoText parts. Only
+// when go/format rejects the substituted source (Go the gsx parser accepted but
+// Go's own parser does not) do the original, unformatted parts flow through.
+//
+// Each resulting GoText part is then printed via multiline (which lays out
 // embedded newlines at the CURRENT indent; at this decl's top-level position
-// that indent is zero, so a multi-line fragment's own original indentation —
-// carried as literal bytes inside each line's Text — reproduces unchanged)
-// and each *ast.Element part goes through the ordinary element printer, the
-// exact same one every other element in the file is printed with. The
-// parser's documented round-trip invariant (concatenating every part's own
-// source reproduces the original span exactly, see ast.GoWithElements) is
-// what makes this recombination faithful: this function never has to parse
-// or re-derive the Go text's structure, only relay it.
+// that indent is zero, so a multi-line fragment's own indentation — carried as
+// literal bytes inside each line's Text — reproduces unchanged) and each
+// *ast.Element part goes through the ordinary element printer, the exact same
+// one every other element in the file is printed with.
 //
 // Only the outermost edges are trimmed, mirroring fmtGoChunk's TrimSpace: the
 // leading whitespace of the FIRST part and the trailing whitespace of the
 // LAST part are the blank-line padding between this decl and its neighbors
 // (file's own blank-line-separator logic re-derives that padding, exactly as
-// it does for a GoChunk's leading/trailing whitespace). Internal parts — Go
-// text between two elements, mid-declaration — are left byte-for-byte
-// untouched; go/format cannot safely re-derive their layout without full
-// syntactic context, and the round-trip invariant already guarantees they
-// are exactly what belongs there.
+// it does for a GoChunk's leading/trailing whitespace).
 func (p *printer) goWithElements(v *ast.GoWithElements) pretty.Doc {
-	last := len(v.Parts) - 1
-	docs := make([]pretty.Doc, 0, len(v.Parts))
-	for i, part := range v.Parts {
-		switch pt := part.(type) {
-		case ast.GoText:
-			src := trimGoTextEdges(pt.Src, i == 0, i == last)
+	parts := v.Parts
+	if formatted, ok := p.fmtGoExprParts(parts); ok {
+		parts = formatted
+	}
+	last := len(parts) - 1
+	docs := make([]pretty.Doc, 0, len(parts))
+	for i, part := range parts {
+		if gt, ok := part.(ast.GoText); ok {
+			src := trimGoTextEdges(gt.Src, i == 0, i == last)
 			if src == "" {
 				continue
 			}
 			docs = append(docs, multiline(src))
-		case *ast.Element:
-			docs = append(docs, p.element(pt))
-		case *ast.Fragment:
-			docs = append(docs, p.fragment(pt))
-		case *ast.EmbeddedInterp:
-			// A prefixed backtick literal in Go-expression value position: render
-			// the raw f`…@{expr}…` literal (no braces, no whole-literal pipeline —
-			// value-position literals carry no Stages), so it splices back into the
-			// surrounding Go source exactly as authored.
-			docs = append(docs, pretty.Text(embeddedLiteralString(ast.EmbeddedText, pt.Segments, embeddedDelim(pt.DoubleQuoted))))
-		default:
+			continue
+		}
+		doc, ok := p.goExprValue(part)
+		if !ok {
 			return p.fail("printer: unknown Go-expression part type %T", part)
 		}
+		docs = append(docs, doc)
 	}
 	return pretty.Concat(docs...)
 }
@@ -1150,6 +1147,189 @@ func fmtGoChunk(src string) string {
 		return strings.TrimSpace(src)
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// goExprWrapper is the synthetic package clause prepended to a GoWithElements'
+// Go text to make it a compilation unit go/format will accept. The gap a
+// GoWithElements spans is always a run of complete top-level declarations, so
+// the clause is all that is missing.
+const goExprWrapper = "package _gsxfmt\n"
+
+// goExprHoleRunes are candidate placeholder runes: Unicode modifier letters,
+// which Go accepts as identifier letters (identifier = letter { letter | digit },
+// letter = unicode_letter, which includes category Lm). Repeating one N times
+// yields a valid Go identifier that is exactly N *runes* wide — and go/format's
+// alignment runs through text/tabwriter, which measures cells in runes. That is
+// what lets a placeholder stand in for a gsx value at its true rendered width
+// (see fmtGoExprParts), down to widths no `_gsx`-prefixed name could reach.
+// They are vanishingly unlikely to occur in real source; if one does, the next
+// candidate is tried.
+var goExprHoleRunes = []string{"ᴳ", "ᴴ", "ᴵ", "ᴶ"}
+
+// goExprHoleRune picks a placeholder rune absent from src, so the formatted
+// output can be re-split at the placeholders unambiguously (a rune occurring
+// inside a string literal or comment would misdirect that split).
+func goExprHoleRune(src string) (string, bool) {
+	for _, r := range goExprHoleRunes {
+		if !strings.Contains(src, r) {
+			return r, true
+		}
+	}
+	return "", false
+}
+
+// goExprFlatWidth reports the rune width of doc rendered on a single line, and
+// whether it fits on one line at all. A forced break (a block element) makes a
+// gsx value multi-line no matter the available width; such a value has no single
+// width to hand to gofmt.
+func goExprFlatWidth(doc pretty.Doc) (int, bool) {
+	const wide = 1 << 20 // wider than any real line: nothing breaks unless forced
+	flat := pretty.Print(doc, wide)
+	if strings.Contains(flat, "\n") {
+		return 0, false
+	}
+	return utf8.RuneCountInString(flat), true
+}
+
+// goExprValue builds the doc for one non-GoText part of a GoWithElements — a
+// gsx value sitting in Go-expression position. Shared by fmtGoExprParts (which
+// measures the value's rendered width) and goWithElements (which prints it), so
+// the width gofmt is told and the text finally spliced in can never disagree.
+func (p *printer) goExprValue(part ast.GoPart) (pretty.Doc, bool) {
+	switch pt := part.(type) {
+	case *ast.Element:
+		return p.element(pt), true
+	case *ast.Fragment:
+		return p.fragment(pt), true
+	case *ast.EmbeddedInterp:
+		// A prefixed backtick literal in Go-expression value position: render the
+		// raw f`…@{expr}…` literal (no braces, no whole-literal pipeline — value-
+		// position literals carry no Stages), so it splices back into the
+		// surrounding Go source exactly as authored.
+		return pretty.Text(embeddedLiteralString(ast.EmbeddedText, pt.Segments, embeddedDelim(pt.DoubleQuoted))), true
+	default:
+		return pretty.Doc{}, false
+	}
+}
+
+// fmtGoExprParts gofmt's the Go text of a GoWithElements decl.
+//
+// A GoText part on its own is an INCOMPLETE Go fragment ("var help = ") that
+// go/format cannot parse. But the fragments are incomplete only because a gsx
+// value — an element, a fragment, an f`…` literal — sits between them, and every
+// position such a value can occupy is a Go *operand* position: a call argument, a
+// composite-literal element, the right-hand side of an assignment. An identifier
+// is a valid operand in all of them. So substituting one placeholder identifier
+// per gsx value turns the whole run back into ordinary, complete Go, which
+// go/format lays out exactly as it would anywhere else. This is the same
+// claim-what-Go-leaves-free move the parser makes elsewhere: gsx never has to
+// parse Go, it only has to hand Go something Go can parse.
+//
+// Each placeholder is made exactly as many runes wide as the value it stands for
+// will render (goExprFlatWidth), because gofmt's column arithmetic — the spaces
+// it lays down to align end-of-line comments — is computed from the value's
+// width. A fixed-width placeholder would align those comments to the
+// placeholder, not to the element, and the misalignment would survive the splice.
+//
+// A value that renders multi-line has no single width to report; it gets a
+// one-rune placeholder. Layout is then still correct except for end-of-line
+// comment columns in that value's alignment section, which gofmt (seeing a real
+// multi-line value) would have split. Everything else in the region — indentation,
+// `=` alignment, blank lines — is unaffected, since none of it depends on value
+// width.
+//
+// The formatted text is re-split at the placeholders and returned as a fresh
+// parts slice (the input, which aliases the AST, is never mutated): GoText parts
+// carry the formatted Go, and the gsx values pass through untouched for the
+// caller to print with the ordinary element/fragment printers.
+//
+// Returns ok=false — leaving the caller to relay the original text verbatim, as
+// it always has — when go/format rejects the substituted source, when no
+// placeholder rune is free, or when a placeholder cannot be located in the
+// output. All are degrade-gracefully paths: gsx fmt must never fail on gsx it
+// was able to parse.
+func (p *printer) fmtGoExprParts(parts []ast.GoPart) ([]ast.GoPart, bool) {
+	var text strings.Builder
+	holeCount := 0
+	for _, part := range parts {
+		if gt, ok := part.(ast.GoText); ok {
+			text.WriteString(gt.Src)
+			continue
+		}
+		holeCount++
+	}
+	if holeCount == 0 {
+		return nil, false
+	}
+	hole, ok := goExprHoleRune(text.String())
+	if !ok {
+		return nil, false
+	}
+
+	var src strings.Builder
+	holes := make([]string, 0, holeCount)
+	for _, part := range parts {
+		if gt, ok := part.(ast.GoText); ok {
+			src.WriteString(gt.Src)
+			continue
+		}
+		doc, ok := p.goExprValue(part)
+		if !ok {
+			return nil, false
+		}
+		width, flat := goExprFlatWidth(doc)
+		if !flat {
+			width = 1
+		}
+		h := strings.Repeat(hole, width)
+		holes = append(holes, h)
+		src.WriteString(h)
+	}
+
+	out, err := format.Source([]byte(goExprWrapper + src.String()))
+	if err != nil {
+		return nil, false
+	}
+	// Drop the synthetic package clause. gofmt always emits it as the first line.
+	formatted := string(out)
+	nl := strings.IndexByte(formatted, '\n')
+	if nl < 0 {
+		return nil, false
+	}
+	formatted = formatted[nl+1:]
+
+	// Re-split at the placeholders, left to right. Placeholders of equal width are
+	// identical strings, which is harmless: the cursor has already consumed every
+	// earlier one, and only Go text (never the hole rune) lies between them.
+	res := make([]ast.GoPart, len(parts))
+	cursor, next := 0, 0
+	for i, part := range parts {
+		if _, ok := part.(ast.GoText); !ok {
+			// A gsx value: the cursor must be sitting exactly on its placeholder.
+			if next >= len(holes) || !strings.HasPrefix(formatted[cursor:], holes[next]) {
+				return nil, false
+			}
+			cursor += len(holes[next])
+			next++
+			res[i] = part
+			continue
+		}
+		// Go text runs up to the next placeholder, or to the end of the output.
+		end := len(formatted)
+		if next < len(holes) {
+			j := strings.Index(formatted[cursor:], holes[next])
+			if j < 0 {
+				return nil, false
+			}
+			end = cursor + j
+		}
+		res[i] = ast.GoText{Src: formatted[cursor:end]}
+		cursor = end
+	}
+	if next != len(holes) {
+		return nil, false
+	}
+	return res, true
 }
 
 // fmtNode renders a go/ast node back to canonical Go source via go/format.Node,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -184,7 +184,12 @@ func (p *printer) goWithElements(v *ast.GoWithElements) pretty.Doc {
 		if !ok {
 			return p.fail("printer: unknown Go-expression part type %T", part)
 		}
-		docs = append(docs, doc)
+		// A gsx value starts partway along its Go line (`n := <div>`), and the Go
+		// text before it is literal bytes inside a Text doc — invisible to the
+		// pretty printer, whose indent level for this decl is zero. Align hangs the
+		// value's breaks off the column its opening tag sits at, so children indent
+		// one level deeper than `<` and the closing tag lines up under it.
+		docs = append(docs, pretty.Align(doc))
 	}
 	return pretty.Concat(docs...)
 }


### PR DESCRIPTION
## The bug

```gsx
package main

var (
hello = "Hello, World!"

xx = <p>{ hello }</p>
)
```

`gsx fmt` exits 0 and returns this **unchanged**. `gsx fmt -l` reports the file as already formatted. Delete the `xx` line and the `var` group formats correctly.

It isn't the `var (…)` group and it isn't the interpolation — it's the mere presence of an **element literal anywhere in the file's Go region**. One `var x = <p/>` leaves every declaration in that region unformatted.

## Root cause

`parser/file.go` hands each pure-Go gap to `splitGoElements`. When the gap contains an element literal the *entire gap* becomes one `ast.GoWithElements`, interleaving verbatim `GoText` runs with parsed elements:

```
GoWithElements (3 parts):
   GoText  "\n\nfunc a() {\nx := 1\n_ = x\n}\n\nvar xx = "
   Element <p>
   GoText  "\n\nfunc b() {\ny := 2\n_ = y\n}\n"
```

`printer.goWithElements` then relayed every `GoText` part byte-for-byte. Its doc comment reasoned that a fragment like `var xx = ` is not a compilation unit `format.Source` can parse — true — and concluded that nothing in the region could be formatted. That conflated **"gsx cannot parse this Go"** with **"Go cannot format this Go."**

`func a()` and `func b()` are complete, gofmt-able declarations dragged along for the ride.

## Fix 1 — placeholder substitution (`91ac2a4`)

The fragments are incomplete *only* because a gsx value sits between them, and every position such a value can occupy is a Go **operand** position. An identifier is a valid operand in all of them:

| Position | `format.Source` w/ placeholder |
|---|---|
| `var (…)` group member | ✅ |
| call arg `wrap(_)` | ✅ |
| conditional operand `pick(c, _, _)` | ✅ |
| composite lit `[]gsx.Node{_, _}` | ✅ |
| short var decl `x := _` | ✅ |

So: substitute one placeholder per value → ordinary complete Go → `go/format` lays it out → re-split at the placeholders → print the elements back with the normal element printer.

**gsx still never parses Go.** It hands Go something Go can parse — the same claim-what-Go-leaves-free move as `|>` in the interp-embedded-literals design. This is why the bug needed **no merged Go+gsx grammar**: `format.Source` *is* a Go parser.

Each placeholder is exactly as many **runes** wide as the value it stands for. gofmt's end-of-line comment columns are computed from value width, so a fixed-width placeholder aligns comments to the *placeholder* and the misalignment survives the splice — strictly worse than before, since comments were previously left as authored. A repeated Unicode modifier letter (a valid Go identifier letter) reaches any width down to one rune, which no `_gsx`-prefixed name could; `go/format` aligns via `text/tabwriter`, which measures cells in runes.

```
var (
	a  = 1                // one
	xx = <p>{ hello }</p> // two
	b  = 3                // three
)
```

`format.Source` rejecting the substituted source, an occupied placeholder rune, or a placeholder lost in the output all fall back to the verbatim relay — `gsx fmt` must never fail on gsx it was able to parse.

## Fix 2 — hanging indent (`01cf41f`)

A separate pre-existing bug, surfaced once the Go around it was formatted: a multi-line element literal broke its lines to column 0. `<div>`'s line is literal bytes inside a `pretty.Text`, and the pretty printer's indent level for a `GoWithElements` decl is zero, so it could not see the column the tag opened at.

`internal/pretty` gains `Align`: a hanging indent that breaks its subtree back to the column where the subtree began, with `Indent` levels stacking tabs on top. The prefix reproduces the line's leading whitespace verbatim and pads the rest with one space per rune — tabs to indent, spaces to align, the split gofmt uses — so it holds at any tab width. `Align` at column zero is a no-op; nothing outside Go-expression position moves.

```
func f() {
	someLongName := <div>
	                	<p>hi</p>
	                </div>
}
```

The column is read back from the output buffer at the moment the value is reached, not tracked alongside it, so a second element on the same line hangs off its own opening tag even when the first rendered multi-line:

```
var ns = []any{<div>
               	<p>a</p>
               </div>, <div>
                       	<p>b</p>
                       </div>}
```

**Trade-off, pinned in `TestGoExprElementRenameShiftsHangingIndent`:** renaming the variable re-indents the element, since the anchor is the tag's column. Inherent to hanging indent — it's why gofmt closes composite literals at the statement indent instead.

## Known residual, documented in the code

A value that renders multi-line has no single width, so it gets a one-rune placeholder. Indentation, `=` alignment and blank lines are unaffected (none depend on value width) — only end-of-line comment columns in that value's alignment section, which real gofmt would have split anyway. Output stays idempotent.

## Verification

- `make ci` green (exit 0).
- 17.3M fuzz execs over the printer, zero crashes (`internal/pretty` changed, so this is the critical one).
- Corpus suite uncached — corpus-wide **idempotence** and **faithfulness** harnesses both pass.
- `gsx fmt -l .` over the repo: no drift.
- `<pre>` bodies stay byte-exact (preserved content flows through `pretty.Text` with newlines intact, never touching the break path).
- New: 14 printer tests + 5 `pretty` tests. Both alignment tests verified RED by temporarily forcing a fixed-width placeholder.

## Not in scope

`fmt -l` now correctly reports these files as needing formatting. `fmtGoChunk` still swallows `format.Source` errors into a verbatim fallback (silent degrade on Go that gsx parsed but Go rejects) — left as-is; worth its own change.

No syntax change, so no sibling-repo (`tree-sitter-gsx`, `vscode-gsx`, `gsxhq.github.io`) updates needed.

https://claude.ai/code/session_01DuP5HdpRusVA2ijZ2zemEU