### PR TITLE
explore fmt errors

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -736,6 +736,24 @@ vocabulary remains a design aspiration, not the current API.
   over the whole tree now completes in well under 1s (down from ~3s), and
   `generate`'s cold path speeds up correspondingly. Output is byte-identical
   (corpus goldens + a real-world `one-learning-gsx generate` diff check).
+  **`gsx fmt` no longer silently succeeds on invalid Go - done:** gsx copies user
+  Go through as an opaque blob, so Go that is invalid only in context (an `import`
+  after a declaration) was caught nowhere in the fmt path: `fmt` exited 0, `fmt -l`
+  called the file clean, and `fmt -w` rewrote it. The skeleton parse that
+  unused-import detection already runs *did* detect it and dropped the error on the
+  floor (`buildPackageSkeletons`). `Module.UnusedImports` now returns those
+  positioned diagnostics (the skeleton's `//line` directives map them back to the
+  exact `.gsx` location) and `gsx fmt` renders them through the same
+  `diag.RenderRich`/`RenderCompact` path `generate` uses, exiting 1. The formatter
+  itself is untouched: diagnostics belong to the analyzer, exactly as in the LSP,
+  where `handleFormatting` only formats and `publishDiagnostics` is a separate
+  channel. Deliberate divergence from gofmt: `fmt` **still formats and writes**,
+  because unlike gofmt it produced correct output (the invalid Go relays verbatim);
+  gofmt refuses only because an unparseable file yields nothing. Scope: detection
+  needs a loadable module and no `-no-imports`, so a `.gsx` outside a module stays
+  silent - same as the LSP without analysis. **Behavior change:** a tree with a Go
+  syntax error now fails a `gsx fmt -l` CI gate that previously passed. Design:
+  `docs/superpowers/specs/2026-07-08-fmt-error-reporting-design.md`.
 
 ## Documentation backlog
 

--- a/docs/superpowers/specs/2026-07-08-fmt-error-reporting-design.md
+++ b/docs/superpowers/specs/2026-07-08-fmt-error-reporting-design.md
@@ -72,22 +72,26 @@ on a separate, debounced channel. In an editor the broken file already gets a
 squiggle *and* still formats.
 
 Meanwhile `gsx fmt` **already runs the analyzer** — `analyzeUnusedImports`
-(`gen/fmt.go:167`) opens a `codegen.Module` per module for unused-import removal —
-and `skeletonParseError` (`internal/codegen/module_importer.go:133`) has already
-converted the skeleton's `scanner.ErrorList` into `.gsx`-positioned diagnostics
-through the skeleton's `//line` directives.
-
-The work is done. Nobody reads the result:
+(`gen/fmt.go`) opens a `codegen.Module` per module for unused-import removal, and
+that path lowers every `.gsx` to a skeleton carrying `//line` directives and parses
+it with `go/parser`. A Go parse error is detected there and thrown away, inside
+`buildPackageSkeletons` (`internal/codegen/unused_imports_syntactic.go:153`):
 
 ```go
-byPath, err := m.UnusedImports(absDir)
-if err != nil {
-    continue        // the positioned parse diagnostic dies here
+gf, perr := goparser.ParseFile(fset, absXpath, skel, goparser.SkipObjectResolution)
+if perr != nil {
+    continue        // the parse error dies here; UnusedImports never sees it
 }
 ```
 
+`skeletonParseError` (`internal/codegen/module_importer.go:133`) already converts
+exactly this `scanner.ErrorList` into `.gsx`-positioned diagnostics — but it serves
+the *type-checking* analyze path that `generate` uses. The syntactic import path
+never calls it, which is why `generate` reports and `fmt` does not.
+
 **The missing piece is not in the formatter. The CLI lacks the diagnostic channel
-the LSP has.**
+the LSP has, and the analyzer's syntactic path drops the diagnostic on the floor
+before the CLI could ask for it.**
 
 ## Design
 
@@ -116,39 +120,37 @@ parse error reports and exits 1, while a good sibling is still formatted to stdo
 
 ### Changes
 
-**`internal/codegen`** — export the extractor that already exists:
+**`internal/codegen/unused_imports_syntactic.go`** — stop dropping the parse error.
+`buildPackageSkeletons` collects it into `packageSkeletons.goParseDiags`, reusing the
+existing `skeletonParseError` → `diagnosticsFromParseError` conversion, and still
+`continue`s (that file keeps all its imports; its siblings are still analyzed).
+`Module.UnusedImports` returns them alongside its map:
 
 ```go
-// ParseDiagnostics reports the positioned .gsx diagnostics carried by err, if err
-// is a skeleton parse failure. Thin export of diagnosticsFromParseError.
-func ParseDiagnostics(err error) ([]diag.Diagnostic, bool)
+func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, []diag.Diagnostic, error)
 ```
 
-**`gen/fmt.go`** — `analyzeUnusedImports` additionally returns diagnostics keyed
-by absolute `.gsx` path:
+They are **diagnostics, not an error**. The `error` return stays reserved for faults
+that make the whole package unanalyzable.
 
-```go
-byPath, err := m.UnusedImports(absDir)
-if err != nil {
-    if diags, ok := codegen.ParseDiagnostics(err); ok {
-        bucketByFilename(diags)   // a real Go syntax error, already positioned
-    }
-    continue                      // every other failure stays silent, as today
-}
-```
+**`gen/fmt.go`** — `analyzeUnusedImports` buckets those diagnostics by the absolute
+`.gsx` path each one points at, and returns them alongside the import map. They are
+collected even when `UnusedImports` also errored.
 
-**`runFmt`** — render the diagnostics for the files in the format set (sorted by
-file/line/column, as `gen/main.go:405` does), choosing `diag.RenderRich` when
-stderr is a TTY and `diag.RenderCompact` otherwise — the same choice
-`gen/main.go:416-429` makes. Set `exit = 1` if any diagnostic is error-severity.
-Then proceed with formatting unchanged.
+**`runFmt`** — `reportGoDiagnostics` renders the diagnostics for the files in the
+format set (sorted by file/line/column, as `gen/main.go:405` does), choosing
+`diag.RenderRich` when stderr is a TTY and `diag.RenderCompact` otherwise — the same
+choice `gen/main.go:416-429` makes. Sets `exit = 1` if any is error-severity.
+Formatting then proceeds unchanged.
 
 ### Error discrimination — what makes this safe
 
-Only `parseDiagnosticsError` is reported. Every other failure from
-`codegen.Open` / `Module.UnusedImports` — unresolved dependencies, network,
-directory not in a module — keeps its `continue`. A project that cannot load must
-never start failing `gsx fmt`. `errors.As` makes the distinction exact.
+Only a `scanner.ErrorList` from the skeleton parse becomes a diagnostic;
+`skeletonParseError` returns any other fault unchanged and `diagnosticsFromParseError`
+then reports `ok=false`, so it is dropped exactly as before. A failure to
+`codegen.Open` a module — unresolved dependencies, network, not a module — keeps its
+`continue` and produces no diagnostics at all. A project that cannot load must never
+start failing `gsx fmt`.
 
 ### Scope limits
 

--- a/docs/superpowers/specs/2026-07-08-fmt-error-reporting-design.md
+++ b/docs/superpowers/specs/2026-07-08-fmt-error-reporting-design.md
@@ -1,0 +1,197 @@
+# `gsx fmt` reports the Go errors its analyzer already found
+
+**Status:** design · **Date:** 2026-07-08
+
+## Problem
+
+`gsx fmt` silently succeeds on a `.gsx` file whose Go is invalid. It exits 0,
+`fmt -l` reports the file as already clean, and `fmt -w` rewrites it — markup
+reformatted, broken Go passed through verbatim — while claiming success.
+
+The same file, same module, through the analyzer:
+
+```
+$ gsx generate .
+input.gsx:9:1: error[parse-error]: imports must appear before other declarations
+
+$ gsx fmt -l .
+(silence, exit 0)
+```
+
+A gsx *syntax* error does report (exit 1). Only Go errors are silent.
+
+## Why it is silent — the load-bearing fallback
+
+gsx treats Go as an opaque blob, so the formatter never parses Go. It hands Go
+*fragments* to `go/format` and, when `format.Source` fails, falls back to relaying
+the fragment verbatim.
+
+That fallback is not an oversight. Instrumenting all seven fallback sites and
+running them over the 614 `.gsx` files in `internal/corpus/testdata/cases` +
+`examples` produced 24 fallback events. **Twenty-one are legitimate, shipped
+syntax:**
+
+| site | case | go/format says |
+|---|---|---|
+| `fmtExprPreserving` | `goexpr-interp-tag/*` | `expected operand, found '<'` |
+| `parseWrapped` | `goexpr-f-literal/*` | `missing ',' in argument list` |
+| `parseWrapped` | `goexpr-valueform-init/*` | `expected ')', found ':='` |
+| `parseWrapped` | `props/byo_splat_*` | `expected ';', found ':'` |
+
+`{ wrap(<Badge/>) }`, `` f`…` ``, `{ if x := ready(); x { "on" } }`, `{ data... }`
+— none of these are Go, and `go/format` rightly rejects them.
+
+Only three events are genuinely invalid Go
+(`xpkg/interleaved_imports_error`, `element-literals/stray-import-after-func`,
+`goexpr-f-literal/js_value_unsupported`).
+
+So the formatter **uses `go/format`'s failure as a classifier** — "this fragment
+contains gsx, leave it alone" — and cannot distinguish that from "this Go is
+broken." This is the same conflation as the `goWithElements` bug fixed in #49
+(*"gsx cannot parse this Go" ≠ "Go cannot format this Go"*), one level up.
+
+Making the formatter itself report Go errors would mean disambiguating at all
+seven sites (placeholder substitution for embedded gsx values, AST routing for
+structurally-gsx constructs, plus wrapper→file position mapping at each). That is
+rejected: it is large, and it would put diagnostics inside the formatter.
+
+## Key observation: diagnostics already do not live in the formatter
+
+`internal/gsxfmt` and `internal/printer` know nothing about diagnostics. The LSP
+already separates the two channels:
+
+| layer | produces | consumes |
+|---|---|---|
+| analyzer (`codegen.Module`) | positioned `.gsx` diagnostics | — |
+| formatter (`gsxfmt`, `printer`) | canonical source | — |
+| LSP | — | `publishDiags` (`server.go:443`) ⟂ `handleFormatting` (`format.go`) |
+| CLI `fmt` | — | **nothing** ← the hole |
+
+`handleFormatting` only formats; on error it returns no edits. Diagnostics arrive
+on a separate, debounced channel. In an editor the broken file already gets a
+squiggle *and* still formats.
+
+Meanwhile `gsx fmt` **already runs the analyzer** — `analyzeUnusedImports`
+(`gen/fmt.go:167`) opens a `codegen.Module` per module for unused-import removal —
+and `skeletonParseError` (`internal/codegen/module_importer.go:133`) has already
+converted the skeleton's `scanner.ErrorList` into `.gsx`-positioned diagnostics
+through the skeleton's `//line` directives.
+
+The work is done. Nobody reads the result:
+
+```go
+byPath, err := m.UnusedImports(absDir)
+if err != nil {
+    continue        // the positioned parse diagnostic dies here
+}
+```
+
+**The missing piece is not in the formatter. The CLI lacks the diagnostic channel
+the LSP has.**
+
+## Design
+
+### Boundary
+
+The formatter is untouched. `internal/printer`, `internal/gsxfmt` and `parser`
+get zero lines. Diagnostics belong to the analyzer and are surfaced by the CLI —
+the same split the LSP uses, with a different transport (stderr instead of
+`publishDiagnostics`).
+
+### Behavior
+
+When the analyzer reports a Go parse error for a file being formatted, `gsx fmt`
+prints the positioned diagnostic to stderr and exits nonzero — **and still
+formats, writes, lists and diffs exactly as before.**
+
+This deliberately diverges from gofmt. gofmt refuses to write because it produced
+*nothing*: an unparseable file yields no output. gsx produced correct output (the
+broken Go relays verbatim, no data loss); refusing to write would discard work it
+successfully did, and would make `gsx fmt` disagree with format-on-save, which
+formats the same buffer. What is adopted from gofmt is the part that matters:
+**never silently succeed.**
+
+This matches the existing precedent in `TestFmtParseError`: a file with a gsx
+parse error reports and exits 1, while a good sibling is still formatted to stdout.
+
+### Changes
+
+**`internal/codegen`** — export the extractor that already exists:
+
+```go
+// ParseDiagnostics reports the positioned .gsx diagnostics carried by err, if err
+// is a skeleton parse failure. Thin export of diagnosticsFromParseError.
+func ParseDiagnostics(err error) ([]diag.Diagnostic, bool)
+```
+
+**`gen/fmt.go`** — `analyzeUnusedImports` additionally returns diagnostics keyed
+by absolute `.gsx` path:
+
+```go
+byPath, err := m.UnusedImports(absDir)
+if err != nil {
+    if diags, ok := codegen.ParseDiagnostics(err); ok {
+        bucketByFilename(diags)   // a real Go syntax error, already positioned
+    }
+    continue                      // every other failure stays silent, as today
+}
+```
+
+**`runFmt`** — render the diagnostics for the files in the format set (sorted by
+file/line/column, as `gen/main.go:405` does), choosing `diag.RenderRich` when
+stderr is a TTY and `diag.RenderCompact` otherwise — the same choice
+`gen/main.go:416-429` makes. Set `exit = 1` if any diagnostic is error-severity.
+Then proceed with formatting unchanged.
+
+### Error discrimination — what makes this safe
+
+Only `parseDiagnosticsError` is reported. Every other failure from
+`codegen.Open` / `Module.UnusedImports` — unresolved dependencies, network,
+directory not in a module — keeps its `continue`. A project that cannot load must
+never start failing `gsx fmt`. `errors.As` makes the distinction exact.
+
+### Scope limits
+
+These are accepted, not oversights:
+
+- **Best-effort, not gofmt's guarantee.** Detection happens only where the
+  analyzer runs: inside a loadable module, without `-no-imports`. A `.gsx` outside
+  a module stays silent — exactly as the LSP shows no squiggles without analysis.
+  Buying the unconditional guarantee costs the seven-site formatter change,
+  rejected above.
+- **The skeleton is per-package.** A broken sibling produces diagnostics
+  attributed to *that* file. If it is not in the format set, its diagnostics are
+  not printed (and, as today, that directory gets no import removal).
+- **Exit 1, not gofmt's 2.** `runFmt` already uses `2` for usage and I/O faults
+  and `1` for per-file problems. A diagnostic is a per-file problem.
+
+## Testing
+
+- Broken Go in a loadable module → positioned diagnostic on stderr, exit 1, file
+  still formatted (stdout) / written (`-w`).
+- Module that cannot load (missing `require`) → no diagnostic, exit unchanged.
+  *This is the regression that would otherwise break every CI.*
+- `-no-imports` → no diagnostic, exit unchanged.
+- Clean file in a loadable module → byte-identical behavior, exit 0, empty stderr.
+- Diagnostics are attributed per file: a broken file and a clean sibling in one
+  `fmt` invocation report only the broken one, and the sibling still formats.
+
+Corpus already carries the true-positive inputs (`xpkg/interleaved_imports_error`,
+`element-literals/stray-import-after-func`); the new coverage is CLI-level in
+`gen/fmt_test.go`, whose `fmtCapture` + `repoRoot` helpers already build real
+modules.
+
+## Behavior change
+
+`gsx fmt` on a tree containing a Go syntax error now exits 1 where it exited 0.
+That is the point of the change, but it breaks anyone gating CI on `gsx fmt -l`
+with such a tree. Note it in `docs/ROADMAP.md`.
+
+## Out of scope
+
+- Teaching the formatter to distinguish gsx syntax from broken Go (the seven-site
+  placeholder change). Would close the no-module gap and let the printer stop
+  using `format.Source` failure as a classifier — but it belongs in the formatter,
+  which must stay diagnostic-free.
+- `fmt --json`. `generate` has `--format=ndjson`; `fmt` has no JSON mode today and
+  does not gain one here.

--- a/gen/fmt.go
+++ b/gen/fmt.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/gsxhq/gsx/internal/codegen"
+	"github.com/gsxhq/gsx/internal/diag"
 	"github.com/gsxhq/gsx/internal/gsxfmt"
 	"github.com/gsxhq/gsx/internal/rawfmt"
 )
@@ -71,11 +72,17 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 	}
 
 	var unusedByPath map[string][]gsxfmt.ImportRef
+	var goDiags map[string][]diag.Diagnostic
 	if !noImports {
-		unusedByPath = analyzeUnusedImports(files, opts)
+		unusedByPath, goDiags = analyzeUnusedImports(files, opts)
 	}
 
 	exit := 0
+	// The analyzer's Go parse errors are reported, but never stop formatting: the
+	// invalid Go passes through verbatim and the markup around it still canonicalizes.
+	if reportGoDiagnostics(stderr, files, goDiags) {
+		exit = 1
+	}
 	widthByDir := map[string]int{}
 	for _, path := range files {
 		orig, err := os.ReadFile(path)
@@ -164,8 +171,16 @@ func printWidthFor(dir string) int {
 // are skipped (those files are then formatted without import removal). opts
 // carries the resolved codegen config so skeletons match what `generate` emits;
 // a zero/builtin opts still works (buildSkeleton tolerates unknown filters).
-func analyzeUnusedImports(files []string, opts codegen.Options) map[string][]gsxfmt.ImportRef {
+//
+// It also returns, per absolute .gsx path, the Go parse diagnostics the skeleton
+// surfaced. gsx copies user Go through as an opaque blob, so Go that is invalid
+// only in context (an `import` after a declaration, say) is caught nowhere else in
+// the fmt path; the skeleton's //line directives have already resolved each
+// position back to its .gsx origin. Only genuine parse failures become diagnostics;
+// a project that will not load yields none, so it can never make `gsx fmt` fail.
+func analyzeUnusedImports(files []string, opts codegen.Options) (map[string][]gsxfmt.ImportRef, map[string][]diag.Diagnostic) {
 	out := map[string][]gsxfmt.ImportRef{}
+	diags := map[string][]diag.Diagnostic{}
 	dirSet := map[string]bool{}
 	for _, f := range files {
 		dirSet[filepath.Dir(f)] = true
@@ -181,16 +196,27 @@ func analyzeUnusedImports(files []string, opts codegen.Options) map[string][]gsx
 		o.ModulePath = g.modPath
 		m, err := codegen.Open(o)
 		if err != nil {
-			continue // not loadable → syntactic-only fallback (no removal)
+			continue // not loadable → syntactic-only fallback (no removal, no diagnostics)
 		}
 		for _, dir := range g.dirs {
 			absDir, err := filepath.Abs(dir)
 			if err != nil {
 				continue
 			}
-			byPath, err := m.UnusedImports(absDir)
+			byPath, goDiags, err := m.UnusedImports(absDir)
+			// Bucket by the .gsx path each diagnostic points at: a package's skeletons
+			// can carry diagnostics for any of its files, not only the ones named on
+			// the command line. Collected even when the call errored, so a package that
+			// is unanalyzable for an unrelated reason still reports the Go it could read.
+			for _, d := range goDiags {
+				abs, aerr := filepath.Abs(d.Start.Filename)
+				if aerr != nil {
+					continue
+				}
+				diags[abs] = append(diags[abs], d)
+			}
 			if err != nil {
-				continue
+				continue // unanalyzable package → not a user-facing Go diagnostic
 			}
 			for gsxPath, imps := range byPath {
 				absPath, err := filepath.Abs(gsxPath)
@@ -205,7 +231,60 @@ func analyzeUnusedImports(files []string, opts codegen.Options) map[string][]gsx
 			}
 		}
 	}
-	return out
+	return out, diags
+}
+
+// reportGoDiagnostics prints, to stderr, the analyzer's Go parse diagnostics for
+// the files being formatted, and reports whether any was an error.
+//
+// Unlike gofmt, `gsx fmt` reports and still formats. gofmt refuses to write
+// because an unparseable file yields no output at all; gsx produced correct output
+// (the invalid Go relays through verbatim), so refusing to write would discard
+// work it successfully did — and would disagree with the LSP, which formats the
+// same buffer while publishing the same diagnostic on its own channel. What is
+// borrowed from gofmt is the part that matters: never silently succeed.
+//
+// Diagnostics for files outside the format set are dropped: the skeleton is
+// per-package, and `gsx fmt a.gsx` must not report on its untouched siblings.
+func reportGoDiagnostics(stderr io.Writer, files []string, byPath map[string][]diag.Diagnostic) bool {
+	if len(byPath) == 0 {
+		return false
+	}
+	var all []diag.Diagnostic
+	for _, path := range files {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		all = append(all, byPath[abs]...)
+	}
+	if len(all) == 0 {
+		return false
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		a, b := all[i].Start, all[j].Start
+		if a.Filename != b.Filename {
+			return a.Filename < b.Filename
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		return a.Column < b.Column
+	})
+	if isTTY(stderr) {
+		diag.RenderRich(stderr, all, func(name string) ([]byte, bool) {
+			b, e := os.ReadFile(name)
+			return b, e == nil
+		})
+	} else {
+		diag.RenderCompact(stderr, all)
+	}
+	for _, d := range all {
+		if d.Severity == diag.Error {
+			return true
+		}
+	}
+	return false
 }
 
 // gsxFiles resolves the path args to a sorted, de-duplicated list of .gsx files

--- a/gen/fmt_diag_test.go
+++ b/gen/fmt_diag_test.go
@@ -1,0 +1,203 @@
+package gen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gsx fmt runs the analyzer already (for unused-import removal), and the analyzer
+// already positions skeleton parse errors back at the .gsx via //line directives.
+// These tests pin that fmt surfaces them instead of discarding them — while still
+// formatting, since unlike gofmt it did produce correct output.
+
+// strayImportGsx is Go that gsx parses (it treats Go as an opaque blob) but Go
+// rejects: an `import` after a declaration. It surfaces only at the skeleton parse.
+const strayImportGsx = `package views
+
+import "github.com/gsxhq/gsx"
+
+func render() gsx.Node {
+	return <div>inline</div>
+}
+
+import "strings"
+
+component Index() {
+	<section>{ render() }</section>
+}
+`
+
+// writeGsxModule makes dir a loadable module (via the existing writeModule) and
+// drops the given name→content .gsx files into it.
+func writeGsxModule(t *testing.T, dir, modPath string, files map[string]string) {
+	t.Helper()
+	writeModule(t, dir, modPath)
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestFmtReportsGoParseErrorAndStillFormats is the headline behavior: the Go
+// error is reported with its .gsx position, the exit code is nonzero, and the
+// formatted output is still produced (gofmt refuses to write only because it
+// produced nothing; gsx produced correct output).
+func TestFmtReportsGoParseErrorAndStillFormats(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeGsxModule(t, dir, "demo/stray", map[string]string{"input.gsx": strayImportGsx})
+
+	code, out, errb := fmtCapture(t, []string{filepath.Join(dir, "input.gsx")})
+	if code == 0 {
+		t.Fatalf("exit = 0, want nonzero; stderr=%q", errb)
+	}
+	if !strings.Contains(errb, "imports must appear before other declarations") {
+		t.Errorf("stderr missing the Go diagnostic:\n%s", errb)
+	}
+	if !strings.Contains(errb, "input.gsx:9") {
+		t.Errorf("diagnostic not positioned at the .gsx stray import (want input.gsx:9):\n%s", errb)
+	}
+	if !strings.Contains(out, "component Index()") {
+		t.Errorf("file was not formatted despite the Go error:\n%s", out)
+	}
+}
+
+// TestFmtWriteStillWritesOnGoParseError pins the deliberate divergence from
+// gofmt: -w writes the formatted file even though the Go is broken. The broken Go
+// relays verbatim, so nothing is lost.
+func TestFmtWriteStillWritesOnGoParseError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Give the component body loose indentation so formatting has something to do.
+	src := strings.Replace(strayImportGsx, "\t<section>{ render() }</section>", "        <section>{ render() }</section>", 1)
+	writeGsxModule(t, dir, "demo/straywrite", map[string]string{"input.gsx": src})
+	path := filepath.Join(dir, "input.gsx")
+
+	code, _, errb := fmtCapture(t, []string{"-w", path})
+	if code == 0 {
+		t.Fatalf("exit = 0, want nonzero; stderr=%q", errb)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), "\t<section>{ render() }</section>") {
+		t.Errorf("-w did not write the formatted file:\n%s", after)
+	}
+	// The broken Go must survive verbatim.
+	if !strings.Contains(string(after), `import "strings"`) {
+		t.Errorf("-w dropped the invalid Go:\n%s", after)
+	}
+}
+
+// TestFmtUnloadableModuleReportsNoDiagnostic is the regression guard: a module
+// that cannot load (no `require`/`replace` for the gsx runtime it imports) must
+// not start failing gsx fmt. Only skeleton PARSE errors are diagnostics; load
+// failures stay silent, as they are today.
+func TestFmtUnloadableModuleReportsNoDiagnostic(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// go.mod with no require/replace for github.com/gsxhq/gsx → module won't load.
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module demo/unloadable\n\ngo 1.26.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(dir, "good.gsx")
+	if err := os.WriteFile(good, []byte(unformattedGsx), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out, errb := fmtCapture(t, []string{good})
+	if errb != "" {
+		t.Errorf("unloadable module produced stderr output: %q", errb)
+	}
+	if code != 0 {
+		t.Errorf("exit = %d, want 0 for an unloadable module", code)
+	}
+	if !strings.Contains(out, "component Hi(name string)") {
+		t.Errorf("file was not formatted:\n%s", out)
+	}
+}
+
+// TestFmtNoImportsSkipsDiagnostics pins that -no-imports (which skips module
+// analysis entirely) also skips diagnostics — there is no analyzer to ask.
+func TestFmtNoImportsSkipsDiagnostics(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeGsxModule(t, dir, "demo/noimports", map[string]string{"input.gsx": strayImportGsx})
+
+	code, _, errb := fmtCapture(t, []string{"-no-imports", filepath.Join(dir, "input.gsx")})
+	if errb != "" {
+		t.Errorf("-no-imports produced stderr output: %q", errb)
+	}
+	if code != 0 {
+		t.Errorf("exit = %d, want 0 with -no-imports", code)
+	}
+}
+
+// TestFmtCleanFileInModuleIsSilent pins no behavior change for the common case:
+// valid Go in a loadable module reports nothing and exits 0.
+func TestFmtCleanFileInModuleIsSilent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeGsxModule(t, dir, "demo/clean", map[string]string{"input.gsx": unformattedGsx})
+
+	code, out, errb := fmtCapture(t, []string{filepath.Join(dir, "input.gsx")})
+	if errb != "" {
+		t.Errorf("clean file produced stderr output: %q", errb)
+	}
+	if code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out, "component Hi(name string)") {
+		t.Errorf("file was not formatted:\n%s", out)
+	}
+}
+
+// TestFmtDiagnosticsOutsideFormatSetAreDropped pins that formatting only the
+// clean sibling is silent, even though the package's skeleton carries a
+// diagnostic for the broken file. `gsx fmt other.gsx` must not report on files
+// the user did not ask it to touch.
+func TestFmtDiagnosticsOutsideFormatSetAreDropped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeGsxModule(t, dir, "demo/outside", map[string]string{
+		"input.gsx": strayImportGsx,
+		"other.gsx": "package views\n\ncomponent   Other() {\n    <p>x</p>\n}\n",
+	})
+
+	code, out, errb := fmtCapture(t, []string{filepath.Join(dir, "other.gsx")})
+	if errb != "" {
+		t.Errorf("reported a diagnostic for a file outside the format set: %q", errb)
+	}
+	if code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out, "component Other()") {
+		t.Errorf("sibling not formatted:\n%s", out)
+	}
+}
+
+// TestFmtGoParseErrorDoesNotStopSiblingFormatting pins per-file attribution: the
+// broken file reports, the clean sibling still formats.
+func TestFmtGoParseErrorDoesNotStopSiblingFormatting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeGsxModule(t, dir, "demo/sibling", map[string]string{
+		"input.gsx": strayImportGsx,
+		"other.gsx": "package views\n\ncomponent   Other() {\n    <p>x</p>\n}\n",
+	})
+
+	code, out, errb := fmtCapture(t, []string{dir})
+	if code == 0 {
+		t.Fatalf("exit = 0, want nonzero; stderr=%q", errb)
+	}
+	if strings.Count(errb, "imports must appear") != 1 {
+		t.Errorf("want exactly one diagnostic, got:\n%s", errb)
+	}
+	if !strings.Contains(out, "component Other() {\n\t<p>x</p>\n}") {
+		t.Errorf("clean sibling not formatted:\n%s", out)
+	}
+}

--- a/gen/fmt_test.go
+++ b/gen/fmt_test.go
@@ -352,7 +352,7 @@ func TestFmtTwoDirsOneModule(t *testing.T) {
 	aPath := writeFile(t, filepath.Join(dir, "a"), "a.gsx", aSrc)
 	bPath := writeFile(t, filepath.Join(dir, "b"), "b.gsx", bSrc)
 
-	refs := analyzeUnusedImports(
+	refs, _ := analyzeUnusedImports(
 		[]string{aPath, bPath},
 		codegen.Options{Classifier: attrclass.Builtin()},
 	)

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -94,6 +94,11 @@ type fileSkeleton struct {
 type packageSkeletons struct {
 	gsxFset *token.FileSet
 	byGsx   map[string]fileSkeleton // .gsx abs path -> skeleton + import specs + sunk set
+	// goParseDiags holds the Go parse errors the skeletons produced, positioned
+	// back at their .gsx origin by the skeletons' //line directives. gsx copies
+	// user Go through as an opaque blob, so Go that is invalid only in context (an
+	// `import` after a declaration) is detectable nowhere earlier than here.
+	goParseDiags []diag.Diagnostic
 }
 
 // buildPackageSkeletons lowers every .gsx file in dir to its skeleton AST WITHOUT
@@ -147,6 +152,14 @@ func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
 		absXpath := filepath.Join(dir, base+".x.go")
 		gf, perr := goparser.ParseFile(fset, absXpath, skel, goparser.SkipObjectResolution)
 		if perr != nil {
+			// The user's Go does not parse. Keep every import (no entry for this
+			// file), but hand the positioned diagnostics up: this is the only place
+			// the fmt path can see them, and `gsx fmt` must not silently succeed on
+			// Go it could not format. A non-ErrorList fault yields no diagnostics
+			// and is dropped, exactly as before.
+			if ds, ok := diagnosticsFromParseError(skeletonParseError(perr)); ok {
+				out.goParseDiags = append(out.goParseDiags, ds...)
+			}
 			continue
 		}
 		sunk := map[sunkImportKey]bool{}
@@ -189,10 +202,17 @@ func (m *Module) resolvePackageNames(paths []string) map[string]string {
 // base is not referenced have their real package name resolved via a single
 // cheap NeedName load before removal, so a package whose name differs from its
 // path base (e.g. gopkg.in/yaml.v3 → "yaml") is handled correctly.
-func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, error) {
+//
+// It also returns the Go parse diagnostics the skeletons produced, already
+// positioned at their .gsx origin. They are diagnostics, not an error: a file
+// whose Go does not parse simply keeps all its imports, and its siblings are
+// still analyzed. The returned error stays reserved for faults that make the
+// whole package unanalyzable (a gsx parse failure, an unloadable module), which
+// callers must not present to the user as a Go diagnostic.
+func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, []diag.Diagnostic, error) {
 	ps, err := m.buildPackageSkeletons(dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	out := map[string][]UnusedImport{}
 	usedByFile := map[string]map[string]bool{}
@@ -230,5 +250,5 @@ func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, error) {
 			}
 		}
 	}
-	return out, nil
+	return out, ps.goParseDiags, nil
 }

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -134,7 +134,7 @@ func TestUnusedImportsSyntactic(t *testing.T) {
 	dir, m := openTestModule(t, map[string]string{
 		"page.gsx": "package testmod\n\nimport (\n\t\"strings\"\n\t\"bytes\"\n)\n\ncomponent Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n",
 	})
-	got, err := m.UnusedImports(dir)
+	got, _, err := m.UnusedImports(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestUnusedImportsDefaultNameMismatchKept(t *testing.T) {
 		"renamedpkg/lib.go": "package renamed\n\nfunc Hello() string { return \"hi\" }\n",
 		"page.gsx":          "package testmod\n\nimport \"testmod/renamedpkg\"\n\ncomponent Page() {\n\t<div>{renamed.Hello()}</div>\n}\n",
 	})
-	got, err := m.UnusedImports(dir)
+	got, _, err := m.UnusedImports(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +335,7 @@ func TestSyntacticMatchesTypecheckOracle(t *testing.T) {
 	for name, files := range cases {
 		t.Run(name, func(t *testing.T) {
 			dir, m := openTestModule(t, files)
-			syn, err := m.UnusedImports(dir)
+			syn, _, err := m.UnusedImports(dir)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
- **docs(spec): gsx fmt surfaces the analyzer's Go parse diagnostics**
- **fix(fmt): report the Go parse errors the analyzer already found**
