### PR TITLE
fix(fmt): stop collapsing the newline after an opening bracket (+ fmt corpus)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,12 @@ Run `make lint`
 - Runtime behavior gets unit tests in the root `gsx` package.
 - **Don't hand-edit `.x.go` or golden files** — they're generated; change the `.gsx`/source and regenerate.
 
+### The fmt corpus is separate
+
+`internal/gsxfmt/testdata/cases/*.txtar` pins **layout** (`input.gsx` + `fmt.golden`); the semantic corpus above pins meaning. Keep them apart: a codegen golden must not churn when line-breaking changes, and a layout golden must not churn when generated code changes. Regenerate with `go test ./internal/gsxfmt -run TestFmtCorpus -update`, then verify without `-update`.
+
+**Any formatter change ships a fmt-corpus case.** The property tests in `internal/printer` (faithfulness, idempotence, re-parse safety, no-verbatim-fallback) cannot catch a layout regression — a formatter that reflows the author's source is still faithful, still idempotent, and still re-parses. Only a pinned golden catches that.
+
 ## Conventions
 
 - **Branches:** feature work in a **git worktree** (use the `superpowers:using-git-worktrees` skill).

--- a/internal/goexprshape/shape.go
+++ b/internal/goexprshape/shape.go
@@ -164,12 +164,21 @@ func isSpace(b byte) bool {
 }
 
 // collapseHoleWhitespace returns a copy of src where, for every hole whose
-// immediately-preceding non-whitespace byte is a REAL (not inside a comment)
-// opening bracket, the whitespace before it is collapsed to a single space
-// (if it contains a newline) — and likewise, for every hole whose
-// immediately-following non-whitespace byte is a real closing bracket, the
-// whitespace after it. Returns each hole's new Start offset in the returned
+// immediately-following non-whitespace byte is a REAL (not inside a comment)
+// closing bracket, the whitespace after it is collapsed to a single space (if
+// it contains a newline). Returns each hole's new Start offset in the returned
 // string, in the same order as holes.
+//
+// Only the whitespace AFTER a hole is ever touched. Go's automatic semicolon
+// insertion fires on the token that ENDS a line, and a placeholder identifier
+// ending a line directly before a closing bracket picks up a semicolon that
+// breaks the parse (`(\nHOLE\n)` becomes `(HOLE;)`). The whitespace between an
+// opening bracket and a hole cannot cause that: the token ending that line is
+// the opening bracket itself, which is not in ASI's trigger set. Collapsing it
+// anyway would be worse than useless — go/printer reads the line break between
+// a composite literal's `{` and its first element to decide whether the literal
+// prints on one line, so erasing it drags the first element up onto the brace
+// line and silently reflows the author's source.
 //
 // Processes holes in ascending Start order (left to right), tracking a
 // cumulative shift so far. This is the opposite of the naive-looking
@@ -198,36 +207,22 @@ func collapseHoleWhitespace(src string, holes []Hole) (string, []int) {
 	shift := 0
 	for _, i := range order {
 		start, end := holes[i].Start+shift, holes[i].End+shift
-		before := start
-		for before > 0 && isSpace(s[before-1]) {
-			before--
-		}
 		after := end
 		for after < len(s) && isSpace(s[after]) {
 			after++
 		}
-		beforeWS, afterWS := s[before:start], s[end:after]
-		collapseBefore := before > 0 && isOpenBracket(s[before-1]) && !insideAny(comments, before-1-shift) && containsNewline(beforeWS)
+		afterWS := s[end:after]
 		collapseAfter := after < len(s) && isCloseBracket(s[after]) && !insideAny(comments, after-shift) && containsNewline(afterWS)
-		if !collapseBefore && !collapseAfter {
-			offsets[i] = start
+		offsets[i] = start
+		if !collapseAfter {
 			continue
 		}
-		newBefore, newAfter := beforeWS, afterWS
-		if collapseBefore {
-			newBefore = " "
-		}
-		if collapseAfter {
-			newAfter = " "
-		}
-		s = s[:before] + newBefore + s[start:end] + newAfter + s[after:]
-		offsets[i] = before + len(newBefore)
-		shift += (len(newBefore) + (end - start) + len(newAfter)) - (after - before)
+		s = s[:end] + " " + s[after:]
+		shift += 1 - (after - end)
 	}
 	return s, offsets
 }
 
-func isOpenBracket(b byte) bool  { return b == '(' || b == '[' || b == '{' }
 func isCloseBracket(b byte) bool { return b == ')' || b == ']' || b == '}' }
 
 func containsNewline(s string) bool {

--- a/internal/goexprshape/shape_test.go
+++ b/internal/goexprshape/shape_test.go
@@ -106,9 +106,9 @@ func indexOf(hay, needle string) int {
 }
 
 // Sanitize is what lets a consumer hand the substituted source to go/parser or
-// go/format at all: a hole alone on its line inside a bracket otherwise picks up
-// an inserted semicolon. It must also be idempotent, since gsx fmt re-formats
-// its own output.
+// go/format at all: a hole ending a line directly before a closing bracket
+// otherwise picks up an inserted semicolon. It must also be idempotent, since
+// gsx fmt re-formats its own output.
 func TestSanitizeCollapsesBracketAdjacentNewlines(t *testing.T) {
 	// `icon: (\n\tH\n),` — gsx fmt's own decorative-paren output.
 	src := "package p\nvar x = []T{\n\t{icon: (\n\t\tH\n\t), page: P{}},\n}\n"
@@ -116,7 +116,9 @@ func TestSanitizeCollapsesBracketAdjacentNewlines(t *testing.T) {
 	holes := []Hole{{Start: start, End: start + 1}}
 
 	got, gotHoles := Sanitize(src, holes)
-	want := "package p\nvar x = []T{\n\t{icon: ( H ), page: P{}},\n}\n"
+	// Only the newline AFTER the hole is collapsed: the one after `(` is left
+	// alone, because an opening bracket cannot trigger semicolon insertion.
+	want := "package p\nvar x = []T{\n\t{icon: (\n\t\tH ), page: P{}},\n}\n"
 	if got != want {
 		t.Errorf("Sanitize:\n got %q\nwant %q", got, want)
 	}
@@ -144,5 +146,19 @@ func TestSanitizeLeavesStatementSeparatingNewline(t *testing.T) {
 	got, _ := Sanitize(src, []Hole{{Start: start, End: start + 1}})
 	if got != src {
 		t.Errorf("Sanitize altered a non-bracket-adjacent newline:\n got %q\nwant %q", got, src)
+	}
+}
+
+// The newline between an opening bracket and a hole must survive Sanitize: an
+// opening bracket never ends a line in a way that triggers semicolon insertion,
+// and go/printer reads that break to decide whether a composite literal prints
+// on one line. Collapsing it reflows the author's source.
+func TestSanitizeKeepsNewlineAfterOpeningBracket(t *testing.T) {
+	src := "package p\nvar x = []gsx.Node{\n\tH,\n\tI,\n}\n"
+	h := strings.Index(src, "H")
+	i := strings.Index(src, "I")
+	got, _ := Sanitize(src, []Hole{{Start: h, End: h + 1}, {Start: i, End: i + 1}})
+	if got != src {
+		t.Errorf("Sanitize collapsed a newline after an opening bracket:\n got %q\nwant %q", got, src)
 	}
 }

--- a/internal/gsxfmt/corpus_test.go
+++ b/internal/gsxfmt/corpus_test.go
@@ -1,0 +1,121 @@
+// The fmt corpus is the authoritative reference for gsx fmt's LAYOUT.
+//
+// It is deliberately separate from internal/corpus, which pins parse → generate
+// → render. Those cases answer "what does this gsx MEAN"; a formatter case
+// answers "where do the bytes go", and the two rot in opposite directions: a
+// codegen golden must not churn when the formatter's line-breaking changes, and
+// a layout golden must not churn when generated code changes. Keeping them apart
+// also keeps this suite fast — no type-checking, no compilation, no rendering.
+//
+// The invariant suite in internal/printer (faithfulness, idempotence, re-parse
+// safety, no-verbatim-fallback) runs over the SEMANTIC corpus and asserts
+// properties that hold for every input. It cannot see a layout regression: a
+// formatter that reflows the author's source is still faithful, still
+// idempotent, still re-parses. Only a pinned golden catches that — which is what
+// this corpus is for.
+//
+// Each case is a txtar with:
+//
+//	-- input.gsx --    the source to format
+//	-- fmt.golden --   the expected output
+//
+// Regenerate with: go test ./internal/gsxfmt -run TestFmtCorpus -update
+// Then re-run without -update to verify.
+package gsxfmt
+
+import (
+	"bytes"
+	"flag"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/txtar"
+	"github.com/gsxhq/gsx/parser"
+)
+
+var update = flag.Bool("update", false, "rewrite fmt.golden files from actual output")
+
+// fmtWidth is the column budget every corpus case is formatted at. Pinned here
+// (not per-case) so a golden's line breaks mean one thing across the suite.
+const fmtWidth = 80
+
+func TestFmtCorpus(t *testing.T) {
+	cases, err := filepath.Glob("testdata/cases/*.txtar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) == 0 {
+		t.Fatal("no fmt corpus cases found — this suite is asserting nothing")
+	}
+	for _, path := range cases {
+		t.Run(strings.TrimSuffix(filepath.Base(path), ".txtar"), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ar := txtar.Parse(data)
+			input, ok := archiveFile(ar, "input.gsx")
+			if !ok {
+				t.Fatal("case has no input.gsx")
+			}
+
+			got, err := Format("input.gsx", input, fmtWidth)
+			if err != nil {
+				t.Fatalf("Format: %v", err)
+			}
+
+			if *update {
+				setArchiveFile(ar, "fmt.golden", got)
+				if err := os.WriteFile(path, txtar.Format(ar), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			want, ok := archiveFile(ar, "fmt.golden")
+			if !ok {
+				t.Fatal("case has no fmt.golden — run with -update")
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("fmt output differs from fmt.golden\n--- got ---\n%s\n--- want ---\n%s", got, want)
+			}
+
+			// Idempotence: the golden is a fixed point of the formatter.
+			again, err := Format("input.gsx", want, fmtWidth)
+			if err != nil {
+				t.Fatalf("re-Format of golden: %v", err)
+			}
+			if !bytes.Equal(again, want) {
+				t.Errorf("fmt is not idempotent on its own golden\n--- once ---\n%s\n--- twice ---\n%s", want, again)
+			}
+
+			// Re-parse safety: fmt never emits gsx it cannot read back.
+			if _, err := parser.ParseFile(token.NewFileSet(), "fmt.golden", want, 0); err != nil {
+				t.Errorf("formatted output does not re-parse: %v", err)
+			}
+		})
+	}
+}
+
+func archiveFile(ar *txtar.Archive, name string) ([]byte, bool) {
+	for _, f := range ar.Files {
+		if f.Name == name {
+			return f.Data, true
+		}
+	}
+	return nil, false
+}
+
+// setArchiveFile overwrites name's data, appending the file if absent, so
+// -update can seed a brand-new case that ships only an input.gsx.
+func setArchiveFile(ar *txtar.Archive, name string, data []byte) {
+	for i := range ar.Files {
+		if ar.Files[i].Name == name {
+			ar.Files[i].Data = data
+			return
+		}
+	}
+	ar.Files = append(ar.Files, txtar.File{Name: name, Data: data})
+}

--- a/internal/gsxfmt/testdata/cases/complit_break_after_opening_brace.txtar
+++ b/internal/gsxfmt/testdata/cases/complit_break_after_opening_brace.txtar
@@ -1,0 +1,19 @@
+Elements as bare composite-literal elements, one per line. The newline between
+`{` and the first element must survive: go/printer reads it to decide whether the
+literal prints on one line. A formatter that collapses it drags <a/> onto the
+brace line.
+
+-- input.gsx --
+package ui
+
+var icons = []gsx.Node{
+	<a/>,
+	<b/>,
+}
+-- fmt.golden --
+package ui
+
+var icons = []gsx.Node{
+	<a/>,
+	<b/>,
+}

--- a/internal/gsxfmt/testdata/cases/complit_keyed_fields_align.txtar
+++ b/internal/gsxfmt/testdata/cases/complit_keyed_fields_align.txtar
@@ -1,0 +1,31 @@
+gofmt owns the layout of embedded Go: it preserves the author's line breaks and
+column-aligns keyed composite-literal fields. Fields the author put on one line
+stay on one line (nonVendor + vendorVisible); fields on their own lines get
+aligned. gsx fmt never introduces a break here.
+
+-- input.gsx --
+package ui
+
+var sections = []appShellNavItem{
+	{
+	label: "Import / Export", 
+	icon: <UploadDownloadIcon/>, 
+page: ImportExportPage{}, 
+pathMatch: "/import-export/", 
+ nonVendor: true, vendorVisible: func(u *db.UserInfo) bool {
+		return u.HasGrantPrefix("", "import")
+	}},
+}
+-- fmt.golden --
+package ui
+
+var sections = []appShellNavItem{
+	{
+		label:     "Import / Export",
+		icon:      <UploadDownloadIcon/>,
+		page:      ImportExportPage{},
+		pathMatch: "/import-export/",
+		nonVendor: true, vendorVisible: func(u *db.UserInfo) bool {
+			return u.HasGrantPrefix("", "import")
+		}},
+}

--- a/internal/gsxfmt/testdata/cases/complit_reformat_own_paren_output.txtar
+++ b/internal/gsxfmt/testdata/cases/complit_reformat_own_paren_output.txtar
@@ -1,0 +1,25 @@
+Feeding gsx fmt its OWN decorative-paren output back in must still reach gofmt.
+The element sits alone on a line inside parens, which is the shape Go's automatic
+semicolon insertion rejects once the element is replaced by a placeholder
+identifier. If that source is not sanitized, format.Source fails and the whole
+region is relayed verbatim — leaving the misindented sibling below untouched.
+
+The paren is stripped and re-derived from width: this line now fits, so the
+element goes flat and the parens vanish.
+
+-- input.gsx --
+package ui
+
+var items = []T{
+	{label: "a", icon: (
+		<Icon/>
+	), page: P{}},
+{label: "b"},
+}
+-- fmt.golden --
+package ui
+
+var items = []T{
+	{label: "a", icon: <Icon/>, page: P{}},
+	{label: "b"},
+}

--- a/internal/gsxfmt/testdata/cases/element_paren_wrap_on_overflow.txtar
+++ b/internal/gsxfmt/testdata/cases/element_paren_wrap_on_overflow.txtar
@@ -1,0 +1,18 @@
+A keyed composite-literal field whose element pushes the line past the width
+budget wraps in decorative parens and breaks. The parens are cosmetic: codegen
+strips them before splicing the element's lowered closure.
+
+-- input.gsx --
+package ui
+
+var items = []T{
+	{label: "Analytics", icon: <BarChart3Icon/>, page: DashboardLanding{}, pathMatch: "/dashboard/", nonVendor: true},
+}
+-- fmt.golden --
+package ui
+
+var items = []T{
+	{label: "Analytics", icon: (
+		<BarChart3Icon/>
+	), page: DashboardLanding{}, pathMatch: "/dashboard/", nonVendor: true},
+}

--- a/internal/gsxfmt/testdata/cases/gochunk_gofmt_canonical.txtar
+++ b/internal/gsxfmt/testdata/cases/gochunk_gofmt_canonical.txtar
@@ -1,0 +1,35 @@
+A Go region with no elements in it is plain gofmt: indentation, alignment, and
+import grouping, with author line breaks preserved.
+
+-- input.gsx --
+package ui
+
+import (
+"fmt"
+	"strings"
+)
+
+type navItem struct {
+label string
+	pathMatch string
+adminOnly bool
+}
+
+func (i navItem) String() string { return fmt.Sprintf("%s %s", strings.TrimSpace(i.label), i.pathMatch) }
+-- fmt.golden --
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+type navItem struct {
+	label     string
+	pathMatch string
+	adminOnly bool
+}
+
+func (i navItem) String() string {
+	return fmt.Sprintf("%s %s", strings.TrimSpace(i.label), i.pathMatch)
+}

--- a/internal/printer/goexpr_test.go
+++ b/internal/printer/goexpr_test.go
@@ -237,3 +237,15 @@ func TestGoWithElementsReformatsItsOwnParenWrappedOutput(t *testing.T) {
 	want := "package main\n\nvar items = []T{\n\t{label: \"a\", icon: <Icon/>, page: P{}},\n\t{label: \"b\"},\n}\n"
 	checkFormat(t, src, want)
 }
+
+// Sanitize collapses the whitespace between a hole and an ADJACENT CLOSING
+// bracket, because a placeholder identifier ending a line makes Go's automatic
+// semicolon insertion break the parse. The whitespace between an OPENING
+// bracket and a hole must survive: an opening bracket never ends a line in a
+// way that triggers ASI, and go/printer reads the `{`-to-first-element line
+// break to decide whether the literal prints on one line. Collapsing it drags
+// the first element up onto the brace line.
+func TestGoWithElementsKeepsBreakAfterOpeningBrace(t *testing.T) {
+	src := "package main\n\nvar icons = []gsx.Node{\n\t<a/>,\n\t<b/>,\n}\n"
+	checkFormat(t, src, src)
+}


### PR DESCRIPTION
## Regression introduced by #57

#57 made `fmtGoExprParts` hand `go/format` the **sanitized** source. That was necessary — a placeholder ending a line before a closing bracket picks up a semicolon from Go's automatic semicolon insertion. But `Sanitize` *also* collapsed the whitespace **before** a hole when an opening bracket preceded it, and gofmt reads exactly that line break:

```go
// go/printer/nodes.go:145, exprList
if prev.IsValid() && prev.Line == line && line == endLine {
	// all list entries on a single line
```

`prev` is the composite literal's `Lbrace`. Erasing the newline between `{` and the first element makes those lines equal, so gofmt prints the literal's first element on the brace line:

```go
// before                      // after #57 (wrong)
var icons = []gsx.Node{        var icons = []gsx.Node{<a/>,
	<a/>,                          <b/>,
	<b/>,                      }
}
```

## Why the collapse-before was never needed

Its own guard requires the preceding byte to be an opening bracket — and an opening bracket is **not** in ASI's trigger set. Semicolon insertion fires on the token that *ends* a line (identifier, literal, `)`, `]`, `}`, …). Only the whitespace **after** a hole can produce `(HOLE;)`. So the before-collapse bought nothing and cost the author's layout. Dropped, along with the now-dead `isOpenBracket`.

`TestClassifyMultipleHolesWhereEarlierOneCollapses` and the rest of the shape suite still pass, confirming after-collapse alone is sufficient.

## The fmt corpus

Adds `internal/gsxfmt/testdata/cases/*.txtar` — `input.gsx` pinned against `fmt.golden`, plus per-case idempotence and re-parse checks. Regenerate with `go test ./internal/gsxfmt -run TestFmtCorpus -update`.

Deliberately **separate** from `internal/corpus`: layout goldens and codegen goldens rot in opposite directions (a codegen golden shouldn't churn when line-breaking changes, and vice versa), and this suite needs no type-checking, compilation, or rendering — it runs in ~10ms.

Verified to discriminate, not just to pass:

| revert | failing case |
|---|---|
| `shape.go` from #57 (collapse-before restored) | `complit_break_after_opening_brace` |
| `printer.go` from pre-#57 (no sanitize before gofmt) | `complit_reformat_own_paren_output` |

Each bug is caught by exactly its own case, and by neither the other's.

This is the class of bug the printer's property tests structurally cannot see. A formatter that reflows the author's source is still faithful, still idempotent, and still re-parses — all four properties in `internal/printer` passed throughout #57. Only a pinned golden catches it. `CLAUDE.md` now says so, and that any formatter change ships a fmt-corpus case.

`make ci` and `make lint` pass.

https://claude.ai/code/session_01NtNWQzQeJjfABhPckkD5qg