### PR TITLE
perf(codegen): per-dir filter tables and class mergers on one Module

### DIFF
--- a/internal/codegen/bundle.go
+++ b/internal/codegen/bundle.go
@@ -23,7 +23,7 @@ func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, expli
 	for _, path := range pkgPaths {
 		pkg, ok := byPath[path]
 		if !ok || pkg == nil {
-			return nil, fmt.Errorf("codegen: filter package %q has no type information in bundle", path)
+			return nil, fmt.Errorf("codegen: filter package %q was not loaded (add it to Options.FilterPkgs or Options.LoadPkgs)", path)
 		}
 		alias := aliases[path]
 		scope := pkg.Scope()
@@ -58,7 +58,7 @@ func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, expli
 	for _, a := range explicitAliases {
 		pkg, ok := byPath[a.PkgPath]
 		if !ok || pkg == nil {
-			return nil, fmt.Errorf("codegen: WithFilter %q: package %q has no type information in bundle", a.Name, a.PkgPath)
+			return nil, fmt.Errorf("codegen: WithFilter %q: package %q was not loaded", a.Name, a.PkgPath)
 		}
 		obj := pkg.Scope().Lookup(a.FuncName)
 		if obj == nil {

--- a/internal/codegen/classmerger.go
+++ b/internal/codegen/classmerger.go
@@ -37,7 +37,25 @@ func ValidateClassMerger(dir string, ref *ClassMergerRef) error {
 	if len(pkgs) == 0 || pkgs[0].Types == nil {
 		return fmt.Errorf("class_merger: package %q not found", ref.PkgPath)
 	}
-	obj := pkgs[0].Types.Scope().Lookup(ref.FuncName)
+	return validateClassMergerObj(pkgs[0].Types, ref)
+}
+
+// validateClassMergerFromTypes is ValidateClassMerger against packages the
+// caller already loaded — no packages.Load, no subprocess. Used for per-dir
+// mergers, where one packages.Load per dir is exactly the cost being removed.
+// A merger package the importer never loaded is an error, not a skipped check.
+func validateClassMergerFromTypes(byPath map[string]*types.Package, ref *ClassMergerRef) error {
+	pkg, ok := byPath[ref.PkgPath]
+	if !ok || pkg == nil {
+		return fmt.Errorf("class_merger: package %q was not loaded (add it to Options.LoadPkgs)", ref.PkgPath)
+	}
+	return validateClassMergerObj(pkg, ref)
+}
+
+// validateClassMergerObj holds the check shared by both validators: ref.FuncName
+// must name an exported package-level func([]string) string.
+func validateClassMergerObj(pkg *types.Package, ref *ClassMergerRef) error {
+	obj := pkg.Scope().Lookup(ref.FuncName)
 	if obj == nil || !obj.Exported() {
 		return fmt.Errorf("class_merger: %q has no exported %s", ref.PkgPath, ref.FuncName)
 	}

--- a/internal/codegen/generate_dirs.go
+++ b/internal/codegen/generate_dirs.go
@@ -40,6 +40,12 @@ func GenerateDirs(moduleRoot string, dirs []string, opts Options, override map[s
 	if err != nil {
 		return nil, fmt.Errorf("codegen: GenerateDirs: open module: %w", err)
 	}
+	// Per-dir mergers are validated against the types the external importer
+	// loads anyway, so N of them cost zero extra packages.Load — the whole
+	// reason ValidateClassMerger's own load is not called per dir here.
+	if err := m.validatePerDirMergers(); err != nil {
+		return nil, fmt.Errorf("codegen: GenerateDirs: %w", err)
+	}
 	for path, src := range override {
 		m.SetOverride(path, src)
 	}

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -2,12 +2,14 @@ package codegen
 
 import (
 	"bytes"
+	"fmt"
 	"go/token"
 	"go/types"
 	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"golang.org/x/tools/go/packages"
@@ -16,12 +18,43 @@ import (
 	"github.com/gsxhq/gsx/internal/diag"
 )
 
+// DirOptions overrides Module-level options for a single package dir. The zero
+// value means "inherit from Options".
+//
+// FilterPkgs, when non-nil, replaces Options.FilterPkgs for this dir's filter
+// table. It must name only packages the Module already loaded — i.e. packages
+// reachable from Options.FilterPkgs, Options.LoadPkgs, or the module's own
+// "./..." — because the table is harvested from the loaded types with NO
+// packages.Load. Naming an unloaded package is a hard error, never an empty
+// table: a silently-empty table would make a "this filter must be rejected"
+// test pass for the wrong reason.
+type DirOptions struct {
+	FilterPkgs  []string        // nil = inherit Options.FilterPkgs
+	ClassMerger *ClassMergerRef // nil = inherit Options.ClassMerger
+}
+
 // Options configures a Module. ModuleRoot is the absolute module root (dir
 // containing go.mod); ModulePath is its declared module path (from go.mod).
 type Options struct {
-	ModuleRoot   string
-	ModulePath   string
-	FilterPkgs   []string
+	ModuleRoot string
+	ModulePath string
+	// FilterPkgs is the module-wide filter set: it is both loaded into the
+	// external importer AND harvested into the default filter table.
+	FilterPkgs []string
+	// LoadPkgs names extra packages to load into the external importer WITHOUT
+	// giving them filter semantics. It is the union half of the union/per-dir
+	// split: a caller that needs several dirs to see different filter tables
+	// lists every filter package here (one load) and narrows each dir's table
+	// via PerDir. A superset here is inert — it only makes more packages
+	// importable — whereas a superset in a dir's table silently widens the
+	// filter whitelist.
+	LoadPkgs []string
+	// PerDir maps a package dir to its option overrides. Keys are matched
+	// against the dir strings passed to Generate/Package (cleaned), and are
+	// also consulted for dirs reached transitively through imports, so an
+	// imported sibling package resolves its own filter table. Unsupported in
+	// Bundle mode (the Bundle carries exactly one prebuilt table).
+	PerDir       map[string]DirOptions
 	Aliases      []FilterAlias
 	FieldMatcher FieldMatcher
 	Classifier   *attrclass.Classifier
@@ -96,11 +129,13 @@ type Module struct {
 	opts             Options
 	overrides        map[string][]byte          // abs .gsx path -> in-memory source
 	ext              types.Importer             // lazily built external importer (stdlib + third-party)
+	extPkgs          map[string]*types.Package  // the types behind ext, kept for subprocess-free filter-table harvests
 	extLoads         int                        // count of external packages.Load calls (observability; test hook)
 	filterTbl        filterTable                // lazily built filter table (see cachedFilterTable)
 	filterTblErr     error                      // error from the filter-table load (cached alongside filterTbl)
 	filterTblDone    bool                       // true once the filter table has been loaded (success or error)
 	filterLoads      int                        // count of filter-table loads performed (observability; test hook)
+	dirFilterTbls    map[string]filterTable     // per-dir filter-table memo, keyed by canonical FilterPkgs key
 	fset             *token.FileSet             // module-wide shared FileSet (see "FileSet" / "Growth" notes above)
 	pkgTypes         map[string]*types.Package  // abs dir -> checked *types.Package cache
 	pkgResults       map[string]*PackageResult  // abs dir -> cached full analysis result (Package path only)
@@ -145,6 +180,7 @@ func Open(opts Options) (*Module, error) {
 		opts:             opts,
 		overrides:        map[string][]byte{},
 		fset:             token.NewFileSet(),
+		dirFilterTbls:    map[string]filterTable{},
 		pkgResults:       map[string]*PackageResult{},
 		depFacts:         map[string]*depPropFacts{},
 		imports:          map[string][]string{},
@@ -251,6 +287,7 @@ func (m *Module) externalImporter() (types.Importer, error) {
 	// so the importer must carry that package. This mirrors newCachedResolver
 	// (resolver.go) which lists "github.com/gsxhq/gsx" first for the same reason.
 	loadPaths := append([]string{"github.com/gsxhq/gsx", stdImportPath}, m.opts.FilterPkgs...)
+	loadPaths = append(loadPaths, m.opts.LoadPkgs...)
 	loadPaths = append(loadPaths, "./...")
 	pkgs, err := packages.Load(cfg, loadPaths...)
 	if err != nil {
@@ -264,6 +301,7 @@ func (m *Module) externalImporter() (types.Importer, error) {
 	})
 	m.mu.Lock()
 	m.ext = mapImporter(mp)
+	m.extPkgs = mp
 	m.extLoads++
 	m.fsetBaseline = m.fset.Base()
 	m.mu.Unlock()
@@ -317,6 +355,100 @@ func (m *Module) filterTableLoads() int {
 	return m.filterLoads
 }
 
+// validatePerDirMergers type-checks every PerDir class merger against the
+// external importer's already-loaded types. It is a no-op when no dir overrides
+// the merger, so the common path pays nothing.
+func (m *Module) validatePerDirMergers() error {
+	var refs []*ClassMergerRef
+	for _, d := range m.opts.PerDir {
+		if d.ClassMerger != nil {
+			refs = append(refs, d.ClassMerger)
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	if _, err := m.externalImporter(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	extPkgs := m.extPkgs
+	m.mu.Unlock()
+	for _, ref := range refs {
+		if err := validateClassMergerFromTypes(extPkgs, ref); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// dirOptionsFor returns the PerDir entry for dir, if any.
+func (m *Module) dirOptionsFor(dir string) (DirOptions, bool) {
+	if len(m.opts.PerDir) == 0 {
+		return DirOptions{}, false
+	}
+	d, ok := m.opts.PerDir[filepath.Clean(dir)]
+	return d, ok
+}
+
+// classMergerFor returns the class merger that applies to dir.
+func (m *Module) classMergerFor(dir string) *ClassMergerRef {
+	if d, ok := m.dirOptionsFor(dir); ok && d.ClassMerger != nil {
+		return d.ClassMerger
+	}
+	return m.opts.ClassMerger
+}
+
+// filterTableFor returns the filter table that applies to dir.
+//
+// Without a PerDir override this is cachedFilterTable — one packages.Load per
+// Module, shared by every dir. With one, the table is harvested from the types
+// the external importer already loaded, so N dirs with N different filter sets
+// cost ONE load between them rather than N. That is the whole point of the
+// union/per-dir split: Options.LoadPkgs is loaded once, DirOptions.FilterPkgs
+// only narrows what that dir may see.
+//
+// A dir naming a filter package the importer never loaded is an error. It must
+// never degrade to an empty table — a corpus case that asserts "this filter is
+// rejected because its package is not whitelisted" would then pass while
+// testing nothing.
+func (m *Module) filterTableFor(dir string) (filterTable, error) {
+	if m.opts.Bundle != nil {
+		return m.opts.Bundle.filters(), nil
+	}
+	d, ok := m.dirOptionsFor(dir)
+	if !ok || d.FilterPkgs == nil {
+		return m.cachedFilterTable()
+	}
+	pkgs := dedupFilterPkgs(d.FilterPkgs)
+	key := strings.Join(pkgs, "\x00")
+
+	m.mu.Lock()
+	if tbl, hit := m.dirFilterTbls[key]; hit {
+		m.mu.Unlock()
+		return tbl, nil
+	}
+	m.mu.Unlock()
+
+	// The importer's types are the harvest source, so it must be loaded first.
+	// Generate/Package already did this; the call is a cache hit there.
+	if _, err := m.externalImporter(); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	extPkgs := m.extPkgs
+	m.mu.Unlock()
+
+	tbl, err := loadFilterTableFromTypes(extPkgs, pkgs, m.opts.Aliases)
+	if err != nil {
+		return nil, fmt.Errorf("codegen: filter table for %s: %w", dir, err)
+	}
+	m.mu.Lock()
+	m.dirFilterTbls[key] = tbl
+	m.mu.Unlock()
+	return tbl, nil
+}
+
 // maybeRebuildFset rebuilds the FileSet (and ext/pkgTypes/pkgResults) when project re-parse
 // growth since the last load exceeds fsetRebuildBytes. A zero threshold disables it.
 // Called at the start of Package/Generate (under analysisMu), before applyDirty.
@@ -340,7 +472,9 @@ func (m *Module) rebuildFset() {
 	defer m.mu.Unlock()
 	m.fset = token.NewFileSet()
 	m.ext = nil
+	m.extPkgs = nil
 	m.filterTbl, m.filterTblErr, m.filterTblDone = filterTable{}, nil, false
+	m.dirFilterTbls = map[string]filterTable{}
 	m.pkgTypes = map[string]*types.Package{}
 	m.pkgResults = map[string]*PackageResult{}
 	m.depFacts = map[string]*depPropFacts{}
@@ -406,7 +540,7 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 		for path, f := range a.gsxFiles {
 			ff := a.factsByFile[path]
 			generateFile(f, a.pkg, a.resolved, a.table, ff.propFields, ff.nodeProps, ff.attrsProps, ff.byo,
-				a.gsxFset, m.opts.Classifier, m.opts.FieldMatcher, a.bag, nil, nil, true, true, m.opts.ClassMerger, a.sunkImports[path])
+				a.gsxFset, m.opts.Classifier, m.opts.FieldMatcher, a.bag, nil, nil, true, true, a.merger, a.sunkImports[path])
 		}
 	}
 	res.Diags = a.bag.Sorted()
@@ -458,7 +592,7 @@ func (m *Module) Generate(dir string) (map[string][]byte, []diag.Diagnostic, err
 		for path, f := range a.gsxFiles {
 			ff := a.factsByFile[path]
 			gen, ok := generateFile(f, a.pkg, a.resolved, a.table, ff.propFields, ff.nodeProps, ff.attrsProps, ff.byo,
-				a.gsxFset, m.opts.Classifier, m.opts.FieldMatcher, bag, m.opts.CSSMin, m.opts.JSMin, m.opts.CSSMinify, m.opts.JSMinify, m.opts.ClassMerger, a.sunkImports[path])
+				a.gsxFset, m.opts.Classifier, m.opts.FieldMatcher, bag, m.opts.CSSMin, m.opts.JSMin, m.opts.CSSMinify, m.opts.JSMinify, a.merger, a.sunkImports[path])
 			if !ok {
 				continue
 			}

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -126,28 +126,30 @@ type Options struct {
 // (path/content-based). Do NOT rebuild the fset per edit, and never reset the fset
 // while keeping ext, pkgTypes, or pkgResults: that would orphan their positions.
 type Module struct {
-	opts             Options
-	overrides        map[string][]byte          // abs .gsx path -> in-memory source
-	ext              types.Importer             // lazily built external importer (stdlib + third-party)
-	extPkgs          map[string]*types.Package  // the types behind ext, kept for subprocess-free filter-table harvests
-	extLoads         int                        // count of external packages.Load calls (observability; test hook)
-	filterTbl        filterTable                // lazily built filter table (see cachedFilterTable)
-	filterTblErr     error                      // error from the filter-table load (cached alongside filterTbl)
-	filterTblDone    bool                       // true once the filter table has been loaded (success or error)
-	filterLoads      int                        // count of filter-table loads performed (observability; test hook)
-	dirFilterTbls    map[string]filterTable     // per-dir filter-table memo, keyed by canonical FilterPkgs key
-	fset             *token.FileSet             // module-wide shared FileSet (see "FileSet" / "Growth" notes above)
-	pkgTypes         map[string]*types.Package  // abs dir -> checked *types.Package cache
-	pkgResults       map[string]*PackageResult  // abs dir -> cached full analysis result (Package path only)
-	depFacts         map[string]*depPropFacts   // abs dep dir -> cached imported prop facts (see importedPropFacts)
-	imports          map[string][]string        // dir -> its project-gsx dependency dirs (forward edges)
-	importedBy       map[string]map[string]bool // dep dir -> set of importer dirs (reverse edges)
-	dirty            map[string]bool            // dirs with a pending content change (consumed by applyDirty)
-	fsetBaseline     int                        // m.fset.Base() captured after the last packages.Load (growth measured since here)
-	fsetRebuildBytes int                        // rebuild fset when fset.Base()-fsetBaseline exceeds this; 0 disables
-	rebuildCount     int                        // count of fset rebuilds performed (observability; exposed via rebuilds())
-	mu               sync.Mutex                 // guards overrides, ext, pkgTypes, pkgResults, depFacts, imports, importedBy, dirty
-	analysisMu       sync.Mutex                 // serializes Package/Generate/typesPackage (see concurrency contract)
+	opts              Options
+	overrides         map[string][]byte          // abs .gsx path -> in-memory source
+	ext               types.Importer             // lazily built external importer (stdlib + third-party)
+	extPkgs           map[string]*types.Package  // the types behind ext, kept for subprocess-free filter-table harvests
+	extLoads          int                        // count of external packages.Load calls (observability; test hook)
+	filterTbl         filterTable                // lazily built filter table (see cachedFilterTable)
+	filterTblErr      error                      // error from the filter-table load (cached alongside filterTbl)
+	filterTblDone     bool                       // true once the filter table has been loaded (success or error)
+	filterLoads       int                        // count of filter-table loads performed (observability; test hook)
+	dirFilterTbls     map[string]filterTable     // per-dir filter-table memo, keyed by canonical FilterPkgs key
+	perDirMergersErr  error                      // cached result of validatePerDirMergers
+	perDirMergersDone bool                       // true once the PerDir mergers have been validated
+	fset              *token.FileSet             // module-wide shared FileSet (see "FileSet" / "Growth" notes above)
+	pkgTypes          map[string]*types.Package  // abs dir -> checked *types.Package cache
+	pkgResults        map[string]*PackageResult  // abs dir -> cached full analysis result (Package path only)
+	depFacts          map[string]*depPropFacts   // abs dep dir -> cached imported prop facts (see importedPropFacts)
+	imports           map[string][]string        // dir -> its project-gsx dependency dirs (forward edges)
+	importedBy        map[string]map[string]bool // dep dir -> set of importer dirs (reverse edges)
+	dirty             map[string]bool            // dirs with a pending content change (consumed by applyDirty)
+	fsetBaseline      int                        // m.fset.Base() captured after the last packages.Load (growth measured since here)
+	fsetRebuildBytes  int                        // rebuild fset when fset.Base()-fsetBaseline exceeds this; 0 disables
+	rebuildCount      int                        // count of fset rebuilds performed (observability; exposed via rebuilds())
+	mu                sync.Mutex                 // guards overrides, ext, pkgTypes, pkgResults, depFacts, imports, importedBy, dirty
+	analysisMu        sync.Mutex                 // serializes Package/Generate/typesPackage (see concurrency contract)
 }
 
 // defaultFsetRebuildBytes bounds the module-lifetime FileSet's project re-parse
@@ -175,6 +177,13 @@ func Open(opts Options) (*Module, error) {
 	if cls == nil {
 		cls = attrclass.Builtin()
 		opts.Classifier = cls
+	}
+	// A Bundle carries exactly one prebuilt importer and one prebuilt filter
+	// table, so per-dir narrowing has nothing to narrow. Silently ignoring PerDir
+	// here would hand a dir the Bundle's whole table — the union leak this design
+	// exists to prevent — so reject the combination outright.
+	if opts.Bundle != nil && (len(opts.PerDir) > 0 || len(opts.LoadPkgs) > 0) {
+		return nil, fmt.Errorf("codegen: Options.Bundle is incompatible with PerDir/LoadPkgs (a Bundle carries one prebuilt filter table)")
 	}
 	return &Module{
 		opts:             opts,
@@ -358,7 +367,20 @@ func (m *Module) filterTableLoads() int {
 // validatePerDirMergers type-checks every PerDir class merger against the
 // external importer's already-loaded types. It is a no-op when no dir overrides
 // the merger, so the common path pays nothing.
+//
+// Called from Generate and Package, not just GenerateDirs: an unvalidated bad
+// merger emits `_gsxcm.<Missing>` into the .x.go and exits 0, so the failure
+// lands on `go build` far from its cause. The module-level Options.ClassMerger
+// is validated by GenerateDirs (and by gen's watch session at startup); this is
+// the per-dir equivalent, memoized so repeated Generate calls pay once.
 func (m *Module) validatePerDirMergers() error {
+	m.mu.Lock()
+	if m.perDirMergersDone {
+		defer m.mu.Unlock()
+		return m.perDirMergersErr
+	}
+	m.mu.Unlock()
+
 	var refs []*ClassMergerRef
 	for _, d := range m.opts.PerDir {
 		if d.ClassMerger != nil {
@@ -366,20 +388,28 @@ func (m *Module) validatePerDirMergers() error {
 		}
 	}
 	if len(refs) == 0 {
+		m.mu.Lock()
+		m.perDirMergersDone = true
+		m.mu.Unlock()
 		return nil
 	}
 	if _, err := m.externalImporter(); err != nil {
-		return err
+		return err // not memoized: a load failure is worth retrying
 	}
 	m.mu.Lock()
 	extPkgs := m.extPkgs
 	m.mu.Unlock()
+
+	var err error
 	for _, ref := range refs {
-		if err := validateClassMergerFromTypes(extPkgs, ref); err != nil {
-			return err
+		if err = validateClassMergerFromTypes(extPkgs, ref); err != nil {
+			break
 		}
 	}
-	return nil
+	m.mu.Lock()
+	m.perDirMergersErr, m.perDirMergersDone = err, true
+	m.mu.Unlock()
+	return err
 }
 
 // dirOptionsFor returns the PerDir entry for dir, if any.
@@ -475,6 +505,7 @@ func (m *Module) rebuildFset() {
 	m.extPkgs = nil
 	m.filterTbl, m.filterTblErr, m.filterTblDone = filterTable{}, nil, false
 	m.dirFilterTbls = map[string]filterTable{}
+	m.perDirMergersErr, m.perDirMergersDone = nil, false
 	m.pkgTypes = map[string]*types.Package{}
 	m.pkgResults = map[string]*PackageResult{}
 	m.depFacts = map[string]*depPropFacts{}
@@ -503,6 +534,9 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 	m.mu.Unlock()
 	if cached != nil {
 		return cached, nil
+	}
+	if err := m.validatePerDirMergers(); err != nil {
+		return nil, err
 	}
 	ext, err := m.externalImporter()
 	if err != nil {
@@ -569,6 +603,9 @@ func (m *Module) Generate(dir string) (map[string][]byte, []diag.Diagnostic, err
 	defer m.analysisMu.Unlock()
 	m.maybeRebuildFset()
 	m.applyDirty()
+	if err := m.validatePerDirMergers(); err != nil {
+		return nil, nil, err
+	}
 	ext, err := m.externalImporter()
 	if err != nil {
 		return nil, nil, err

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -638,6 +638,7 @@ type analyzed struct {
 	goFiles            []*goast.File                  // parsed skeletons + shared helper
 	compsByXGo         map[string][]*gsxast.Component // skeleton abs path -> components
 	table              filterTable
+	merger             *ClassMergerRef // the class merger for this dir (Options.ClassMerger, or its PerDir override)
 	propFields         map[string]map[string]bool
 	nodeProps          map[string]map[string]bool
 	attrsProps         map[string]map[string]bool
@@ -756,7 +757,9 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	if scriptErr {
 		gsxFiles = nil // package-level skip: Generate's loop emits nothing
 	}
-	table, err := m.cachedFilterTable()
+	// Per-dir: an imported sibling package resolves its OWN filter table here,
+	// because analyze is the recursion point for the import graph.
+	table, err := m.filterTableFor(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -1222,6 +1225,7 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 		goFiles:            goFiles,
 		compsByXGo:         compsByXGo,
 		table:              table,
+		merger:             m.classMergerFor(dir),
 		propFields:         propFields,
 		nodeProps:          nodeProps,
 		attrsProps:         attrsProps,

--- a/internal/codegen/module_perdir_test.go
+++ b/internal/codegen/module_perdir_test.go
@@ -176,6 +176,47 @@ func TestPerDirClassMergerApplies(t *testing.T) {
 	}
 }
 
+// TestPerDirBadMergerFailsOnGeneratePath: an invalid per-dir merger must be
+// caught by Generate itself, not only by GenerateDirs. Otherwise the Open+Generate
+// path (watch, LSP) emits `_gsxcm.<Missing>` into the .x.go and exits 0, moving
+// the failure to `go build`, far from its cause.
+func TestPerDirBadMergerFailsOnGeneratePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	m, root := setupPerDirModule(t, map[string]DirOptions{
+		"a": {
+			FilterPkgs:  []string{StdImportPath, "example.com/x/afilters"},
+			ClassMerger: &ClassMergerRef{PkgPath: "example.com/x/mrg", FuncName: "NoSuchFunc"},
+		},
+	}, []string{"example.com/x/afilters", "example.com/x/mrg"})
+
+	out, _, err := m.Generate(filepath.Join(root, "a"))
+	if err == nil {
+		t.Fatalf("Generate accepted a merger naming a missing func; emitted %d file(s)", len(out))
+	}
+	if !strings.Contains(err.Error(), "NoSuchFunc") {
+		t.Fatalf("wrong error: %v", err)
+	}
+}
+
+// TestBundleRejectsPerDir: a Bundle carries ONE prebuilt filter table, so a
+// PerDir narrowing has nothing to narrow. Accepting both would hand the dir the
+// Bundle's entire table — the union leak this design prevents.
+func TestBundleRejectsPerDir(t *testing.T) {
+	_, err := Open(Options{
+		ModuleRoot: t.TempDir(),
+		Bundle:     &Bundle{},
+		PerDir:     map[string]DirOptions{"a": {FilterPkgs: []string{StdImportPath}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("Open(Bundle+PerDir) = %v; want an incompatibility error", err)
+	}
+	if _, err := Open(Options{ModuleRoot: t.TempDir(), Bundle: &Bundle{}}); err != nil {
+		t.Fatalf("Bundle alone must still open: %v", err)
+	}
+}
+
 // TestPerDirUnloadedMergerIsHardError guards the merger half the same way.
 func TestPerDirUnloadedMergerIsHardError(t *testing.T) {
 	if testing.Short() {

--- a/internal/codegen/module_perdir_test.go
+++ b/internal/codegen/module_perdir_test.go
@@ -1,0 +1,191 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupPerDirModule builds a module with two gsx packages, each with its OWN
+// filter package, plus a class-merger package. Both filter packages export a
+// filter named "shout" with different bodies, so a table leak is observable in
+// the generated output rather than merely in a count.
+func setupPerDirModule(t *testing.T, perDir map[string]DirOptions, loadPkgs []string) (*Module, string) {
+	t.Helper()
+	root := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	repoRoot = filepath.Dir(repoRoot)
+	must := func(p, c string) {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/x\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	must("afilters/f.go", "package afilters\n\nfunc Shout(s string) string { return s + \"!A\" }\n")
+	must("bfilters/f.go", "package bfilters\n\nfunc Shout(s string) string { return s + \"!B\" }\n")
+	must("mrg/mrg.go", "package mrg\n\nfunc Keep(cs []string) string { return cs[0] }\n")
+	must("a/a.gsx", "package a\n\ncomponent A(s string) {\n\t<p>{ s |> shout }</p>\n}\n")
+	must("b/b.gsx", "package b\n\ncomponent B(s string) {\n\t<p>{ s |> shout }</p>\n}\n")
+
+	abs := map[string]DirOptions{}
+	for d, o := range perDir {
+		abs[filepath.Join(root, d)] = o
+	}
+	m, err := Open(Options{
+		ModuleRoot: root, ModulePath: "example.com/x",
+		FilterPkgs: []string{StdImportPath},
+		LoadPkgs:   loadPkgs,
+		PerDir:     abs,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return m, root
+}
+
+// TestPerDirFilterTablesIsolated is the load-bearing test for the union/per-dir
+// split: two dirs, two different filter packages, ONE Module. Each dir must see
+// only its own filter, and the whole thing must cost one packages.Load.
+func TestPerDirFilterTablesIsolated(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	loadPkgs := []string{"example.com/x/afilters", "example.com/x/bfilters"}
+	m, root := setupPerDirModule(t, map[string]DirOptions{
+		"a": {FilterPkgs: []string{StdImportPath, "example.com/x/afilters"}},
+		"b": {FilterPkgs: []string{StdImportPath, "example.com/x/bfilters"}},
+	}, loadPkgs)
+
+	genOf := func(dir string) string {
+		out, diags, err := m.Generate(filepath.Join(root, dir))
+		if err != nil {
+			t.Fatalf("generate %s: %v", dir, err)
+		}
+		for _, d := range diags {
+			t.Fatalf("generate %s: unexpected diagnostic: %s", dir, d.Message)
+		}
+		var sb strings.Builder
+		for _, b := range out {
+			sb.Write(b)
+		}
+		return sb.String()
+	}
+
+	genA, genB := genOf("a"), genOf("b")
+
+	// Dir a resolved shout -> afilters.Shout, and must not even mention bfilters.
+	if !strings.Contains(genA, "afilters") || strings.Contains(genA, "bfilters") {
+		t.Errorf("dir a resolved the wrong filter package\n%s", genA)
+	}
+	if !strings.Contains(genB, "bfilters") || strings.Contains(genB, "afilters") {
+		t.Errorf("dir b resolved the wrong filter package\n%s", genB)
+	}
+
+	// The whole point: one go-list for the importer, and ZERO filter-table loads,
+	// because both tables were harvested from the types that load already produced.
+	if got := m.externalLoads(); got != 1 {
+		t.Errorf("externalLoads = %d; want 1", got)
+	}
+	if got := m.filterTableLoads(); got != 0 {
+		t.Errorf("filterTableLoads = %d; want 0 (per-dir tables must harvest from loaded types, not packages.Load)", got)
+	}
+}
+
+// TestPerDirFilterTableRejectsForeignFilter is the anti-vacuity guard. `shout`
+// exists in bfilters and bfilters IS loaded — but dir a does not whitelist it,
+// so the pipe must be rejected. If per-dir narrowing ever degrades to "use the
+// union", this test is the only thing that notices.
+func TestPerDirFilterTableRejectsForeignFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	m, root := setupPerDirModule(t, map[string]DirOptions{
+		"a": {FilterPkgs: []string{StdImportPath}}, // std only: no shout
+	}, []string{"example.com/x/afilters", "example.com/x/bfilters"})
+
+	_, diags, err := m.Generate(filepath.Join(root, "a"))
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var found bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "shout") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("dir a whitelists only std, yet `shout` resolved: the union leaked into the per-dir table. diags=%v", diags)
+	}
+}
+
+// TestPerDirUnloadedFilterPkgIsHardError: naming a filter package that was never
+// loaded must fail loudly. An empty table here would silently disable every
+// filter for that dir.
+//
+// The package must live OUTSIDE the module: the importer's load ends with
+// "./...", so any in-module package is loaded whether or not LoadPkgs names it.
+// A mistyped or non-vendored filter package is the case that actually reaches
+// this guard.
+func TestPerDirUnloadedFilterPkgIsHardError(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	m, root := setupPerDirModule(t, map[string]DirOptions{
+		"a": {FilterPkgs: []string{StdImportPath, "example.com/x/missing"}},
+	}, nil)
+
+	_, _, err := m.Generate(filepath.Join(root, "a"))
+	if err == nil {
+		t.Fatal("expected a hard error for an unloaded filter package; got nil")
+	}
+	if !strings.Contains(err.Error(), "was not loaded") {
+		t.Fatalf("wrong error: %v", err)
+	}
+}
+
+// TestPerDirClassMergerApplies pins the merger half of DirOptions.
+func TestPerDirClassMergerApplies(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	m, root := setupPerDirModule(t, map[string]DirOptions{
+		"a": {
+			FilterPkgs:  []string{StdImportPath, "example.com/x/afilters"},
+			ClassMerger: &ClassMergerRef{PkgPath: "example.com/x/mrg", FuncName: "Keep"},
+		},
+		"b": {FilterPkgs: []string{StdImportPath, "example.com/x/bfilters"}},
+	}, []string{"example.com/x/afilters", "example.com/x/bfilters", "example.com/x/mrg"})
+
+	if err := m.validatePerDirMergers(); err != nil {
+		t.Fatalf("validatePerDirMergers: %v", err)
+	}
+	if got := m.classMergerFor(filepath.Join(root, "a")); got == nil || got.FuncName != "Keep" {
+		t.Errorf("dir a merger = %v; want mrg.Keep", got)
+	}
+	if got := m.classMergerFor(filepath.Join(root, "b")); got != nil {
+		t.Errorf("dir b merger = %v; want nil (inherit)", got)
+	}
+	// Validation must not cost a second load beyond the importer's.
+	if got := m.externalLoads(); got != 1 {
+		t.Errorf("externalLoads = %d; want 1 (merger validated from loaded types)", got)
+	}
+}
+
+// TestPerDirUnloadedMergerIsHardError guards the merger half the same way.
+func TestPerDirUnloadedMergerIsHardError(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	m, _ := setupPerDirModule(t, map[string]DirOptions{
+		"a": {ClassMerger: &ClassMergerRef{PkgPath: "example.com/x/nope", FuncName: "Keep"}},
+	}, nil)
+	err := m.validatePerDirMergers()
+	if err == nil || !strings.Contains(err.Error(), "was not loaded") {
+		t.Fatalf("expected hard error for unloaded merger package; got %v", err)
+	}
+}

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -130,7 +130,7 @@ func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
 	for _, f := range gsxFiles {
 		jsx.ResolveScripts(f, bag) // best-effort; failure just means we may skip that file below
 	}
-	table, err := m.cachedFilterTable()
+	table, err := m.filterTableFor(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/corpus/batch.go
+++ b/internal/corpus/batch.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gsxhq/gsx/internal/codegen"
 	"github.com/gsxhq/gsx/internal/diag"
 )
 
@@ -102,28 +103,45 @@ func batchCodegen(repoRoot string, candidates []*caseDoc) (map[string]*caseCodeg
 		states[i] = cs
 	}
 
-	// Step 3: codegen. Cases with no per-case codegen options (no class merger,
-	// no filterPackages) are batched into one call; cases with either get their
-	// own call so Options.ClassMerger/FilterPkgs can be set independently.
-	var defaultDirs []string
+	// Step 3: codegen — ONE call for every dir. Cases carrying a gsx.toml
+	// (class_merger and/or filterPackages) contribute a PerDir entry; their filter
+	// packages go into the shared load set. Previously each such case opened its
+	// own Module, and every Module re-ran packages.Load over the gsx runtime: 27
+	// cases cost 10.7s of the corpus's 13.2s.
+	var allDirs, loadPkgs []string
+	perDir := map[string]codegen.DirOptions{}
+	seenPkg := map[string]bool{}
 	for _, cs := range states {
-		if cs.c.classMerger == nil && len(cs.c.filterPkgs) == 0 {
-			defaultDirs = append(defaultDirs, cs.pkgDirs...)
-		}
-	}
-	pkgResults, err := codegenDirs(tmp, defaultDirs, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("batchCodegen: codegenDirs: %w", err)
-	}
-	for _, cs := range states {
+		allDirs = append(allDirs, cs.pkgDirs...)
 		if cs.c.classMerger == nil && len(cs.c.filterPkgs) == 0 {
 			continue
 		}
-		mergerResults, merr := codegenDirs(tmp, cs.pkgDirs, cs.c.classMerger, cs.c.filterPkgs)
-		if merr != nil {
-			return nil, fmt.Errorf("batchCodegen: codegenDirs(%s): %w", cs.c.name, merr)
+		var filters []string
+		if len(cs.c.filterPkgs) > 0 {
+			filters = append([]string{codegen.StdImportPath}, cs.c.filterPkgs...)
+			for _, p := range cs.c.filterPkgs {
+				if !seenPkg[p] {
+					seenPkg[p] = true
+					loadPkgs = append(loadPkgs, p)
+				}
+			}
 		}
-		maps.Copy(pkgResults, mergerResults)
+		if cs.c.classMerger != nil && !seenPkg[cs.c.classMerger.PkgPath] {
+			seenPkg[cs.c.classMerger.PkgPath] = true
+			loadPkgs = append(loadPkgs, cs.c.classMerger.PkgPath)
+		}
+		// Every dir of a multi-package case shares that case's options — an
+		// imported sibling must resolve the same filters as the dir importing it.
+		for _, d := range cs.pkgDirs {
+			perDir[filepath.Clean(d)] = codegen.DirOptions{
+				FilterPkgs:  filters, // nil ⇒ inherit the std-only default
+				ClassMerger: cs.c.classMerger,
+			}
+		}
+	}
+	pkgResults, err := codegenDirs(tmp, allDirs, loadPkgs, perDir)
+	if err != nil {
+		return nil, fmt.Errorf("batchCodegen: codegenDirs: %w", err)
 	}
 
 	// Step 4: reassemble per-case results.

--- a/internal/corpus/codegen.go
+++ b/internal/corpus/codegen.go
@@ -61,16 +61,21 @@ func (c *caseDoc) astAndParserDiag() (astDump []byte, parserDiag []byte, single 
 	return dump.Bytes(), diag.Bytes(), true
 }
 
-// codegenDirs generates .x.go for every .gsx across the given package dirs via
-// codegen.GenerateDirs. Options: std filter (plus any case-local filterPkgs),
-// CSS+JS minify on. merger is the per-case class merger (nil means use the
-// built-in DefaultClassMerge path).
-func codegenDirs(moduleDir string, dirs []string, merger *codegen.ClassMergerRef, filterPkgs []string) (map[string]codegen.DirResult, error) {
+// codegenDirs generates .x.go for every .gsx across the given package dirs in ONE
+// codegen.Module. Options: std filter, CSS+JS minify on.
+//
+// loadPkgs is the union of every case's filter packages: they are loaded once,
+// into one importer. perDir then narrows each dir to its OWN filter table and
+// class merger, harvested from those loaded types with no further packages.Load.
+// The union must not leak into the tables — a case that asserts a non-whitelisted
+// package is rejected as a filter source would otherwise pass while testing nothing.
+func codegenDirs(moduleDir string, dirs []string, loadPkgs []string, perDir map[string]codegen.DirOptions) (map[string]codegen.DirResult, error) {
 	return codegen.GenerateDirs(moduleDir, dirs, codegen.Options{
-		FilterPkgs:  append([]string{codegen.StdImportPath}, filterPkgs...),
-		CSSMinify:   true,
-		JSMinify:    true,
-		ClassMerger: merger,
+		FilterPkgs: []string{codegen.StdImportPath},
+		LoadPkgs:   loadPkgs,
+		PerDir:     perDir,
+		CSSMinify:  true,
+		JSMinify:   true,
 	}, nil)
 }
 


### PR DESCRIPTION
Implements the design in #55. **`internal/corpus`: 13.2s → 2.4s (5.5×), zero golden churn.**

## What was slow

27 corpus cases carry a `gsx.toml` (`class_merger` / `filterPackages`). Each got its own `codegenDirs` call → its own `codegen.Module` → its own `packages.Load` of the gsx runtime. That was **10.7s of a 13.2s suite**, versus 550ms for the *other 509 dirs* in one call.

Two fixes were measured and rejected first (recorded in #55 so they aren't retried): parallelizing gave **no speedup** (`packages.Load` already saturates every core; 204s on a cold cache), and shrinking the `"./..."` load set was worth **1.2×**.

## The split

`FilterPkgs` feeds two consumers with different semantics. In the importer's **load set** a superset is inert — it only makes packages importable. In a dir's **filter table** a superset silently widens the filter whitelist.

So: load the union once, harvest each dir's table from the types that load already produced.

- `Options.LoadPkgs` — packages loaded into the importer **without** filter semantics (the union).
- `Options.PerDir map[string]DirOptions` — narrows a dir to its own `FilterPkgs` + `ClassMerger`.
- `Module.filterTableFor(dir)` harvests via the existing `loadFilterTableFromTypes` — **no subprocess**. `analyze()` is the recursion point for the import graph, so an imported sibling resolves its own table.
- Per-dir class mergers are validated from loaded types (`validateClassMergerFromTypes`) instead of one `packages.Load` each. `ValidateClassMerger` and the new validator now share `validateClassMergerObj` so they can't drift.

`gsx fmt` / LSP are unaffected: they set no `PerDir`, so `filterTableFor` short-circuits to `cachedFilterTable()` — byte-identical behavior, no new load. (`TestBuildPackageSkeletonsNoExternalLoad` still passes.)

## The invariant this rests on

`filterimport/user_plain_import_no_filter` asserts a non-whitelisted package's funcs are **not** usable as pipe filters. If the union ever leaks into a dir's table, that case passes while testing nothing. So a dir naming an unloaded filter package is a **hard error, never an empty table**.

Tests pin the invariant, not the speed:

| Test | Pins |
|---|---|
| `TestPerDirFilterTablesIsolated` | two dirs, two filter pkgs, one Module → `externalLoads==1`, `filterTableLoads==0` |
| `TestPerDirFilterTableRejectsForeignFilter` | a *loaded but unwhitelisted* filter is rejected |
| `TestPerDirUnloadedFilterPkgIsHardError` | unloaded filter pkg → error, not empty table |
| `TestPerDirBadMergerFailsOnGeneratePath` | invalid merger fails at `Generate`, not `go build` |
| `TestBundleRejectsPerDir` | `Bundle`+`PerDir` rejected at `Open` |

Mutating `filterTableFor` to leak the union turns three of them red **plus** a corpus golden. Every guard was mutation-tested.

## Adversarial review

An independent reviewer probed table leakage, memo-key ordering under last-wins precedence, `nil` vs empty `FilterPkgs`, cross-import recursion, dir canonicalization (trailing slash / symlink), `rebuildFset` TOCTOU under `analysisMu`, the `fmt` fast path, and `-race`. It found no isolation bug, and two latent silent-wrong-answer gaps, both now fixed with regression tests in the second commit:

1. `validatePerDirMergers` ran only in `GenerateDirs`, so `Open`+`Generate` (watch/LSP) emitted `_gsxcm.NoSuchFunc` and exited 0. Now validated on the `Generate`/`Package` path, memoized.
2. `filterTableFor` returned `Bundle.filters()` before consulting `PerDir` — the exact union leak, silently. `Open` now rejects `Bundle` + `PerDir`/`LoadPkgs`.

## Verification

- `make ci` exit 0, `make lint` exit 0, `gofmt` clean, `-race` clean.
- `go test ./internal/corpus -count=1`: 14.1s → 3.5s. `TestCorpus`: 13.2s → 2.4s.
- `git status -- internal/corpus/testdata examples` empty: **no golden churn**.

## Note on `make ci` wall time

This does **not** speed up `make ci` (~120s). Its lanes run under `-j4` and `go test ./...` runs packages in parallel, so wall time is set by the slowest package — `internal/codegen`'s own suite (~91s), which the corpus never gated. That suite makes ~78 `GenerateDirs` calls across 52 test files, each opening its own temp module and paying its own `packages.Load`: the same disease, and now the dominant one. Worth a follow-up; out of scope here.

Implements #55 (merge that first — this does not close it).

https://claude.ai/code/session_011BLviYFuAN33mKbxoDn3jp