### PR TITLE
feat(fmt): gofmt/goimports import modes + LSP source.organizeImports

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -640,11 +640,12 @@ vocabulary remains a design aspiration, not the current API.
   never compiled non-renderable cases, which is where all six non-compiling-output
   bugs hid. Spec `2026-07-08-gsx-alias-generator-imports-design.md`.
   **Follow-ups (none blocking):**
-  1. `gsx fmt` / LSP `source.organizeImports` do not *add* a missing `gsx` import
-     (goimports mode uses `imports.Process` with `FormatOnly: true`, which skips
-     usage-based add/remove). The type-check already knows the identifier is
-     undefined, so this is tractable against the organize-imports spec. **This is
-     the one ergonomic cost of the rule.**
+  1. `gsx fmt` / LSP `source.organizeImports` do not *add* a missing `gsx` import.
+     Investigated and closed as permanent while shipping the gofmt/goimports
+     import-mode work below: a gsx Go chunk's body never references the
+     surrounding template's imports, so there is no symbol for the formatter to
+     resolve to a package — real `goimports`' add step has nothing to key off of
+     here. **This remains the one ergonomic cost of the rule.**
   2. `classMergeExpr(mergeExpr, rt)` is passed at two sites (`emit.go`, into
      `childPropsLiteral`'s subtree) where the callee provably never emits the
      string — `classEntryExpr` ends with `_ = mergeExpr`. It is the one live
@@ -843,6 +844,24 @@ vocabulary remains a design aspiration, not the current API.
   silent - same as the LSP without analysis. **Behavior change:** a tree with a Go
   syntax error now fails a `gsx fmt -l` CI gate that previously passed. Design:
   `docs/superpowers/specs/2026-07-08-fmt-error-reporting-design.md`.
+- [x] **gofmt/goimports import modes + LSP `source.organizeImports` - SHIPPED
+  (2026-07-09).** `gsx fmt` and the language server now offer the same two
+  import-handling modes gopls does, selected by `gsx.toml` `[formatter]
+  imports = "goimports" | "gofmt"` (default `"goimports"`) or the CLI's
+  `-imports goimports|gofmt`; `-no-imports` is now an alias for `-imports
+  gofmt` (asking for both is a usage error, exit 2). `goimports` removes unused
+  imports and merges every import declaration into one block, dedups identical
+  specs, splits the standard library from third-party with a blank line, and
+  sorts each group; `gofmt` only sorts within an existing group and never
+  removes, merges, dedups, or regroups. Mode resolves **CLI > config >
+  default**, per directory, so one run can span directories with different
+  `gsx.toml`. The LSP's `textDocument/formatting` honors the configured mode; a
+  new `source.organizeImports` code action always organizes regardless of it -
+  exactly like gopls, where formatting can be plain gofmt while the action
+  still organizes - with a whole-document edit (gsx has no partial formatter),
+  so applying it also canonicalizes the rest of the file. As always, `gsx`
+  cannot *add* a missing import (see the follow-up above). Spec
+  `docs/superpowers/specs/2026-07-07-organize-imports-design.md`.
 
 ## Documentation backlog
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -224,11 +224,12 @@ Formats `.gsx` files to their canonical, idempotent form. The flag surface is
 faithful to `gofmt`:
 
 ```bash
-gsx fmt                 # print formatted "." to stdout
-gsx fmt -w ./web        # rewrite files in place
-gsx fmt -l              # list files whose formatting differs
-gsx fmt -d file.gsx     # show a unified diff of the changes
-gsx fmt -w -no-imports  # rewrite, but keep unused imports
+gsx fmt                     # print formatted "." to stdout
+gsx fmt -w ./web            # rewrite files in place
+gsx fmt -l                  # list files whose formatting differs
+gsx fmt -d file.gsx         # show a unified diff of the changes
+gsx fmt -w -imports gofmt   # rewrite; keep unused imports, don't reorder
+gsx fmt -w -no-imports      # same as above — -no-imports is an alias
 ```
 
 | Flag | Effect |
@@ -237,7 +238,8 @@ gsx fmt -w -no-imports  # rewrite, but keep unused imports
 | `-w` | rewrite each changed file in place |
 | `-l` | list the paths of files whose formatting differs |
 | `-d` | write a unified diff of the changes to stdout |
-| `-no-imports` | keep unused imports (skip the module analysis that finds them) |
+| `-imports goimports\|gofmt` | override `[formatter] imports` for this run |
+| `-no-imports` | alias for `-imports gofmt` |
 
 Path arguments are `.gsx` files or directories (walked recursively, skipping
 `.git`, hidden dirs, `vendor`, `node_modules`, and `testdata`). No arguments
@@ -256,12 +258,30 @@ the print width. Write it inline and it stays inline; write it multi-line and it
 stays multi-line. (A block-level child, e.g. a nested element, still forces the
 enclosing body to break regardless, so the document hierarchy stays visible.)
 
-**Unused imports.** Like `goimports`, `gsx fmt` **removes unused imports** from a
-`.gsx` file's pass-through Go by default — detected via the type-checker, so it
-runs a module analysis (`go list` + type-check). Pass `-no-imports` to format
-whitespace only and skip that analysis (faster, and works outside a resolvable
-module). The language server's format action drops unused imports too, so
-format-on-save in an editor keeps imports tidy.
+**Import handling.** `gsx fmt` has two import modes, mirroring gopls's own
+gofmt/goimports split:
+
+- **`goimports`** (default) — remove unused imports (detected via a module
+  analysis), then merge every import declaration into one block, dedup
+  identical specs, split the standard library from everything else, and sort
+  within each group.
+- **`gofmt`** — format only: sort within an existing group, but never remove,
+  merge, dedup, or regroup. Skips the module analysis entirely, so it's faster
+  and works outside a resolvable module.
+
+The mode resolves with **CLI flag > `gsx.toml` `[formatter] imports` > default
+`goimports`**, per directory — one `gsx fmt` invocation can span directories
+governed by different `gsx.toml` files. `-imports goimports` combined with
+`-no-imports` is a usage error (exit `2`), since they ask for opposite modes.
+
+`gsx` cannot **add** a missing import the way real `goimports` does: a gsx Go
+chunk's body never references the surrounding template's imports, so there's no
+symbol for the formatter to resolve to a package.
+
+The language server's `textDocument/formatting` honors the same
+`[formatter] imports` setting, so `gsx fmt` and format-on-save always agree —
+see [Organize imports on save](./editor.md#organize-imports-on-save) for the
+code action that always organizes regardless of the configured mode.
 
 **Embedded CSS & JS.** `gsx fmt` also formats the languages embedded in your
 markup — the CSS inside `<style>`, and (in a follow-up) the JavaScript inside

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -218,10 +218,18 @@ The default is `80`.
 declarations in a file's pass-through Go, mirroring the two modes gopls offers:
 
 - **`goimports`** (default) — remove unused imports, then merge every import
-  declaration into one block, dedup identical specs, split the standard library
-  from everything else with a blank line, and sort within each group.
+  declaration into one block, dedup identical specs, and sort within each group.
+  A block with no blank lines is split into a standard-library group and an
+  everything-else group.
 - **`gofmt`** — format only: sort within an existing parenthesized group, but
   never remove, merge, dedup, or regroup imports.
+
+`goimports` mode calls the real `goimports` formatter, so it inherits its
+grouping rule: **blank lines you wrote are group boundaries, and they are never
+merged away.** If you hand-split a block into groups, those groups survive — a
+standard-library import in one and another in a second stay separated, exactly
+as the `goimports` command leaves them. Delete the blank lines to get the plain
+std / everything-else split.
 
 Unlike real `goimports`, `gsx` cannot **add** a missing import: a gsx Go
 chunk's body never references the surrounding template's imports, so there is

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -206,6 +206,7 @@ command and editor format-on-save via the language server read it.
 ```toml
 [formatter]
 print_width = 100   # line width the formatter wraps at (default 80)
+imports = "goimports"   # "goimports" (default) or "gofmt"
 ```
 
 `print_width` is the column budget for a line. An opening tag whose attribute
@@ -213,9 +214,23 @@ list fits stays on one line; one that exceeds the width wraps with one
 attribute per line (and its children break onto their own indented lines).
 The default is `80`.
 
-The width is resolved **per directory** from the nearest `gsx.toml` (same
-[discovery walk](#location--discovery) as everything else), so files in
-different modules of a monorepo can format to different widths.
+`imports` selects how `gsx fmt` and the language server treat the import
+declarations in a file's pass-through Go, mirroring the two modes gopls offers:
+
+- **`goimports`** (default) — remove unused imports, then merge every import
+  declaration into one block, dedup identical specs, split the standard library
+  from everything else with a blank line, and sort within each group.
+- **`gofmt`** — format only: sort within an existing parenthesized group, but
+  never remove, merge, dedup, or regroup imports.
+
+Unlike real `goimports`, `gsx` cannot **add** a missing import: a gsx Go
+chunk's body never references the surrounding template's imports, so there is
+no symbol for the formatter to resolve to a package.
+
+Both `print_width` and `imports` are resolved **per directory** from the
+nearest `gsx.toml` (same [discovery walk](#location--discovery) as everything
+else), so files in different modules of a monorepo can format with different
+settings.
 
 Like `[dev]`, this table only affects formatting — it never changes generated
 output, so it does not participate in the incremental codegen cache.
@@ -337,9 +352,10 @@ filterPackages = ["example.com/myproject/templatefuncs"]
 [[urlAttrs]]
 name = "data-href"
 
-# Formatter line width for gsx fmt and editor formatting (default 80).
+# Formatter settings for gsx fmt and editor formatting.
 [formatter]
 print_width = 100
+imports = "goimports"
 
 # Asset minification level (per asset; "none" default, "full" for prod).
 [minify]

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -29,11 +29,30 @@ gsx lsp                 # blocks, reading LSP messages on stdin
 | **Go-to-definition** | `textDocument/definition` | jump from a Go symbol anywhere Go appears — `{ }` interpolations, attribute expressions, spreads, class/style parts and their `: cond` guards, `{ if … }` conditional-attribute conditions, value-form `if`/`switch` control expressions and arms, `for`/`if`/`switch` clauses, and `{{ }}` blocks — to its definition; from a `<Card/>` tag to its `component` declaration; and from a `.go` component reference back to the `.gsx` |
 | **Hover** | `textDocument/hover` | gopls-style type/signature for an identifier or expression in all the same positions as go-to-definition; a component tag shows its signature (answered from the AST even mid-edit when type-checking can't complete) |
 | **Find references** | `textDocument/references` | `.go` call sites and `.gsx` tag sites for project components discovered by module analysis; external/non-project packages are skipped |
-| **Formatting** | `textDocument/formatting` | canonical `gsx fmt` form, including unused-import removal — wire it to format-on-save |
+| **Formatting** | `textDocument/formatting` | canonical `gsx fmt` form, honoring the configured [`[formatter] imports`](./config.md#formatter--gsx-fmt--editor-formatting) mode — wire it to format-on-save |
+| **Organize imports** | `textDocument/codeAction` (`source.organizeImports`) | always removes unused imports and reorders, regardless of the configured mode — see [below](#organize-imports-on-save) |
 
 **Deferred:** completion. References cover project components discovered during
 module analysis; external/non-project references are deferred. See [Status](./status.md) and the
 [roadmap](https://github.com/gsxhq/gsx/blob/main/docs/ROADMAP.md) for current scope.
+
+### Organize imports on save
+
+The gsx language server offers the standard `source.organizeImports` code
+action. It always organizes — remove unused, merge, dedup, group, sort — even
+when [`[formatter] imports`](./config.md#formatter--gsx-fmt--editor-formatting)
+is `"gofmt"`, exactly like gopls, where formatting can be plain gofmt while the
+action still organizes.
+
+```json
+"[gsx]": {
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": { "source.organizeImports": "explicit" }
+}
+```
+
+Because gsx has no partial formatter, the action's edit spans the whole
+document: applying it also canonicalizes the rest of the file.
 
 ### Configure your editor
 

--- a/docs/superpowers/plans/2026-07-09-goimports-modes.md
+++ b/docs/superpowers/plans/2026-07-09-goimports-modes.md
@@ -88,7 +88,10 @@ Create `internal/gsxfmt/mode_test.go`:
 ```go
 package gsxfmt
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseImportsMode(t *testing.T) {
 	for _, tc := range []struct {
@@ -115,23 +118,10 @@ func TestParseImportsModeRejectsUnknown(t *testing.T) {
 		t.Fatal("want error for unknown mode")
 	}
 	for _, want := range []string{"gofumpt", "gofmt", "goimports"} {
-		if !contains(err.Error(), want) {
+		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q does not mention %q", err, want)
 		}
 	}
-}
-
-func contains(s, sub string) bool {
-	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
-}
-
-func indexOf(s, sub string) int {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
 }
 
 // TestImportsModeZeroIsUnset: the zero value must be ImportsUnset so an absent
@@ -459,7 +449,7 @@ func deleteChunkImports(src string, unused []ImportRef) (string, bool) {
 	file, err := goparser.ParseFile(fset, "", goChunkPkg+src, goparser.ParseComments)
 ```
 
-and further down replace `out = out[nl+1:]` block's comment reference to `"package _gsxp"` if it names the literal.
+Leave the rest of `deleteChunkImports` (including its `// Drop the synthetic "package _gsxp" line we prepended.` comment) exactly as-is. The only change is that the local `const pkg` is gone in favor of the shared `goChunkPkg`.
 
 Now append to `internal/gsxfmt/imports.go`:
 
@@ -1361,9 +1351,16 @@ import (
 	"testing"
 )
 
-// codeActions drives one textDocument/codeAction request over a server whose
-// buffer holds src, and returns the decoded result.
+// codeActions drives one textDocument/codeAction request against a server backed
+// by nilAnalyzer, and returns the decoded result.
 func codeActions(t *testing.T, uri, src string, only []string) []CodeAction {
+	t.Helper()
+	return codeActionsWith(t, uri, src, only, nilAnalyzer{})
+}
+
+// codeActionsWith is codeActions with an explicit Analyzer, so a test can vary
+// the reported [formatter] imports mode.
+func codeActionsWith(t *testing.T, uri, src string, only []string, a Analyzer) []CodeAction {
 	t.Helper()
 	in := framed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}})
 	in += framed(t, map[string]any{
@@ -1385,7 +1382,7 @@ func codeActions(t *testing.T, uri, src string, only []string) []CodeAction {
 	in += framed(t, map[string]any{"jsonrpc": "2.0", "method": "exit"})
 
 	var out bytes.Buffer
-	srv := NewServer(strings.NewReader(in), &out, nilAnalyzer{})
+	srv := NewServer(strings.NewReader(in), &out, a)
 	if err := srv.Run(); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -1511,23 +1508,17 @@ func TestInitializeAdvertisesOrganizeImports(t *testing.T) {
 }
 ```
 
-Add to the bottom of `internal/lsp/codeaction_test.go` the analyzer variant and the parameterized driver:
+Add to the bottom of `internal/lsp/codeaction_test.go` the analyzer variant used by `TestCodeActionOrganizeImportsIgnoresGofmtMode`:
 
 ```go
-// gofmtAnalyzer reports gofmt mode, to prove the code action ignores it.
+// gofmtAnalyzer reports gofmt mode, to prove the code action ignores it and
+// organizes anyway. It embeds nilAnalyzer for every other Analyzer method.
 type gofmtAnalyzer struct{ nilAnalyzer }
 
 func (gofmtAnalyzer) ImportsMode(string) gsxfmt.ImportsMode { return gsxfmt.ImportsGofmt }
-
-// codeActionsWith is codeActions with an explicit Analyzer.
-func codeActionsWith(t *testing.T, uri, src string, only []string, a Analyzer) []CodeAction {
-	t.Helper()
-	// (same body as codeActions, but passing `a` to NewServer)
-	...
-}
 ```
 
-**Implementer note:** rather than duplicating the body, refactor `codeActions` to delegate to `codeActionsWith(t, uri, src, only, nilAnalyzer{})` and put the single implementation in `codeActionsWith`. Import `"github.com/gsxhq/gsx/internal/gsxfmt"`.
+Import `"github.com/gsxhq/gsx/internal/gsxfmt"` in this file.
 
 - [ ] **Step 2: Run test to verify it fails**
 

--- a/docs/superpowers/plans/2026-07-09-goimports-modes.md
+++ b/docs/superpowers/plans/2026-07-09-goimports-modes.md
@@ -233,7 +233,10 @@ func (m ImportsMode) RemoveUnused() bool { return m == ImportsGoimports }
 // Only goimports does.
 func (m ImportsMode) Reorder() bool { return m == ImportsGoimports }
 
-// String returns the gsx.toml spelling; it round-trips through ParseImportsMode.
+// String returns the gsx.toml spelling for ImportsGofmt ("gofmt") and ImportsGoimports
+// ("goimports"), which round-trip through ParseImportsMode. ImportsUnset and any
+// out-of-range value stringify to "unset", a diagnostic spelling that ParseImportsMode
+// deliberately does not accept.
 func (m ImportsMode) String() string {
 	switch m {
 	case ImportsGofmt:

--- a/docs/superpowers/plans/2026-07-09-goimports-modes.md
+++ b/docs/superpowers/plans/2026-07-09-goimports-modes.md
@@ -1,0 +1,1853 @@
+# gofmt/goimports Import Modes + LSP `source.organizeImports` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `gsx fmt` and the gsx language server two gopls-style import modes — `gofmt` (format only) and `goimports` (remove unused + merge/dedup/group/sort) — configurable via `gsx.toml` and CLI, plus an LSP `source.organizeImports` code action.
+
+**Architecture:** Reuse the *real* upstream implementations, never a port. `gofmt` mode = the stdlib `go/format.Source` the printer already applies to every `GoChunk` (so it needs zero new formatting code — just skip the organize passes). `goimports` mode = the existing unused-removal pass plus a new `reorderImports` pass that calls `golang.org/x/tools/imports.Process` with `Options{FormatOnly: true}` on each `GoChunk` that declares imports. `FormatOnly` is mandatory: it merges/dedups/groups but skips goimports' usage-based add/remove, which would wrongly strip every import because a gsx chunk body never references the template's imports.
+
+**Tech Stack:** Go 1.26.1, `golang.org/x/tools v0.46.0` (already a module requirement — `imports.Process` adds no new dependency and only +1,811 bytes to `gsx.wasm`), stdlib `go/format`, `go/parser`.
+
+## Global Constraints
+
+- Pin Go to **1.26.1** (`GO_VERSION` in `.github/workflows/ci.yml`). A different minor re-introduces gofmt drift.
+- Work in the worktree `/Users/jackieli/personal/gsxhq/gsx/.claude/worktrees/gsx-goimports` on branch `worktree-gsx-goimports`. **Never commit to `main`.**
+- The runtime (root `gsx` package) is standard-library only. `internal/gsxfmt`, `gen`, and `internal/lsp` are tooling and may use `golang.org/x/tools`.
+- **No "simple heuristics."** The "does this chunk declare imports?" gate is decided by the parsed AST, never a substring match on the word `import` (which would hit the word inside a string or comment).
+- **Do not hand-edit generated files** (`.x.go`, `*.golden`).
+- The `gsx` binary name collides with Ghostscript on PATH — always `go run ./cmd/gsx …`.
+- Before merging: `make ci` (authoritative, uncached). Inner loop: `make check`. Also `make lint`.
+- **Behavior preservation:** `Format`, `FormatRemovingImports`, and `FormatRemovingImportsWith` must keep their exact current semantics (`Reorder: false`). `internal/gsxfmt/imports_test.go:TestNoUnusedIsPlainFormat` asserts `FormatRemovingImports(nil unused) == Format`; it must stay green untouched.
+- **Pre-existing gap — preserve, do not fix:** `internal/lsp/format.go` calls the *non-*`With` variant, so LSP formatting does not run the `<style>`/`<script>` css/js formatters that the CLI runs. When moving it to `FormatWith`, pass nil `CSSFmt`/`JSFmt` to preserve today's output byte-for-byte. Closing that gap is a separate change.
+
+## Design Vocabulary (locked — use these exact names)
+
+```go
+// internal/gsxfmt
+type ImportsMode int
+const (
+    ImportsUnset     ImportsMode = iota // zero value: not configured
+    ImportsGofmt
+    ImportsGoimports
+)
+func ParseImportsMode(s string) (ImportsMode, error)
+func (m ImportsMode) Or(def ImportsMode) ImportsMode
+func (m ImportsMode) RemoveUnused() bool  // true only for ImportsGoimports
+func (m ImportsMode) Reorder() bool       // true only for ImportsGoimports
+func (m ImportsMode) String() string
+
+type FormatOptions struct {
+    Unused  []ImportRef      // imports to remove; nil = remove nothing
+    Width   int
+    CSSFmt  rawfmt.Formatter // nil = printer default
+    JSFmt   rawfmt.Formatter // nil = printer default
+    Reorder bool             // run reorderImports (goimports mode)
+}
+func FormatWith(name string, src []byte, opts FormatOptions) ([]byte, error)
+```
+
+`ImportsMode` lives in `internal/gsxfmt` because it is the one package both `gen` and `internal/lsp` already import (`internal/lsp` cannot import `gen` — `gen` imports `internal/lsp`).
+
+`FormatOptions.Reorder` is a plain bool, not a mode: `gsxfmt` stays mechanical and mode-agnostic, and the zero `FormatOptions` is the safe (no-reorder) one. The mode vocabulary lives at the config/CLI/LSP layer, which maps `mode.Reorder()` → `opts.Reorder` and uses `mode.RemoveUnused()` to decide whether to compute `Unused` at all.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/gsxfmt/mode.go` (new) | `ImportsMode` type, parsing, predicates. The shared vocabulary. |
+| `internal/gsxfmt/imports.go` (modify) | Add `reorderImports` / `reorderChunkImports` / `chunkHasImports`; hoist the shared `goChunkPkg` const. |
+| `internal/gsxfmt/gsxfmt.go` (modify) | `FormatOptions` + `FormatWith`; existing three funcs become thin wrappers. |
+| `gen/configfile.go` (modify) | `tomlFormatter.Imports` key; parse/validate into `config.importsMode`; `mergeConfig` carry. |
+| `gen/main.go` (modify) | `config.importsMode` field + `effectiveImportsMode()`. |
+| `gen/fmt.go` (modify) | `-imports` / `-no-imports` flags; per-dir mode resolution; plumb into `FormatWith`. |
+| `internal/lsp/server.go` (modify) | `Analyzer.ImportsMode`; `textDocument/codeAction` dispatch; advertise capability. |
+| `internal/lsp/protocol.go` (modify) | `CodeActionOptions`, `codeActionParams`, `CodeAction`, `WorkspaceEdit`. |
+| `internal/lsp/format.go` (modify) | Formatting honors the configured mode. |
+| `internal/lsp/codeaction.go` (new) | `handleCodeAction` — always the goimports transform. |
+| `gen/lsp.go` (modify) | `lspAnalyzer.ImportsMode(dir)`. |
+| `docs/guide/{config,cli,editor}.md` (modify) | User-facing docs. |
+
+**Testing lives where formatter behavior is actually pinned:** `internal/gsxfmt/*_test.go` (unit) and `gen/fmt_test.go` (CLI E2E). **The txtar corpus is NOT the vehicle here** — `internal/corpus` pins parse/codegen/render and never runs the formatter, so a corpus case would not exercise reorder at all. This is a formatter change, not a syntax/codegen change.
+
+---
+
+### Task 1: `ImportsMode` vocabulary
+
+**Files:**
+- Create: `internal/gsxfmt/mode.go`
+- Test: `internal/gsxfmt/mode_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `gsxfmt.ImportsMode`, `ImportsUnset`, `ImportsGofmt`, `ImportsGoimports`, `ParseImportsMode(string) (ImportsMode, error)`, `(ImportsMode).Or(ImportsMode) ImportsMode`, `(ImportsMode).RemoveUnused() bool`, `(ImportsMode).Reorder() bool`, `(ImportsMode).String() string`. Every later task depends on these exact names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/gsxfmt/mode_test.go`:
+
+```go
+package gsxfmt
+
+import "testing"
+
+func TestParseImportsMode(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want ImportsMode
+	}{
+		{"gofmt", ImportsGofmt},
+		{"goimports", ImportsGoimports},
+	} {
+		got, err := ParseImportsMode(tc.in)
+		if err != nil {
+			t.Fatalf("ParseImportsMode(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseImportsMode(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseImportsModeRejectsUnknown: the error names both valid spellings.
+func TestParseImportsModeRejectsUnknown(t *testing.T) {
+	_, err := ParseImportsMode("gofumpt")
+	if err == nil {
+		t.Fatal("want error for unknown mode")
+	}
+	for _, want := range []string{"gofumpt", "gofmt", "goimports"} {
+		if !contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestImportsModeZeroIsUnset: the zero value must be ImportsUnset so an absent
+// config key is distinguishable from an explicit "gofmt".
+func TestImportsModeZeroIsUnset(t *testing.T) {
+	var m ImportsMode
+	if m != ImportsUnset {
+		t.Fatalf("zero ImportsMode = %v, want ImportsUnset", m)
+	}
+}
+
+// TestImportsModeOr: Or falls back to def only when unset.
+func TestImportsModeOr(t *testing.T) {
+	if got := ImportsUnset.Or(ImportsGoimports); got != ImportsGoimports {
+		t.Fatalf("Unset.Or(goimports) = %v", got)
+	}
+	if got := ImportsGofmt.Or(ImportsGoimports); got != ImportsGofmt {
+		t.Fatalf("Gofmt.Or(goimports) = %v, want Gofmt", got)
+	}
+}
+
+// TestImportsModePredicates: only goimports removes and reorders.
+func TestImportsModePredicates(t *testing.T) {
+	if !ImportsGoimports.RemoveUnused() || !ImportsGoimports.Reorder() {
+		t.Fatal("goimports must remove and reorder")
+	}
+	if ImportsGofmt.RemoveUnused() || ImportsGofmt.Reorder() {
+		t.Fatal("gofmt must neither remove nor reorder")
+	}
+	if ImportsUnset.RemoveUnused() || ImportsUnset.Reorder() {
+		t.Fatal("unset must neither remove nor reorder (callers must resolve via Or first)")
+	}
+}
+
+func TestImportsModeString(t *testing.T) {
+	if ImportsGofmt.String() != "gofmt" || ImportsGoimports.String() != "goimports" {
+		t.Fatal("String() spellings must round-trip ParseImportsMode")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jackieli/personal/gsxhq/gsx/.claude/worktrees/gsx-goimports && go test ./internal/gsxfmt/ -run TestImportsMode -v`
+Expected: FAIL — build error, `undefined: ImportsMode`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/gsxfmt/mode.go`:
+
+```go
+package gsxfmt
+
+import "fmt"
+
+// ImportsMode selects how `gsx fmt` and the language server treat the import
+// declarations of a .gsx file's pass-through Go chunks. It mirrors gopls, which
+// offers gofmt (format only) and goimports (organize), rather than a set of
+// independent knobs.
+//
+// The zero value is ImportsUnset so that an absent gsx.toml key is
+// distinguishable from an explicit "gofmt"; callers resolve it with Or.
+type ImportsMode int
+
+const (
+	// ImportsUnset means no mode was configured. Resolve it with Or before use;
+	// its predicates report false so an unresolved mode never silently rewrites.
+	ImportsUnset ImportsMode = iota
+	// ImportsGofmt formats with gofmt only: imports are sorted within their
+	// existing parenthesized group, but separate import declarations are never
+	// merged, duplicates are never dropped, and no std/third-party split is made.
+	ImportsGofmt
+	// ImportsGoimports removes unused imports and reorders the rest: merge every
+	// import declaration into one block, dedup identical specs, group standard
+	// library separately from everything else, sort within each group.
+	ImportsGoimports
+)
+
+// DefaultImportsMode is the mode used when gsx.toml says nothing.
+const DefaultImportsMode = ImportsGoimports
+
+// ParseImportsMode converts a gsx.toml / CLI spelling into an ImportsMode. Any
+// other string is an error naming both valid spellings.
+func ParseImportsMode(s string) (ImportsMode, error) {
+	switch s {
+	case "gofmt":
+		return ImportsGofmt, nil
+	case "goimports":
+		return ImportsGoimports, nil
+	default:
+		return ImportsUnset, fmt.Errorf("invalid imports mode %q (want %q or %q)", s, "gofmt", "goimports")
+	}
+}
+
+// Or returns m, or def when m is ImportsUnset. It is how a CLI flag layers over
+// a config value, and a config value over the built-in default.
+func (m ImportsMode) Or(def ImportsMode) ImportsMode {
+	if m == ImportsUnset {
+		return def
+	}
+	return m
+}
+
+// RemoveUnused reports whether this mode drops imports the file never uses.
+// Only goimports does; gofmt never removes an import.
+func (m ImportsMode) RemoveUnused() bool { return m == ImportsGoimports }
+
+// Reorder reports whether this mode merges, dedups, groups and sorts imports.
+// Only goimports does.
+func (m ImportsMode) Reorder() bool { return m == ImportsGoimports }
+
+// String returns the gsx.toml spelling; it round-trips through ParseImportsMode.
+func (m ImportsMode) String() string {
+	switch m {
+	case ImportsGofmt:
+		return "gofmt"
+	case ImportsGoimports:
+		return "goimports"
+	default:
+		return "unset"
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/gsxfmt/ -run 'TestImportsMode|TestParseImportsMode' -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gsxfmt/mode.go internal/gsxfmt/mode_test.go
+git commit -m "feat(gsxfmt): add ImportsMode vocabulary (gofmt|goimports)"
+```
+
+---
+
+### Task 2: `reorderImports` — the goimports pass
+
+**Files:**
+- Modify: `internal/gsxfmt/imports.go`
+- Test: `internal/gsxfmt/reorder_test.go` (new)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent).
+- Produces: unexported `reorderImports(f *gsxast.File)`, `reorderChunkImports(src string) (string, bool)`, `chunkHasImports(src string) bool`, and the package const `goChunkPkg = "package _gsxp\n"`. Task 3 calls `reorderImports`.
+
+**Background the implementer needs:**
+Imports are not AST nodes in gsx — they live verbatim inside `ast.GoChunk` spans. The parser (`parser/goexpr.go splitGoElements`) peels a leading run of `import` declarations, single-line **and** grouped, into one plain `GoChunk`. Imports therefore **never** appear in a `GoWithElements` decl, so a per-`GoChunk` walk misses nothing; skip every other decl type. A `GoChunk` is element-free, complete top-level Go, so parsing it (wrapped in a synthetic package clause) is safe — the sibling `deleteChunkImports` already does exactly this on every `gsx fmt`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/gsxfmt/reorder_test.go`:
+
+```go
+package gsxfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+// reorder formats src through the goimports path (reorder on, no removal).
+func reorder(t *testing.T, src string) string {
+	t.Helper()
+	out, err := FormatWith("x.gsx", []byte(src), FormatOptions{Width: 80, Reorder: true})
+	if err != nil {
+		t.Fatalf("FormatWith: %v", err)
+	}
+	return string(out)
+}
+
+// TestReorderMergesAndDedups: a single-line import plus a grouped one that
+// repeats it collapse into one block with the duplicate gone. This is the
+// motivating case: gofmt leaves both declarations and the duplicate alone.
+func TestReorderMergesAndDedups(t *testing.T) {
+	src := "package x\n\n" +
+		"import \"strings\"\n\n" +
+		"import (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	got := reorder(t, src)
+	if n := strings.Count(got, "import"); n != 1 {
+		t.Fatalf("want exactly 1 import keyword, got %d:\n%s", n, got)
+	}
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("duplicate strings import not deduped (%d occurrences):\n%s", n, got)
+	}
+	if !strings.Contains(got, "\"fmt\"") {
+		t.Fatalf("fmt import lost:\n%s", got)
+	}
+}
+
+// TestReorderGroupsStdAndThirdParty: std and non-std land in separate
+// blank-line-separated groups, goimports' default two-group split.
+func TestReorderGroupsStdAndThirdParty(t *testing.T) {
+	src := "package x\n\n" +
+		"import (\n\t\"github.com/gsxhq/gsx\"\n\t\"fmt\"\n)\n\n" +
+		"component C() {\n\t<p>hi</p>\n}\n"
+	got := reorder(t, src)
+	fmtAt := strings.Index(got, "\"fmt\"")
+	gsxAt := strings.Index(got, "\"github.com/gsxhq/gsx\"")
+	if fmtAt < 0 || gsxAt < 0 {
+		t.Fatalf("imports missing:\n%s", got)
+	}
+	if fmtAt > gsxAt {
+		t.Fatalf("std must sort before third-party:\n%s", got)
+	}
+	between := got[fmtAt:gsxAt]
+	if !strings.Contains(between, "\n\n") {
+		t.Fatalf("want blank line between std and third-party groups:\n%s", got)
+	}
+}
+
+// TestReorderIdempotent: reorder output is stable, including after the printer
+// re-gofmt's every chunk (gofmt sorts within a group but never regroups, so the
+// std/third-party split survives).
+func TestReorderIdempotent(t *testing.T) {
+	src := "package x\n\n" +
+		"import \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	once := reorder(t, src)
+	twice := reorder(t, once)
+	if once != twice {
+		t.Fatalf("reorder not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+}
+
+// TestReorderOffLeavesImportsAlone: with Reorder:false the duplicate and the two
+// separate declarations survive — that is gofmt mode.
+func TestReorderOffLeavesImportsAlone(t *testing.T) {
+	src := "package x\n\n" +
+		"import \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	out, err := FormatWith("x.gsx", []byte(src), FormatOptions{Width: 80, Reorder: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if n := strings.Count(got, "\"strings\""); n != 2 {
+		t.Fatalf("gofmt mode must keep the duplicate (got %d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 2 {
+		t.Fatalf("gofmt mode must keep both import declarations (got %d):\n%s", n, got)
+	}
+}
+
+// TestReorderPreservesBlankAndAliasedImports: `_` and aliased specs survive a
+// reorder (FormatOnly never drops a spec).
+func TestReorderPreservesBlankAndAliasedImports(t *testing.T) {
+	src := "package x\n\n" +
+		"import (\n\t_ \"embed\"\n\tsx \"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ sx.ToUpper(\"x\") }</p>\n}\n"
+	got := reorder(t, src)
+	if !strings.Contains(got, "_ \"embed\"") {
+		t.Fatalf("blank import lost:\n%s", got)
+	}
+	if !strings.Contains(got, "sx \"strings\"") {
+		t.Fatalf("aliased import lost:\n%s", got)
+	}
+}
+
+// TestReorderSamePathDifferentAliasBothKept: same path under two aliases is two
+// distinct imports; dedup must not collapse them.
+func TestReorderSamePathDifferentAliasBothKept(t *testing.T) {
+	src := "package x\n\n" +
+		"import (\n\tsx \"strings\"\n\tst \"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ sx.ToUpper(st.ToLower(\"x\")) }</p>\n}\n"
+	got := reorder(t, src)
+	if !strings.Contains(got, "sx \"strings\"") || !strings.Contains(got, "st \"strings\"") {
+		t.Fatalf("distinct aliases wrongly collapsed:\n%s", got)
+	}
+}
+
+// TestChunkHasImportsIgnoresWordInStringsAndComments: the gate is AST-based, so
+// the word "import" inside a string or comment must not trigger a reorder.
+func TestChunkHasImportsIgnoresWordInStringsAndComments(t *testing.T) {
+	if chunkHasImports("// import \"strings\"\nvar x = 1\n") {
+		t.Fatal("comment mentioning import must not count as an import decl")
+	}
+	if chunkHasImports("var s = \"import \\\"strings\\\"\"\n") {
+		t.Fatal("string containing import must not count as an import decl")
+	}
+	if !chunkHasImports("import \"strings\"\n") {
+		t.Fatal("a real import decl must be detected")
+	}
+}
+
+// TestReorderChunkImportsLeavesInvalidGoUntouched: a chunk that is not
+// standalone-valid Go is returned unchanged rather than mangled.
+func TestReorderChunkImportsLeavesInvalidGoUntouched(t *testing.T) {
+	const bad = "import \"strings\"\n\nfunc ( {\n"
+	got, changed := reorderChunkImports(bad)
+	if changed || got != bad {
+		t.Fatalf("invalid Go must be left untouched, got changed=%v:\n%s", changed, got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/gsxfmt/ -run 'TestReorder|TestChunkHasImports' -v`
+Expected: FAIL — build error, `undefined: FormatWith`, `undefined: chunkHasImports`, `undefined: reorderChunkImports`.
+
+(`FormatWith` arrives in Task 3. To keep Task 2 independently testable, implement `FormatWith` **minimally here** as part of Step 3 — Task 3 then only adds the wrappers and `FormatOptions` fields already used. See Step 3.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+First, in `internal/gsxfmt/imports.go`: hoist the synthetic package clause to a package-level const and reuse it in `deleteChunkImports`.
+
+Replace the body of `deleteChunkImports`'s first two lines:
+
+```go
+func deleteChunkImports(src string, unused []ImportRef) (string, bool) {
+	const pkg = "package _gsxp\n"
+	fset := token.NewFileSet()
+	file, err := goparser.ParseFile(fset, "", pkg+src, goparser.ParseComments)
+```
+
+with:
+
+```go
+func deleteChunkImports(src string, unused []ImportRef) (string, bool) {
+	fset := token.NewFileSet()
+	file, err := goparser.ParseFile(fset, "", goChunkPkg+src, goparser.ParseComments)
+```
+
+and further down replace `out = out[nl+1:]` block's comment reference to `"package _gsxp"` if it names the literal.
+
+Now append to `internal/gsxfmt/imports.go`:
+
+```go
+// goChunkPkg is the synthetic package clause prepended to a GoChunk so that the
+// chunk — which carries no package declaration of its own — parses as a
+// standalone Go file. It is stripped from every reprinted result.
+const goChunkPkg = "package _gsxp\n"
+
+// chunkHasImports reports whether src declares at least one import. The decision
+// is made on the parsed AST, never on a substring of the text: the word `import`
+// can appear inside a string literal or a comment. A chunk that is not
+// standalone-valid Go reports false, so it is left untouched downstream.
+//
+// goparser.ImportsOnly stops the parse after the import block, which is all this
+// gate needs and keeps the common (import-free) chunk cheap.
+func chunkHasImports(src string) bool {
+	fset := token.NewFileSet()
+	file, err := goparser.ParseFile(fset, "", goChunkPkg+src, goparser.ImportsOnly)
+	if err != nil {
+		return false
+	}
+	return len(file.Imports) > 0
+}
+
+// reorderChunkImports runs goimports' formatter over one Go chunk: it merges
+// every import declaration into a single block, drops duplicate specs, splits
+// standard-library from third-party imports with a blank line, and sorts each
+// group. Returns the rewritten chunk and whether anything changed.
+//
+// FormatOnly is essential. Without it goimports would also ADD and REMOVE
+// imports based on what the chunk body references — and a gsx chunk body never
+// references the template's imports, so plain goimports would strip every one of
+// them. Unused-import removal is a separate, module-analysis-driven pass
+// (removeImports); adding imports is impossible for gsx (a chunk body cannot
+// tell us which package a template's identifier came from).
+//
+// Comments/TabIndent/TabWidth make FormatOnly's output match gofmt's tabbed
+// chunk formatting; without them it emits spaces and the printer's own gofmt
+// would fight it.
+func reorderChunkImports(src string) (string, bool) {
+	if !chunkHasImports(src) {
+		return src, false
+	}
+	out, err := imports.Process("chunk.go", []byte(goChunkPkg+src), &imports.Options{
+		FormatOnly: true,
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+	})
+	if err != nil {
+		return src, false // not standalone-valid Go; leave it
+	}
+	s := string(out)
+	// Drop the synthetic package clause we prepended.
+	if nl := strings.IndexByte(s, '\n'); nl >= 0 {
+		s = s[nl+1:]
+	}
+	s = strings.TrimSpace(s)
+	if s == strings.TrimSpace(src) {
+		return src, false
+	}
+	return s, true
+}
+
+// reorderImports rewrites the imports of every GoChunk in f, in place, to
+// goimports' canonical form. Non-GoChunk decls are skipped: imports never live
+// in a GoWithElements region, because the parser peels a leading import run into
+// its own plain GoChunk before building the element region.
+//
+// Unlike removeImports this can never empty a chunk (FormatOnly deletes no
+// specs), so no decl is dropped here.
+func reorderImports(f *gsxast.File) {
+	for _, d := range f.Decls {
+		gc, ok := d.(*gsxast.GoChunk)
+		if !ok {
+			continue
+		}
+		if out, changed := reorderChunkImports(gc.Src); changed {
+			gc.Src = out
+		}
+	}
+}
+```
+
+Add `"golang.org/x/tools/imports"` to the import block of `internal/gsxfmt/imports.go`.
+
+Then, in `internal/gsxfmt/gsxfmt.go`, add `FormatOptions` and `FormatWith` (Task 3 will refactor the existing three funcs onto it; here we just add it so Task 2's tests compile):
+
+```go
+// FormatOptions carries the knobs of FormatWith. The zero value is the safe one:
+// no imports removed, no reorder, printer defaults for <style>/<script>.
+type FormatOptions struct {
+	// Unused lists imports to delete from the file's Go chunks; nil removes none.
+	Unused []ImportRef
+	// Width is the printer's target line width (0 → printer default).
+	Width int
+	// CSSFmt/JSFmt format <style>/<script> bodies; nil uses the printer default.
+	CSSFmt rawfmt.Formatter
+	JSFmt  rawfmt.Formatter
+	// Reorder runs the goimports pass (merge/dedup/group/sort). It is a plain
+	// bool, not an ImportsMode: gsxfmt stays mechanical, and callers map
+	// ImportsMode.Reorder() onto it.
+	Reorder bool
+}
+
+// FormatWith is the one formatting entry point: parse → remove unused imports →
+// (optionally) reorder imports → whitespace-normalize → print. A non-nil error is
+// a parse or print failure; callers formatting unsaved buffers should treat that
+// as "leave the buffer untouched".
+func FormatWith(name string, src []byte, opts FormatOptions) ([]byte, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, name, src, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Remove first, then reorder: an import that was both unused and duplicated is
+	// gone before the merge, so reorder only canonicalizes what survives.
+	removeImports(f, opts.Unused)
+	if opts.Reorder {
+		reorderImports(f)
+	}
+	wsnorm.Normalize(f)
+	var b bytes.Buffer
+	if opts.CSSFmt == nil && opts.JSFmt == nil {
+		if err := printer.Fprint(&b, f, opts.Width); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := printer.FprintWith(&b, f, opts.Width, opts.CSSFmt, opts.JSFmt); err != nil {
+			return nil, err
+		}
+	}
+	return b.Bytes(), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/gsxfmt/ -v`
+Expected: PASS — the new reorder tests **and** every pre-existing test (`TestRemoveIdempotent`, `TestNoUnusedIsPlainFormat`, …) still green.
+
+- [ ] **Step 5: Verify the wasm cost claim did not regress**
+
+Run:
+```bash
+GOOS=js GOARCH=wasm go build -o /tmp/w.wasm ./playground/wasm && wc -c < /tmp/w.wasm && rm -f /tmp/w.wasm
+```
+Expected: ~17.3 MB (baseline 17,290,466 bytes; the goimports link adds ≈1,811 bytes). A jump of megabytes means `imports.Process` pulled in the module resolver — investigate before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/gsxfmt/imports.go internal/gsxfmt/gsxfmt.go internal/gsxfmt/reorder_test.go
+git commit -m "feat(gsxfmt): reorderImports via goimports FormatOnly; add FormatWith"
+```
+
+---
+
+### Task 3: Fold the existing wrappers onto `FormatWith`
+
+**Files:**
+- Modify: `internal/gsxfmt/gsxfmt.go`
+
+**Interfaces:**
+- Consumes: `FormatWith`, `FormatOptions` (Task 2).
+- Produces: unchanged public signatures `Format`, `FormatRemovingImports`, `FormatRemovingImportsWith` — now thin delegates. No caller changes.
+
+**Why `Reorder: false` in all three:** these are the pre-existing entry points. `internal/gsxfmt/imports_test.go:TestNoUnusedIsPlainFormat` pins `FormatRemovingImports(nil) == Format`; reordering in either would break it and would silently change every existing caller's output. Only new callers opt into reorder.
+
+- [ ] **Step 1: Verify the guard test exists and passes today**
+
+Run: `go test ./internal/gsxfmt/ -run TestNoUnusedIsPlainFormat -v`
+Expected: PASS. This test is the contract Task 3 must not break. Do not modify it.
+
+- [ ] **Step 2: Rewrite the three wrappers**
+
+In `internal/gsxfmt/gsxfmt.go`, replace the bodies of `Format`, `FormatRemovingImports`, and `FormatRemovingImportsWith` with delegations (keep every doc comment, appending the noted sentence):
+
+```go
+// Format parses src (named for diagnostics), normalizes whitespace, and returns
+// the canonical gsx source. A non-nil error is a parse or print failure; callers
+// formatting unsaved buffers should treat that as "leave the buffer untouched"
+// rather than a hard failure. Imports are left exactly as written (gofmt mode).
+func Format(name string, src []byte, width int) ([]byte, error) {
+	return FormatWith(name, src, FormatOptions{Width: width})
+}
+
+// FormatRemovingImports formats src exactly like Format, but first removes every
+// import listed in `unused` from the file's pass-through Go chunks. With an empty
+// or nil `unused` it is identical to Format. A parse error is returned unchanged
+// (the caller decides whether to surface or ignore it). It never reorders.
+func FormatRemovingImports(name string, src []byte, unused []ImportRef, width int) ([]byte, error) {
+	return FormatWith(name, src, FormatOptions{Unused: unused, Width: width})
+}
+
+// FormatRemovingImportsWith is FormatRemovingImports with explicit CSS and JS
+// formatters for <style>/<script> bodies (nil → built-in default at width). It
+// never reorders.
+func FormatRemovingImportsWith(name string, src []byte, unused []ImportRef, width int, cssFmt, jsFmt rawfmt.Formatter) ([]byte, error) {
+	return FormatWith(name, src, FormatOptions{Unused: unused, Width: width, CSSFmt: cssFmt, JSFmt: jsFmt})
+}
+```
+
+Remove now-unused imports from `gsxfmt.go` (`bytes`, `go/token`, `printer`, `wsnorm`, `parser` are still used by `FormatWith`, which lives in this file — so nothing should become unused; run the build to confirm).
+
+- [ ] **Step 3: Run the full gsxfmt suite**
+
+Run: `go test ./internal/gsxfmt/ -count=1 -v`
+Expected: PASS, all tests, including `TestNoUnusedIsPlainFormat` and `TestFormatIdempotent`.
+
+- [ ] **Step 4: Run every downstream consumer**
+
+Run: `go test ./gen/... ./internal/lsp/... -count=1`
+Expected: PASS. No behavior changed for existing callers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gsxfmt/gsxfmt.go
+git commit -m "refactor(gsxfmt): Format/FormatRemovingImports* delegate to FormatWith"
+```
+
+---
+
+### Task 4: `gsx.toml` `[formatter] imports` key
+
+**Files:**
+- Modify: `gen/configfile.go` (`tomlFormatter` ~line 42; `loadConfig` ~line 197; `mergeConfig` ~line 264)
+- Modify: `gen/main.go` (`config` struct ~line 45; add `effectiveImportsMode` next to `effectivePrintWidth` ~line 54)
+- Test: `gen/configfile_test.go`
+
+**Interfaces:**
+- Consumes: `gsxfmt.ImportsMode`, `gsxfmt.ParseImportsMode`, `gsxfmt.DefaultImportsMode`, `(ImportsMode).Or` (Task 1).
+- Produces: `config.importsMode gsxfmt.ImportsMode` field and `func (c config) effectiveImportsMode() gsxfmt.ImportsMode`. Tasks 5 and 6 call `effectiveImportsMode()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `gen/configfile_test.go`:
+
+```go
+// TestConfigImportsMode: [formatter] imports selects the mode.
+func TestConfigImportsMode(t *testing.T) {
+	for _, tc := range []struct {
+		toml string
+		want gsxfmt.ImportsMode
+	}{
+		{"[formatter]\nimports = \"gofmt\"\n", gsxfmt.ImportsGofmt},
+		{"[formatter]\nimports = \"goimports\"\n", gsxfmt.ImportsGoimports},
+	} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "gsx.toml")
+		if err := os.WriteFile(path, []byte(tc.toml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := loadConfig(path)
+		if err != nil {
+			t.Fatalf("loadConfig: %v", err)
+		}
+		if got := cfg.effectiveImportsMode(); got != tc.want {
+			t.Fatalf("imports = %v, want %v", got, tc.want)
+		}
+	}
+}
+
+// TestConfigImportsModeDefault: absent key ⇒ goimports.
+func TestConfigImportsModeDefault(t *testing.T) {
+	var c config
+	if got := c.effectiveImportsMode(); got != gsxfmt.ImportsGoimports {
+		t.Fatalf("default imports mode = %v, want goimports", got)
+	}
+}
+
+// TestConfigImportsModeInvalid: an unknown spelling errors, naming the key and
+// both valid values.
+func TestConfigImportsModeInvalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gsx.toml")
+	if err := os.WriteFile(path, []byte("[formatter]\nimports = \"gofumpt\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadConfig(path)
+	if err == nil {
+		t.Fatal("want error for invalid imports mode")
+	}
+	for _, want := range []string{"formatter.imports", "gofmt", "goimports"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestConfigImportsModeUnknownKeyRejected: strict decoding still rejects typos
+// inside [formatter].
+func TestConfigImportsModeUnknownKeyRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gsx.toml")
+	if err := os.WriteFile(path, []byte("[formatter]\nimport = \"gofmt\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadConfig(path); err == nil || !strings.Contains(err.Error(), "import") {
+		t.Fatalf("loadConfig err = %v, want unknown-key error naming import", err)
+	}
+}
+```
+
+Ensure `gen/configfile_test.go` imports `"github.com/gsxhq/gsx/internal/gsxfmt"` and `"strings"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./gen/ -run TestConfigImports -v`
+Expected: FAIL — `cfg.effectiveImportsMode undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `gen/configfile.go`, extend `tomlFormatter`:
+
+```go
+// tomlFormatter is the [formatter] table: knobs for `gsx fmt` and LSP
+// formatting. Like [dev], it never changes generated output and is NOT folded
+// into computeKey. A nil pointer (table absent) leaves the defaults
+// (print_width 80, imports "goimports").
+type tomlFormatter struct {
+	PrintWidth int    `toml:"print_width"`
+	Imports    string `toml:"imports"` // "goimports" (default) | "gofmt"
+}
+```
+
+In `loadConfig`, replace the `if tc.Formatter != nil { … }` block (~line 197):
+
+```go
+	if tc.Formatter != nil {
+		cfg.printWidth = tc.Formatter.PrintWidth
+		if s := tc.Formatter.Imports; s != "" {
+			m, err := gsxfmt.ParseImportsMode(s)
+			if err != nil {
+				return config{}, fmt.Errorf("%s: formatter.imports: %w", path, err)
+			}
+			cfg.importsMode = m
+		}
+	}
+```
+
+Add `"github.com/gsxhq/gsx/internal/gsxfmt"` to `gen/configfile.go`'s imports.
+
+In `mergeConfig`, next to the `printWidth` merge (~line 264):
+
+```go
+	merged.importsMode = base.importsMode
+	if opts.importsMode != gsxfmt.ImportsUnset {
+		merged.importsMode = opts.importsMode
+	}
+```
+
+In `gen/main.go`, add the field to `config` (keep the aligned-comment style):
+
+```go
+	printWidth     int                     // gsx.toml [formatter] print_width; 0 means "unset" → 80 at use
+	importsMode    gsxfmt.ImportsMode      // gsx.toml [formatter] imports; Unset → goimports at use
+```
+
+and the accessor next to `effectivePrintWidth`:
+
+```go
+// effectiveImportsMode returns the configured import-handling mode, defaulting
+// to goimports (remove unused + reorder) when unset — matching gopls, where
+// organizing imports is the norm and plain gofmt is the opt-out.
+func (c config) effectiveImportsMode() gsxfmt.ImportsMode {
+	return c.importsMode.Or(gsxfmt.DefaultImportsMode)
+}
+```
+
+Add `"github.com/gsxhq/gsx/internal/gsxfmt"` to `gen/main.go`'s imports if absent.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./gen/ -run TestConfig -count=1 -v`
+Expected: PASS, including the pre-existing `TestConfigPrintWidth*` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gen/configfile.go gen/main.go gen/configfile_test.go
+git commit -m "feat(config): [formatter] imports = gofmt|goimports"
+```
+
+---
+
+### Task 5: `gsx fmt` CLI flags and per-directory mode
+
+**Files:**
+- Modify: `gen/fmt.go` (flags ~line 47-62; `unusedByPath` ~line 73-76; format loop ~line 80-126; add `importsModeFor` next to `printWidthFor` ~line 148)
+- Test: `gen/fmt_test.go`
+
+**Interfaces:**
+- Consumes: `gsxfmt.ImportsMode`, `ParseImportsMode`, `Or`, `RemoveUnused`, `Reorder` (Task 1); `gsxfmt.FormatWith`/`FormatOptions` (Task 2); `config.effectiveImportsMode()` (Task 4).
+- Produces: `importsModeFor(dir string) gsxfmt.ImportsMode`. No later task consumes it.
+
+**Why mode is resolved per directory:** `gsx.toml` is discovered by walking up from each file's directory, so two files in one `gsx fmt` run can resolve different modes. A CLI flag, when given, overrides every directory.
+
+**Why removal files are filtered:** `analyzeUnusedImports` opens a `codegen.Module` per module — expensive. Files whose directory resolves to `gofmt` need no unused analysis at all, so they must not be passed in.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `gen/fmt_test.go` (follow the existing helpers in that file for building a temp module — see `TestFmtRemovesUnusedImport` at line 234 for the exact `go.mod` + `replace` recipe):
+
+```go
+// TestFmtGoimportsMergesAndDedups: the default mode merges a single-line import
+// with a grouped one and drops the duplicate.
+func TestFmtGoimportsMergesAndDedups(t *testing.T) {
+	dir := newFmtModule(t)
+	src := "package u\n\nimport \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	p := filepath.Join(dir, "c.gsx")
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if code := runFmt(&out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+	}
+	got := readFile(t, p)
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("duplicate not deduped (%d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 1 {
+		t.Fatalf("declarations not merged (%d import keywords):\n%s", n, got)
+	}
+}
+
+// TestFmtImportsGofmtLeavesImportsAlone: -imports gofmt keeps the duplicate, the
+// two declarations, AND an unused import (gofmt never removes).
+func TestFmtImportsGofmtLeavesImportsAlone(t *testing.T) {
+	dir := newFmtModule(t)
+	src := "package u\n\nimport \"bytes\"\n\nimport (\n\t\"fmt\"\n\n\t\"bytes\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(1) }</p>\n}\n"
+	p := filepath.Join(dir, "c.gsx")
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if code := runFmt(&out, &errb, []string{"-w", "-imports", "gofmt", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+	}
+	got := readFile(t, p)
+	if n := strings.Count(got, "\"bytes\""); n != 2 {
+		t.Fatalf("gofmt mode must keep the unused duplicate (%d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 2 {
+		t.Fatalf("gofmt mode must keep both declarations (%d):\n%s", n, got)
+	}
+}
+
+// TestFmtNoImportsIsGofmtAlias: -no-imports behaves exactly like -imports gofmt.
+func TestFmtNoImportsIsGofmtAlias(t *testing.T) {
+	src := "package u\n\nimport \"bytes\"\n\nimport (\n\t\"fmt\"\n\n\t\"bytes\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(1) }</p>\n}\n"
+	run := func(args ...string) string {
+		dir := newFmtModule(t)
+		p := filepath.Join(dir, "c.gsx")
+		if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var out, errb bytes.Buffer
+		if code := runFmt(&out, &errb, append(args, p), nil, nil, codegen.Options{}, dir); code != 0 {
+			t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+		}
+		return readFile(t, p)
+	}
+	if a, b := run("-w", "-no-imports"), run("-w", "-imports", "gofmt"); a != b {
+		t.Fatalf("-no-imports != -imports gofmt:\n%s\n---\n%s", a, b)
+	}
+}
+
+// TestFmtImportsFlagConflict: -imports goimports with -no-imports is a usage
+// error (exit 2), not a silent winner.
+func TestFmtImportsFlagConflict(t *testing.T) {
+	dir := newFmtModule(t)
+	var out, errb bytes.Buffer
+	code := runFmt(&out, &errb, []string{"-imports", "goimports", "-no-imports", dir}, nil, nil, codegen.Options{}, dir)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2; stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "-no-imports") {
+		t.Fatalf("stderr must explain the conflict: %s", errb.String())
+	}
+}
+
+// TestFmtImportsFlagInvalid: an unknown -imports value is exit 2 naming both
+// valid spellings.
+func TestFmtImportsFlagInvalid(t *testing.T) {
+	dir := newFmtModule(t)
+	var out, errb bytes.Buffer
+	code := runFmt(&out, &errb, []string{"-imports", "gofumpt", dir}, nil, nil, codegen.Options{}, dir)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	for _, want := range []string{"gofmt", "goimports"} {
+		if !strings.Contains(errb.String(), want) {
+			t.Fatalf("stderr %q must name %q", errb.String(), want)
+		}
+	}
+}
+
+// TestFmtConfigGofmtModeHonored: [formatter] imports = "gofmt" in gsx.toml is
+// honored with no CLI flag.
+func TestFmtConfigGofmtModeHonored(t *testing.T) {
+	dir := newFmtModule(t)
+	if err := os.WriteFile(filepath.Join(dir, "gsx.toml"), []byte("[formatter]\nimports = \"gofmt\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := "package u\n\nimport \"bytes\"\n\ncomponent C() {\n\t<p>hi</p>\n}\n"
+	p := filepath.Join(dir, "c.gsx")
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if code := runFmt(&out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(readFile(t, p), "\"bytes\"") {
+		t.Fatal("gofmt mode from gsx.toml must keep the unused import")
+	}
+}
+```
+
+Add these helpers to `gen/fmt_test.go` **only if they do not already exist** (check first — `TestFmtRemovesUnusedImport` already builds a module inline; extract if convenient, otherwise add):
+
+```go
+// newFmtModule creates a temp dir containing a go.mod that replaces gsx with the
+// repo under test, ready for module-resolving fmt runs.
+func newFmtModule(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod := "module example.com/u\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => " + repoRoot + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(mod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func readFile(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./gen/ -run TestFmtImports -count=1 -v`
+Expected: FAIL — `flag provided but not defined: -imports`, exit 2 for the wrong reason / assertions fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `gen/fmt.go`, extend the flag block:
+
+```go
+	var (
+		write       bool
+		list        bool
+		diff        bool
+		noImports   bool
+		importsFlag string
+	)
+	fs.BoolVar(&write, "w", false, "write result to (source) file instead of stdout")
+	fs.BoolVar(&list, "l", false, "list files whose formatting differs")
+	fs.BoolVar(&diff, "d", false, "display diffs instead of rewriting files")
+	fs.StringVar(&importsFlag, "imports", "", `import handling: "goimports" (default; remove unused + merge/dedup/group) or "gofmt" (format only)`)
+	fs.BoolVar(&noImports, "no-imports", false, `alias for -imports gofmt`)
+```
+
+After `fs.Parse`, resolve the CLI-level mode (before `paths`/`files`):
+
+```go
+	// CLI mode: -imports wins; -no-imports is its "gofmt" alias. Asking for both
+	// goimports and no-imports is contradictory, so it is a usage error rather
+	// than a silent precedence rule.
+	var cliMode gsxfmt.ImportsMode
+	if importsFlag != "" {
+		m, err := gsxfmt.ParseImportsMode(importsFlag)
+		if err != nil {
+			fmt.Fprintf(stderr, "gsx: -imports: %v\n", err)
+			return 2
+		}
+		cliMode = m
+	}
+	if noImports {
+		if cliMode == gsxfmt.ImportsGoimports {
+			fmt.Fprintf(stderr, "gsx: -no-imports conflicts with -imports goimports\n")
+			return 2
+		}
+		cliMode = gsxfmt.ImportsGofmt
+	}
+```
+
+Replace the `unusedByPath` block:
+
+```go
+	// Mode is resolved per directory (gsx.toml is discovered by walking up from
+	// each file), with the CLI flag — when given — overriding every directory.
+	modeByDir := map[string]gsxfmt.ImportsMode{}
+	modeFor := func(path string) gsxfmt.ImportsMode {
+		dir := filepath.Dir(path)
+		m, ok := modeByDir[dir]
+		if !ok {
+			m = cliMode.Or(importsModeFor(dir))
+			modeByDir[dir] = m
+		}
+		return m
+	}
+
+	// Only files whose mode removes unused imports need the (expensive) module
+	// analysis; gofmt-mode files are excluded so no codegen.Module is opened for
+	// them.
+	var removalFiles []string
+	for _, p := range files {
+		if modeFor(p).RemoveUnused() {
+			removalFiles = append(removalFiles, p)
+		}
+	}
+	var unusedByPath map[string][]gsxfmt.ImportRef
+	if len(removalFiles) > 0 {
+		unusedByPath = analyzeUnusedImports(removalFiles, opts)
+	}
+```
+
+In the per-file loop, replace the `gsxfmt.FormatRemovingImportsWith(...)` call:
+
+```go
+		mode := modeFor(path)
+		formatted, err := gsxfmt.FormatWith(path, orig, gsxfmt.FormatOptions{
+			Unused:  unusedByPath[abs], // nil for gofmt-mode files
+			Width:   width,
+			CSSFmt:  cssFmt,
+			JSFmt:   jsFmt,
+			Reorder: mode.Reorder(),
+		})
+```
+
+Add `importsModeFor` next to `printWidthFor`:
+
+```go
+// importsModeFor returns the effective gsx.toml [formatter] imports mode for dir
+// (default goimports), best-effort: discovery/decoding failures fall back to the
+// default, exactly like printWidthFor.
+func importsModeFor(dir string) gsxfmt.ImportsMode {
+	path, ok := discoverConfig(dir)
+	if !ok {
+		return gsxfmt.DefaultImportsMode
+	}
+	cfg, err := loadConfig(path)
+	if err != nil {
+		return gsxfmt.DefaultImportsMode
+	}
+	return cfg.effectiveImportsMode()
+}
+```
+
+Update `runFmt`'s doc comment: document `-imports` and `-no-imports`, and note that the default (`goimports`) both removes unused imports and merges/dedups/groups them.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./gen/ -run TestFmt -count=1 -v`
+Expected: PASS — new tests plus the pre-existing `TestFmtRemovesUnusedImport`, `TestFmtNoImportsKeepsUnused`, `TestFmtOutsideModuleFallsBack`, `TestFmtWriteIdempotent`.
+
+Note: `TestFmtNoImportsKeepsUnused` must still pass — `-no-imports` still keeps unused imports, it just now also skips reorder.
+
+- [ ] **Step 5: Manually drive the real CLI on the motivating example**
+
+```bash
+tmp=$(mktemp -d)
+printf 'module example.com/u\n\ngo 1.26.1\n' > "$tmp/go.mod"
+printf 'package u\n\nimport "strings"\n\nimport (\n\t"fmt"\n\n\t"strings"\n)\n\ncomponent C() {\n\t<p>{ fmt.Sprint(strings.ToUpper("x")) }</p>\n}\n' > "$tmp/c.gsx"
+go run ./cmd/gsx fmt "$tmp/c.gsx"
+echo "--- with -imports gofmt ---"
+go run ./cmd/gsx fmt -imports gofmt "$tmp/c.gsx"
+rm -rf "$tmp"
+```
+Expected: the first prints ONE merged, deduped, std/third-party-grouped import block. The second prints the two original declarations with the duplicate intact.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gen/fmt.go gen/fmt_test.go
+git commit -m "feat(fmt): -imports gofmt|goimports flag, per-dir mode resolution"
+```
+
+---
+
+### Task 6: LSP formatting honors the configured mode
+
+**Files:**
+- Modify: `internal/lsp/server.go` (`Analyzer` interface, ~line 34)
+- Modify: `internal/lsp/format.go` (`handleFormatting`)
+- Modify: `gen/lsp.go` (`lspAnalyzer.PrintWidth` is at ~line 334; add `ImportsMode` beside it)
+- Modify (test stubs): `internal/lsp/documentsymbol_test.go`, `internal/lsp/references_cache_test.go`, `internal/lsp/server_async_test.go`, `internal/lsp/server_debounce_test.go`, `internal/lsp/server_lifecycle_test.go`, `internal/lsp/server_sync_test.go`, `internal/lsp/workspacesymbol_test.go`
+- Test: `gen/formatting_e2e_test.go`
+
+**Interfaces:**
+- Consumes: `gsxfmt.ImportsMode` + predicates (Task 1); `gsxfmt.FormatWith` (Task 2); `config.effectiveImportsMode()` (Task 4).
+- Produces: `Analyzer.ImportsMode(dir string) gsxfmt.ImportsMode`. Task 7's code action uses the same `Analyzer`, but deliberately ignores the mode.
+
+**Heads-up:** adding a method to the `Analyzer` interface breaks **seven** test analyzers. Each needs a one-line stub returning `gsxfmt.ImportsGoimports`. Find them all with:
+`grep -rln "PrintWidth" internal/lsp/*_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `gen/formatting_e2e_test.go` (mirror `TestFormattingRemovesUnusedImport` at line ~86 for the module + `formattingEdits` helper):
+
+```go
+// TestFormattingGoimportsModeMergesImports: with no gsx.toml (default
+// goimports), textDocument/formatting merges and dedups import declarations.
+func TestFormattingGoimportsModeMergesImports(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	must := func(p, c string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/u\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	src := "package u\n\nimport \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	must("c.gsx", src)
+	uri := "file://" + filepath.Join(dir, "c.gsx")
+
+	edits := formattingEdits(t, uri, src)
+	if len(edits) != 1 {
+		t.Fatalf("want 1 edit, got %d", len(edits))
+	}
+	if n := strings.Count(edits[0].NewText, "\"strings\""); n != 1 {
+		t.Fatalf("formatting did not dedup strings (%d):\n%s", n, edits[0].NewText)
+	}
+}
+
+// TestFormattingGofmtModeLeavesImportsAlone: [formatter] imports = "gofmt" makes
+// textDocument/formatting stop removing AND stop reordering imports.
+func TestFormattingGofmtModeLeavesImportsAlone(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	must := func(p, c string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/u\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	must("gsx.toml", "[formatter]\nimports = \"gofmt\"\n")
+	// An unused import: goimports mode would drop it, gofmt mode must not.
+	src := "package u\n\nimport \"strings\"\n\ncomponent C() {\n\t<p>hi</p>\n}\n"
+	must("c.gsx", src)
+	uri := "file://" + filepath.Join(dir, "c.gsx")
+
+	edits := formattingEdits(t, uri, src)
+	// Already canonical under gofmt mode ⇒ no edits at all.
+	if len(edits) != 0 {
+		t.Fatalf("gofmt mode must not touch imports, got edit:\n%s", edits[0].NewText)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./gen/ -run TestFormattingGo -count=1 -v`
+Expected: FAIL — `TestFormattingGofmtModeLeavesImportsAlone` gets an edit removing `"strings"` (mode ignored).
+
+- [ ] **Step 3: Add `ImportsMode` to the `Analyzer` interface**
+
+In `internal/lsp/server.go`, inside the `Analyzer` interface, after `PrintWidth`:
+
+```go
+	// PrintWidth returns the gsx.toml print width for the given directory
+	// (default 80). Used by textDocument/formatting.
+	PrintWidth(dir string) int
+	// ImportsMode returns the gsx.toml [formatter] imports mode for the given
+	// directory (default goimports). Used by textDocument/formatting; the
+	// source.organizeImports code action deliberately ignores it and always
+	// organizes.
+	ImportsMode(dir string) gsxfmt.ImportsMode
+```
+
+Add `"github.com/gsxhq/gsx/internal/gsxfmt"` to `internal/lsp/server.go`'s imports.
+
+- [ ] **Step 4: Implement it on the real analyzer**
+
+In `gen/lsp.go`, directly below `PrintWidth`:
+
+```go
+// ImportsMode resolves the effective gsx.toml [formatter] imports mode for dir,
+// layering the programmatic optCfg over the file config exactly like PrintWidth.
+// Best-effort: returns the default (goimports) on any failure.
+func (a lspAnalyzer) ImportsMode(dir string) gsxfmt.ImportsMode {
+	merged := resolveConfigBestEffort(dir, a.optCfg, a.warnw)
+	return merged.effectiveImportsMode()
+}
+```
+
+- [ ] **Step 5: Add the stub to all seven test analyzers**
+
+For each file listed under **Files**, add one method next to its `PrintWidth`. Example for `internal/lsp/server_lifecycle_test.go`:
+
+```go
+func (nilAnalyzer) PrintWidth(string) int                     { return 80 }
+func (nilAnalyzer) ImportsMode(string) gsxfmt.ImportsMode     { return gsxfmt.ImportsGoimports }
+```
+
+Repeat with the correct receiver type for `symbolFileAnalyzer`, `blockingAnalyzer`, `moduleRefsAnalyzer`, `countingAnalyzer`, and whichever types `server_sync_test.go` / `workspacesymbol_test.go` declare. Add the `gsxfmt` import to each file.
+
+Run `go build ./... && go vet ./internal/lsp/` to find any you missed.
+
+- [ ] **Step 6: Make `handleFormatting` honor the mode**
+
+In `internal/lsp/format.go`, replace the body from `path := uriToPath(uri)` through the `formatted, err := …` call:
+
+```go
+	path := uriToPath(uri)
+	dir := filepath.Dir(path)
+	mode := s.analyzer.ImportsMode(dir)
+
+	// Only goimports mode removes unused imports; gofmt mode leaves them.
+	var unused []gsxfmt.ImportRef
+	if mode.RemoveUnused() {
+		if pkg := s.pkgs[dir]; pkg != nil {
+			unused = pkg.UnusedImports[path] // nil when analysis is unavailable/unreliable
+		}
+	}
+	width := s.analyzer.PrintWidth(dir)
+	// CSSFmt/JSFmt stay nil: LSP formatting has never run the <style>/<script>
+	// formatters that the CLI runs. Preserving that here keeps output identical;
+	// closing the gap is a separate change.
+	formatted, err := gsxfmt.FormatWith(path, []byte(text), gsxfmt.FormatOptions{
+		Unused:  unused,
+		Width:   width,
+		Reorder: mode.Reorder(),
+	})
+```
+
+Also update `handleFormatting`'s doc comment to say it honors `[formatter] imports`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `go test ./internal/lsp/ ./gen/ -run 'TestFormatting|TestServer' -count=1 -v`
+Expected: PASS, including both new tests and the pre-existing `TestFormattingRemovesUnusedImport`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/lsp/server.go internal/lsp/format.go gen/lsp.go internal/lsp/*_test.go gen/formatting_e2e_test.go
+git commit -m "feat(lsp): textDocument/formatting honors [formatter] imports mode"
+```
+
+---
+
+### Task 7: LSP `source.organizeImports` code action
+
+**Files:**
+- Modify: `internal/lsp/protocol.go` (`serverCapabilities` ~line 51; add new types)
+- Modify: `internal/lsp/server.go` (`handle` dispatch ~line 204; `handleInitialize` capabilities ~line 228)
+- Create: `internal/lsp/codeaction.go`
+- Test: `internal/lsp/codeaction_test.go` (new); `gen/formatting_e2e_test.go` (capability assertion)
+
+**Interfaces:**
+- Consumes: `gsxfmt.FormatWith`/`FormatOptions` (Task 2); `s.docs.text(uri)`, `s.pkgs[dir]`, `s.analyzer.PrintWidth(dir)`, `endPosition(text, s.enc)` (existing, see `internal/lsp/format.go`).
+- Produces: `handleCodeAction(f frame) error`, `CodeAction`, `WorkspaceEdit`, `CodeActionOptions`.
+
+**Semantics (do not "improve" these):**
+- The action **always** applies the goimports transform — remove unused **and** reorder — **regardless** of `[formatter] imports`. `source.organizeImports` *means* goimports, exactly as in gopls, where formatting can be plain gofmt while the action still organizes. Gating it on the mode would make it a no-op in gofmt mode, defeating its purpose.
+- The edit is a **whole-document** `TextEdit`. gsx has no partial/region formatter; its canonical form comes from a whole-document parse → print. This is a deliberate, documented deviation from gopls's import-region-only edits.
+- Return an **empty list** when the organized document equals the buffer (no no-op edits on save), when the buffer fails to parse (mid-edit), when the file is not `.gsx`, or when `context.only` excludes the kind.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/lsp/codeaction_test.go`:
+
+```go
+package lsp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// codeActions drives one textDocument/codeAction request over a server whose
+// buffer holds src, and returns the decoded result.
+func codeActions(t *testing.T, uri, src string, only []string) []CodeAction {
+	t.Helper()
+	in := framed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}})
+	in += framed(t, map[string]any{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "languageId": "gsx", "version": 1, "text": src}},
+	})
+	ctx := map[string]any{"diagnostics": []any{}}
+	if only != nil {
+		ctx["only"] = only
+	}
+	in += framed(t, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/codeAction",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"range":        map[string]any{"start": map[string]any{"line": 0, "character": 0}, "end": map[string]any{"line": 0, "character": 0}},
+			"context":      ctx,
+		},
+	})
+	in += framed(t, map[string]any{"jsonrpc": "2.0", "method": "exit"})
+
+	var out bytes.Buffer
+	srv := NewServer(strings.NewReader(in), &out, nilAnalyzer{})
+	if err := srv.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, m := range readFrames(t, out.String()) {
+		raw, ok := m["result"]
+		if !ok {
+			continue
+		}
+		var actions []CodeAction
+		if err := json.Unmarshal(raw, &actions); err == nil && len(actions) > 0 {
+			return actions
+		}
+		// An empty result array decodes to len 0; distinguish it from the
+		// initialize result (an object, which fails to unmarshal into a slice).
+		if string(raw) == "[]" {
+			return nil
+		}
+	}
+	return nil
+}
+
+const dupImportSrc = "package x\n\nimport \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+	"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+
+// TestCodeActionOrganizeImports: the action is offered and its edit merges and
+// dedups the imports.
+func TestCodeActionOrganizeImports(t *testing.T) {
+	actions := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, []string{"source.organizeImports"})
+	if len(actions) != 1 {
+		t.Fatalf("want 1 action, got %d", len(actions))
+	}
+	a := actions[0]
+	if a.Kind != "source.organizeImports" {
+		t.Fatalf("kind = %q", a.Kind)
+	}
+	if a.Edit == nil || len(a.Edit.Changes["file:///tmp/c.gsx"]) != 1 {
+		t.Fatalf("want one whole-document edit, got %+v", a.Edit)
+	}
+	got := a.Edit.Changes["file:///tmp/c.gsx"][0].NewText
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("duplicate not deduped (%d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 1 {
+		t.Fatalf("declarations not merged (%d):\n%s", n, got)
+	}
+}
+
+// TestCodeActionOrganizeImportsIgnoresGofmtMode: the action organizes even when
+// the configured formatter mode is gofmt — organizing is its entire purpose.
+func TestCodeActionOrganizeImportsIgnoresGofmtMode(t *testing.T) {
+	// gofmtAnalyzer reports ImportsMode = gofmt; the action must ignore it.
+	actions := codeActionsWith(t, "file:///tmp/c.gsx", dupImportSrc, []string{"source.organizeImports"}, gofmtAnalyzer{})
+	if len(actions) != 1 {
+		t.Fatalf("action must be offered under gofmt mode, got %d", len(actions))
+	}
+	got := actions[0].Edit.Changes["file:///tmp/c.gsx"][0].NewText
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("action must organize under gofmt mode (%d):\n%s", n, got)
+	}
+}
+
+// TestCodeActionNoOpWhenAlreadyOrganized: an already-canonical document yields
+// no action, so codeActionsOnSave is a no-op.
+func TestCodeActionNoOpWhenAlreadyOrganized(t *testing.T) {
+	src := "package x\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	if got := codeActions(t, "file:///tmp/c.gsx", src, []string{"source.organizeImports"}); len(got) != 0 {
+		t.Fatalf("want no action for canonical doc, got %+v", got)
+	}
+}
+
+// TestCodeActionSkipsNonGsx: gopls owns .go files.
+func TestCodeActionSkipsNonGsx(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.go", dupImportSrc, []string{"source.organizeImports"}); len(got) != 0 {
+		t.Fatalf("want no action for .go, got %+v", got)
+	}
+}
+
+// TestCodeActionHonorsOnlyFilter: a request restricted to quickfix gets nothing.
+func TestCodeActionHonorsOnlyFilter(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, []string{"quickfix"}); len(got) != 0 {
+		t.Fatalf("want no action when only=[quickfix], got %+v", got)
+	}
+}
+
+// TestCodeActionOnlySourcePrefixMatches: "source" is a prefix of
+// "source.organizeImports" in LSP's kind hierarchy, so it must match.
+func TestCodeActionOnlySourcePrefixMatches(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, []string{"source"}); len(got) != 1 {
+		t.Fatalf("only=[source] must match, got %d", len(got))
+	}
+}
+
+// TestCodeActionEmptyOnlyOffersAction: an unrestricted request offers it.
+func TestCodeActionEmptyOnlyOffersAction(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, nil); len(got) != 1 {
+		t.Fatalf("unrestricted request must offer the action, got %d", len(got))
+	}
+}
+
+// TestCodeActionParseErrorYieldsNothing: a mid-edit buffer never gets a
+// destructive whole-file edit.
+func TestCodeActionParseErrorYieldsNothing(t *testing.T) {
+	bad := "package x\n\ncomponent C() {\n\t<p>unclosed\n"
+	if got := codeActions(t, "file:///tmp/c.gsx", bad, []string{"source.organizeImports"}); len(got) != 0 {
+		t.Fatalf("want no action for unparseable buffer, got %+v", got)
+	}
+}
+
+// TestInitializeAdvertisesOrganizeImports: the capability names the kind so the
+// client can wire editor.codeActionsOnSave.
+func TestInitializeAdvertisesOrganizeImports(t *testing.T) {
+	in := framed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}})
+	in += framed(t, map[string]any{"jsonrpc": "2.0", "method": "exit"})
+	var out bytes.Buffer
+	srv := NewServer(strings.NewReader(in), &out, nilAnalyzer{})
+	if err := srv.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"source.organizeImports"`) {
+		t.Fatalf("initialize did not advertise source.organizeImports:\n%s", out.String())
+	}
+}
+```
+
+Add to the bottom of `internal/lsp/codeaction_test.go` the analyzer variant and the parameterized driver:
+
+```go
+// gofmtAnalyzer reports gofmt mode, to prove the code action ignores it.
+type gofmtAnalyzer struct{ nilAnalyzer }
+
+func (gofmtAnalyzer) ImportsMode(string) gsxfmt.ImportsMode { return gsxfmt.ImportsGofmt }
+
+// codeActionsWith is codeActions with an explicit Analyzer.
+func codeActionsWith(t *testing.T, uri, src string, only []string, a Analyzer) []CodeAction {
+	t.Helper()
+	// (same body as codeActions, but passing `a` to NewServer)
+	...
+}
+```
+
+**Implementer note:** rather than duplicating the body, refactor `codeActions` to delegate to `codeActionsWith(t, uri, src, only, nilAnalyzer{})` and put the single implementation in `codeActionsWith`. Import `"github.com/gsxhq/gsx/internal/gsxfmt"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/lsp/ -run TestCodeAction -count=1 -v`
+Expected: FAIL — build error, `undefined: CodeAction`.
+
+- [ ] **Step 3: Add the protocol types**
+
+In `internal/lsp/protocol.go`, extend `serverCapabilities` and add the new types:
+
+```go
+type serverCapabilities struct {
+	PositionEncoding           string             `json:"positionEncoding"`
+	TextDocumentSync           int                `json:"textDocumentSync"`
+	DefinitionProvider         bool               `json:"definitionProvider"`
+	ReferencesProvider         bool               `json:"referencesProvider"`
+	DocumentFormattingProvider bool               `json:"documentFormattingProvider"`
+	HoverProvider              bool               `json:"hoverProvider"`
+	DocumentSymbolProvider     bool               `json:"documentSymbolProvider"`
+	WorkspaceSymbolProvider    bool               `json:"workspaceSymbolProvider"`
+	CodeActionProvider         *CodeActionOptions `json:"codeActionProvider,omitempty"`
+}
+
+// CodeActionOptions advertises which code-action kinds the server produces. It
+// is a struct rather than a bare `true` so clients know they can wire
+// editor.codeActionsOnSave to source.organizeImports.
+type CodeActionOptions struct {
+	CodeActionKinds []string `json:"codeActionKinds"`
+}
+
+// organizeImportsKind is the LSP kind for the organize-imports source action.
+const organizeImportsKind = "source.organizeImports"
+
+type codeActionContext struct {
+	// Only restricts the kinds the client wants. Empty means "any".
+	Only []string `json:"only"`
+}
+
+type codeActionParams struct {
+	TextDocument textDocumentIdentifier `json:"textDocument"`
+	Range        Range                  `json:"range"`
+	Context      codeActionContext      `json:"context"`
+}
+
+// WorkspaceEdit maps a document URI to the edits to apply to it.
+type WorkspaceEdit struct {
+	Changes map[string][]TextEdit `json:"changes"`
+}
+
+// CodeAction is one entry of the textDocument/codeAction result. Edit is carried
+// inline, so the server advertises no resolveProvider.
+type CodeAction struct {
+	Title string         `json:"title"`
+	Kind  string         `json:"kind"`
+	Edit  *WorkspaceEdit `json:"edit,omitempty"`
+}
+```
+
+- [ ] **Step 4: Dispatch and advertise**
+
+In `internal/lsp/server.go` `handle`, after the `textDocument/formatting` case:
+
+```go
+	case "textDocument/codeAction":
+		return s.handleCodeAction(f)
+```
+
+In `handleInitialize`, add to the `serverCapabilities` literal:
+
+```go
+		WorkspaceSymbolProvider:    true,
+		CodeActionProvider:         &CodeActionOptions{CodeActionKinds: []string{organizeImportsKind}},
+```
+
+- [ ] **Step 5: Write `handleCodeAction`**
+
+Create `internal/lsp/codeaction.go`:
+
+```go
+package lsp
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/gsxhq/gsx/internal/gsxfmt"
+)
+
+// handleCodeAction answers textDocument/codeAction for a .gsx document. The only
+// action offered is source.organizeImports.
+//
+// The action ALWAYS applies the goimports transform — remove unused imports and
+// reorder (merge/dedup/group/sort) — regardless of the configured
+// [formatter] imports mode. That is the point of the action, and it mirrors
+// gopls: textDocument/formatting may be plain gofmt while source.organizeImports
+// still organizes. This is what lets a project set imports = "gofmt" for
+// format-on-save and wire editor.codeActionsOnSave to organize separately.
+//
+// The edit is a single whole-document TextEdit: gsx has no partial formatter, so
+// its canonical form is produced by a whole-document parse → print. Applying the
+// action therefore also canonicalizes the rest of the document — a deliberate
+// deviation from gopls's import-region-only edits.
+//
+// An empty result (no action) is returned when the document is not .gsx, when
+// context.only excludes the kind, when the buffer does not parse (mid-edit), or
+// when the organized document already equals the buffer — so an on-save action
+// is a true no-op rather than a redundant edit.
+func (s *Server) handleCodeAction(f frame) error {
+	var p codeActionParams
+	if err := json.Unmarshal(f.Params, &p); err != nil {
+		return s.reply(f.ID, []CodeAction{})
+	}
+	uri := p.TextDocument.URI
+	path := uriToPath(uri)
+	if !strings.HasSuffix(path, ".gsx") {
+		return s.reply(f.ID, []CodeAction{}) // gopls owns .go
+	}
+	if !wantsKind(p.Context.Only, organizeImportsKind) {
+		return s.reply(f.ID, []CodeAction{})
+	}
+	text, ok := s.docs.text(uri)
+	if !ok {
+		return s.reply(f.ID, []CodeAction{})
+	}
+	dir := filepath.Dir(path)
+	var unused []gsxfmt.ImportRef
+	if pkg := s.pkgs[dir]; pkg != nil {
+		unused = pkg.UnusedImports[path] // nil when analysis is unavailable
+	}
+	organized, err := gsxfmt.FormatWith(path, []byte(text), gsxfmt.FormatOptions{
+		Unused:  unused,
+		Width:   s.analyzer.PrintWidth(dir),
+		Reorder: true, // always: this action IS goimports
+	})
+	if err != nil || string(organized) == text {
+		return s.reply(f.ID, []CodeAction{}) // unparseable mid-edit, or already organized
+	}
+	edit := TextEdit{
+		Range:   Range{Start: Position{Line: 0, Character: 0}, End: endPosition(text, s.enc)},
+		NewText: string(organized),
+	}
+	return s.reply(f.ID, []CodeAction{{
+		Title: "Organize Imports",
+		Kind:  organizeImportsKind,
+		Edit:  &WorkspaceEdit{Changes: map[string][]TextEdit{uri: {edit}}},
+	}})
+}
+
+// wantsKind reports whether a client asking for the kinds in `only` wants `kind`.
+// An empty `only` means "any kind". LSP kinds are dot-separated hierarchies, so a
+// requested "source" matches "source.organizeImports".
+func wantsKind(only []string, kind string) bool {
+	if len(only) == 0 {
+		return true
+	}
+	for _, k := range only {
+		if k == kind || strings.HasPrefix(kind, k+".") {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/lsp/ -run 'TestCodeAction|TestInitialize' -count=1 -v`
+Expected: PASS (9 tests).
+
+- [ ] **Step 7: Run the whole LSP + gen suites**
+
+Run: `go test ./internal/lsp/ ./gen/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/lsp/protocol.go internal/lsp/server.go internal/lsp/codeaction.go internal/lsp/codeaction_test.go
+git commit -m "feat(lsp): source.organizeImports code action (always goimports)"
+```
+
+---
+
+### Task 8: Documentation
+
+**Files:**
+- Modify: `docs/guide/config.md` (the `[formatter]` section — it already documents `print_width`)
+- Modify: `docs/guide/cli.md` (the `gsx fmt` section — it already documents `-no-imports`)
+- Modify: `docs/guide/editor.md` (add `codeActionsOnSave` usage)
+- Modify: `docs/ROADMAP.md` (tick off / record the shipped feature)
+
+**Interfaces:**
+- Consumes: the final user-facing surface from Tasks 4, 5, 7.
+- Produces: nothing consumed by code.
+
+**Constraint:** literal `{{ }}` in `docs/guide/**` prose must be wrapped in a `::: v-pre` block — VitePress parses `{{ }}` as a Vue interpolation and the build fails otherwise. None of the content below contains `{{ }}`, but check any example you add.
+
+- [ ] **Step 1: Read the existing sections you are extending**
+
+Run:
+```bash
+grep -n "print_width" -B 5 -A 10 docs/guide/config.md
+grep -n "no-imports" -B 10 -A 10 docs/guide/cli.md
+```
+Match the surrounding heading depth, table style, and voice. Do not restructure the pages.
+
+- [ ] **Step 2: Document the config key**
+
+In `docs/guide/config.md`, in the `[formatter]` table/section, add `imports` alongside `print_width`:
+
+```toml
+[formatter]
+print_width = 80
+# How `gsx fmt` and the language server treat imports.
+#   "goimports" (default) — remove unused imports, then merge every import
+#                           declaration into one block, drop duplicates, split
+#                           standard library from third-party, sort each group.
+#   "gofmt"               — format only: sort within an existing group, never
+#                           remove, merge, dedup, or regroup.
+imports = "goimports"
+```
+
+Explain the gopls parallel in prose: these are the same two behaviors gopls offers, and `gsx` cannot *add* missing imports (a gsx Go chunk never references the template's imports, so there is no symbol to resolve to a package).
+
+- [ ] **Step 3: Document the CLI flags**
+
+In `docs/guide/cli.md`, under `gsx fmt`, document:
+
+- `-imports goimports|gofmt` — override `[formatter] imports` for this run.
+- `-no-imports` — alias for `-imports gofmt`.
+
+State the resolution order explicitly: `-imports` / `-no-imports` → `gsx.toml` `[formatter] imports` → default `goimports`. Note that `-imports goimports` together with `-no-imports` is a usage error.
+
+Update any existing sentence claiming `-no-imports` merely "skips module analysis" — it now selects gofmt mode, which also skips reordering.
+
+- [ ] **Step 4: Document the editor code action**
+
+In `docs/guide/editor.md`, add a short section:
+
+````markdown
+### Organize imports on save
+
+The gsx language server offers the standard `source.organizeImports` code
+action. It always organizes — remove unused, merge, dedup, group, sort — even
+when `[formatter] imports = "gofmt"`, exactly like gopls, where formatting can
+be plain gofmt while the action still organizes.
+
+```json
+"[gsx]": {
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": { "source.organizeImports": "explicit" }
+}
+```
+
+Because gsx has no partial formatter, the action's edit spans the whole
+document: applying it also canonicalizes the rest of the file.
+````
+
+- [ ] **Step 5: Update the roadmap**
+
+In `docs/ROADMAP.md`, record that gofmt/goimports import modes and the LSP `source.organizeImports` action shipped. Remove any entry this supersedes.
+
+- [ ] **Step 6: Verify the docs build is not broken**
+
+Run: `grep -rn "{{" docs/guide/config.md docs/guide/cli.md docs/guide/editor.md | grep -v "v-pre"`
+Expected: no output (or only pre-existing lines already inside a `::: v-pre` block).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/guide/config.md docs/guide/cli.md docs/guide/editor.md docs/ROADMAP.md
+git commit -m "docs: [formatter] imports mode, gsx fmt -imports, organize-imports action"
+```
+
+---
+
+### Task 9: Full verification and sibling check
+
+**Files:** none modified (unless a check fails).
+
+- [ ] **Step 1: Run the authoritative CI-equivalent suite**
+
+Run: `make ci`
+Expected: PASS. This is uncached (`-count=1`) and mirrors `.github/workflows/ci.yml` — build/vet/test both modules, examples drift, `gofmt` + `gsx fmt`.
+
+**If `gsx fmt` drift is reported on the repo's own `.gsx` files:** that is a *real finding*, not a nuisance — the new default (goimports) now reorders imports in checked-in `.gsx` files. Inspect the diff. If it is correct organization, commit the reformatted files as their own commit (`chore: reformat .gsx imports under goimports mode`). Do not suppress it by changing the default.
+
+- [ ] **Step 2: Run the linter**
+
+Run: `make lint`
+Expected: PASS (golangci-lint: SA\*, QF\*, modernize).
+
+- [ ] **Step 3: Confirm no syntax change reached the siblings**
+
+This feature changes no gsx syntax, so `../tree-sitter-gsx`, `../vscode-gsx`, and `../gsxhq.github.io` need **no grammar work**. Verify by reasoning, not by editing: no token, no AST node, and no `.gsx` grammar production was added — only formatter behavior, a TOML key, a CLI flag, and an LSP method.
+
+One optional sibling follow-up (do **not** do it in this branch): `vscode-gsx` may want to ship a default `editor.codeActionsOnSave` for `.gsx`. Note it for a separate PR.
+
+- [ ] **Step 4: Verify the motivating example end-to-end one final time**
+
+Run the Task 5 Step 5 shell snippet again. Expected: `gsx fmt` merges + dedups + groups; `gsx fmt -imports gofmt` leaves the duplicate and both declarations.
+
+- [ ] **Step 5: Request an independent adversarial review**
+
+Per `CLAUDE.md`, a subsystem gets **one independent adversarial reviewer** before merge — one that *builds throwaway probe programs*, not just reads the diff. Probes worth writing:
+- A `.gsx` file whose `GoChunk` contains the word `import` inside a string and a comment, plus no real import → assert `reorderImports` leaves it byte-identical.
+- A `.gsx` file with element literals (`GoWithElements`) plus a leading import block → assert reorder touches only the import chunk and the element region round-trips unchanged.
+- A file where an import is *both* unused and duplicated → assert remove-then-reorder converges and is idempotent.
+- A `gsx.toml` with `imports = "gofmt"` next to one without → assert a single `gsx fmt` run over both directories applies different modes per directory.
+- Assert `gsx fmt` twice is a fixed point on every `.gsx` file in `examples/`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** every spec section maps to a task — modes vocabulary (T1), reorder pass + `FormatOnly` rationale + per-`GoChunk` walk + parse-error fallback (T2), `FormatWith`/wrappers (T3), `[formatter] imports` config (T4), `-imports`/`-no-imports` CLI + precedence + conflict error (T5), LSP formatting honoring mode + `ImportsMode` on the `Analyzer` interface at its **corrected** location (T6), `source.organizeImports` always-goimports whole-document action + capability + `only` filter + no-op suppression (T7), docs (T8), `make ci`/`make lint`/adversarial review (T9).
+
+**Spec deviation, deliberate:** the spec's "Testing" section calls for txtar **corpus cases**. Verified against the tree: `internal/corpus` pins parse → codegen → render and **never runs the formatter**, so a corpus case cannot exercise reorder. Formatter behavior is pinned in `internal/gsxfmt/*_test.go` and `gen/fmt_test.go`, and that is where this plan puts it. The CLAUDE.md rule "every syntax/codegen change ships a corpus case" does not bind here: this changes neither syntax nor codegen.
+
+**Type consistency:** `ImportsMode`, `ImportsUnset`, `ImportsGofmt`, `ImportsGoimports`, `DefaultImportsMode`, `ParseImportsMode`, `Or`, `RemoveUnused`, `Reorder`, `String`, `FormatOptions{Unused,Width,CSSFmt,JSFmt,Reorder}`, `FormatWith`, `reorderImports`, `reorderChunkImports`, `chunkHasImports`, `goChunkPkg`, `importsModeFor`, `effectiveImportsMode`, `Analyzer.ImportsMode`, `handleCodeAction`, `wantsKind`, `organizeImportsKind`, `CodeActionOptions`, `CodeAction`, `WorkspaceEdit`, `codeActionParams`, `codeActionContext` — each defined exactly once and used with the same spelling and signature throughout.
+
+**Ordering dependency:** Task 2 introduces `FormatWith` (needed by its own tests) and Task 3 folds the legacy wrappers onto it. Task 2 must land before Task 3; Tasks 4–7 all depend on Tasks 1–3. Task 6 must land before Task 7 (the code action's test analyzer embeds `nilAnalyzer`, which only satisfies `Analyzer` once Task 6 adds `ImportsMode` to every stub).

--- a/docs/superpowers/plans/2026-07-09-goimports-modes.md
+++ b/docs/superpowers/plans/2026-07-09-goimports-modes.md
@@ -18,7 +18,7 @@
 - The `gsx` binary name collides with Ghostscript on PATH — always `go run ./cmd/gsx …`.
 - Before merging: `make ci` (authoritative, uncached). Inner loop: `make check`. Also `make lint`.
 - **Behavior preservation:** `Format`, `FormatRemovingImports`, and `FormatRemovingImportsWith` must keep their exact current semantics (`Reorder: false`). `internal/gsxfmt/imports_test.go:TestNoUnusedIsPlainFormat` asserts `FormatRemovingImports(nil unused) == Format`; it must stay green untouched.
-- **Pre-existing gap — preserve, do not fix:** `internal/lsp/format.go` calls the *non-*`With` variant, so LSP formatting does not run the `<style>`/`<script>` css/js formatters that the CLI runs. When moving it to `FormatWith`, pass nil `CSSFmt`/`JSFmt` to preserve today's output byte-for-byte. Closing that gap is a separate change.
+- **Pre-existing gap — preserve, do not fix:** `internal/lsp/format.go` calls the *non-*`With` variant, passing no css/js formatters. Careful: nil does **not** mean "no `<style>`/`<script>` formatting" — `printer.Fprint` delegates to `FprintWith(…, defaultCSSFormatter(width), defaultJSFormatter(width))`, so nil selects the printer's built-in defaults, and LSP output matches the CLI for the stock binary. The real gap is that `runFmt` threads a project's **custom** configured formatters (`cfg.cssFmt`/`cfg.jsFmt`) while the LSP always passes nil. When moving to `FormatWith`, pass nil `CSSFmt`/`JSFmt` to preserve today's output byte-for-byte. Wiring custom formatters through the LSP is a separate change.
 
 ## Design Vocabulary (locked — use these exact names)
 

--- a/docs/superpowers/specs/2026-07-07-organize-imports-design.md
+++ b/docs/superpowers/specs/2026-07-07-organize-imports-design.md
@@ -242,13 +242,16 @@ imports; the organize behavior then comes exclusively from the code action
 below. This is precisely the gopls split: `textDocument/formatting` = gofmt,
 import organizing = a separate action.
 
-**Pre-existing gap, preserve don't fix:** `handleFormatting` today calls
-`FormatRemovingImports` — the *non*-`With` variant — so LSP formatting does not
-run the `<style>`/`<script>` css/js formatters that the CLI runs. Moving it to
-`FormatWith` makes that gap explicit (`CSSFmt`/`JSFmt` become visible nil
-fields). Keep current behavior: pass nil formatters, preserving today's LSP
-output byte-for-byte. Closing the gap is a separate change with its own tests —
-do not fold it into this effort.
+**Pre-existing gap, preserve don't fix:** `handleFormatting` calls the *non*-`With`
+variant, so it passes no css/js formatters. Note what nil actually means here:
+`printer.Fprint` delegates to `FprintWith(…, defaultCSSFormatter(width),
+defaultJSFormatter(width))`, so nil selects the printer's **built-in default**
+`<style>`/`<script>` formatters — *not* "no formatting". LSP and CLI therefore
+produce identical output for the stock binary. The real, narrower gap is that
+`runFmt` threads a project's **custom** configured formatters (`cfg.cssFmt` /
+`cfg.jsFmt`, from `gen.WithCSSFormatter`/`WithJSFormatter`) while the LSP always
+passes nil. Keep that behavior: pass nil, preserving today's LSP output
+byte-for-byte. Wiring custom formatters through the LSP is a separate change.
 
 ### LSP `source.organizeImports` code action — `internal/lsp/codeaction.go` (new)
 

--- a/gen/configfile.go
+++ b/gen/configfile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gsxhq/gsx/internal/attrclass"
 	"github.com/gsxhq/gsx/internal/codegen"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // configFileName is the project config filename gsx discovers (TOML).
@@ -38,9 +39,10 @@ type tomlConfig struct {
 // tomlFormatter is the [formatter] table: knobs for `gsx fmt` and LSP
 // formatting. Like [dev], it never changes generated output and is NOT folded
 // into computeKey. A nil pointer (table absent) leaves the defaults
-// (print_width 80).
+// (print_width 80, imports "goimports").
 type tomlFormatter struct {
-	PrintWidth int `toml:"print_width"`
+	PrintWidth int    `toml:"print_width"`
+	Imports    string `toml:"imports"` // "goimports" (default) | "gofmt"
 }
 
 // tomlDev is the [dev] table read ONLY by `gsx dev` (runDev) — it is NOT part of
@@ -196,6 +198,13 @@ func loadConfig(path string) (config, error) {
 	}
 	if tc.Formatter != nil {
 		cfg.printWidth = tc.Formatter.PrintWidth
+		if s := tc.Formatter.Imports; s != "" {
+			m, err := gsxfmt.ParseImportsMode(s)
+			if err != nil {
+				return config{}, fmt.Errorf("%s: formatter.imports: %w", path, err)
+			}
+			cfg.importsMode = m
+		}
 	}
 	return cfg, nil
 }
@@ -264,6 +273,11 @@ func mergeConfig(base, opts config) config {
 	merged.printWidth = base.printWidth
 	if opts.printWidth > 0 {
 		merged.printWidth = opts.printWidth
+	}
+
+	merged.importsMode = base.importsMode
+	if opts.importsMode != gsxfmt.ImportsUnset {
+		merged.importsMode = opts.importsMode
 	}
 
 	// MinifyLevel fields use minifyLevelSet as the sentinel so opts.MinifyNone

--- a/gen/configfile_test.go
+++ b/gen/configfile_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gsxhq/gsx/internal/codegen"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // mkfile writes content to path, creating parent dirs.
@@ -378,5 +379,69 @@ func TestLoadConfigClassMergerBadValue(t *testing.T) {
 	mkfile(t, path, `class_merger = "noDotHere"`)
 	if _, err := loadConfig(path); err == nil {
 		t.Fatalf("want error for unqualified ref")
+	}
+}
+
+// TestConfigImportsMode: [formatter] imports selects the mode.
+func TestConfigImportsMode(t *testing.T) {
+	for _, tc := range []struct {
+		toml string
+		want gsxfmt.ImportsMode
+	}{
+		{"[formatter]\nimports = \"gofmt\"\n", gsxfmt.ImportsGofmt},
+		{"[formatter]\nimports = \"goimports\"\n", gsxfmt.ImportsGoimports},
+	} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "gsx.toml")
+		if err := os.WriteFile(path, []byte(tc.toml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := loadConfig(path)
+		if err != nil {
+			t.Fatalf("loadConfig: %v", err)
+		}
+		if got := cfg.effectiveImportsMode(); got != tc.want {
+			t.Fatalf("imports = %v, want %v", got, tc.want)
+		}
+	}
+}
+
+// TestConfigImportsModeDefault: absent key ⇒ goimports.
+func TestConfigImportsModeDefault(t *testing.T) {
+	var c config
+	if got := c.effectiveImportsMode(); got != gsxfmt.ImportsGoimports {
+		t.Fatalf("default imports mode = %v, want goimports", got)
+	}
+}
+
+// TestConfigImportsModeInvalid: an unknown spelling errors, naming the key and
+// both valid values.
+func TestConfigImportsModeInvalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gsx.toml")
+	if err := os.WriteFile(path, []byte("[formatter]\nimports = \"gofumpt\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadConfig(path)
+	if err == nil {
+		t.Fatal("want error for invalid imports mode")
+	}
+	for _, want := range []string{"formatter.imports", "gofmt", "goimports"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestConfigImportsModeUnknownKeyRejected: strict decoding still rejects typos
+// inside [formatter].
+func TestConfigImportsModeUnknownKeyRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gsx.toml")
+	if err := os.WriteFile(path, []byte("[formatter]\nimport = \"gofmt\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadConfig(path); err == nil || !strings.Contains(err.Error(), "import") {
+		t.Fatalf("loadConfig err = %v, want unknown-key error naming import", err)
 	}
 }

--- a/gen/fmt.go
+++ b/gen/fmt.go
@@ -25,6 +25,18 @@ import (
 //	-w         rewrite each file in place (only when its content changed)
 //	-l         list the paths of files whose formatting differs
 //	-d         write a unified diff of the changes to stdout
+//	-imports   import handling: "goimports" (default) or "gofmt"
+//	-no-imports  alias for -imports gofmt
+//
+// Import handling has two modes, resolved per directory (a CLI flag, when
+// given, overrides every directory's gsx.toml):
+//
+//	goimports (default)  remove unused imports; merge every import declaration
+//	                      into one block, dedup identical specs, group the
+//	                      standard library separately from everything else,
+//	                      and sort within each group
+//	gofmt                 format only: imports are never removed, merged,
+//	                      deduped, or grouped
 //
 // Path args are .gsx FILES or DIRECTORIES; directories are walked recursively
 // for .gsx files, skipping the same junk dirs as discovery (.git, hidden dirs,
@@ -34,6 +46,8 @@ import (
 //
 //	0  success: all files parsed, and for default/-w no errors occurred
 //	1  a parse error on any file, OR (with -l or -d) any file differs
+//	2  a usage error: an unparseable flag, an invalid -imports value, or
+//	   -imports goimports combined with -no-imports
 //
 // The -l/-d non-zero-on-difference choice is deliberately CI-friendly: it lets
 // a build fail when sources are not canonically formatted (like `gofmt -l` used
@@ -46,20 +60,42 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 	fs := flag.NewFlagSet("gsx fmt", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
-		write     bool
-		list      bool
-		diff      bool
-		noImports bool
+		write       bool
+		list        bool
+		diff        bool
+		noImports   bool
+		importsFlag string
 	)
 	fs.BoolVar(&write, "w", false, "write result to (source) file instead of stdout")
 	fs.BoolVar(&list, "l", false, "list files whose formatting differs")
 	fs.BoolVar(&diff, "d", false, "display diffs instead of rewriting files")
-	fs.BoolVar(&noImports, "no-imports", false, "do not remove unused imports (skip module analysis)")
+	fs.StringVar(&importsFlag, "imports", "", `import handling: "goimports" (default; remove unused + merge/dedup/group) or "gofmt" (format only)`)
+	fs.BoolVar(&noImports, "no-imports", false, `alias for -imports gofmt`)
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
 		}
 		return 2
+	}
+
+	// CLI mode: -imports wins; -no-imports is its "gofmt" alias. Asking for both
+	// goimports and no-imports is contradictory, so it is a usage error rather
+	// than a silent precedence rule.
+	var cliMode gsxfmt.ImportsMode
+	if importsFlag != "" {
+		m, err := gsxfmt.ParseImportsMode(importsFlag)
+		if err != nil {
+			fmt.Fprintf(stderr, "gsx: -imports: %v\n", err)
+			return 2
+		}
+		cliMode = m
+	}
+	if noImports {
+		if cliMode == gsxfmt.ImportsGoimports {
+			fmt.Fprintf(stderr, "gsx: -no-imports conflicts with -imports goimports\n")
+			return 2
+		}
+		cliMode = gsxfmt.ImportsGofmt
 	}
 
 	// Anchor relative path arguments (and the default ".") at workDir so fmt never
@@ -71,10 +107,32 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 		return 2
 	}
 
+	// Mode is resolved per directory (gsx.toml is discovered by walking up from
+	// each file), with the CLI flag — when given — overriding every directory.
+	modeByDir := map[string]gsxfmt.ImportsMode{}
+	modeFor := func(path string) gsxfmt.ImportsMode {
+		dir := filepath.Dir(path)
+		m, ok := modeByDir[dir]
+		if !ok {
+			m = cliMode.Or(importsModeFor(dir))
+			modeByDir[dir] = m
+		}
+		return m
+	}
+
+	// Only files whose mode removes unused imports need the (expensive) module
+	// analysis; gofmt-mode files are excluded so no codegen.Module is opened for
+	// them.
+	var removalFiles []string
+	for _, p := range files {
+		if modeFor(p).RemoveUnused() {
+			removalFiles = append(removalFiles, p)
+		}
+	}
 	var unusedByPath map[string][]gsxfmt.ImportRef
 	var goDiags map[string][]diag.Diagnostic
-	if !noImports {
-		unusedByPath, goDiags = analyzeUnusedImports(files, opts)
+	if len(removalFiles) > 0 {
+		unusedByPath, goDiags = analyzeUnusedImports(removalFiles, opts)
 	}
 
 	exit := 0
@@ -98,7 +156,14 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 			width = printWidthFor(dir)
 			widthByDir[dir] = width
 		}
-		formatted, err := gsxfmt.FormatRemovingImportsWith(path, orig, unusedByPath[abs], width, cssFmt, jsFmt)
+		mode := modeFor(path)
+		formatted, err := gsxfmt.FormatWith(path, orig, gsxfmt.FormatOptions{
+			Unused:  unusedByPath[abs], // nil for gofmt-mode files
+			Width:   width,
+			CSSFmt:  cssFmt,
+			JSFmt:   jsFmt,
+			Reorder: mode.Reorder(),
+		})
 		if err != nil {
 			fmt.Fprintf(stderr, "%s: %v\n", path, err)
 			exit = 1
@@ -162,6 +227,21 @@ func printWidthFor(dir string) int {
 		return 80
 	}
 	return cfg.effectivePrintWidth()
+}
+
+// importsModeFor returns the effective gsx.toml [formatter] imports mode for dir
+// (default goimports), best-effort: discovery/decoding failures fall back to the
+// default, exactly like printWidthFor.
+func importsModeFor(dir string) gsxfmt.ImportsMode {
+	path, ok := discoverConfig(dir)
+	if !ok {
+		return gsxfmt.DefaultImportsMode
+	}
+	cfg, err := loadConfig(path)
+	if err != nil {
+		return gsxfmt.DefaultImportsMode
+	}
+	return cfg.effectiveImportsMode()
 }
 
 // analyzeUnusedImports computes, per absolute .gsx path, the imports the file

--- a/gen/fmt_test.go
+++ b/gen/fmt_test.go
@@ -383,3 +383,155 @@ func TestFmtToleratesMalformedConfig(t *testing.T) {
 		t.Fatalf("exit=%d stderr=%s", code, errb)
 	}
 }
+
+// newFmtModule creates a temp dir containing a go.mod that replaces gsx with the
+// repo under test, ready for module-resolving fmt runs.
+func newFmtModule(t *testing.T) string {
+	t.Helper()
+	return newModule(t, "example.com/u")
+}
+
+func readFile(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// TestFmtGoimportsMergesAndDedups: the default mode merges a single-line import
+// with a grouped one and drops the duplicate.
+func TestFmtGoimportsMergesAndDedups(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newFmtModule(t)
+	src := "package u\n\nimport \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	p := filepath.Join(dir, "c.gsx")
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if code := runFmt(&out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+	}
+	got := readFile(t, p)
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("duplicate not deduped (%d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 1 {
+		t.Fatalf("declarations not merged (%d import keywords):\n%s", n, got)
+	}
+}
+
+// TestFmtImportsGofmtLeavesImportsAlone: -imports gofmt keeps the duplicate, the
+// two declarations, AND an unused import (gofmt never removes).
+func TestFmtImportsGofmtLeavesImportsAlone(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newFmtModule(t)
+	src := "package u\n\nimport \"bytes\"\n\nimport (\n\t\"fmt\"\n\n\t\"bytes\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(1) }</p>\n}\n"
+	p := filepath.Join(dir, "c.gsx")
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if code := runFmt(&out, &errb, []string{"-w", "-imports", "gofmt", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+	}
+	got := readFile(t, p)
+	if n := strings.Count(got, "\"bytes\""); n != 2 {
+		t.Fatalf("gofmt mode must keep the unused duplicate (%d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 2 {
+		t.Fatalf("gofmt mode must keep both declarations (%d):\n%s", n, got)
+	}
+}
+
+// TestFmtNoImportsIsGofmtAlias: -no-imports behaves exactly like -imports gofmt.
+func TestFmtNoImportsIsGofmtAlias(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	src := "package u\n\nimport \"bytes\"\n\nimport (\n\t\"fmt\"\n\n\t\"bytes\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(1) }</p>\n}\n"
+	run := func(args ...string) string {
+		dir := newFmtModule(t)
+		p := filepath.Join(dir, "c.gsx")
+		if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var out, errb bytes.Buffer
+		if code := runFmt(&out, &errb, append(args, p), nil, nil, codegen.Options{}, dir); code != 0 {
+			t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+		}
+		return readFile(t, p)
+	}
+	if a, b := run("-w", "-no-imports"), run("-w", "-imports", "gofmt"); a != b {
+		t.Fatalf("-no-imports != -imports gofmt:\n%s\n---\n%s", a, b)
+	}
+}
+
+// TestFmtImportsFlagConflict: -imports goimports with -no-imports is a usage
+// error (exit 2), not a silent winner.
+func TestFmtImportsFlagConflict(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	var out, errb bytes.Buffer
+	code := runFmt(&out, &errb, []string{"-imports", "goimports", "-no-imports", dir}, nil, nil, codegen.Options{}, dir)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2; stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "-no-imports") {
+		t.Fatalf("stderr must explain the conflict: %s", errb.String())
+	}
+}
+
+// TestFmtImportsFlagInvalid: an unknown -imports value is exit 2 naming both
+// valid spellings.
+func TestFmtImportsFlagInvalid(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	var out, errb bytes.Buffer
+	code := runFmt(&out, &errb, []string{"-imports", "gofumpt", dir}, nil, nil, codegen.Options{}, dir)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	for _, want := range []string{"gofmt", "goimports"} {
+		if !strings.Contains(errb.String(), want) {
+			t.Fatalf("stderr %q must name %q", errb.String(), want)
+		}
+	}
+}
+
+// TestFmtConfigGofmtModeHonored: [formatter] imports = "gofmt" in gsx.toml is
+// honored with no CLI flag.
+func TestFmtConfigGofmtModeHonored(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newFmtModule(t)
+	if err := os.WriteFile(filepath.Join(dir, "gsx.toml"), []byte("[formatter]\nimports = \"gofmt\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := "package u\n\nimport \"bytes\"\n\ncomponent C() {\n\t<p>hi</p>\n}\n"
+	p := filepath.Join(dir, "c.gsx")
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if code := runFmt(&out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(readFile(t, p), "\"bytes\"") {
+		t.Fatal("gofmt mode from gsx.toml must keep the unused import")
+	}
+}

--- a/gen/formatting_e2e_test.go
+++ b/gen/formatting_e2e_test.go
@@ -111,6 +111,65 @@ func TestFormattingRemovesUnusedImport(t *testing.T) {
 	}
 }
 
+// TestFormattingGoimportsModeMergesImports: with no gsx.toml (default
+// goimports), textDocument/formatting merges and dedups import declarations.
+func TestFormattingGoimportsModeMergesImports(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	must := func(p, c string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/u\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	src := "package u\n\nimport \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	must("c.gsx", src)
+	uri := "file://" + filepath.Join(dir, "c.gsx")
+
+	edits := formattingEdits(t, uri, src)
+	if len(edits) != 1 {
+		t.Fatalf("want 1 edit, got %d", len(edits))
+	}
+	if n := strings.Count(edits[0].NewText, "\"strings\""); n != 1 {
+		t.Fatalf("formatting did not dedup strings (%d):\n%s", n, edits[0].NewText)
+	}
+}
+
+// TestFormattingGofmtModeLeavesImportsAlone: [formatter] imports = "gofmt" makes
+// textDocument/formatting stop removing AND stop reordering imports.
+func TestFormattingGofmtModeLeavesImportsAlone(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	must := func(p, c string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/u\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	must("gsx.toml", "[formatter]\nimports = \"gofmt\"\n")
+	// An unused import: goimports mode would drop it, gofmt mode must not.
+	src := "package u\n\nimport \"strings\"\n\ncomponent C() {\n\t<p>hi</p>\n}\n"
+	must("c.gsx", src)
+	uri := "file://" + filepath.Join(dir, "c.gsx")
+
+	edits := formattingEdits(t, uri, src)
+	// Already canonical under gofmt mode ⇒ no edits at all.
+	if len(edits) != 0 {
+		t.Fatalf("gofmt mode must not touch imports, got edit:\n%s", edits[0].NewText)
+	}
+}
+
 // formattingEdits opens uri with the given text and returns the edits from a
 // textDocument/formatting request (id 2).
 func formattingEdits(t *testing.T, uri, text string) []lsp.TextEdit {

--- a/gen/lsp.go
+++ b/gen/lsp.go
@@ -336,6 +336,14 @@ func (a lspAnalyzer) PrintWidth(dir string) int {
 	return merged.effectivePrintWidth()
 }
 
+// ImportsMode resolves the effective gsx.toml [formatter] imports mode for dir,
+// layering the programmatic optCfg over the file config exactly like PrintWidth.
+// Best-effort: returns the default (goimports) on any failure.
+func (a lspAnalyzer) ImportsMode(dir string) gsxfmt.ImportsMode {
+	merged := resolveConfigBestEffort(dir, a.optCfg, a.warnw)
+	return merged.effectiveImportsMode()
+}
+
 // resolveConfigBestEffort resolves the LSP's effective config: it discovers a
 // gsx.toml from dir (walking up, bounded by .git/module root) and merges it under
 // optCfg — exactly as resolveConfig does for generate/info — but for the LSP it

--- a/gen/main.go
+++ b/gen/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gsxhq/gsx/internal/codegen"
 	"github.com/gsxhq/gsx/internal/diag"
 	"github.com/gsxhq/gsx/internal/fullmin"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 	"github.com/gsxhq/gsx/internal/rawfmt"
 )
 
@@ -43,6 +44,7 @@ type config struct {
 	fieldMatcher   codegen.FieldMatcher
 	errs           []error
 	printWidth     int                     // gsx.toml [formatter] print_width; 0 means "unset" → 80 at use
+	importsMode    gsxfmt.ImportsMode      // gsx.toml [formatter] imports; Unset → goimports at use
 	cssMinLevel    MinifyLevel             // <style> minification level (zero = MinifyNone)
 	jsMinLevel     MinifyLevel             // <script> minification level (zero = MinifyNone)
 	minifyLevelSet bool                    // true once an option (WithMinifyLevel) pinned the levels
@@ -56,6 +58,13 @@ func (c config) effectivePrintWidth() int {
 		return 80
 	}
 	return c.printWidth
+}
+
+// effectiveImportsMode returns the configured import-handling mode, defaulting
+// to goimports (remove unused + reorder) when unset — matching gopls, where
+// organizing imports is the norm and plain gofmt is the opt-out.
+func (c config) effectiveImportsMode() gsxfmt.ImportsMode {
+	return c.importsMode.Or(gsxfmt.DefaultImportsMode)
 }
 
 // effectiveCSSMin returns the CSS minifier to thread into codegen when the gate

--- a/internal/gsxfmt/corpus_test.go
+++ b/internal/gsxfmt/corpus_test.go
@@ -141,7 +141,7 @@ func TestFmtCorpus(t *testing.T) {
 // `alias path` (aliased import).
 func parseUnusedRefs(raw string) ([]ImportRef, error) {
 	var refs []ImportRef
-	for _, line := range strings.Split(raw, "\n") {
+	for line := range strings.SplitSeq(raw, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue

--- a/internal/gsxfmt/corpus_test.go
+++ b/internal/gsxfmt/corpus_test.go
@@ -19,6 +19,20 @@
 //	-- input.gsx --    the source to format
 //	-- fmt.golden --   the expected output
 //
+// Two more sections are optional:
+//
+//	-- imports --   "gofmt" (default when absent) or "goimports", parsed with
+//	                this package's own ParseImportsMode. Selects the import
+//	                handling mode the case formats under (FormatOptions.Reorder).
+//	-- unused --    newline-separated import refs to delete before formatting,
+//	                one per line as `path` or `alias path`; blank lines and lines
+//	                starting with # are ignored. Absent means Unused is nil.
+//	                This section exists so unused-import removal can be pinned
+//	                deterministically and fast: the real `gsx fmt` CLI derives
+//	                its Unused list from full module analysis (type-checking,
+//	                `go list`), which this suite deliberately avoids to stay
+//	                quick — the corpus case supplies the same list by hand.
+//
 // Regenerate with: go test ./internal/gsxfmt -run TestFmtCorpus -update
 // Then re-run without -update to verify.
 package gsxfmt
@@ -26,6 +40,7 @@ package gsxfmt
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"go/token"
 	"os"
 	"path/filepath"
@@ -62,9 +77,29 @@ func TestFmtCorpus(t *testing.T) {
 				t.Fatal("case has no input.gsx")
 			}
 
-			got, err := Format("input.gsx", input, fmtWidth)
+			modeStr := "gofmt"
+			if raw, ok := archiveFile(ar, "imports"); ok {
+				modeStr = strings.TrimSpace(string(raw))
+			}
+			mode, err := ParseImportsMode(modeStr)
 			if err != nil {
-				t.Fatalf("Format: %v", err)
+				t.Fatalf("case %s: %v", path, err)
+			}
+
+			var unused []ImportRef
+			if raw, ok := archiveFile(ar, "unused"); ok {
+				refs, err := parseUnusedRefs(string(raw))
+				if err != nil {
+					t.Fatalf("case %s: %v", path, err)
+				}
+				unused = refs
+			}
+
+			opts := FormatOptions{Unused: unused, Width: fmtWidth, Reorder: mode.Reorder()}
+
+			got, err := FormatWith("input.gsx", input, opts)
+			if err != nil {
+				t.Fatalf("FormatWith: %v", err)
 			}
 
 			if *update {
@@ -82,10 +117,12 @@ func TestFmtCorpus(t *testing.T) {
 				t.Errorf("fmt output differs from fmt.golden\n--- got ---\n%s\n--- want ---\n%s", got, want)
 			}
 
-			// Idempotence: the golden is a fixed point of the formatter.
-			again, err := Format("input.gsx", want, fmtWidth)
+			// Idempotence: the golden is a fixed point of the formatter under the
+			// case's own mode (an "unused" list already gone from the golden must
+			// still be a no-op re-applied to it).
+			again, err := FormatWith("input.gsx", want, opts)
 			if err != nil {
-				t.Fatalf("re-Format of golden: %v", err)
+				t.Fatalf("re-FormatWith of golden: %v", err)
 			}
 			if !bytes.Equal(again, want) {
 				t.Errorf("fmt is not idempotent on its own golden\n--- once ---\n%s\n--- twice ---\n%s", want, again)
@@ -97,6 +134,29 @@ func TestFmtCorpus(t *testing.T) {
 			}
 		})
 	}
+}
+
+// parseUnusedRefs parses a "-- unused --" section body into ImportRefs, one per
+// non-blank, non-comment line, each spelled `path` (default import) or
+// `alias path` (aliased import).
+func parseUnusedRefs(raw string) ([]ImportRef, error) {
+	var refs []ImportRef
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		switch len(fields) {
+		case 1:
+			refs = append(refs, ImportRef{Path: fields[0]})
+		case 2:
+			refs = append(refs, ImportRef{Name: fields[0], Path: fields[1]})
+		default:
+			return nil, fmt.Errorf("malformed unused-import line %q (want `path` or `alias path`)", line)
+		}
+	}
+	return refs, nil
 }
 
 func archiveFile(ar *txtar.Archive, name string) ([]byte, bool) {

--- a/internal/gsxfmt/gsxfmt.go
+++ b/internal/gsxfmt/gsxfmt.go
@@ -16,7 +16,9 @@ import (
 // Format parses src (named for diagnostics), normalizes whitespace, and returns
 // the canonical gsx source. A non-nil error is a parse or print failure; callers
 // formatting unsaved buffers should treat that as "leave the buffer untouched"
-// rather than a hard failure. Imports are left exactly as written (gofmt mode).
+// rather than a hard failure. Imports get gofmt mode: no import is removed,
+// merged, deduped or regrouped, though gofmt still sorts within an existing
+// parenthesized group when the printer runs go/format over each Go chunk.
 func Format(name string, src []byte, width int) ([]byte, error) {
 	return FormatWith(name, src, FormatOptions{Width: width})
 }

--- a/internal/gsxfmt/gsxfmt.go
+++ b/internal/gsxfmt/gsxfmt.go
@@ -72,3 +72,49 @@ func FormatRemovingImportsWith(name string, src []byte, unused []ImportRef, widt
 	}
 	return b.Bytes(), nil
 }
+
+// FormatOptions carries the knobs of FormatWith. The zero value is the safe one:
+// no imports removed, no reorder, printer defaults for <style>/<script>.
+type FormatOptions struct {
+	// Unused lists imports to delete from the file's Go chunks; nil removes none.
+	Unused []ImportRef
+	// Width is the printer's target line width (0 → printer default).
+	Width int
+	// CSSFmt/JSFmt format <style>/<script> bodies; nil uses the printer default.
+	CSSFmt rawfmt.Formatter
+	JSFmt  rawfmt.Formatter
+	// Reorder runs the goimports pass (merge/dedup/group/sort). It is a plain
+	// bool, not an ImportsMode: gsxfmt stays mechanical, and callers map
+	// ImportsMode.Reorder() onto it.
+	Reorder bool
+}
+
+// FormatWith is the one formatting entry point: parse → remove unused imports →
+// (optionally) reorder imports → whitespace-normalize → print. A non-nil error is
+// a parse or print failure; callers formatting unsaved buffers should treat that
+// as "leave the buffer untouched".
+func FormatWith(name string, src []byte, opts FormatOptions) ([]byte, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, name, src, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Remove first, then reorder: an import that was both unused and duplicated is
+	// gone before the merge, so reorder only canonicalizes what survives.
+	removeImports(f, opts.Unused)
+	if opts.Reorder {
+		reorderImports(f)
+	}
+	wsnorm.Normalize(f)
+	var b bytes.Buffer
+	if opts.CSSFmt == nil && opts.JSFmt == nil {
+		if err := printer.Fprint(&b, f, opts.Width); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := printer.FprintWith(&b, f, opts.Width, opts.CSSFmt, opts.JSFmt); err != nil {
+			return nil, err
+		}
+	}
+	return b.Bytes(), nil
+}

--- a/internal/gsxfmt/gsxfmt.go
+++ b/internal/gsxfmt/gsxfmt.go
@@ -16,61 +16,24 @@ import (
 // Format parses src (named for diagnostics), normalizes whitespace, and returns
 // the canonical gsx source. A non-nil error is a parse or print failure; callers
 // formatting unsaved buffers should treat that as "leave the buffer untouched"
-// rather than a hard failure.
+// rather than a hard failure. Imports are left exactly as written (gofmt mode).
 func Format(name string, src []byte, width int) ([]byte, error) {
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, name, src, 0)
-	if err != nil {
-		return nil, err
-	}
-	wsnorm.Normalize(f)
-	var b bytes.Buffer
-	if err := printer.Fprint(&b, f, width); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
+	return FormatWith(name, src, FormatOptions{Width: width})
 }
 
 // FormatRemovingImports formats src exactly like Format, but first removes every
 // import listed in `unused` from the file's pass-through Go chunks. With an empty
 // or nil `unused` it is identical to Format. A parse error is returned unchanged
-// (the caller decides whether to surface or ignore it).
+// (the caller decides whether to surface or ignore it). It never reorders.
 func FormatRemovingImports(name string, src []byte, unused []ImportRef, width int) ([]byte, error) {
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, name, src, 0)
-	if err != nil {
-		return nil, err
-	}
-	removeImports(f, unused)
-	wsnorm.Normalize(f)
-	var b bytes.Buffer
-	if err := printer.Fprint(&b, f, width); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
+	return FormatWith(name, src, FormatOptions{Unused: unused, Width: width})
 }
 
 // FormatRemovingImportsWith is FormatRemovingImports with explicit CSS and JS
-// formatters for <style>/<script> bodies (nil → built-in default at width).
+// formatters for <style>/<script> bodies (nil → built-in default at width). It
+// never reorders.
 func FormatRemovingImportsWith(name string, src []byte, unused []ImportRef, width int, cssFmt, jsFmt rawfmt.Formatter) ([]byte, error) {
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, name, src, 0)
-	if err != nil {
-		return nil, err
-	}
-	removeImports(f, unused)
-	wsnorm.Normalize(f)
-	var b bytes.Buffer
-	if cssFmt == nil && jsFmt == nil {
-		if err := printer.Fprint(&b, f, width); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := printer.FprintWith(&b, f, width, cssFmt, jsFmt); err != nil {
-			return nil, err
-		}
-	}
-	return b.Bytes(), nil
+	return FormatWith(name, src, FormatOptions{Unused: unused, Width: width, CSSFmt: cssFmt, JSFmt: jsFmt})
 }
 
 // FormatOptions carries the knobs of FormatWith. The zero value is the safe one:

--- a/internal/gsxfmt/imports.go
+++ b/internal/gsxfmt/imports.go
@@ -69,12 +69,68 @@ func deleteChunkImports(src string, unused []ImportRef) (string, bool) {
 	if err := goformat.Node(&b, fset, file); err != nil {
 		return src, false
 	}
-	out := b.String()
-	// Drop the synthetic "package _gsxp" line we prepended.
-	if nl := strings.IndexByte(out, '\n'); nl >= 0 {
-		out = out[nl+1:]
+	stripped, ok := stripSyntheticPackage([]byte(b.String()))
+	if !ok {
+		return src, false
 	}
-	return strings.TrimSpace(out), true
+	return preserveTrailing(src, normalizeStripped(stripped)), true
+}
+
+// stripSyntheticPackage removes the synthetic goChunkPkg clause from formatted —
+// the output of a Go formatter fed goChunkPkg+chunk. It locates the clause by
+// PARSING, never by assuming it is the first line: go/printer relocates
+// build-constraint comments (//go:build) above the package clause, and a
+// line-index strip would delete the constraint and leave `package _gsxp` spliced
+// into the user's source.
+//
+// ok is false when formatted does not parse; the caller then leaves the chunk
+// untouched.
+func stripSyntheticPackage(formatted []byte) (string, bool) {
+	fset := token.NewFileSet()
+	file, err := goparser.ParseFile(fset, "", formatted, goparser.PackageClauseOnly|goparser.ParseComments)
+	if err != nil {
+		return "", false
+	}
+	start := fset.Position(file.Package).Offset  // offset of the `package` keyword
+	end := fset.Position(file.Name.End()).Offset // end of the package name
+	for end < len(formatted) && formatted[end] != '\n' {
+		end++
+	}
+	if end < len(formatted) {
+		end++ // consume the newline terminating the clause
+	}
+	return string(formatted[:start]) + string(formatted[end:]), true
+}
+
+// normalizeStripped closes up the blank-line gap that stripSyntheticPackage can
+// leave where the package clause sat: the clause always had a blank line on
+// each side in formatted output, so deleting just the clause line merges those
+// into a double blank line (three consecutive newlines).
+//
+// This is done by mechanical string collapsing, NOT by another go/format pass.
+// go/format.Source contains the identical "insert `package p`, then strip a
+// fixed byte range" logic this file's whole fix removes (see internal.go's
+// parse/sourceAdj) — verified: feeding it a fragment led by a //go:build
+// comment reproduces Finding 1 inside the stdlib helper itself (the comment
+// gets hoisted above the injected clause, and the fixed-offset strip leaks
+// "package p" into the output). A real Go formatter never emits 3+ consecutive
+// newlines on its own, so collapsing them here only ever touches the gap this
+// function created.
+func normalizeStripped(stripped string) string {
+	for strings.Contains(stripped, "\n\n\n") {
+		stripped = strings.ReplaceAll(stripped, "\n\n\n", "\n\n")
+	}
+	return stripped
+}
+
+// preserveTrailing reattaches orig's trailing whitespace to a rewritten chunk
+// body. A GoChunk's trailing newlines are a layout fact, not slack: the printer
+// reads them (endsWithBlankLine) to decide whether a blank line separates this
+// chunk from the next declaration. TrimSpace-ing them away silently collapses
+// that blank line.
+func preserveTrailing(orig, body string) string {
+	trimmed := strings.TrimRight(orig, " \t\n")
+	return strings.TrimSpace(body) + orig[len(trimmed):]
 }
 
 // goChunkPkg is the synthetic package clause prepended to a GoChunk so that the
@@ -126,16 +182,15 @@ func reorderChunkImports(src string) (string, bool) {
 	if err != nil {
 		return src, false // not standalone-valid Go; leave it
 	}
-	s := string(out)
-	// Drop the synthetic package clause we prepended.
-	if nl := strings.IndexByte(s, '\n'); nl >= 0 {
-		s = s[nl+1:]
-	}
-	s = strings.TrimSpace(s)
-	if s == strings.TrimSpace(src) {
+	stripped, ok := stripSyntheticPackage(out)
+	if !ok {
 		return src, false
 	}
-	return s, true
+	res := preserveTrailing(src, normalizeStripped(stripped))
+	if res == src {
+		return src, false
+	}
+	return res, true
 }
 
 // reorderImports rewrites the imports of every GoChunk in f, in place, to

--- a/internal/gsxfmt/imports.go
+++ b/internal/gsxfmt/imports.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/imports"
 
 	gsxast "github.com/gsxhq/gsx/ast"
 )
@@ -50,9 +51,8 @@ func removeImports(f *gsxast.File, unused []ImportRef) {
 // rewritten chunk and whether anything changed. The chunk is gofmt'd here; the
 // gsx printer also gofmt's chunks on output, so the result is stable.
 func deleteChunkImports(src string, unused []ImportRef) (string, bool) {
-	const pkg = "package _gsxp\n"
 	fset := token.NewFileSet()
-	file, err := goparser.ParseFile(fset, "", pkg+src, goparser.ParseComments)
+	file, err := goparser.ParseFile(fset, "", goChunkPkg+src, goparser.ParseComments)
 	if err != nil {
 		return src, false // not standalone-valid Go; leave it
 	}
@@ -75,4 +75,84 @@ func deleteChunkImports(src string, unused []ImportRef) (string, bool) {
 		out = out[nl+1:]
 	}
 	return strings.TrimSpace(out), true
+}
+
+// goChunkPkg is the synthetic package clause prepended to a GoChunk so that the
+// chunk — which carries no package declaration of its own — parses as a
+// standalone Go file. It is stripped from every reprinted result.
+const goChunkPkg = "package _gsxp\n"
+
+// chunkHasImports reports whether src declares at least one import. The decision
+// is made on the parsed AST, never on a substring of the text: the word `import`
+// can appear inside a string literal or a comment. A chunk that is not
+// standalone-valid Go reports false, so it is left untouched downstream.
+//
+// goparser.ImportsOnly stops the parse after the import block, which is all this
+// gate needs and keeps the common (import-free) chunk cheap.
+func chunkHasImports(src string) bool {
+	fset := token.NewFileSet()
+	file, err := goparser.ParseFile(fset, "", goChunkPkg+src, goparser.ImportsOnly)
+	if err != nil {
+		return false
+	}
+	return len(file.Imports) > 0
+}
+
+// reorderChunkImports runs goimports' formatter over one Go chunk: it merges
+// every import declaration into a single block, drops duplicate specs, splits
+// standard-library from third-party imports with a blank line, and sorts each
+// group. Returns the rewritten chunk and whether anything changed.
+//
+// FormatOnly is essential. Without it goimports would also ADD and REMOVE
+// imports based on what the chunk body references — and a gsx chunk body never
+// references the template's imports, so plain goimports would strip every one of
+// them. Unused-import removal is a separate, module-analysis-driven pass
+// (removeImports); adding imports is impossible for gsx (a chunk body cannot
+// tell us which package a template's identifier came from).
+//
+// Comments/TabIndent/TabWidth make FormatOnly's output match gofmt's tabbed
+// chunk formatting; without them it emits spaces and the printer's own gofmt
+// would fight it.
+func reorderChunkImports(src string) (string, bool) {
+	if !chunkHasImports(src) {
+		return src, false
+	}
+	out, err := imports.Process("chunk.go", []byte(goChunkPkg+src), &imports.Options{
+		FormatOnly: true,
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+	})
+	if err != nil {
+		return src, false // not standalone-valid Go; leave it
+	}
+	s := string(out)
+	// Drop the synthetic package clause we prepended.
+	if nl := strings.IndexByte(s, '\n'); nl >= 0 {
+		s = s[nl+1:]
+	}
+	s = strings.TrimSpace(s)
+	if s == strings.TrimSpace(src) {
+		return src, false
+	}
+	return s, true
+}
+
+// reorderImports rewrites the imports of every GoChunk in f, in place, to
+// goimports' canonical form. Non-GoChunk decls are skipped: imports never live
+// in a GoWithElements region, because the parser peels a leading import run into
+// its own plain GoChunk before building the element region.
+//
+// Unlike removeImports this can never empty a chunk (FormatOnly deletes no
+// specs), so no decl is dropped here.
+func reorderImports(f *gsxast.File) {
+	for _, d := range f.Decls {
+		gc, ok := d.(*gsxast.GoChunk)
+		if !ok {
+			continue
+		}
+		if out, changed := reorderChunkImports(gc.Src); changed {
+			gc.Src = out
+		}
+	}
 }

--- a/internal/gsxfmt/imports.go
+++ b/internal/gsxfmt/imports.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/tools/imports"
 
 	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/printer"
 )
 
 // ImportRef identifies an import to remove from a .gsx file's pass-through Go
@@ -69,58 +70,11 @@ func deleteChunkImports(src string, unused []ImportRef) (string, bool) {
 	if err := goformat.Node(&b, fset, file); err != nil {
 		return src, false
 	}
-	stripped, ok := stripSyntheticPackage([]byte(b.String()))
+	stripped, ok := printer.StripSyntheticPackage([]byte(b.String()))
 	if !ok {
 		return src, false
 	}
-	return preserveTrailing(src, normalizeStripped(stripped)), true
-}
-
-// stripSyntheticPackage removes the synthetic goChunkPkg clause from formatted —
-// the output of a Go formatter fed goChunkPkg+chunk. It locates the clause by
-// PARSING, never by assuming it is the first line: go/printer relocates
-// build-constraint comments (//go:build) above the package clause, and a
-// line-index strip would delete the constraint and leave `package _gsxp` spliced
-// into the user's source.
-//
-// ok is false when formatted does not parse; the caller then leaves the chunk
-// untouched.
-func stripSyntheticPackage(formatted []byte) (string, bool) {
-	fset := token.NewFileSet()
-	file, err := goparser.ParseFile(fset, "", formatted, goparser.PackageClauseOnly|goparser.ParseComments)
-	if err != nil {
-		return "", false
-	}
-	start := fset.Position(file.Package).Offset  // offset of the `package` keyword
-	end := fset.Position(file.Name.End()).Offset // end of the package name
-	for end < len(formatted) && formatted[end] != '\n' {
-		end++
-	}
-	if end < len(formatted) {
-		end++ // consume the newline terminating the clause
-	}
-	return string(formatted[:start]) + string(formatted[end:]), true
-}
-
-// normalizeStripped closes up the blank-line gap that stripSyntheticPackage can
-// leave where the package clause sat: the clause always had a blank line on
-// each side in formatted output, so deleting just the clause line merges those
-// into a double blank line (three consecutive newlines).
-//
-// This is done by mechanical string collapsing, NOT by another go/format pass.
-// go/format.Source contains the identical "insert `package p`, then strip a
-// fixed byte range" logic this file's whole fix removes (see internal.go's
-// parse/sourceAdj) — verified: feeding it a fragment led by a //go:build
-// comment reproduces Finding 1 inside the stdlib helper itself (the comment
-// gets hoisted above the injected clause, and the fixed-offset strip leaks
-// "package p" into the output). A real Go formatter never emits 3+ consecutive
-// newlines on its own, so collapsing them here only ever touches the gap this
-// function created.
-func normalizeStripped(stripped string) string {
-	for strings.Contains(stripped, "\n\n\n") {
-		stripped = strings.ReplaceAll(stripped, "\n\n\n", "\n\n")
-	}
-	return stripped
+	return preserveTrailing(src, stripped), true
 }
 
 // preserveTrailing reattaches orig's trailing whitespace to a rewritten chunk
@@ -182,11 +136,11 @@ func reorderChunkImports(src string) (string, bool) {
 	if err != nil {
 		return src, false // not standalone-valid Go; leave it
 	}
-	stripped, ok := stripSyntheticPackage(out)
+	stripped, ok := printer.StripSyntheticPackage(out)
 	if !ok {
 		return src, false
 	}
-	res := preserveTrailing(src, normalizeStripped(stripped))
+	res := preserveTrailing(src, stripped)
 	if res == src {
 		return src, false
 	}

--- a/internal/gsxfmt/mode.go
+++ b/internal/gsxfmt/mode.go
@@ -1,0 +1,71 @@
+package gsxfmt
+
+import "fmt"
+
+// ImportsMode selects how `gsx fmt` and the language server treat the import
+// declarations of a .gsx file's pass-through Go chunks. It mirrors gopls, which
+// offers gofmt (format only) and goimports (organize), rather than a set of
+// independent knobs.
+//
+// The zero value is ImportsUnset so that an absent gsx.toml key is
+// distinguishable from an explicit "gofmt"; callers resolve it with Or.
+type ImportsMode int
+
+const (
+	// ImportsUnset means no mode was configured. Resolve it with Or before use;
+	// its predicates report false so an unresolved mode never silently rewrites.
+	ImportsUnset ImportsMode = iota
+	// ImportsGofmt formats with gofmt only: imports are sorted within their
+	// existing parenthesized group, but separate import declarations are never
+	// merged, duplicates are never dropped, and no std/third-party split is made.
+	ImportsGofmt
+	// ImportsGoimports removes unused imports and reorders the rest: merge every
+	// import declaration into one block, dedup identical specs, group standard
+	// library separately from everything else, sort within each group.
+	ImportsGoimports
+)
+
+// DefaultImportsMode is the mode used when gsx.toml says nothing.
+const DefaultImportsMode = ImportsGoimports
+
+// ParseImportsMode converts a gsx.toml / CLI spelling into an ImportsMode. Any
+// other string is an error naming both valid spellings.
+func ParseImportsMode(s string) (ImportsMode, error) {
+	switch s {
+	case "gofmt":
+		return ImportsGofmt, nil
+	case "goimports":
+		return ImportsGoimports, nil
+	default:
+		return ImportsUnset, fmt.Errorf("invalid imports mode %q (want %q or %q)", s, "gofmt", "goimports")
+	}
+}
+
+// Or returns m, or def when m is ImportsUnset. It is how a CLI flag layers over
+// a config value, and a config value over the built-in default.
+func (m ImportsMode) Or(def ImportsMode) ImportsMode {
+	if m == ImportsUnset {
+		return def
+	}
+	return m
+}
+
+// RemoveUnused reports whether this mode drops imports the file never uses.
+// Only goimports does; gofmt never removes an import.
+func (m ImportsMode) RemoveUnused() bool { return m == ImportsGoimports }
+
+// Reorder reports whether this mode merges, dedups, groups and sorts imports.
+// Only goimports does.
+func (m ImportsMode) Reorder() bool { return m == ImportsGoimports }
+
+// String returns the gsx.toml spelling; it round-trips through ParseImportsMode.
+func (m ImportsMode) String() string {
+	switch m {
+	case ImportsGofmt:
+		return "gofmt"
+	case ImportsGoimports:
+		return "goimports"
+	default:
+		return "unset"
+	}
+}

--- a/internal/gsxfmt/mode.go
+++ b/internal/gsxfmt/mode.go
@@ -58,7 +58,10 @@ func (m ImportsMode) RemoveUnused() bool { return m == ImportsGoimports }
 // Only goimports does.
 func (m ImportsMode) Reorder() bool { return m == ImportsGoimports }
 
-// String returns the gsx.toml spelling; it round-trips through ParseImportsMode.
+// String returns the gsx.toml spelling for ImportsGofmt ("gofmt") and ImportsGoimports
+// ("goimports"), which round-trip through ParseImportsMode. ImportsUnset and any
+// out-of-range value stringify to "unset", a diagnostic spelling that ParseImportsMode
+// deliberately does not accept.
 func (m ImportsMode) String() string {
 	switch m {
 	case ImportsGofmt:

--- a/internal/gsxfmt/mode_test.go
+++ b/internal/gsxfmt/mode_test.go
@@ -1,0 +1,75 @@
+package gsxfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseImportsMode(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want ImportsMode
+	}{
+		{"gofmt", ImportsGofmt},
+		{"goimports", ImportsGoimports},
+	} {
+		got, err := ParseImportsMode(tc.in)
+		if err != nil {
+			t.Fatalf("ParseImportsMode(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseImportsMode(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseImportsModeRejectsUnknown: the error names both valid spellings.
+func TestParseImportsModeRejectsUnknown(t *testing.T) {
+	_, err := ParseImportsMode("gofumpt")
+	if err == nil {
+		t.Fatal("want error for unknown mode")
+	}
+	for _, want := range []string{"gofumpt", "gofmt", "goimports"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestImportsModeZeroIsUnset: the zero value must be ImportsUnset so an absent
+// config key is distinguishable from an explicit "gofmt".
+func TestImportsModeZeroIsUnset(t *testing.T) {
+	var m ImportsMode
+	if m != ImportsUnset {
+		t.Fatalf("zero ImportsMode = %v, want ImportsUnset", m)
+	}
+}
+
+// TestImportsModeOr: Or falls back to def only when unset.
+func TestImportsModeOr(t *testing.T) {
+	if got := ImportsUnset.Or(ImportsGoimports); got != ImportsGoimports {
+		t.Fatalf("Unset.Or(goimports) = %v", got)
+	}
+	if got := ImportsGofmt.Or(ImportsGoimports); got != ImportsGofmt {
+		t.Fatalf("Gofmt.Or(goimports) = %v, want Gofmt", got)
+	}
+}
+
+// TestImportsModePredicates: only goimports removes and reorders.
+func TestImportsModePredicates(t *testing.T) {
+	if !ImportsGoimports.RemoveUnused() || !ImportsGoimports.Reorder() {
+		t.Fatal("goimports must remove and reorder")
+	}
+	if ImportsGofmt.RemoveUnused() || ImportsGofmt.Reorder() {
+		t.Fatal("gofmt must neither remove nor reorder")
+	}
+	if ImportsUnset.RemoveUnused() || ImportsUnset.Reorder() {
+		t.Fatal("unset must neither remove nor reorder (callers must resolve via Or first)")
+	}
+}
+
+func TestImportsModeString(t *testing.T) {
+	if ImportsGofmt.String() != "gofmt" || ImportsGoimports.String() != "goimports" {
+		t.Fatal("String() spellings must round-trip ParseImportsMode")
+	}
+}

--- a/internal/gsxfmt/reorder_test.go
+++ b/internal/gsxfmt/reorder_test.go
@@ -247,3 +247,42 @@ func TestReorderChunkImportsGoBuildIdempotent(t *testing.T) {
 		t.Fatalf("not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
 	}
 }
+
+// TestFormatWithPreservesGoBuildThroughPrinter is the end-to-end regression
+// test for the printer corruption bug: deleteChunkImports/reorderChunkImports
+// preserve a //go:build comment when they rewrite a chunk's imports, but the
+// GoChunk is then printed by internal/printer's Fprint — which independently
+// runs every chunk through go/format via fmtGoChunk. Before fmtGoChunk wrapped
+// the chunk in a synthetic package clause (making format.Source see a valid
+// file, so it never enters its byte-count-stripping fragment mode), that
+// second pass re-corrupted the comment even though gsxfmt's own import
+// rewrite had left it intact. This must hold both with Reorder off (gofmt
+// mode) and on (goimports mode).
+func TestFormatWithPreservesGoBuildThroughPrinter(t *testing.T) {
+	// The //go:build comment must lead a GoChunk that is NOT the file's own
+	// package-clause decl: that first chunk already carries a real package
+	// clause of its own, so format.Source parses it directly and never enters
+	// the byte-stripping fragment path this test guards against. Attaching
+	// the comment to the (import-bearing) second chunk instead reproduces the
+	// shape go/format actually mishandles.
+	src := "package x\n\n" +
+		"//go:build linux\n\n" +
+		"import \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+
+	for _, reorder := range []bool{false, true} {
+		out, err := FormatWith("x.gsx", []byte(src), FormatOptions{Width: 80, Reorder: reorder})
+		if err != nil {
+			t.Fatalf("Reorder=%v: FormatWith: %v", reorder, err)
+		}
+		got := string(out)
+		if !strings.Contains(got, "//go:build linux") {
+			t.Fatalf("Reorder=%v: build constraint lost or corrupted:\n%s", reorder, got)
+		}
+		for _, bad := range []string{"_gsxp", "_gsxfmt", "package p"} {
+			if strings.Contains(got, bad) {
+				t.Fatalf("Reorder=%v: synthetic package clause %q leaked:\n%s", reorder, bad, got)
+			}
+		}
+	}
+}

--- a/internal/gsxfmt/reorder_test.go
+++ b/internal/gsxfmt/reorder_test.go
@@ -139,3 +139,111 @@ func TestReorderChunkImportsLeavesInvalidGoUntouched(t *testing.T) {
 		t.Fatalf("invalid Go must be left untouched, got changed=%v:\n%s", changed, got)
 	}
 }
+
+// TestDeleteChunkImportsPreservesGoBuild: go/printer relocates a //go:build
+// comment ABOVE the synthetic package clause used internally to make a
+// GoChunk parse standalone. deleteChunkImports must locate that clause by
+// parsing, not by stripping "the first line" — otherwise the build constraint
+// is deleted and "package _gsxp" leaks into the user's source.
+func TestDeleteChunkImportsPreservesGoBuild(t *testing.T) {
+	const src = "//go:build linux\n\nimport (\n\t\"bytes\"\n\t\"fmt\"\n)\n"
+	got, changed := deleteChunkImports(src, []ImportRef{{Path: "bytes"}})
+	if !changed {
+		t.Fatalf("expected a change (bytes import removed)")
+	}
+	if !strings.Contains(got, "//go:build linux") {
+		t.Fatalf("build constraint lost:\n%s", got)
+	}
+	if strings.Contains(got, "_gsxp") {
+		t.Fatalf("synthetic package clause leaked:\n%s", got)
+	}
+	if strings.Contains(got, "\"bytes\"") {
+		t.Fatalf("bytes import not removed:\n%s", got)
+	}
+}
+
+// TestReorderChunkImportsPreservesGoBuild: the same relocation hazard as
+// TestDeleteChunkImportsPreservesGoBuild, but through the goimports
+// (imports.Process) path.
+func TestReorderChunkImportsPreservesGoBuild(t *testing.T) {
+	const src = "//go:build linux\n\nimport (\n\t\"bytes\"\n\n\t\"fmt\"\n)\n"
+	got, _ := reorderChunkImports(src)
+	if !strings.Contains(got, "//go:build linux") {
+		t.Fatalf("build constraint lost:\n%s", got)
+	}
+	if strings.Contains(got, "_gsxp") {
+		t.Fatalf("synthetic package clause leaked:\n%s", got)
+	}
+	if !strings.Contains(got, "\"bytes\"") || !strings.Contains(got, "\"fmt\"") {
+		t.Fatalf("imports lost:\n%s", got)
+	}
+}
+
+// TestReorderPreservesBlankLineBeforeNextDecl: a GoChunk's trailing blank line
+// is a layout fact (internal/printer's endsWithBlankLine), not slack. A reorder
+// that actually rewrites the chunk (here: the motivating dup-import case) must
+// not collapse the blank line the author left before the next declaration.
+func TestReorderPreservesBlankLineBeforeNextDecl(t *testing.T) {
+	src := "package x\n\n" +
+		"import \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	got := reorder(t, src)
+	if !strings.Contains(got, ")\n\ncomponent C()") {
+		t.Fatalf("blank line before component C() lost:\n%s", got)
+	}
+}
+
+// TestRemovePreservesBlankLineBeforeNextDecl: same layout-fact requirement as
+// TestReorderPreservesBlankLineBeforeNextDecl, but through the unused-import
+// removal path (deleteChunkImports / FormatRemovingImports).
+func TestRemovePreservesBlankLineBeforeNextDecl(t *testing.T) {
+	src := "package x\n\nimport (\n\t\"strings\"\n\t\"fmt\"\n)\n\ncomponent C() {\n\t<p>{ fmt.Sprint(1) }</p>\n}\n"
+	got := mustFormat(t, src, []ImportRef{{Path: "strings"}})
+	if !strings.Contains(got, ")\n\ncomponent C()") {
+		t.Fatalf("blank line before component C() lost:\n%s", got)
+	}
+}
+
+// TestRemoveNoBlankLineStaysNoBlankLine: a chunk with NO trailing blank line
+// (the import block runs straight into the next declaration) must not gain one
+// after a rewrite — preserveTrailing must not manufacture layout that wasn't
+// there.
+func TestRemoveNoBlankLineStaysNoBlankLine(t *testing.T) {
+	src := "package x\n\nimport (\n\t\"strings\"\n\t\"fmt\"\n)\ncomponent C() {\n\t<p>{ fmt.Sprint(1) }</p>\n}\n"
+	got := mustFormat(t, src, []ImportRef{{Path: "strings"}})
+	if strings.Contains(got, ")\n\ncomponent C()") {
+		t.Fatalf("blank line wrongly introduced before component C():\n%s", got)
+	}
+	if !strings.Contains(got, ")\ncomponent C()") {
+		t.Fatalf("expected no blank line between import block and component C():\n%s", got)
+	}
+}
+
+// TestDeleteChunkImportsGoBuildIdempotent: re-running the go:build-preserving
+// removal on its own output is a no-op.
+func TestDeleteChunkImportsGoBuildIdempotent(t *testing.T) {
+	const src = "//go:build linux\n\nimport (\n\t\"bytes\"\n\t\"fmt\"\n)\n"
+	once, _ := deleteChunkImports(src, []ImportRef{{Path: "bytes"}})
+	twice, changed := deleteChunkImports(once, []ImportRef{{Path: "bytes"}})
+	if changed {
+		t.Fatalf("second pass should find nothing left to remove")
+	}
+	if once != twice {
+		t.Fatalf("not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+}
+
+// TestReorderChunkImportsGoBuildIdempotent: re-running the go:build-preserving
+// reorder on its own output is a no-op (goimports never regroups what it just
+// grouped).
+func TestReorderChunkImportsGoBuildIdempotent(t *testing.T) {
+	const src = "//go:build linux\n\nimport (\n\t\"bytes\"\n\n\t\"fmt\"\n)\n"
+	once, _ := reorderChunkImports(src)
+	twice, changed := reorderChunkImports(once)
+	if changed {
+		t.Fatalf("second pass should find nothing left to reorder:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+	if once != twice {
+		t.Fatalf("not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+}

--- a/internal/gsxfmt/reorder_test.go
+++ b/internal/gsxfmt/reorder_test.go
@@ -1,0 +1,141 @@
+package gsxfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+// reorder formats src through the goimports path (reorder on, no removal).
+func reorder(t *testing.T, src string) string {
+	t.Helper()
+	out, err := FormatWith("x.gsx", []byte(src), FormatOptions{Width: 80, Reorder: true})
+	if err != nil {
+		t.Fatalf("FormatWith: %v", err)
+	}
+	return string(out)
+}
+
+// TestReorderMergesAndDedups: a single-line import plus a grouped one that
+// repeats it collapse into one block with the duplicate gone. This is the
+// motivating case: gofmt leaves both declarations and the duplicate alone.
+func TestReorderMergesAndDedups(t *testing.T) {
+	src := "package x\n\n" +
+		"import \"strings\"\n\n" +
+		"import (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	got := reorder(t, src)
+	if n := strings.Count(got, "import"); n != 1 {
+		t.Fatalf("want exactly 1 import keyword, got %d:\n%s", n, got)
+	}
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("duplicate strings import not deduped (%d occurrences):\n%s", n, got)
+	}
+	if !strings.Contains(got, "\"fmt\"") {
+		t.Fatalf("fmt import lost:\n%s", got)
+	}
+}
+
+// TestReorderGroupsStdAndThirdParty: std and non-std land in separate
+// blank-line-separated groups, goimports' default two-group split.
+func TestReorderGroupsStdAndThirdParty(t *testing.T) {
+	src := "package x\n\n" +
+		"import (\n\t\"github.com/gsxhq/gsx\"\n\t\"fmt\"\n)\n\n" +
+		"component C() {\n\t<p>hi</p>\n}\n"
+	got := reorder(t, src)
+	fmtAt := strings.Index(got, "\"fmt\"")
+	gsxAt := strings.Index(got, "\"github.com/gsxhq/gsx\"")
+	if fmtAt < 0 || gsxAt < 0 {
+		t.Fatalf("imports missing:\n%s", got)
+	}
+	if fmtAt > gsxAt {
+		t.Fatalf("std must sort before third-party:\n%s", got)
+	}
+	between := got[fmtAt:gsxAt]
+	if !strings.Contains(between, "\n\n") {
+		t.Fatalf("want blank line between std and third-party groups:\n%s", got)
+	}
+}
+
+// TestReorderIdempotent: reorder output is stable, including after the printer
+// re-gofmt's every chunk (gofmt sorts within a group but never regroups, so the
+// std/third-party split survives).
+func TestReorderIdempotent(t *testing.T) {
+	src := "package x\n\n" +
+		"import \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	once := reorder(t, src)
+	twice := reorder(t, once)
+	if once != twice {
+		t.Fatalf("reorder not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+}
+
+// TestReorderOffLeavesImportsAlone: with Reorder:false the duplicate and the two
+// separate declarations survive — that is gofmt mode.
+func TestReorderOffLeavesImportsAlone(t *testing.T) {
+	src := "package x\n\n" +
+		"import \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	out, err := FormatWith("x.gsx", []byte(src), FormatOptions{Width: 80, Reorder: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if n := strings.Count(got, "\"strings\""); n != 2 {
+		t.Fatalf("gofmt mode must keep the duplicate (got %d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 2 {
+		t.Fatalf("gofmt mode must keep both import declarations (got %d):\n%s", n, got)
+	}
+}
+
+// TestReorderPreservesBlankAndAliasedImports: `_` and aliased specs survive a
+// reorder (FormatOnly never drops a spec).
+func TestReorderPreservesBlankAndAliasedImports(t *testing.T) {
+	src := "package x\n\n" +
+		"import (\n\t_ \"embed\"\n\tsx \"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ sx.ToUpper(\"x\") }</p>\n}\n"
+	got := reorder(t, src)
+	if !strings.Contains(got, "_ \"embed\"") {
+		t.Fatalf("blank import lost:\n%s", got)
+	}
+	if !strings.Contains(got, "sx \"strings\"") {
+		t.Fatalf("aliased import lost:\n%s", got)
+	}
+}
+
+// TestReorderSamePathDifferentAliasBothKept: same path under two aliases is two
+// distinct imports; dedup must not collapse them.
+func TestReorderSamePathDifferentAliasBothKept(t *testing.T) {
+	src := "package x\n\n" +
+		"import (\n\tsx \"strings\"\n\tst \"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ sx.ToUpper(st.ToLower(\"x\")) }</p>\n}\n"
+	got := reorder(t, src)
+	if !strings.Contains(got, "sx \"strings\"") || !strings.Contains(got, "st \"strings\"") {
+		t.Fatalf("distinct aliases wrongly collapsed:\n%s", got)
+	}
+}
+
+// TestChunkHasImportsIgnoresWordInStringsAndComments: the gate is AST-based, so
+// the word "import" inside a string or comment must not trigger a reorder.
+func TestChunkHasImportsIgnoresWordInStringsAndComments(t *testing.T) {
+	if chunkHasImports("// import \"strings\"\nvar x = 1\n") {
+		t.Fatal("comment mentioning import must not count as an import decl")
+	}
+	if chunkHasImports("var s = \"import \\\"strings\\\"\"\n") {
+		t.Fatal("string containing import must not count as an import decl")
+	}
+	if !chunkHasImports("import \"strings\"\n") {
+		t.Fatal("a real import decl must be detected")
+	}
+}
+
+// TestReorderChunkImportsLeavesInvalidGoUntouched: a chunk that is not
+// standalone-valid Go is returned unchanged rather than mangled.
+func TestReorderChunkImportsLeavesInvalidGoUntouched(t *testing.T) {
+	const bad = "import \"strings\"\n\nfunc ( {\n"
+	got, changed := reorderChunkImports(bad)
+	if changed || got != bad {
+		t.Fatalf("invalid Go must be left untouched, got changed=%v:\n%s", changed, got)
+	}
+}

--- a/internal/gsxfmt/testdata/cases/gochunk_gobuild_preserved.txtar
+++ b/internal/gsxfmt/testdata/cases/gochunk_gobuild_preserved.txtar
@@ -1,0 +1,35 @@
+A Go chunk (the region after the .gsx file's own `package` clause) that carries
+a //go:build comment above its import block must survive gofmt's chunk-local
+formatting. go/format wraps the chunk in a synthetic `package _gsxfmt` clause
+before formatting it, and go/printer hoists a //go:build comment above that
+clause when it reprints — a line-index strip (the old implementation) sheared
+the build tag and spliced "package _gsxfmt" straight into the output. Stripping
+the clause by parsing (the fix) keeps the tag intact and never leaks the
+synthetic package name or a second package declaration into the golden.
+
+-- imports --
+gofmt
+-- input.gsx --
+package ui
+
+//go:build linux
+
+import (
+	"fmt"
+)
+
+func Only() string {
+	return fmt.Sprintf("linux")
+}
+-- fmt.golden --
+package ui
+
+//go:build linux
+
+import (
+	"fmt"
+)
+
+func Only() string {
+	return fmt.Sprintf("linux")
+}

--- a/internal/gsxfmt/testdata/cases/imports_gofmt_leaves_imports_alone.txtar
+++ b/internal/gsxfmt/testdata/cases/imports_gofmt_leaves_imports_alone.txtar
@@ -1,0 +1,34 @@
+gofmt mode (the default when -- imports -- is absent, spelled out here for
+clarity) never merges, dedups, or regroups imports — only sorts within an
+existing parenthesized group. Same source as imports_goimports_merge_dedup:
+the lone `import "strings"` and the separate block that redundantly imports
+"strings" again both survive untouched, duplicate included.
+
+-- imports --
+gofmt
+-- input.gsx --
+package ui
+
+import "strings"
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Shout(s string) string {
+	return fmt.Sprintf("%s!", strings.ToUpper(s))
+}
+-- fmt.golden --
+package ui
+
+import "strings"
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Shout(s string) string {
+	return fmt.Sprintf("%s!", strings.ToUpper(s))
+}

--- a/internal/gsxfmt/testdata/cases/imports_goimports_group_std_thirdparty.txtar
+++ b/internal/gsxfmt/testdata/cases/imports_goimports_group_std_thirdparty.txtar
@@ -1,0 +1,29 @@
+goimports mode splits a single blank-line-free import block into a standard-
+library group and an everything-else group, separated by a blank line, even
+though the author wrote no blank line at all.
+
+-- imports --
+goimports
+-- input.gsx --
+package ui
+
+import (
+	"fmt"
+	"github.com/gsxhq/gsx"
+)
+
+func Describe() string {
+	return fmt.Sprintf("%s", gsx.Version)
+}
+-- fmt.golden --
+package ui
+
+import (
+	"fmt"
+
+	"github.com/gsxhq/gsx"
+)
+
+func Describe() string {
+	return fmt.Sprintf("%s", gsx.Version)
+}

--- a/internal/gsxfmt/testdata/cases/imports_goimports_merge_dedup.txtar
+++ b/internal/gsxfmt/testdata/cases/imports_goimports_merge_dedup.txtar
@@ -1,0 +1,31 @@
+goimports mode merges every import declaration into a single block and dedups
+identical specs. The author wrote a lone `import "strings"` and a separate
+parenthesized block that redundantly imports "strings" again; both collapse
+into one block with "strings" appearing once.
+
+-- imports --
+goimports
+-- input.gsx --
+package ui
+
+import "strings"
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Shout(s string) string {
+	return fmt.Sprintf("%s!", strings.ToUpper(s))
+}
+-- fmt.golden --
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Shout(s string) string {
+	return fmt.Sprintf("%s!", strings.ToUpper(s))
+}

--- a/internal/gsxfmt/testdata/cases/imports_goimports_preserves_author_groups.txtar
+++ b/internal/gsxfmt/testdata/cases/imports_goimports_preserves_author_groups.txtar
@@ -1,0 +1,31 @@
+goimports mode never merges away a blank-line group the author already wrote,
+even when both groups are standard library. This is real goimports semantics
+(imports.Process with FormatOnly), verified byte-identical against the
+goimports binary on this exact input — do not "fix" it into one group.
+
+-- imports --
+goimports
+-- input.gsx --
+package ui
+
+import (
+	"fmt"
+
+	"strings"
+)
+
+func F() string {
+	return fmt.Sprintf("%s", strings.ToUpper("x"))
+}
+-- fmt.golden --
+package ui
+
+import (
+	"fmt"
+
+	"strings"
+)
+
+func F() string {
+	return fmt.Sprintf("%s", strings.ToUpper("x"))
+}

--- a/internal/gsxfmt/testdata/cases/imports_removes_unused.txtar
+++ b/internal/gsxfmt/testdata/cases/imports_removes_unused.txtar
@@ -1,0 +1,32 @@
+goimports mode removes an import named in the case's -- unused -- list. The
+component never references "strings", so it is dropped while "fmt" (which the
+component does use) survives, and the blank line the author left between the
+import block and the following func declaration is preserved (pins the
+preserveTrailing fix — a naive TrimSpace on the rewritten chunk body would
+silently swallow that blank line).
+
+-- imports --
+goimports
+-- unused --
+strings
+-- input.gsx --
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Greet(name string) string {
+	return fmt.Sprintf("Hello, %s", name)
+}
+-- fmt.golden --
+package ui
+
+import (
+	"fmt"
+)
+
+func Greet(name string) string {
+	return fmt.Sprintf("Hello, %s", name)
+}

--- a/internal/lsp/codeaction.go
+++ b/internal/lsp/codeaction.go
@@ -1,0 +1,84 @@
+package lsp
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/gsxhq/gsx/internal/gsxfmt"
+)
+
+// handleCodeAction answers textDocument/codeAction for a .gsx document. The only
+// action offered is source.organizeImports.
+//
+// The action ALWAYS applies the goimports transform — remove unused imports and
+// reorder (merge/dedup/group/sort) — regardless of the configured
+// [formatter] imports mode. That is the point of the action, and it mirrors
+// gopls: textDocument/formatting may be plain gofmt while source.organizeImports
+// still organizes. This is what lets a project set imports = "gofmt" for
+// format-on-save and wire editor.codeActionsOnSave to organize separately.
+//
+// The edit is a single whole-document TextEdit: gsx has no partial formatter, so
+// its canonical form is produced by a whole-document parse → print. Applying the
+// action therefore also canonicalizes the rest of the document — a deliberate
+// deviation from gopls's import-region-only edits.
+//
+// An empty result (no action) is returned when the document is not .gsx, when
+// context.only excludes the kind, when the buffer does not parse (mid-edit), or
+// when the organized document already equals the buffer — so an on-save action
+// is a true no-op rather than a redundant edit.
+func (s *Server) handleCodeAction(f frame) error {
+	var p codeActionParams
+	if err := json.Unmarshal(f.Params, &p); err != nil {
+		return s.reply(f.ID, []CodeAction{})
+	}
+	uri := p.TextDocument.URI
+	path := uriToPath(uri)
+	if !strings.HasSuffix(path, ".gsx") {
+		return s.reply(f.ID, []CodeAction{}) // gopls owns .go
+	}
+	if !wantsKind(p.Context.Only, organizeImportsKind) {
+		return s.reply(f.ID, []CodeAction{})
+	}
+	text, ok := s.docs.text(uri)
+	if !ok {
+		return s.reply(f.ID, []CodeAction{})
+	}
+	dir := filepath.Dir(path)
+	var unused []gsxfmt.ImportRef
+	if pkg := s.pkgs[dir]; pkg != nil {
+		unused = pkg.UnusedImports[path] // nil when analysis is unavailable
+	}
+	organized, err := gsxfmt.FormatWith(path, []byte(text), gsxfmt.FormatOptions{
+		Unused:  unused,
+		Width:   s.analyzer.PrintWidth(dir),
+		Reorder: true, // always: this action IS goimports
+	})
+	if err != nil || string(organized) == text {
+		return s.reply(f.ID, []CodeAction{}) // unparseable mid-edit, or already organized
+	}
+	edit := TextEdit{
+		Range:   Range{Start: Position{Line: 0, Character: 0}, End: endPosition(text, s.enc)},
+		NewText: string(organized),
+	}
+	return s.reply(f.ID, []CodeAction{{
+		Title: "Organize Imports",
+		Kind:  organizeImportsKind,
+		Edit:  &WorkspaceEdit{Changes: map[string][]TextEdit{uri: {edit}}},
+	}})
+}
+
+// wantsKind reports whether a client asking for the kinds in `only` wants `kind`.
+// An empty `only` means "any kind". LSP kinds are dot-separated hierarchies, so a
+// requested "source" matches "source.organizeImports".
+func wantsKind(only []string, kind string) bool {
+	if len(only) == 0 {
+		return true
+	}
+	for _, k := range only {
+		if k == kind || strings.HasPrefix(kind, k+".") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/lsp/codeaction_test.go
+++ b/internal/lsp/codeaction_test.go
@@ -1,0 +1,172 @@
+package lsp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/gsxfmt"
+)
+
+// codeActions drives one textDocument/codeAction request against a server backed
+// by nilAnalyzer, and returns the decoded result.
+func codeActions(t *testing.T, uri, src string, only []string) []CodeAction {
+	t.Helper()
+	return codeActionsWith(t, uri, src, only, nilAnalyzer{})
+}
+
+// codeActionsWith is codeActions with an explicit Analyzer, so a test can vary
+// the reported [formatter] imports mode.
+func codeActionsWith(t *testing.T, uri, src string, only []string, a Analyzer) []CodeAction {
+	t.Helper()
+	in := framed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}})
+	in += framed(t, map[string]any{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "languageId": "gsx", "version": 1, "text": src}},
+	})
+	ctx := map[string]any{"diagnostics": []any{}}
+	if only != nil {
+		ctx["only"] = only
+	}
+	in += framed(t, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/codeAction",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"range":        map[string]any{"start": map[string]any{"line": 0, "character": 0}, "end": map[string]any{"line": 0, "character": 0}},
+			"context":      ctx,
+		},
+	})
+	in += framed(t, map[string]any{"jsonrpc": "2.0", "method": "exit"})
+
+	var out bytes.Buffer
+	srv := NewServer(strings.NewReader(in), &out, a)
+	if err := srv.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, m := range readFrames(t, out.String()) {
+		raw, ok := m["result"]
+		if !ok {
+			continue
+		}
+		var actions []CodeAction
+		if err := json.Unmarshal(raw, &actions); err == nil && len(actions) > 0 {
+			return actions
+		}
+		// An empty result array decodes to len 0; distinguish it from the
+		// initialize result (an object, which fails to unmarshal into a slice).
+		if string(raw) == "[]" {
+			return nil
+		}
+	}
+	return nil
+}
+
+const dupImportSrc = "package x\n\nimport \"strings\"\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+	"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+
+// TestCodeActionOrganizeImports: the action is offered and its edit merges and
+// dedups the imports.
+func TestCodeActionOrganizeImports(t *testing.T) {
+	actions := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, []string{"source.organizeImports"})
+	if len(actions) != 1 {
+		t.Fatalf("want 1 action, got %d", len(actions))
+	}
+	a := actions[0]
+	if a.Kind != "source.organizeImports" {
+		t.Fatalf("kind = %q", a.Kind)
+	}
+	if a.Edit == nil || len(a.Edit.Changes["file:///tmp/c.gsx"]) != 1 {
+		t.Fatalf("want one whole-document edit, got %+v", a.Edit)
+	}
+	got := a.Edit.Changes["file:///tmp/c.gsx"][0].NewText
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("duplicate not deduped (%d):\n%s", n, got)
+	}
+	if n := strings.Count(got, "import"); n != 1 {
+		t.Fatalf("declarations not merged (%d):\n%s", n, got)
+	}
+}
+
+// TestCodeActionOrganizeImportsIgnoresGofmtMode: the action organizes even when
+// the configured formatter mode is gofmt — organizing is its entire purpose.
+func TestCodeActionOrganizeImportsIgnoresGofmtMode(t *testing.T) {
+	// gofmtAnalyzer reports ImportsMode = gofmt; the action must ignore it.
+	actions := codeActionsWith(t, "file:///tmp/c.gsx", dupImportSrc, []string{"source.organizeImports"}, gofmtAnalyzer{})
+	if len(actions) != 1 {
+		t.Fatalf("action must be offered under gofmt mode, got %d", len(actions))
+	}
+	got := actions[0].Edit.Changes["file:///tmp/c.gsx"][0].NewText
+	if n := strings.Count(got, "\"strings\""); n != 1 {
+		t.Fatalf("action must organize under gofmt mode (%d):\n%s", n, got)
+	}
+}
+
+// TestCodeActionNoOpWhenAlreadyOrganized: an already-canonical document yields
+// no action, so codeActionsOnSave is a no-op.
+func TestCodeActionNoOpWhenAlreadyOrganized(t *testing.T) {
+	src := "package x\n\nimport (\n\t\"fmt\"\n\n\t\"strings\"\n)\n\n" +
+		"component C() {\n\t<p>{ fmt.Sprint(strings.ToUpper(\"x\")) }</p>\n}\n"
+	if got := codeActions(t, "file:///tmp/c.gsx", src, []string{"source.organizeImports"}); len(got) != 0 {
+		t.Fatalf("want no action for canonical doc, got %+v", got)
+	}
+}
+
+// TestCodeActionSkipsNonGsx: gopls owns .go files.
+func TestCodeActionSkipsNonGsx(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.go", dupImportSrc, []string{"source.organizeImports"}); len(got) != 0 {
+		t.Fatalf("want no action for .go, got %+v", got)
+	}
+}
+
+// TestCodeActionHonorsOnlyFilter: a request restricted to quickfix gets nothing.
+func TestCodeActionHonorsOnlyFilter(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, []string{"quickfix"}); len(got) != 0 {
+		t.Fatalf("want no action when only=[quickfix], got %+v", got)
+	}
+}
+
+// TestCodeActionOnlySourcePrefixMatches: "source" is a prefix of
+// "source.organizeImports" in LSP's kind hierarchy, so it must match.
+func TestCodeActionOnlySourcePrefixMatches(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, []string{"source"}); len(got) != 1 {
+		t.Fatalf("only=[source] must match, got %d", len(got))
+	}
+}
+
+// TestCodeActionEmptyOnlyOffersAction: an unrestricted request offers it.
+func TestCodeActionEmptyOnlyOffersAction(t *testing.T) {
+	if got := codeActions(t, "file:///tmp/c.gsx", dupImportSrc, nil); len(got) != 1 {
+		t.Fatalf("unrestricted request must offer the action, got %d", len(got))
+	}
+}
+
+// TestCodeActionParseErrorYieldsNothing: a mid-edit buffer never gets a
+// destructive whole-file edit.
+func TestCodeActionParseErrorYieldsNothing(t *testing.T) {
+	bad := "package x\n\ncomponent C() {\n\t<p>unclosed\n"
+	if got := codeActions(t, "file:///tmp/c.gsx", bad, []string{"source.organizeImports"}); len(got) != 0 {
+		t.Fatalf("want no action for unparseable buffer, got %+v", got)
+	}
+}
+
+// TestInitializeAdvertisesOrganizeImports: the capability names the kind so the
+// client can wire editor.codeActionsOnSave.
+func TestInitializeAdvertisesOrganizeImports(t *testing.T) {
+	in := framed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}})
+	in += framed(t, map[string]any{"jsonrpc": "2.0", "method": "exit"})
+	var out bytes.Buffer
+	srv := NewServer(strings.NewReader(in), &out, nilAnalyzer{})
+	if err := srv.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"source.organizeImports"`) {
+		t.Fatalf("initialize did not advertise source.organizeImports:\n%s", out.String())
+	}
+}
+
+// gofmtAnalyzer reports gofmt mode, to prove the code action ignores it and
+// organizes anyway. It embeds nilAnalyzer for every other Analyzer method.
+type gofmtAnalyzer struct{ nilAnalyzer }
+
+func (gofmtAnalyzer) ImportsMode(string) gsxfmt.ImportsMode { return gsxfmt.ImportsGofmt }

--- a/internal/lsp/documentsymbol_test.go
+++ b/internal/lsp/documentsymbol_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 	gsxparser "github.com/gsxhq/gsx/parser"
 )
 
@@ -39,6 +40,9 @@ func (symbolFileAnalyzer) ModuleSymbols(string, map[string][]byte) ([]Symbol, er
 	return nil, nil
 }
 func (symbolFileAnalyzer) PrintWidth(string) int { return 80 }
+func (symbolFileAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
+	return gsxfmt.ImportsGoimports
+}
 
 func TestDocumentSymbol(t *testing.T) {
 	uri := "file:///m/page.gsx"

--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -45,9 +45,9 @@ func (s *Server) handleFormatting(f frame) error {
 		}
 	}
 	width := s.analyzer.PrintWidth(dir)
-	// CSSFmt/JSFmt stay nil: LSP formatting has never run the <style>/<script>
-	// formatters that the CLI runs. Preserving that here keeps output identical;
-	// closing the gap is a separate change.
+	// CSSFmt/JSFmt nil selects the printer's built-in <style>/<script> formatters,
+	// producing output identical to the CLI default. The LSP does not thread a
+	// project's custom configured formatters; gsx fmt does. Wiring is separate.
 	formatted, err := gsxfmt.FormatWith(path, []byte(text), gsxfmt.FormatOptions{
 		Unused:  unused,
 		Width:   width,

--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -13,6 +13,10 @@ import (
 // whole-document TextEdit. It operates on the live buffer text, so unsaved edits
 // are formatted. Only .gsx files are handled; gopls owns .go formatting.
 //
+// It honors the resolved gsx.toml [formatter] imports mode: goimports mode
+// removes unused imports and reorders/merges import declarations, gofmt mode
+// does neither.
+//
 // On a parse failure (the buffer is mid-edit and not valid gsx) it returns no
 // edits rather than a destructive whole-file replacement; the same for a buffer
 // that is already canonical.
@@ -30,12 +34,25 @@ func (s *Server) handleFormatting(f frame) error {
 		return s.reply(f.ID, []TextEdit{})
 	}
 	path := uriToPath(uri)
+	dir := filepath.Dir(path)
+	mode := s.analyzer.ImportsMode(dir)
+
+	// Only goimports mode removes unused imports; gofmt mode leaves them.
 	var unused []gsxfmt.ImportRef
-	if pkg := s.pkgs[filepath.Dir(path)]; pkg != nil {
-		unused = pkg.UnusedImports[path] // nil when analysis is unavailable/unreliable
+	if mode.RemoveUnused() {
+		if pkg := s.pkgs[dir]; pkg != nil {
+			unused = pkg.UnusedImports[path] // nil when analysis is unavailable/unreliable
+		}
 	}
-	width := s.analyzer.PrintWidth(filepath.Dir(path))
-	formatted, err := gsxfmt.FormatRemovingImports(path, []byte(text), unused, width)
+	width := s.analyzer.PrintWidth(dir)
+	// CSSFmt/JSFmt stay nil: LSP formatting has never run the <style>/<script>
+	// formatters that the CLI runs. Preserving that here keeps output identical;
+	// closing the gap is a separate change.
+	formatted, err := gsxfmt.FormatWith(path, []byte(text), gsxfmt.FormatOptions{
+		Unused:  unused,
+		Width:   width,
+		Reorder: mode.Reorder(),
+	})
 	if err != nil || string(formatted) == text {
 		return s.reply(f.ID, []TextEdit{}) // invalid mid-edit, or already canonical
 	}

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -49,14 +49,49 @@ type initializeResult struct {
 }
 
 type serverCapabilities struct {
-	PositionEncoding           string `json:"positionEncoding"`
-	TextDocumentSync           int    `json:"textDocumentSync"`
-	DefinitionProvider         bool   `json:"definitionProvider"`
-	ReferencesProvider         bool   `json:"referencesProvider"`
-	DocumentFormattingProvider bool   `json:"documentFormattingProvider"`
-	HoverProvider              bool   `json:"hoverProvider"`
-	DocumentSymbolProvider     bool   `json:"documentSymbolProvider"`
-	WorkspaceSymbolProvider    bool   `json:"workspaceSymbolProvider"`
+	PositionEncoding           string             `json:"positionEncoding"`
+	TextDocumentSync           int                `json:"textDocumentSync"`
+	DefinitionProvider         bool               `json:"definitionProvider"`
+	ReferencesProvider         bool               `json:"referencesProvider"`
+	DocumentFormattingProvider bool               `json:"documentFormattingProvider"`
+	HoverProvider              bool               `json:"hoverProvider"`
+	DocumentSymbolProvider     bool               `json:"documentSymbolProvider"`
+	WorkspaceSymbolProvider    bool               `json:"workspaceSymbolProvider"`
+	CodeActionProvider         *CodeActionOptions `json:"codeActionProvider,omitempty"`
+}
+
+// CodeActionOptions advertises which code-action kinds the server produces. It
+// is a struct rather than a bare `true` so clients know they can wire
+// editor.codeActionsOnSave to source.organizeImports.
+type CodeActionOptions struct {
+	CodeActionKinds []string `json:"codeActionKinds"`
+}
+
+// organizeImportsKind is the LSP kind for the organize-imports source action.
+const organizeImportsKind = "source.organizeImports"
+
+type codeActionContext struct {
+	// Only restricts the kinds the client wants. Empty means "any".
+	Only []string `json:"only"`
+}
+
+type codeActionParams struct {
+	TextDocument textDocumentIdentifier `json:"textDocument"`
+	Range        Range                  `json:"range"`
+	Context      codeActionContext      `json:"context"`
+}
+
+// WorkspaceEdit maps a document URI to the edits to apply to it.
+type WorkspaceEdit struct {
+	Changes map[string][]TextEdit `json:"changes"`
+}
+
+// CodeAction is one entry of the textDocument/codeAction result. Edit is carried
+// inline, so the server advertises no resolveProvider.
+type CodeAction struct {
+	Title string         `json:"title"`
+	Kind  string         `json:"kind"`
+	Edit  *WorkspaceEdit `json:"edit,omitempty"`
 }
 
 // TextEdit is a single text replacement: NewText replaces the span at Range.

--- a/internal/lsp/references_cache_test.go
+++ b/internal/lsp/references_cache_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // errFake is a sentinel error returned by moduleRefsAnalyzer to exercise the
@@ -38,6 +40,9 @@ func (a *moduleRefsAnalyzer) ModuleSymbols(string, map[string][]byte) ([]Symbol,
 	return nil, nil
 }
 func (a *moduleRefsAnalyzer) PrintWidth(string) int { return 80 }
+func (a *moduleRefsAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
+	return gsxfmt.ImportsGoimports
+}
 
 // drive runs the given pre-framed messages through a fresh server over the
 // analyzer and returns the raw output. Helper mirrors the existing

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -209,6 +209,8 @@ func (s *Server) handle(f frame) error {
 		return s.handleHover(f)
 	case "textDocument/formatting":
 		return s.handleFormatting(f)
+	case "textDocument/codeAction":
+		return s.handleCodeAction(f)
 	case "textDocument/documentSymbol":
 		return s.handleDocumentSymbol(f)
 	case "workspace/symbol":
@@ -239,6 +241,7 @@ func (s *Server) handleInitialize(f frame) error {
 		HoverProvider:              true,
 		DocumentSymbolProvider:     true,
 		WorkspaceSymbolProvider:    true,
+		CodeActionProvider:         &CodeActionOptions{CodeActionKinds: []string{organizeImportsKind}},
 	}})
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gsxhq/gsx/internal/diag"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // defaultDebounce is how long the server waits for typing to settle before
@@ -32,6 +33,11 @@ type Analyzer interface {
 	// PrintWidth returns the gsx.toml print width for the given directory
 	// (default 80). Used by textDocument/formatting.
 	PrintWidth(dir string) int
+	// ImportsMode returns the gsx.toml [formatter] imports mode for the given
+	// directory (default goimports). Used by textDocument/formatting; the
+	// source.organizeImports code action deliberately ignores it and always
+	// organizes.
+	ImportsMode(dir string) gsxfmt.ImportsMode
 }
 
 // Server is a stdio LSP server that publishes gsx diagnostics. It owns the

--- a/internal/lsp/server_async_test.go
+++ b/internal/lsp/server_async_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gsxhq/gsx/internal/diag"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // blockingAnalyzer parks inside Analyze until the test releases that specific
@@ -44,6 +45,9 @@ func (a *blockingAnalyzer) Analyze(_ string, override map[string][]byte) (*Packa
 }
 
 func (a *blockingAnalyzer) PrintWidth(string) int { return 80 }
+func (a *blockingAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
+	return gsxfmt.ImportsGoimports
+}
 
 // TestAnalysisIsAsyncAndSupersededResultsDiscarded proves two Phase-2 properties
 // deterministically (no sleeps): (1) the Run loop answers requests while an

--- a/internal/lsp/server_debounce_test.go
+++ b/internal/lsp/server_debounce_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gsxhq/gsx/internal/diag"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // countingAnalyzer behaves like fakeAnalyzer (one diag for its file) but counts
@@ -46,6 +47,9 @@ func (a *countingAnalyzer) Analyze(_ string, override map[string][]byte) (*Packa
 }
 
 func (a *countingAnalyzer) PrintWidth(string) int { return 80 }
+func (a *countingAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
+	return gsxfmt.ImportsGoimports
+}
 
 func (a *countingAnalyzer) calls() int {
 	a.mu.Lock()

--- a/internal/lsp/server_lifecycle_test.go
+++ b/internal/lsp/server_lifecycle_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // nilAnalyzer satisfies Analyzer and returns nothing.
@@ -17,6 +19,7 @@ func (nilAnalyzer) AnalyzeModule(string, map[string][]byte) ([]CrossRef, error) 
 }
 func (nilAnalyzer) ModuleSymbols(string, map[string][]byte) ([]Symbol, error) { return nil, nil }
 func (nilAnalyzer) PrintWidth(string) int                                     { return 80 }
+func (nilAnalyzer) ImportsMode(string) gsxfmt.ImportsMode                     { return gsxfmt.ImportsGoimports }
 
 // framed wraps a JSON-RPC body in Content-Length framing.
 func framed(t *testing.T, v any) string {

--- a/internal/lsp/server_sync_test.go
+++ b/internal/lsp/server_sync_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gsxhq/gsx/internal/diag"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 // fakeAnalyzer returns one error diagnostic for the file it is told about.
@@ -35,6 +36,9 @@ func (a fakeAnalyzer) Analyze(dir string, override map[string][]byte) (*Package,
 }
 
 func (a fakeAnalyzer) PrintWidth(string) int { return 80 }
+func (a fakeAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
+	return gsxfmt.ImportsGoimports
+}
 
 func TestDidOpenPublishesDiagnostics(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "page.gsx")

--- a/internal/lsp/workspacesymbol_test.go
+++ b/internal/lsp/workspacesymbol_test.go
@@ -4,6 +4,8 @@ import (
 	"go/token"
 	"strings"
 	"testing"
+
+	"github.com/gsxhq/gsx/internal/gsxfmt"
 )
 
 func wsSymFrame(id int, query string) string {
@@ -28,6 +30,9 @@ func (a *wsSymAnalyzer) ModuleSymbols(string, map[string][]byte) ([]Symbol, erro
 	return a.syms, nil
 }
 func (a *wsSymAnalyzer) PrintWidth(string) int { return 80 }
+func (a *wsSymAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
+	return gsxfmt.ImportsGoimports
+}
 
 func TestWorkspaceSymbolQueryAndCache(t *testing.T) {
 	uri := "file:///m/a.gsx"

--- a/internal/printer/gochunk_test.go
+++ b/internal/printer/gochunk_test.go
@@ -1,0 +1,69 @@
+package printer
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFmtGoChunkPreservesBuildComment guards the corruption bug fixed by
+// wrapping GoChunk text in a synthetic package clause before formatting:
+// go/format.Source's fragment mode strips a fixed byte count off its output,
+// which shears a //go:build comment that go/printer hoists above the clause
+// it injects internally — turning "//go:build linux" into "linux" and
+// leaking "package p" into the chunk. fmtGoChunk must instead feed
+// format.Source a complete, valid file (goExprWrapper + src) and remove the
+// synthetic clause by parsing, so the build comment survives untouched and no
+// package declaration leaks into the printed chunk.
+func TestFmtGoChunkPreservesBuildComment(t *testing.T) {
+	src := "//go:build linux\n\nimport (\n\t\"fmt\"\n)\n\nvar _ = fmt.Sprint"
+	got := fmtGoChunk(src)
+
+	if !strings.Contains(got, "//go:build linux") {
+		t.Fatalf("build comment not preserved verbatim; got:\n%s", got)
+	}
+	if strings.Contains(got, "package ") {
+		t.Fatalf("synthetic package clause leaked into output; got:\n%s", got)
+	}
+	if strings.Contains(got, "linux\n") && !strings.Contains(got, "//go:build linux\n") {
+		t.Fatalf("build comment corrupted (comment marker sheared off); got:\n%s", got)
+	}
+}
+
+// TestStripSyntheticPackage covers the three shapes StripSyntheticPackage must
+// handle: a clause on line 1, a clause relocated below a hoisted //go:build
+// comment, and unparseable input.
+func TestStripSyntheticPackage(t *testing.T) {
+	t.Run("clause on line 1", func(t *testing.T) {
+		formatted := []byte("package _gsxfmt\n\nimport (\n\t\"fmt\"\n)\n")
+		got, ok := StripSyntheticPackage(formatted)
+		if !ok {
+			t.Fatalf("expected ok=true")
+		}
+		want := "import (\n\t\"fmt\"\n)\n"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("clause below hoisted build comment", func(t *testing.T) {
+		// This is the shape go/printer actually produces when a //go:build
+		// comment sits above the synthetic clause: the comment stays first,
+		// separated from the clause by a blank line.
+		formatted := []byte("//go:build linux\n\npackage _gsxfmt\n\nimport (\n\t\"fmt\"\n)\n")
+		got, ok := StripSyntheticPackage(formatted)
+		if !ok {
+			t.Fatalf("expected ok=true")
+		}
+		want := "//go:build linux\n\nimport (\n\t\"fmt\"\n)\n"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unparseable input", func(t *testing.T) {
+		_, ok := StripSyntheticPackage([]byte("this is not { valid Go"))
+		if ok {
+			t.Fatalf("expected ok=false for unparseable input")
+		}
+	})
+}

--- a/internal/printer/goexpr_test.go
+++ b/internal/printer/goexpr_test.go
@@ -210,6 +210,33 @@ func TestGoWithElementsInvalidGoLeftVerbatim(t *testing.T) {
 	}
 }
 
+// TestGoWithElementsPreservesBuildComment guards the twin of the fmtGoChunk
+// corruption bug (see TestFmtGoChunkPreservesBuildComment): fmtGoExprParts
+// wraps a GoWithElements region's Go text in the same goExprWrapper synthetic
+// package clause, and go/printer hoists a //go:build comment ABOVE that
+// clause. The old strip assumed the clause was always the first line of
+// gofmt's output, so it deleted the hoisted build comment instead and spliced
+// `package _gsxfmt` into the user's source — silently, with exit 0. The strip
+// must locate the clause by parsing (StripSyntheticPackage) so the comment
+// survives and nothing leaks.
+func TestGoWithElementsPreservesBuildComment(t *testing.T) {
+	src := "package probe\n\n//go:build linux\nvar greeting = <a href=\"x\">hi</a>\n"
+	want := "package probe\n\n//go:build linux\n\nvar greeting = <a href=\"x\">hi</a>\n"
+	checkFormat(t, src, want)
+}
+
+// TestGoWithElementsNoBuildCommentUnchanged pins that an ordinary
+// GoWithElements region (no hoisted build comment) is unaffected by routing
+// the clause-strip through StripSyntheticPackage: it removes the clause line
+// AND the following blank line, one more byte than the old first-line strip
+// removed, but goWithElements' own trimGoTextEdges already trims the first
+// part's leading whitespace regardless — so the extra removed byte is
+// invisible here. This guards against a regression in that assumption.
+func TestGoWithElementsNoBuildCommentUnchanged(t *testing.T) {
+	src := "package main\n\nvar greeting = <a href=\"x\">hi</a>\n"
+	checkFormat(t, src, src)
+}
+
 func contains(hay, needle string) bool {
 	return len(hay) >= len(needle) && indexOf(hay, needle) >= 0
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1447,13 +1447,14 @@ func (p *printer) fmtGoExprParts(parts []ast.GoPart) ([]ast.GoPart, []goexprshap
 	if err != nil {
 		return nil, shapes, false
 	}
-	// Drop the synthetic package clause. gofmt always emits it as the first line.
-	formatted := string(out)
-	nl := strings.IndexByte(formatted, '\n')
-	if nl < 0 {
+	// Drop the synthetic package clause. It is NOT reliably the first line:
+	// go/printer hoists a //go:build comment above the package clause, so a
+	// line-index strip would shear the constraint and splice `package
+	// _gsxfmt` into the user's source. Locate it by parsing instead.
+	formatted, ok := StripSyntheticPackage(out)
+	if !ok {
 		return nil, shapes, false
 	}
-	formatted = formatted[nl+1:]
 
 	// Re-split at the placeholders, left to right. Placeholders of equal width are
 	// identical strings, which is harmless: the cursor has already consumed every

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1248,11 +1248,18 @@ func isExecutableScript(e *ast.Element) bool {
 
 // fmtGoChunk formats a top-level Go declaration chunk (imports/types/funcs/etc.).
 func fmtGoChunk(src string) string {
-	out, err := format.Source([]byte(src))
+	// Format the chunk as a VALID FILE, not a fragment: go/format.Source's
+	// fragment mode strips a fixed byte count off its output, which shears a
+	// //go:build comment that go/printer hoisted above the injected clause.
+	out, err := format.Source([]byte(goExprWrapper + src))
 	if err != nil {
 		return strings.TrimSpace(src)
 	}
-	return strings.TrimSpace(string(out))
+	stripped, ok := StripSyntheticPackage(out)
+	if !ok {
+		return strings.TrimSpace(src)
+	}
+	return strings.TrimSpace(stripped)
 }
 
 // goExprWrapper is the synthetic package clause prepended to a GoWithElements'
@@ -1260,6 +1267,39 @@ func fmtGoChunk(src string) string {
 // GoWithElements spans is always a run of complete top-level declarations, so
 // the clause is all that is missing.
 const goExprWrapper = "package _gsxfmt\n"
+
+// StripSyntheticPackage removes the synthetic package clause from formatted —
+// the output of a Go formatter that was fed a synthetic clause + a GoChunk's
+// text. It locates the clause by PARSING, never by assuming it is the first
+// line: go/printer relocates build-constraint comments (//go:build) above the
+// package clause, so a line- or byte-index strip would shear the constraint and
+// leave the synthetic `package` declaration spliced into the user's source.
+//
+// The single blank line the formatter always places between the package clause
+// and the following declaration is removed too — it is separation we introduced
+// by adding the clause, not layout the author wrote.
+//
+// ok is false when formatted does not parse; the caller then leaves the text
+// untouched.
+func StripSyntheticPackage(formatted []byte) (string, bool) {
+	fset := gotoken.NewFileSet()
+	file, err := goparser.ParseFile(fset, "", formatted, goparser.PackageClauseOnly|goparser.ParseComments)
+	if err != nil {
+		return "", false
+	}
+	start := fset.Position(file.Package).Offset  // offset of the `package` keyword
+	end := fset.Position(file.Name.End()).Offset // end of the package name
+	for end < len(formatted) && formatted[end] != '\n' {
+		end++
+	}
+	if end < len(formatted) {
+		end++ // the newline terminating the clause
+	}
+	if end < len(formatted) && formatted[end] == '\n' {
+		end++ // the single blank line the formatter puts after the clause
+	}
+	return string(formatted[:start]) + string(formatted[end:]), true
+}
 
 // goExprHoleRunes are candidate placeholder runes: Unicode modifier letters,
 // which Go accepts as identifier letters (identifier = letter { letter | digit },


### PR DESCRIPTION
Adds two gopls-style import-handling modes to `gsx fmt` and the language server, and fixes **two pre-existing silent source-corruption bugs** found during review.

## The feature

`gsx fmt` never merged, deduped, or grouped imports. This input was left untouched:

```go
import "github.com/tespkg/one-learning/db"

import (
	"fmt"
	"strings"

	"github.com/gsxhq/gsx"
	"github.com/tespkg/one-learning/db"
)
```

Now, by default, it becomes one merged, deduped, grouped block.

Two modes, mirroring what gopls offers — not a pile of independent knobs:

| Mode | Behavior |
|---|---|
| `goimports` (default) | remove unused imports, merge declarations, dedup specs, sort each group |
| `gofmt` | format only: sort within an existing group; never remove, merge, dedup, or regroup |

```toml
[formatter]
imports = "goimports"   # "goimports" (default) | "gofmt"
```

```
gsx fmt -imports gofmt|goimports   # override for one run
gsx fmt -no-imports                # alias for -imports gofmt
```

Precedence: CLI flag → `gsx.toml` → default `goimports`, resolved **per directory** (one run can span directories governed by different `gsx.toml` files). `-imports goimports` with `-no-imports` is a usage error (exit 2).

**LSP:** `textDocument/formatting` honors the mode. A new `source.organizeImports` code action **always** organizes regardless of mode — exactly gopls's split, so you can keep `imports = "gofmt"` for format-on-save and wire `editor.codeActionsOnSave` separately.

## Reuse, not reimplementation

Both modes call the upstream code:

- **gofmt** = stdlib `go/format.Source`, which the printer already applied per Go chunk. gofmt mode needed **zero new formatting code** — it just skips the organize passes.
- **goimports** = `golang.org/x/tools/imports.Process` with `Options{FormatOnly: true}`, already a module requirement (+1,811 bytes to `gsx.wasm`, 0.01%).

`FormatOnly` is load-bearing: without it goimports would add/remove imports based on chunk-body usage, and a gsx Go chunk body never references the template's imports — plain goimports would strip every one. For the same reason gsx **cannot add** a missing import; that's documented, not papered over.

Grouping is byte-identical to the real `goimports` binary, including its rule that author-written blank lines are group boundaries and are never merged away.

## Two pre-existing bugs fixed (both silent, both on `main` today)

Review falsified two "unreachable" assumptions with real repros.

**1. Synthetic package clause stripped by line index.** Go chunks carry no package clause, so gsx wraps them before formatting, then strips the clause. But `go/printer` *hoists* `//go:build` comments **above** the clause, so the strip deleted the build tag and spliced the synthetic clause into user source:

```
//go:build linux            →     package _gsxfmt
var greeting = <a>hi</a>          var greeting = <a>hi</a>
```

Exit 0. `-w` wrote it to disk. It hit both `fmtGoChunk` and `fmtGoExprParts` (`GoWithElements`). Root cause ran deeper: `go/format.Source` on a package-less **fragment** injects `package p;` then strips a *fixed byte count*, shearing `//go:build linux` into `linux`. Fixed by formatting chunks as valid whole files and removing the clause via a parse-based `printer.StripSyntheticPackage`.

**2. Chunk trailing newlines are a layout fact, not slack.** The printer reads them (`endsWithBlankLine`) to decide whether a blank line precedes the next declaration. `strings.TrimSpace` destroyed them, collapsing the blank line after every rewritten import block. Fixed with `preserveTrailing`.

## Testing

Rebased onto `main`, which meanwhile introduced a **fmt corpus** (`internal/gsxfmt/testdata/cases/*.txtar`, pinning layout via `input.gsx` + `fmt.golden`) and the rule *"any formatter change ships a fmt-corpus case."* This branch now complies.

The harness was extended with two optional txtar sections — `-- imports --` (`gofmt`|`goimports`) and `-- unused --` (explicit `ImportRef` list, so removal is exercised deterministically without module analysis, keeping the suite type-check-free and fast). Six new cases pin: merge+dedup, std/third-party grouping, **author-group preservation**, gofmt-leaves-imports-alone, unused removal with blank-line preservation, and `//go:build` survival through the synthetic package clause. The five pre-existing cases and their goldens are untouched.

Behavior is additionally pinned in `internal/gsxfmt/*_test.go` and `gen/fmt_test.go` (CLI + LSP E2E).

Adversarial review probed: `import` inside strings/comments/raw strings, element literals beside import blocks, both-unused-and-duplicated imports, per-directory mode divergence, dot/blank/aliased imports, non-ASCII last lines under utf-8 and utf-16, and `gsx fmt` as a fixed point across all 608 corpus + example `.gsx` files.

`make ci` ✅ · `make lint` ✅ · `gsx fmt -l .` → 0 drift

No syntax change, so no `tree-sitter-gsx` / `vscode-gsx` / CodeMirror grammar work.

Design: `docs/superpowers/specs/2026-07-07-organize-imports-design.md`
Plan: `docs/superpowers/plans/2026-07-09-goimports-modes.md`

https://claude.ai/code/session_019iePKYNP1kgfX1MHBbCk8s

