### PR TITLE
docs(spec): per-dir codegen options — one Module, many filter tables

### DIFF
--- a/docs/superpowers/specs/2026-07-07-organize-imports-design.md
+++ b/docs/superpowers/specs/2026-07-07-organize-imports-design.md
@@ -89,6 +89,40 @@ the std/third-party grouping shown above. The `TabIndent: true, TabWidth: 8,
 Comments: true` options are required so `FormatOnly` matches gofmt's tabbed
 chunk formatting (otherwise it emits spaces).
 
+### Interaction with recent main work (verified at HEAD f6fbd8c)
+
+Checked because PR #51/#52 churned adjacent code. All clear:
+
+- **`d813a1e` "tokenize for the `_gsx` reservation instead of parsing"** does
+  *not* constrain this design. Its rule targets **element-bearing** Go regions,
+  which codegen used to reconstruct by substituting a padded `_()` placeholder
+  and parsing — and fmt's new paren-wrap (`return ( <>…</> )`) made those
+  reconstructions invalid Go under automatic semicolon insertion. A `GoChunk` is
+  by definition **element-free, complete top-level Go**; the shipped
+  `deleteChunkImports` already parses one (wrapped in `package _gsxp`) on every
+  `gsx fmt`, and `d813a1e` touched only `internal/codegen`, never
+  `internal/gsxfmt`. So `reorderImports` may parse its chunk exactly as
+  `deleteChunkImports` does.
+- **Imports never live in a `GoWithElements`.** `parser/goexpr.go
+  splitGoElements` peels a leading import run into its own plain `GoChunk`
+  before building the element region. A per-`GoChunk` walk therefore misses no
+  import, and skipping `GoWithElements` (as `removeImports` already does via its
+  type switch) is correct.
+- **`435a91c` / PR #51 / `internal/goexprshape`** all operate solely on
+  element-literal positions inside `GoWithElements` (paren wrap/strip,
+  placeholder gofmt round-trip). Disjoint decl types — they cannot fight the
+  reorder pass. `435a91c` changed `canonGo` in `corpus_test.go`, a test
+  normalizer, not the printer.
+- **`fmtGoChunk` still runs `format.Source` on every chunk** (`printer.go:1250`),
+  so "gofmt mode = zero new formatting code" holds, as does reorder idempotency
+  (gofmt sorts within a group but never merges or regroups, so the goimports
+  std/third-party split survives the printer's re-gofmt).
+- **WASM cost is negligible.** `gsxfmt` is in the `playground/wasm` dep graph
+  (it exposes `gsxFormat`), but linking `golang.org/x/tools/imports` adds only 4
+  packages and **+1,811 bytes** to a 17.3 MB `gsx.wasm` (0.01%) — `go/packages`
+  machinery is already linked via `gen`. `golang.org/x/tools v0.46.0` is already
+  a module requirement, so no new dependency.
+
 ## Pipeline ordering (goimports mode)
 
 Within one `gsx fmt` invocation: **remove-unused → reorder → normalize/print.**
@@ -197,13 +231,24 @@ imports = "goimports"   # "goimports" (default) | "gofmt"
 
 `textDocument/formatting` **honors the configured mode**, mirroring the CLI. No
 CLI flag exists in the editor, so the mode comes from resolved config only: add
-an `ImportsMode(dir)` accessor next to the existing `PrintWidth(dir)` on the
-analyzer, map it through the shared mode→options helper, and pass `Unused`
-(from analysis, only in goimports mode) and `Reorder` into `FormatWith`. So in
+an `ImportsMode(dir)` accessor next to the existing `PrintWidth(dir)` — declared
+on the `Analyzer` interface in `internal/lsp/server.go` and implemented on
+`lspAnalyzer` in `gen/lsp.go` (that is where `PrintWidth` actually lives, *not*
+`internal/lsp/analysis.go`). Map it through the shared mode→options helper, and
+pass `Unused` (from analysis, only in goimports mode) and `Reorder` into
+`FormatWith`. So in
 `gofmt` mode, format-on-save is gofmt only — it stops removing/reordering
 imports; the organize behavior then comes exclusively from the code action
 below. This is precisely the gopls split: `textDocument/formatting` = gofmt,
 import organizing = a separate action.
+
+**Pre-existing gap, preserve don't fix:** `handleFormatting` today calls
+`FormatRemovingImports` — the *non*-`With` variant — so LSP formatting does not
+run the `<style>`/`<script>` css/js formatters that the CLI runs. Moving it to
+`FormatWith` makes that gap explicit (`CSSFmt`/`JSFmt` become visible nil
+fields). Keep current behavior: pass nil formatters, preserving today's LSP
+output byte-for-byte. Closing the gap is a separate change with its own tests —
+do not fold it into this effort.
 
 ### LSP `source.organizeImports` code action — `internal/lsp/codeaction.go` (new)
 
@@ -303,8 +348,9 @@ scoped to what a formatter mode needs.
 - `internal/lsp/protocol.go` — `CodeActionOptions`, `codeActionProvider`
   capability, `textDocument/codeAction` param/result types.
 - `internal/lsp/server.go` — dispatch `textDocument/codeAction`; advertise the
-  capability.
-- `internal/lsp/analysis.go` — `ImportsMode(dir)` accessor for the resolved mode.
+  capability; declare `ImportsMode(dir)` on the `Analyzer` interface.
+- `gen/lsp.go` — implement `lspAnalyzer.ImportsMode(dir)` (next to
+  `PrintWidth`, via `resolveConfigBestEffort(...).effectiveImportsMode()`).
 - Corpus cases + unit/config/CLI/LSP tests as above.
 - Docs: `[formatter] imports` config reference + `gsx fmt` page (in
   `gsxhq.github.io`); note editor `codeActionsOnSave: source.organizeImports`

--- a/docs/superpowers/specs/2026-07-09-per-dir-codegen-options-design.md
+++ b/docs/superpowers/specs/2026-07-09-per-dir-codegen-options-design.md
@@ -1,0 +1,222 @@
+# Per-dir codegen options: one `Module`, many filter tables
+
+## Problem
+
+`internal/corpus` runs in **13.2s**. **10.7s of that (82%)** is a single loop —
+batch.go:99-108 — which gives every case carrying a `gsx.toml` its own
+`codegenDirs` call:
+
+```go
+for _, cs := range states {
+	if cs.c.classMerger == nil && len(cs.c.filterPkgs) == 0 {
+		continue
+	}
+	mergerResults, merr := codegenDirs(tmp, cs.pkgDirs, cs.c.classMerger, cs.c.filterPkgs)
+	...
+}
+```
+
+27 cases → 27 calls → 27 `codegen.Module`s. Measured against the shared
+all-cases temp module:
+
+```
+step3a default codegenDirs (509 dirs)   550ms   ← ONE call
+step3b per-case codegenDirs (27 cases) 10.73s   ← 27 calls
+step5  go run                            1.51s
+```
+
+509 dirs cost 550ms; 27 dirs cost 10.7s. The asymmetry is entirely per-`Module`
+fixed cost.
+
+Each `Module` pays up to **three** `packages.Load` (`go list`) invocations:
+
+| # | Site | Cost | Cases affected |
+|---|------|------|----------------|
+| 1 | `externalImporter` — module.go:253 | ~340ms | all 27 |
+| 2 | `cachedFilterTable` → `loadFilterTableMulti` — filters.go:370 | ~150ms | all 27 |
+| 3 | `ValidateClassMerger` — generate_dirs.go:35 | ~150ms | 4 merger cases |
+
+That is ~60–80 subprocess `go list` runs to generate 27 directories.
+
+Loads 1 and 2 are **not** corpus-only. Every `codegen.Open` consumer pays #2 on
+first `Generate` — the LSP, `gsx fmt`, and the warm-core `--watch` path included.
+
+## Two hypotheses, both measured false
+
+Recording these so they are not re-litigated.
+
+**Parallelize the loop.** `errgroup` with `GOMAXPROCS` limit: **11.8s vs 10.7s
+serial — no speedup**, and 204s on a cold build cache. `packages.Load` already
+saturates every core (parallel `go list` + parallel type-check), so the loop is
+CPU-bound, not latency-bound. Adding goroutines only adds build-cache contention.
+
+**Shrink the load set.** `externalImporter` ends `loadPaths` with `"./..."`
+(module.go:254). Against the shared temp module holding all 566 cases, that is
+509 packages type-checked per call. Isolating one case into its own 2-package
+module: **404ms → 340ms, a 1.2× win.** The `./...` walk is nearly free; the fixed
+load of `github.com/gsxhq/gsx` + `gsx/std` dominates. Splitting the corpus into
+per-case temp modules is therefore not worth it.
+
+## The ceiling
+
+One `Module` over all 27 dirs, loading the **union** of their filter packages:
+
+```
+today (27 serial Modules):  11.23s
+ceiling (1 Module, union):   0.42s   → 26.8×
+```
+
+Corpus total: **13.2s → ~3s.**
+
+## Why the union cannot simply be adopted
+
+`FilterPkgs` feeds two consumers with different semantics:
+
+1. **`externalImporter` load set** (module.go:253) — decides which packages the
+   skeleton type-checker *can* import. A superset here is **inert**: it makes
+   more packages available to an importer that is only consulted by import path.
+2. **`cachedFilterTable`** (module.go:305) — decides which packages' exported
+   funcs become *pipe filters in scope*. A superset here is **semantically
+   load-bearing**: it silently widens the filter whitelist.
+
+`testdata/cases/filterimport/user_plain_import_no_filter.txtar` asserts that a
+package which is imported but **not** listed in `filterPackages` is rejected as
+a filter source. A union load would make that case pass for the wrong reason —
+worse, it would keep passing while testing nothing.
+
+The corpus filter packages are also genuinely distinct (`Parse`+`Pick`,
+`First[T any]`, `Fail`/`Detonate`, `Who(ctx)`), so consolidating testdata into
+one shared `filters` package is rejected too: it would erode the
+self-containment that makes each txtar readable as a standalone syntax
+reference.
+
+## Design
+
+**Split the union (load) from the per-dir (table).**
+
+- Load the union of all filter packages **once**, into one `Module`'s importer.
+- Build the filter table **per directory**, from the already-loaded
+  `*types.Package` values — no subprocess.
+
+The primitive already exists. `bundle.go` has:
+
+```go
+func loadFilterTableFromTypes(byPath map[string]*types.Package, pkgPaths []string, explicitAliases []FilterAlias) (filterTable, error)
+```
+
+It mirrors `loadFilterTableMulti`'s precedence (whole-package paths in order,
+last-wins, then explicit aliases) and harvests purely from type information.
+Today it is reachable only via `NewCachedResolverFromTypes` on the WASM
+`Bundle` path.
+
+`externalImporter` already retains exactly the map it needs
+(module.go:260-264):
+
+```go
+mp := map[string]*types.Package{}
+packages.Visit(pkgs, nil, func(p *packages.Package) {
+	if p.Types != nil { mp[p.PkgPath] = p.Types }
+})
+```
+
+So a per-dir table is `loadFilterTableFromTypes(mp, dirFilterPkgs, aliases)` —
+a scope walk over already-type-checked packages, microseconds.
+
+### API
+
+Add a per-dir override carried alongside the dir, leaving `Generate(dir)`
+untouched:
+
+```go
+// DirOptions overrides Module-level options for a single Generate call.
+// Zero value means "inherit from Options".
+type DirOptions struct {
+	FilterPkgs  []string        // nil = inherit Options.FilterPkgs
+	ClassMerger *ClassMergerRef // nil = inherit Options.ClassMerger
+}
+
+// GenerateWith is Generate with per-dir option overrides. FilterPkgs must be a
+// subset of the Module's loaded filter packages (Options.FilterPkgs); the table
+// is harvested from loaded types with no packages.Load.
+func (m *Module) GenerateWith(dir string, over DirOptions) (map[string][]byte, []diag.Diagnostic, error)
+```
+
+`Generate(dir)` becomes `GenerateWith(dir, DirOptions{})`.
+
+`ClassMerger` already reaches `generateFile` as a plain parameter
+(module.go:409, module.go:461), so threading a per-dir value is a parameter
+change, not a redesign.
+
+Filter tables are memoized per distinct `FilterPkgs` key (sorted, deduped, joined)
+rather than once per Module — `cachedFilterTable` becomes
+`filterTableFor(pkgs []string)` over a `map[string]filterTable`. The existing
+`filterTableLoads` test hook keeps guarding the warm-regen invariant (a warm
+regeneration must trigger **zero** go-list reloads); it should now also assert
+zero reloads across *differing* per-dir filter sets.
+
+**Invariant:** `Options.FilterPkgs` is the union (the load set);
+`DirOptions.FilterPkgs` is a subset (the table). `GenerateWith` returns an error
+if a dir names a filter package absent from the loaded importer — this must be a
+hard error, never a silent empty table, or `user_plain_import_no_filter` degrades
+into a vacuous pass.
+
+### `ValidateClassMerger`
+
+Its doc comment already explains why it is *not* called from `Open`: "that path
+is shared by the LSP and fmt, which must not pay a packages.Load per-Open."
+Given a loaded importer we can validate from types with no load at all. Add:
+
+```go
+func validateClassMergerFromTypes(byPath map[string]*types.Package, ref *ClassMergerRef) error
+```
+
+reusing `isStringSliceToString` verbatim. `ValidateClassMerger` (the
+`packages.Load` form) stays for `gen.newWatchSession`, which validates at
+startup before any Module exists.
+
+### Corpus harness
+
+batch.go step 3 collapses to one call:
+
+```go
+perDir := map[string]codegen.DirOptions{} // absDir → its case's options
+unionFilters := []string{codegen.StdImportPath}
+// ...populate from states...
+pkgResults, err := codegenDirsWithPerDir(tmp, allDirs, unionFilters, perDir)
+```
+
+`selectedCaseNamesForRun` **stays**. It is what makes a focused
+`-run TestCorpus/attrs/spread_byo` cost 0.5s, and after this change a full batch
+is still ~1s codegen + ~1.5s `go run`. Keeping it also documents the lesson: that
+optimization made the inner dev loop fast by *skipping* the 27-case loop
+entirely, which is precisely why the 10.7s never surfaced.
+
+## Beneficiaries beyond the corpus
+
+- **LSP / `fmt` / warm `--watch`**: drop `packages.Load` #2 (the filter-table
+  load) on first `Generate` of every Module.
+- **`gsx generate` with a class merger**: drops `packages.Load` #3.
+- **Multi-root analysis (Module Phase 2)**: per-dir option scoping is a
+  prerequisite for one warm graph serving dirs with differing `gsx.toml`.
+
+## Non-goals
+
+- Parallelizing codegen. Measured useless (above); revisit only if the load
+  itself becomes cheap.
+- Per-case temp modules. Measured 1.2×.
+- Consolidating corpus filter packages. Erodes case self-containment.
+- Changing `Bundle`/WASM mode. It already has per-Bundle tables.
+
+## Verification
+
+- `go test ./internal/corpus -run TestCorpus -count=1` — all 566 cases green,
+  **no golden churn**. Any diff in `generated.x.go.golden` means a filter table
+  changed scope; that is the failure mode this design exists to prevent.
+- `filterimport/user_plain_import_no_filter` must still pin its rejection
+  diagnostic. Add a probe that inverts it: a case whose filter lives in *another
+  case's* filter package must be rejected. Without this, a regression to
+  union-table semantics is invisible.
+- New unit test in `internal/codegen`: two dirs, disjoint `FilterPkgs`, one
+  Module — assert `externalLoads() == 1`, `filterTableLoads() == 0`, and that
+  each dir sees only its own filters.
+- Wall-clock gate: corpus `TestCorpus` under 4s on CI hardware.

--- a/docs/superpowers/specs/2026-07-09-per-dir-codegen-options-design.md
+++ b/docs/superpowers/specs/2026-07-09-per-dir-codegen-options-design.md
@@ -38,8 +38,9 @@ Each `Module` pays up to **three** `packages.Load` (`go list`) invocations:
 
 That is ~60–80 subprocess `go list` runs to generate 27 directories.
 
-Loads 1 and 2 are **not** corpus-only. Every `codegen.Open` consumer pays #2 on
-first `Generate` — the LSP, `gsx fmt`, and the warm-core `--watch` path included.
+Every `codegen.Open` consumer pays #2 once per Module, so this is not purely a
+corpus problem — but it is **one** load per Module, not 27. Only the corpus opens
+Modules in bulk.
 
 ## Two hypotheses, both measured false
 
@@ -124,35 +125,38 @@ a scope walk over already-type-checked packages, microseconds.
 
 ### API
 
-Add a per-dir override carried alongside the dir, leaving `Generate(dir)`
-untouched:
-
 ```go
-// DirOptions overrides Module-level options for a single Generate call.
+// DirOptions overrides Module-level options for a single package dir.
 // Zero value means "inherit from Options".
 type DirOptions struct {
 	FilterPkgs  []string        // nil = inherit Options.FilterPkgs
 	ClassMerger *ClassMergerRef // nil = inherit Options.ClassMerger
 }
 
-// GenerateWith is Generate with per-dir option overrides. FilterPkgs must be a
-// subset of the Module's loaded filter packages (Options.FilterPkgs); the table
-// is harvested from loaded types with no packages.Load.
-func (m *Module) GenerateWith(dir string, over DirOptions) (map[string][]byte, []diag.Diagnostic, error)
+type Options struct {
+	FilterPkgs []string             // loaded AND harvested into the default table
+	LoadPkgs   []string             // loaded, NO filter semantics (the union half)
+	PerDir     map[string]DirOptions // per-dir narrowing (the table half)
+	// ...
+}
 ```
 
-`Generate(dir)` becomes `GenerateWith(dir, DirOptions{})`.
+An earlier draft proposed `Module.GenerateWith(dir, DirOptions)` — a per-call
+override. That does not work. `analyze(dir)` is the recursion point for the
+import graph: a multi-package case's imported sibling is analyzed through
+`moduleImporter → typesPackageWith → analyze`, never through a top-level
+`Generate`, so a per-call override never reaches it and the sibling would
+type-check its pipes against the wrong table. The override must be addressable
+by dir, hence the map, consulted inside `analyze`.
 
-`ClassMerger` already reaches `generateFile` as a plain parameter
-(module.go:409, module.go:461), so threading a per-dir value is a parameter
-change, not a redesign.
+Relatedly, the table is **not** an emit-time concern: `buildSkeleton(f, table, …)`
+consumes it during skeleton construction, so it cannot be swapped in at
+`generateFile`. `ClassMerger` *is* emit-only, and rides on `analyzed.merger`.
 
-Filter tables are memoized per distinct `FilterPkgs` key (sorted, deduped, joined)
-rather than once per Module — `cachedFilterTable` becomes
-`filterTableFor(pkgs []string)` over a `map[string]filterTable`. The existing
-`filterTableLoads` test hook keeps guarding the warm-regen invariant (a warm
-regeneration must trigger **zero** go-list reloads); it should now also assert
-zero reloads across *differing* per-dir filter sets.
+Filter tables are memoized per distinct `FilterPkgs` key (deduped, joined). The
+key is order-sensitive on purpose: filter precedence is last-wins, so
+`[std, a, b]` and `[std, b, a]` are different tables and must not share a memo
+entry.
 
 **Invariant:** `Options.FilterPkgs` is the union (the load set);
 `DirOptions.FilterPkgs` is a subset (the table). `GenerateWith` returns an error
@@ -193,11 +197,19 @@ entirely, which is precisely why the 10.7s never surfaced.
 
 ## Beneficiaries beyond the corpus
 
-- **LSP / `fmt` / warm `--watch`**: drop `packages.Load` #2 (the filter-table
-  load) on first `Generate` of every Module.
-- **`gsx generate` with a class merger**: drops `packages.Load` #3.
+- **`gsx generate` with a per-dir class merger**: drops `packages.Load` #3,
+  validating from the types the importer already loaded.
 - **Multi-root analysis (Module Phase 2)**: per-dir option scoping is a
   prerequisite for one warm graph serving dirs with differing `gsx.toml`.
+
+**Correction (post-implementation).** An earlier draft claimed `fmt` and the LSP
+would also drop load #2. They will not, and must not. `buildPackageSkeletons` —
+the syntactic-imports fast path that took `gsx fmt -l` from ~16s to 0.58s —
+deliberately never calls `externalImporter`. Harvesting its table from loaded
+types would *add* the full `./...` load it exists to avoid. So `filterTableFor`
+falls back to `cachedFilterTable()` whenever a dir has no `PerDir` entry, which
+is every dir on the `fmt`/LSP path: their behavior is byte-identical and no
+faster. The win here is bulk-Module callers only.
 
 ## Non-goals
 
@@ -220,3 +232,25 @@ entirely, which is precisely why the 10.7s never surfaced.
   Module — assert `externalLoads() == 1`, `filterTableLoads() == 0`, and that
   each dir sees only its own filters.
 - Wall-clock gate: corpus `TestCorpus` under 4s on CI hardware.
+
+## Outcome (implemented in #56)
+
+`TestCorpus` 13.2s → **2.4s**; `go test ./internal/corpus` 14.1s → 3.5s. Zero
+golden churn. `make ci` and `make lint` exit 0; `-race` clean.
+
+Every guard was mutation-tested: making `filterTableFor` return the union turns
+three unit tests red **plus** a corpus golden.
+
+Adversarial review found two silent-wrong-answer gaps, both fixed:
+`validatePerDirMergers` ran only in `GenerateDirs`, so `Open`+`Generate`
+(watch/LSP) emitted `_gsxcm.<Missing>` and exited 0; and `filterTableFor`
+returned `Bundle.filters()` before consulting `PerDir`, handing a dir the
+Bundle's whole table. `Open` now rejects `Bundle` + `PerDir`/`LoadPkgs`.
+
+**This does not speed up `make ci`.** Its lanes run `-j4` and `go test ./...`
+runs packages in parallel, so wall time (~120s) is set by the slowest package —
+`internal/codegen`'s own suite (~91s), which the 13.2s corpus never gated. That
+suite makes ~78 `GenerateDirs` calls across 52 test files, each opening its own
+temp module and paying its own `packages.Load`: **the same disease, now the
+dominant one.** ~730 CPU-seconds. Fixing it means sharing a Module fixture
+across tests, and is the natural next step.


### PR DESCRIPTION
Design spec for the corpus perf fix. **Spec only — no code.**

## Problem

`internal/corpus` runs in **13.2s**. **10.7s (82%)** is one loop (`batch.go:99-108`) giving every case with a `gsx.toml` its own `codegenDirs` call — 27 cases, 27 `codegen.Module`s.

```
step3a default codegenDirs (509 dirs)   550ms   ← ONE call
step3b per-case codegenDirs (27 cases) 10.73s   ← 27 calls
step5  go run                            1.51s
```

509 dirs cost 550ms; 27 dirs cost 10.7s. Every `Module` pays up to three `packages.Load` (`go list`) runs — `externalImporter`, `cachedFilterTable` → `loadFilterTableMulti`, and `ValidateClassMerger`. That's ~60–80 subprocesses to generate 27 directories.

Loads 1 and 2 are **not corpus-only**: every `codegen.Open` consumer pays the filter-table load on first `Generate` — the LSP, `gsx fmt`, and the warm `--watch` path included.

## Two hypotheses, both measured false

Recorded in the spec so they aren't re-litigated.

**Parallelize the loop.** `errgroup` at `GOMAXPROCS`: **11.8s vs 10.7s serial — no speedup**, and 204s on a cold build cache. `packages.Load` already saturates every core, so the loop is CPU-bound, not latency-bound.

**Shrink the load set.** `loadPaths` ends with `"./..."`, which against the shared all-cases module means 509 packages type-checked per call. Isolating a case into its own 2-package module: **404ms → 340ms, 1.2×**. The fixed load of `github.com/gsxhq/gsx` + `gsx/std` dominates; the corpus walk is nearly free.

## Design

Split the **union** (load set) from the **per-dir** (filter table).

`FilterPkgs` feeds two consumers with different semantics. In the `externalImporter` load set a superset is **inert** — it only makes more packages importable. In `cachedFilterTable` a superset is **load-bearing** — it silently widens the filter whitelist, and `filterimport/user_plain_import_no_filter` exists precisely to assert a non-whitelisted package is *rejected*. A plain union load would keep that case passing while testing nothing.

So: load the union once into one `Module`'s importer; harvest each dir's table from the already-loaded `*types.Package` values. The primitive already exists in `bundle.go`:

```go
func loadFilterTableFromTypes(byPath map[string]*types.Package, pkgPaths []string, explicitAliases []FilterAlias) (filterTable, error)
```

No subprocess. `externalImporter` already retains exactly the `map[string]*types.Package` it needs.

Proposed API — `Generate(dir)` becomes `GenerateWith(dir, DirOptions{})`:

```go
type DirOptions struct {
    FilterPkgs  []string        // nil = inherit Options.FilterPkgs
    ClassMerger *ClassMergerRef // nil = inherit Options.ClassMerger
}

func (m *Module) GenerateWith(dir string, over DirOptions) (map[string][]byte, []diag.Diagnostic, error)
```

**Measured ceiling: 26.8× (10.7s → 0.42s), suite to ~3s.**

**Invariant:** `Options.FilterPkgs` is the union (load set); `DirOptions.FilterPkgs` is a subset (table). A dir naming a filter package absent from the loaded importer must be a **hard error**, never a silent empty table — otherwise `user_plain_import_no_filter` degrades into a vacuous pass. The spec calls for a probe test that inverts it.

## Beneficiaries beyond the corpus

- LSP / `fmt` / warm `--watch`: drop the filter-table `packages.Load` on first `Generate` of every Module.
- `gsx generate` with a class merger: drops `ValidateClassMerger`'s load.
- Multi-root analysis (Module Phase 2): per-dir option scoping is a prerequisite for one warm graph serving dirs with differing `gsx.toml`.

## Rejected

Consolidating the corpus filter packages into one shared package would collapse the loop with no codegen change, but their contents genuinely differ (`Parse`+`Pick`, `First[T any]`, `Fail`/`Detonate`, `Who(ctx)`) and merging them erodes the self-containment that makes each txtar readable as a standalone syntax reference.

## Related

Harness cleanups (independent, no perf change): #54.

https://claude.ai/code/session_011BLviYFuAN33mKbxoDn3jp