### PR TITLE
fix(fmt): sanitize substituted Go before gofmt, so fmt reformats its own output

### DIFF
--- a/internal/goexprshape/shape.go
+++ b/internal/goexprshape/shape.go
@@ -78,7 +78,11 @@ type Result struct {
 // this function depends on in the other direction.
 func Classify(src string, holes []Hole) []Result {
 	results := make([]Result, len(holes))
-	sanitized, offsets := collapseHoleWhitespace(src, holes)
+	sanitized, sanHoles := Sanitize(src, holes)
+	offsets := make([]int, len(sanHoles))
+	for i, h := range sanHoles {
+		offsets[i] = h.Start
+	}
 	fset := gotoken.NewFileSet()
 	f, err := goparser.ParseFile(fset, "", sanitized, 0)
 	if err != nil {
@@ -126,6 +130,31 @@ func Classify(src string, holes []Hole) []Result {
 		return true
 	})
 	return results
+}
+
+// Sanitize returns src with every bracket-adjacent newline touching a hole
+// collapsed to a single space, plus each hole's range within the returned
+// string (same order as holes; the placeholder text itself is never altered,
+// only the whitespace around it).
+//
+// A hole alone on its own line directly inside a bracket — `(\nHOLE\n)`, the
+// shape gsx fmt's own decorative-paren output takes — makes Go's automatic
+// semicolon insertion place a semicolon after the placeholder identifier, so
+// the source no longer parses. Every consumer that hands the substituted
+// source to go/parser or go/format must sanitize it first, or that consumer
+// silently fails on any file gsx fmt has already formatted once. Classify does
+// this internally; internal/printer calls it directly, because go/format needs
+// the same treatment for the same reason.
+//
+// Sanitize is idempotent: its output has no newline left adjacent to a hole's
+// brackets, so re-running it is a no-op.
+func Sanitize(src string, holes []Hole) (string, []Hole) {
+	sanitized, offsets := collapseHoleWhitespace(src, holes)
+	out := make([]Hole, len(holes))
+	for i, h := range holes {
+		out[i] = Hole{Start: offsets[i], End: offsets[i] + (h.End - h.Start)}
+	}
+	return sanitized, out
 }
 
 // isSpace reports whether b is Go source whitespace (the same set go/scanner

--- a/internal/goexprshape/shape_test.go
+++ b/internal/goexprshape/shape_test.go
@@ -1,6 +1,9 @@
 package goexprshape
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestClassify(t *testing.T) {
 	tests := []struct {
@@ -100,4 +103,46 @@ func indexOf(hay, needle string) int {
 		}
 	}
 	return -1
+}
+
+// Sanitize is what lets a consumer hand the substituted source to go/parser or
+// go/format at all: a hole alone on its line inside a bracket otherwise picks up
+// an inserted semicolon. It must also be idempotent, since gsx fmt re-formats
+// its own output.
+func TestSanitizeCollapsesBracketAdjacentNewlines(t *testing.T) {
+	// `icon: (\n\tH\n),` — gsx fmt's own decorative-paren output.
+	src := "package p\nvar x = []T{\n\t{icon: (\n\t\tH\n\t), page: P{}},\n}\n"
+	start := strings.Index(src, "H")
+	holes := []Hole{{Start: start, End: start + 1}}
+
+	got, gotHoles := Sanitize(src, holes)
+	want := "package p\nvar x = []T{\n\t{icon: ( H ), page: P{}},\n}\n"
+	if got != want {
+		t.Errorf("Sanitize:\n got %q\nwant %q", got, want)
+	}
+	if n := len(gotHoles); n != 1 {
+		t.Fatalf("got %d holes, want 1", n)
+	}
+	if got[gotHoles[0].Start:gotHoles[0].End] != "H" {
+		t.Errorf("hole range %v does not cover the placeholder in %q", gotHoles[0], got)
+	}
+
+	again, againHoles := Sanitize(got, gotHoles)
+	if again != got {
+		t.Errorf("Sanitize is not idempotent:\n once %q\ntwice %q", got, again)
+	}
+	if againHoles[0] != gotHoles[0] {
+		t.Errorf("idempotent Sanitize moved the hole: %v -> %v", gotHoles[0], againHoles[0])
+	}
+}
+
+// A newline NOT adjacent to a bracket is a real statement separator that Go's
+// own semicolon insertion needs; collapsing it would break the parse.
+func TestSanitizeLeavesStatementSeparatingNewline(t *testing.T) {
+	src := "package p\nfunc f() {\n\tn := H\n\tg()\n}\n"
+	start := strings.Index(src, "H")
+	got, _ := Sanitize(src, []Hole{{Start: start, End: start + 1}})
+	if got != src {
+		t.Errorf("Sanitize altered a non-bracket-adjacent newline:\n got %q\nwant %q", got, src)
+	}
 }

--- a/internal/printer/goexpr_gofmt_property_test.go
+++ b/internal/printer/goexpr_gofmt_property_test.go
@@ -1,0 +1,97 @@
+package printer
+
+import (
+	"go/token"
+	"testing"
+
+	"github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/wsnorm"
+	"github.com/gsxhq/gsx/parser"
+)
+
+// fmtGoExprParts degrades gracefully: when go/format rejects the
+// placeholder-substituted source it returns ok=false and the caller relays the
+// whole GoWithElements region VERBATIM. That fallback is silent, and a verbatim
+// relay is perfectly idempotent and perfectly render-faithful — so neither
+// TestCorpusInputsProperty nor TestCorpusIdempotence can see it. The only way
+// to catch a region that silently stopped being gofmt'd is to assert the
+// non-fallback path was actually taken.
+//
+// The regression that motivated this test only fires on the SECOND format: it
+// takes fmt's own decorative-paren output (`icon: (\n\t<Icon/>\n)`) to put a
+// placeholder alone on a line inside a bracket, where Go's automatic semicolon
+// insertion makes the substituted source unparseable. So each input is checked
+// both as authored and as formatted.
+// invalidGoFixtures are the corpus inputs whose embedded Go is deliberately not
+// valid Go, independent of gsx. go/format is right to reject them, so a verbatim
+// relay is the correct outcome and the fallback is doing its job. Every entry is
+// asserted to actually fall back, so this list cannot rot into a silent
+// suppression of a real regression.
+var invalidGoFixtures = map[string]string{
+	"element-literals/stray-import-after-func.txtar:input.gsx": `an "import" decl after a func decl is not valid Go`,
+	"imports/reserved_prefix_decl_element_gostmt.txtar:input.gsx": "`go <b/>` substitutes to `go IDENT`, " +
+		"and a go statement requires a call expression",
+}
+
+func TestCorpusGoExprRegionsAlwaysReachGofmt(t *testing.T) {
+	checked := 0
+	fellBack := map[string]bool{}
+	for _, c := range corpusGsxSources(t) {
+		fset := token.NewFileSet()
+		if _, err := parser.ParseFile(fset, "x.gsx", c.src, 0); err != nil {
+			continue // parser-error fixture: out of scope
+		}
+		formatted, err := normPrint(t, c.src)
+		if err != nil {
+			t.Errorf("%s: fmt failed: %v", c.name, err)
+			continue
+		}
+		for _, pass := range []struct {
+			label string
+			src   string
+		}{{"as authored", c.src}, {"as formatted", formatted}} {
+			for _, parts := range goWithElementsParts(t, pass.src) {
+				checked++
+				p := printer{}
+				if _, _, ok := p.fmtGoExprParts(parts); ok {
+					continue
+				}
+				fellBack[c.name] = true
+				if _, expected := invalidGoFixtures[c.name]; !expected {
+					t.Errorf("%s (%s): GoWithElements region fell back to a verbatim relay — go/format rejected the substituted source, so this region is no longer gofmt'd", c.name, pass.label)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no GoWithElements regions found in the corpus — this test is asserting nothing")
+	}
+	// A pinned exception that no longer falls back means the fixture changed or
+	// the fallback path moved: drop it from the list rather than let it hide a
+	// future regression.
+	for name, why := range invalidGoFixtures {
+		if !fellBack[name] {
+			t.Errorf("%s is pinned as invalid Go (%s) but no longer falls back — remove it from invalidGoFixtures", name, why)
+		}
+	}
+	t.Logf("checked %d GoWithElements regions", checked)
+}
+
+// goWithElementsParts parses src and returns the Parts of every GoWithElements
+// decl in it.
+func goWithElementsParts(t *testing.T, src string) [][]ast.GoPart {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.gsx", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	wsnorm.Normalize(f)
+	var out [][]ast.GoPart
+	for _, d := range f.Decls {
+		if g, ok := d.(*ast.GoWithElements); ok {
+			out = append(out, g.Parts)
+		}
+	}
+	return out
+}

--- a/internal/printer/goexpr_test.go
+++ b/internal/printer/goexpr_test.go
@@ -222,3 +222,18 @@ func indexOf(hay, needle string) int {
 	}
 	return -1
 }
+
+// Feeding gsx fmt its OWN output back in must still gofmt the region. A
+// decorative paren puts the element alone on its line inside a bracket —
+// exactly the shape Go's automatic semicolon insertion rejects once the
+// element is replaced by a placeholder identifier. If the placeholder-
+// substituted source is not sanitized before go/format sees it, format.Source
+// fails, fmtGoExprParts falls back to relaying the region verbatim, and the
+// misindented sibling below never gets fixed.
+func TestGoWithElementsReformatsItsOwnParenWrappedOutput(t *testing.T) {
+	src := "package main\n\nvar items = []T{\n\t{label: \"a\", icon: (\n\t\t<Icon/>\n\t), page: P{}},\n{label: \"b\"},\n}\n"
+	// The paren is stripped and re-derived from width: this line now fits, so
+	// the element goes flat and the parens vanish. The sibling gets indented.
+	want := "package main\n\nvar items = []T{\n\t{label: \"a\", icon: <Icon/>, page: P{}},\n\t{label: \"b\"},\n}\n"
+	checkFormat(t, src, want)
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1394,9 +1394,16 @@ func (p *printer) fmtGoExprParts(parts []ast.GoPart) ([]ast.GoPart, []goexprshap
 		holes = append(holes, h)
 		src.WriteString(h)
 	}
-	shapes := goexprshape.Classify(goExprWrapper+src.String(), shapeHoles)
+	// go/format, like go/parser, chokes on a placeholder sitting alone on its
+	// own line inside a bracket — the shape this printer's OWN decorative-paren
+	// output takes. Sanitize collapses exactly those newlines, so re-formatting
+	// an already-formatted file reaches gofmt instead of falling back to a
+	// verbatim relay. Classify sees the same source, so the paren it reports as
+	// Wrapped is the paren that survives into `formatted` for the caller to strip.
+	sanitized, sanHoles := goexprshape.Sanitize(goExprWrapper+src.String(), shapeHoles)
+	shapes := goexprshape.Classify(sanitized, sanHoles)
 
-	out, err := format.Source([]byte(goExprWrapper + src.String()))
+	out, err := format.Source([]byte(sanitized))
 	if err != nil {
 		return nil, shapes, false
 	}


### PR DESCRIPTION
## The bug

`gsx fmt` was a one-shot: once it had formatted a file, re-formatting it silently stopped running gofmt on any `GoWithElements` region.

`fmtGoExprParts` substitutes each gsx value with a placeholder identifier and hands the result to `go/format.Source`. It passed the **raw** concatenation, while `goexprshape.Classify` sanitized the same source first. fmt's own decorative-paren output puts the element alone on its line inside a bracket:

```go
icon: (
	<BarChart3Icon/>
), page: ...
```

Substituting a placeholder yields `( IDENT \n )`, where Go's automatic semicolon insertion places a semicolon after the identifier — so `format.Source` fails, `fmtGoExprParts` returns `ok=false`, and `goWithElements` relays the **entire** region verbatim.

Reported from a real file: composite-literal fields kept their column-0 indentation and were never expanded one-per-line. Both symptoms were the same fallback — gofmt simply never ran.

Before / after on the reported input:

```go
// before (fmt output, unchanged across runs)
{
        label: "Import / Export", 
        icon: <UploadDownloadIcon/>, 
page: ImportExportPage{}, 

// after
{
	label:     "Import / Export",
	icon:      <UploadDownloadIcon/>,
	page:      ImportExportPage{},
	pathMatch: "/import-export/",
```

## The fix

Export `goexprshape.Sanitize` — the collapse `Classify` already performed internally, now also returning each hole's adjusted range — and run it before **both** `Classify` and `format.Source`. The two then see the same source, so the paren `Classify` reports as `Wrapped` is the paren that survives into the formatted text for the caller to strip. `Sanitize` is idempotent, so `Classify`'s internal call is a no-op.

No behavior change for `internal/codegen`, which calls `Classify` as before.

## Testing

The existing corpus properties (faithfulness, **idempotence**, re-parse safety) all passed throughout and could never have caught this: a verbatim relay is byte-stable under re-formatting and preserves the AST exactly. It just isn't formatted.

The property that catches it is that the graceful-degradation path is never taken. `TestCorpusGoExprRegionsAlwaysReachGofmt` asserts `fmtGoExprParts` returns `ok` for every corpus input, checked both **as authored and as formatted** — the bug only fires on the second format. It reports 12 failing regions on the unfixed code and passes on the fixed one.

Two fixtures whose embedded Go is deliberately invalid (`import` after a `func` decl; `go <b/>`, which substitutes to `go IDENT` where a call expression is required) are pinned with reasons and asserted to *still* fall back, so the exception list can't rot into a silent suppression.

Also added: a unit regression test reproducing the reported shape (`internal/printer`), and direct `Sanitize` tests covering collapse, idempotence, and the non-bracket-adjacent newline that must be preserved (`internal/goexprshape`).

`make ci` and `make lint` pass.

https://claude.ai/code/session_01NtNWQzQeJjfABhPckkD5qg