### PR TITLE
test(corpus): replace package-name heuristic, fail loudly on harness invariants

### DIFF
--- a/docs/superpowers/specs/2026-07-07-organize-imports-design.md
+++ b/docs/superpowers/specs/2026-07-07-organize-imports-design.md
@@ -89,6 +89,40 @@ the std/third-party grouping shown above. The `TabIndent: true, TabWidth: 8,
 Comments: true` options are required so `FormatOnly` matches gofmt's tabbed
 chunk formatting (otherwise it emits spaces).
 
+### Interaction with recent main work (verified at HEAD f6fbd8c)
+
+Checked because PR #51/#52 churned adjacent code. All clear:
+
+- **`d813a1e` "tokenize for the `_gsx` reservation instead of parsing"** does
+  *not* constrain this design. Its rule targets **element-bearing** Go regions,
+  which codegen used to reconstruct by substituting a padded `_()` placeholder
+  and parsing — and fmt's new paren-wrap (`return ( <>…</> )`) made those
+  reconstructions invalid Go under automatic semicolon insertion. A `GoChunk` is
+  by definition **element-free, complete top-level Go**; the shipped
+  `deleteChunkImports` already parses one (wrapped in `package _gsxp`) on every
+  `gsx fmt`, and `d813a1e` touched only `internal/codegen`, never
+  `internal/gsxfmt`. So `reorderImports` may parse its chunk exactly as
+  `deleteChunkImports` does.
+- **Imports never live in a `GoWithElements`.** `parser/goexpr.go
+  splitGoElements` peels a leading import run into its own plain `GoChunk`
+  before building the element region. A per-`GoChunk` walk therefore misses no
+  import, and skipping `GoWithElements` (as `removeImports` already does via its
+  type switch) is correct.
+- **`435a91c` / PR #51 / `internal/goexprshape`** all operate solely on
+  element-literal positions inside `GoWithElements` (paren wrap/strip,
+  placeholder gofmt round-trip). Disjoint decl types — they cannot fight the
+  reorder pass. `435a91c` changed `canonGo` in `corpus_test.go`, a test
+  normalizer, not the printer.
+- **`fmtGoChunk` still runs `format.Source` on every chunk** (`printer.go:1250`),
+  so "gofmt mode = zero new formatting code" holds, as does reorder idempotency
+  (gofmt sorts within a group but never merges or regroups, so the goimports
+  std/third-party split survives the printer's re-gofmt).
+- **WASM cost is negligible.** `gsxfmt` is in the `playground/wasm` dep graph
+  (it exposes `gsxFormat`), but linking `golang.org/x/tools/imports` adds only 4
+  packages and **+1,811 bytes** to a 17.3 MB `gsx.wasm` (0.01%) — `go/packages`
+  machinery is already linked via `gen`. `golang.org/x/tools v0.46.0` is already
+  a module requirement, so no new dependency.
+
 ## Pipeline ordering (goimports mode)
 
 Within one `gsx fmt` invocation: **remove-unused → reorder → normalize/print.**
@@ -197,13 +231,24 @@ imports = "goimports"   # "goimports" (default) | "gofmt"
 
 `textDocument/formatting` **honors the configured mode**, mirroring the CLI. No
 CLI flag exists in the editor, so the mode comes from resolved config only: add
-an `ImportsMode(dir)` accessor next to the existing `PrintWidth(dir)` on the
-analyzer, map it through the shared mode→options helper, and pass `Unused`
-(from analysis, only in goimports mode) and `Reorder` into `FormatWith`. So in
+an `ImportsMode(dir)` accessor next to the existing `PrintWidth(dir)` — declared
+on the `Analyzer` interface in `internal/lsp/server.go` and implemented on
+`lspAnalyzer` in `gen/lsp.go` (that is where `PrintWidth` actually lives, *not*
+`internal/lsp/analysis.go`). Map it through the shared mode→options helper, and
+pass `Unused` (from analysis, only in goimports mode) and `Reorder` into
+`FormatWith`. So in
 `gofmt` mode, format-on-save is gofmt only — it stops removing/reordering
 imports; the organize behavior then comes exclusively from the code action
 below. This is precisely the gopls split: `textDocument/formatting` = gofmt,
 import organizing = a separate action.
+
+**Pre-existing gap, preserve don't fix:** `handleFormatting` today calls
+`FormatRemovingImports` — the *non*-`With` variant — so LSP formatting does not
+run the `<style>`/`<script>` css/js formatters that the CLI runs. Moving it to
+`FormatWith` makes that gap explicit (`CSSFmt`/`JSFmt` become visible nil
+fields). Keep current behavior: pass nil formatters, preserving today's LSP
+output byte-for-byte. Closing the gap is a separate change with its own tests —
+do not fold it into this effort.
 
 ### LSP `source.organizeImports` code action — `internal/lsp/codeaction.go` (new)
 
@@ -303,8 +348,9 @@ scoped to what a formatter mode needs.
 - `internal/lsp/protocol.go` — `CodeActionOptions`, `codeActionProvider`
   capability, `textDocument/codeAction` param/result types.
 - `internal/lsp/server.go` — dispatch `textDocument/codeAction`; advertise the
-  capability.
-- `internal/lsp/analysis.go` — `ImportsMode(dir)` accessor for the resolved mode.
+  capability; declare `ImportsMode(dir)` on the `Analyzer` interface.
+- `gen/lsp.go` — implement `lspAnalyzer.ImportsMode(dir)` (next to
+  `PrintWidth`, via `resolveConfigBestEffort(...).effectiveImportsMode()`).
 - Corpus cases + unit/config/CLI/LSP tests as above.
 - Docs: `[formatter] imports` config reference + `gsx fmt` page (in
   `gsxhq.github.io`); note editor `codeActionsOnSave: source.organizeImports`

--- a/internal/corpus/batch.go
+++ b/internal/corpus/batch.go
@@ -8,11 +8,19 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/gsxhq/gsx/internal/diag"
 )
+
+// genFile is one generated .x.go: the package dir it belongs to, the original
+// .gsx path it came from, and its bytes.
+type genFile struct {
+	dir  string
+	path string
+	data []byte
+}
 
 type caseCodegen struct {
 	gen  []byte // concatenated generated .x.go (sorted by gsx path), for the generated.x.go.golden facet
@@ -52,6 +60,17 @@ func writeCaseSources(moduleDir string, c *caseDoc) error {
 func batchCodegen(repoRoot string, candidates []*caseDoc) (map[string]*caseCodegen, error) {
 	if len(candidates) == 0 {
 		return map[string]*caseCodegen{}, nil
+	}
+
+	// caseDoc.dir flattens the case name ("a/b" → "a_b") to name its directory in
+	// the shared temp module, so "a/b_c" and "a_b/c" would land in the same place
+	// and silently overwrite each other's sources. Reject that up front.
+	byDirName := make(map[string]string, len(candidates))
+	for _, c := range candidates {
+		if prev, dup := byDirName[c.dir]; dup {
+			return nil, fmt.Errorf("case dir collision: %q and %q both map to %q; rename one", prev, c.name, c.dir)
+		}
+		byDirName[c.dir] = c.name
 	}
 
 	tmp := mustTempModule(repoRoot)
@@ -117,21 +136,17 @@ func batchCodegen(repoRoot string, candidates []*caseDoc) (map[string]*caseCodeg
 
 		// Collect package results for this case.
 		// Check if any package has an error.
-		var allFiles []struct {
-			dir  string
-			path string // original .gsx path
-			data []byte
-		}
+		var allFiles []genFile
 		hasErr := false
 		var diagBuf bytes.Buffer
 
 		for _, pkgDir := range cs.pkgDirs {
 			pr, ok := pkgResults[pkgDir]
 			if !ok {
-				// Shouldn't happen; treat as error.
-				fmt.Fprintf(&diagBuf, "codegen: no result for %s\n", pkgDir)
-				hasErr = true
-				continue
+				// A harness invariant, not a case outcome: every pkgDir was passed
+				// to codegenDirs, so a missing result means the batch is broken.
+				// Never fold this into diagnostics.golden, where a golden could absorb it.
+				return nil, fmt.Errorf("case %s: codegen produced no result for %s", c.name, pkgDir)
 			}
 			// Render diagnostics from pr.Diags.
 			// Format: "line:col: message" for positioned diagnostics (Start.Line > 0),
@@ -147,11 +162,7 @@ func batchCodegen(repoRoot string, candidates []*caseDoc) (map[string]*caseCodeg
 			for gsxPath, genData := range pr.Files {
 				// Rewrite import paths in generated output (no-op when modulePath=="").
 				out := rewriteImportPath(genData, c.modulePath, root)
-				allFiles = append(allFiles, struct {
-					dir  string
-					path string
-					data []byte
-				}{dir: pkgDir, path: gsxPath, data: out})
+				allFiles = append(allFiles, genFile{dir: pkgDir, path: gsxPath, data: out})
 			}
 		}
 
@@ -163,27 +174,20 @@ func batchCodegen(repoRoot string, candidates []*caseDoc) (map[string]*caseCodeg
 			orderedDirs := cs.pkgDirs // already in packageDirs() order
 
 			// Group files by dir.
-			byDir := map[string][]struct {
-				path string
-				data []byte
-			}{}
+			byDir := map[string][]genFile{}
 			for _, f := range allFiles {
-				byDir[f.dir] = append(byDir[f.dir], struct {
-					path string
-					data []byte
-				}{f.path, f.data})
+				byDir[f.dir] = append(byDir[f.dir], f)
 			}
 			// Sort within each dir by gsx path.
 			for dir := range byDir {
-				sort.Slice(byDir[dir], func(i, j int) bool {
-					return byDir[dir][i].path < byDir[dir][j].path
+				slices.SortFunc(byDir[dir], func(a, b genFile) int {
+					return strings.Compare(a.path, b.path)
 				})
 			}
 
 			var genBuf bytes.Buffer
 			for _, dir := range orderedDirs {
-				files := byDir[dir]
-				for _, f := range files {
+				for _, f := range byDir[dir] {
 					genBuf.Write(f.data)
 				}
 			}
@@ -304,10 +308,14 @@ func (c *caseDoc) writeEntry(moduleDir, root string) (string, error) {
 		// Import only packages the invoke references, by package name.
 		nameToPath := map[string]string{}
 		for _, dir := range c.packageDirs() {
-			nameToPath[c.packageNameInDir(dir)] = root + "/" + dir
+			pkgName, err := c.packageNameInDir(dir)
+			if err != nil {
+				return "", fmt.Errorf("dir %s: %w", dir, err)
+			}
+			nameToPath[pkgName] = root + "/" + dir
 		}
 		var imps bytes.Buffer
-		for name := range referencedQualifiers(c.invoke) {
+		for _, name := range slices.Sorted(maps.Keys(referencedQualifiers(c.invoke))) {
 			if p, ok := nameToPath[name]; ok {
 				fmt.Fprintf(&imps, "\t%s %q\n", name, p)
 			}
@@ -319,7 +327,13 @@ func (c *caseDoc) writeEntry(moduleDir, root string) (string, error) {
 		return root + "/gsxentry", nil
 	}
 
-	pkgName := packageNameOf(c.files["input.gsx"])
+	// Read the clause from whichever root .gsx exists — single-package cases are
+	// not required to name their file input.gsx (examples/100-template-composition
+	// uses components.gsx + page.gsx).
+	pkgName, err := c.packageNameInDir(".")
+	if err != nil {
+		return "", err
+	}
 	// If the invoke references gsx. (e.g. gsx.Raw, gsx.Attrs), add the import so
 	// the generated entry file compiles. Each Go file in a package needs its own
 	// import declarations even though other files in the package already import gsx.
@@ -334,14 +348,15 @@ func (c *caseDoc) writeEntry(moduleDir, root string) (string, error) {
 	return root, nil
 }
 
-// packageNameInDir returns the package clause of the first .gsx file in dir.
-func (c *caseDoc) packageNameInDir(dir string) string {
-	for name, data := range c.files {
+// packageNameInDir returns the package clause of the first .gsx file in dir,
+// in sorted filename order so the choice is deterministic.
+func (c *caseDoc) packageNameInDir(dir string) (string, error) {
+	for _, name := range slices.Sorted(maps.Keys(c.files)) {
 		if strings.HasSuffix(name, ".gsx") && filepath.ToSlash(filepath.Dir(name)) == dir {
-			return packageNameOf(data)
+			return packageNameOf(c.files[name])
 		}
 	}
-	return "views"
+	return "", fmt.Errorf("no .gsx file in dir %q", dir)
 }
 
 var qualifierRe = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\.`)

--- a/internal/corpus/batch_test.go
+++ b/internal/corpus/batch_test.go
@@ -9,9 +9,18 @@ func TestBatchCodegenSingleAndMulti(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip batch build in -short")
 	}
-	repoRoot, _ := filepath.Abs("../..")
-	single, _ := loadCase("testdata/loadertest/single.txtar")
-	multi, _ := loadCase("testdata/loadertest/multi.txtar")
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	single, err := loadCase("testdata/loadertest/single.txtar")
+	if err != nil {
+		t.Fatalf("load single: %v", err)
+	}
+	multi, err := loadCase("testdata/loadertest/multi.txtar")
+	if err != nil {
+		t.Fatalf("load multi: %v", err)
+	}
 	out, err := batchCodegen(repoRoot, []*caseDoc{single, multi})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/corpus/codegen.go
+++ b/internal/corpus/codegen.go
@@ -3,10 +3,12 @@ package corpus
 import (
 	"bytes"
 	"fmt"
+	goparser "go/parser"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/gsxhq/gsx/ast"
@@ -82,11 +84,8 @@ func (c *caseDoc) packageDirs() []string {
 		}
 		seen[filepath.ToSlash(filepath.Dir(name))] = true
 	}
-	var out []string
-	for d := range seen {
-		out = append(out, d)
-	}
-	sort.Strings(out)
+	out := slices.Collect(maps.Keys(seen))
+	slices.Sort(out)
 	return out
 }
 
@@ -102,12 +101,13 @@ func normalizeDiagPaths(diag []byte, tmpDir string) []byte {
 	return bytes.ReplaceAll(diag, []byte(prefix), nil)
 }
 
-func packageNameOf(src []byte) string {
-	for line := range strings.SplitSeq(string(src), "\n") {
-		line = strings.TrimSpace(line)
-		if after, ok := strings.CutPrefix(line, "package "); ok {
-			return strings.TrimSpace(after)
-		}
+// packageNameOf returns the package clause of a .gsx source. PackageClauseOnly
+// stops the parse right after the clause, so the gsx-specific body that follows
+// (component declarations, elements) is never scanned as Go.
+func packageNameOf(src []byte) (string, error) {
+	f, err := goparser.ParseFile(token.NewFileSet(), "input.gsx", src, goparser.PackageClauseOnly)
+	if err != nil {
+		return "", fmt.Errorf("package clause: %w", err)
 	}
-	return "views"
+	return f.Name.Name, nil
 }

--- a/internal/corpus/codegen_test.go
+++ b/internal/corpus/codegen_test.go
@@ -5,7 +5,10 @@ import (
 )
 
 func TestAstAndParserDiagClean(t *testing.T) {
-	c, _ := loadCase("testdata/loadertest/single.txtar")
+	c, err := loadCase("testdata/loadertest/single.txtar")
+	if err != nil {
+		t.Fatalf("load case: %v", err)
+	}
 	dump, diag, single := c.astAndParserDiag()
 	if !single {
 		t.Fatal("single = false, want true")

--- a/internal/corpus/corpus_test.go
+++ b/internal/corpus/corpus_test.go
@@ -3,11 +3,9 @@ package corpus
 import (
 	"bytes"
 	"flag"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"testing"
 
@@ -17,15 +15,14 @@ import (
 var update = flag.Bool("update", false, "regenerate golden sections in testdata/cases")
 
 func TestCorpus(t *testing.T) {
-	repoRoot, _ := filepath.Abs("../..")
-	var files []string
-	filepath.WalkDir("testdata/cases", func(p string, d fs.DirEntry, err error) error {
-		if err == nil && !d.IsDir() && strings.HasSuffix(p, ".txtar") {
-			files = append(files, p)
-		}
-		return nil
-	})
-	sort.Strings(files)
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	files, err := txtarFiles("testdata/cases")
+	if err != nil {
+		t.Fatalf("walk testdata/cases: %v", err)
+	}
 	if len(files) == 0 {
 		t.Fatal("no testdata/cases/**/*.txtar")
 	}
@@ -44,32 +41,25 @@ func TestCorpus(t *testing.T) {
 	// Classify cases and collect codegen candidates for ONE batchCodegen call.
 	// A candidate is any case that is NOT a parse-error case and NOT a parser-layer case.
 	type classification struct {
-		single      bool
-		parserDiag  []byte
-		astDump     []byte
-		isCandidate bool
+		single     bool
+		parserDiag []byte
+		astDump    []byte
 	}
 	classif := make(map[string]*classification, len(cases))
 	var candidates []*caseDoc
 
 	for _, c := range cases {
 		astDump, parserDiag, single := c.astAndParserDiag()
-		cl := &classification{
+		classif[c.name] = &classification{
 			single:     single,
 			parserDiag: parserDiag,
 			astDump:    astDump,
 		}
-		if single && len(parserDiag) > 0 {
-			// parse-error case — no codegen
-			cl.isCandidate = false
-		} else if single && hasAstGolden(c) {
-			// parser-layer snapshot — no codegen
-			cl.isCandidate = false
-		} else {
-			cl.isCandidate = true
+		parseError := single && len(parserDiag) > 0
+		parserSnapshot := single && hasAstGolden(c)
+		if !parseError && !parserSnapshot {
 			candidates = append(candidates, c)
 		}
-		classif[c.name] = cl
 	}
 
 	// Single batchCodegen call for candidate cases that can match this test run.
@@ -296,7 +286,7 @@ func setSection(arc *txtar.Archive, name string, data []byte) {
 // writeArchive writes the archive back to path.
 func writeArchive(t *testing.T, path string, arc *txtar.Archive) {
 	t.Helper()
-	if err := os.WriteFile(path, txtar.Format(arc), 0644); err != nil {
+	if err := os.WriteFile(path, txtar.Format(arc), 0o644); err != nil {
 		t.Fatalf("writeArchive %s: %v", path, err)
 	}
 }

--- a/internal/corpus/coverage.go
+++ b/internal/corpus/coverage.go
@@ -3,13 +3,13 @@ package corpus
 import (
 	"bytes"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
 func coverageReport(cases []*caseDoc) []byte {
-	sorted := append([]*caseDoc(nil), cases...)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].name < sorted[j].name })
+	sorted := slices.Clone(cases)
+	slices.SortFunc(sorted, func(a, b *caseDoc) int { return strings.Compare(a.name, b.name) })
 	var buf bytes.Buffer
 	var render, errc, gen int
 	for _, c := range sorted {

--- a/internal/corpus/examples_test.go
+++ b/internal/corpus/examples_test.go
@@ -1,10 +1,7 @@
 package corpus
 
 import (
-	"io/fs"
 	"path/filepath"
-	"sort"
-	"strings"
 	"testing"
 )
 
@@ -12,17 +9,16 @@ import (
 // pipeline (codegen + go run) and asserts its render.golden — the same harness
 // TestCorpus uses. Run with -update to (re)generate the render.golden sections.
 func TestExamples(t *testing.T) {
-	repoRoot, _ := filepath.Abs("../..")
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
 	examplesDir := filepath.Join(repoRoot, "examples")
 
-	var files []string
-	filepath.WalkDir(examplesDir, func(p string, d fs.DirEntry, err error) error {
-		if err == nil && !d.IsDir() && strings.HasSuffix(p, ".txtar") {
-			files = append(files, p)
-		}
-		return nil
-	})
-	sort.Strings(files)
+	files, err := txtarFiles(examplesDir)
+	if err != nil {
+		t.Fatalf("walk examples: %v", err)
+	}
 	if len(files) == 0 {
 		t.Fatal("no examples/*.txtar found")
 	}

--- a/internal/corpus/htmlcompare.go
+++ b/internal/corpus/htmlcompare.go
@@ -3,7 +3,7 @@ package corpus
 import (
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -83,7 +83,7 @@ func attrSet(n *html.Node) string {
 		}
 		parts = append(parts, key+"="+a.Val)
 	}
-	sort.Strings(parts)
+	slices.Sort(parts)
 	return strings.Join(parts, " ")
 }
 

--- a/internal/corpus/loader.go
+++ b/internal/corpus/loader.go
@@ -2,9 +2,10 @@ package corpus
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -38,6 +39,27 @@ var goldenSections = map[string]bool{
 	"render.golden":         true,
 	"generated.x.go.golden": true,
 	"ast.golden":            true,
+}
+
+// txtarFiles returns every *.txtar under root, sorted. Walk errors are
+// reported rather than skipped: a corpus that silently loses cases to an
+// unreadable directory would still pass.
+func txtarFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(p, ".txtar") {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(files)
+	return files, nil
 }
 
 // loadCase parses one txtar case file. name is derived from path relative to
@@ -129,11 +151,9 @@ func (c *caseDoc) facets() []string {
 	if _, ok := c.goldens["ast.golden"]; ok {
 		out = append(out, "ast")
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }
-
-var _ = fmt.Sprintf
 
 // splitCasePkgFunc splits a "pkg/path.FuncName" string into its import path
 // and exported func name by splitting at the last ".". Used to parse


### PR DESCRIPTION
Rigorous review pass over `internal/corpus`. No behavior change to any case — **zero golden churn**.

## The real bug

`packageNameOf` was a line-scan heuristic ending in `return "views"`:

```go
for line := range strings.SplitSeq(string(src), "\n") {
    if after, ok := strings.CutPrefix(strings.TrimSpace(line), "package "); ok {
        return strings.TrimSpace(after)
    }
}
return "views"
```

That fallback was **silently load-bearing**. Single-package cases aren't required to name their file `input.gsx` — `examples/100-template-composition` uses `components.gsx` + `page.gsx` — so `c.files["input.gsx"]` was `nil` and the case got `"views"` by accident. Six cases depend on it. It works only because they all happen to declare `package views`; rename one to `package layout` and the generated entry file fails to compile with an error pointing nowhere near the cause.

Replaced with `go/parser` + `PackageClauseOnly` (which stops before the gsx-specific body, so `.gsx` parses fine), reading the clause from whichever root `.gsx` exists. Switching to it is what surfaced the bug — `TestExamples` failed immediately.

## Other loud-failure fixes

- **`caseDoc.dir` collision.** `name` is flattened `"a/b"` → `"a_b"` to name the case's directory in the shared temp module, so `a/b_c` and `a_b/c` land in the same place and silently overwrite each other's sources. No collisions today across all 566 cases, but the corpus is full of names mixing `_` and `/` (`orderedattrs/parse_literal`), so one rename triggers it. Now rejected at batch entry.
- **"Shouldn't happen" synthetic diagnostic.** A missing codegen result for a `pkgDir` was written into `diagBuf` and flowed into `diagnostics.golden` — a golden could absorb a harness invariant violation. Now a hard error.
- **Dropped errors.** `filepath.WalkDir`'s return was discarded in both `TestCorpus` and `TestExamples` (and the callback swallowed per-entry `err`); `loadCase` errors were ignored in `batch_test.go` and `codegen_test.go`, where a load failure was a nil-pointer dereference rather than a readable failure.

## Hygiene

- `writeEntry` emitted imports by ranging a map — nondeterministic order. Sorted.
- The same anonymous `struct{dir, path string; data []byte}` was spelled out three times in `batch.go`; now a named `genFile`.
- Dead `classification.isCandidate` (assigned 3×, never read) and leftover `var _ = fmt.Sprintf` removed.
- `sort.Slice`/`sort.Strings` → `slices.SortFunc`/`slices.Sort`; `0644` → `0o644`.

## Verification

- `go test ./internal/corpus -count=1` green; `git status -- internal/corpus/testdata examples` empty (no golden churn).
- `gofmt`, `go vet`, `golangci-lint` clean.
- Focused run unaffected: `-run TestCorpus/attrs/spread_byo` still 0.54s.
- Both new guards verified to actually fire via throwaway probes (deleted before commit): the collision guard rejects `x/y_z` vs `x_y/z`, and `packageNameOf` errors on a missing clause while ignoring a `// package fake` decoy comment.

## Not in this PR

The corpus takes **13.2s, of which 10.7s (82%)** is 27 serial per-case `codegenDirs` calls, each re-running `packages.Load` of the gsx runtime. Measured ceiling for a fix: **26.8×** (10.7s → 0.42s), taking the suite to ~3s. Design written up in `docs/superpowers/specs/2026-07-09-per-dir-codegen-options-design.md` — it needs a small `internal/codegen` API addition, so it ships separately.

https://claude.ai/code/session_011BLviYFuAN33mKbxoDn3jp