### PR TITLE
perf(codegen): harvest the filter table from the importer's types, not a second go list

### DIFF
--- a/internal/codegen/bundle.go
+++ b/internal/codegen/bundle.go
@@ -10,14 +10,20 @@ import (
 // values (e.g. reconstructed from an embedded typebundle), so the gsx transform
 // can run in a WASM build with no `go list`.
 //
-// NOTE: harvestFromTypes duplicates the scope-iteration of harvestFilters
-// (which is coupled to *packages.Package for its Errors/dir-specific messages).
-// Worth DRYing once the WASM path is settled.
-
-// harvestFromTypes harvests filters from already-type-checked packages keyed by
-// import path — no packages.Load. aliases maps each package path to its reserved
-// import alias (filterAliases). Mirrors harvestFilters' precedence: whole-package
-// paths in order (last-wins), then explicit aliases.
+// harvestFromTypes is THE filter harvest. Every path that builds a filter table
+// funnels here: harvestFilters (go list) validates *packages.Package errors and
+// then delegates; Module.filterTableFromExt harvests the external importer's
+// already-loaded types; NewCachedResolverFromTypes serves the WASM Bundle.
+//
+// One implementation is not a tidiness preference. Precedence (whole-package
+// paths in order, last-wins, then explicit aliases), signature classification,
+// and `_gsxf<i>` alias assignment all feed the emitted .x.go, so two harvests
+// that disagree produce different generated code from the same input. They did:
+// only the go-list copy recognized the removed curried shape, so the same bad
+// WithFilter got a migration hint or an unhelpful contract error depending on
+// which path ran.
+//
+// aliases maps each package path to its reserved import alias (filterAliases).
 func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, explicitAliases []FilterAlias, aliases map[string]string) (map[string][]filterEntry, error) {
 	harvested := map[string][]filterEntry{}
 	for _, path := range pkgPaths {
@@ -74,6 +80,11 @@ func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, expli
 		}
 		wantsCtx, ok := classifyFilter(sig)
 		if !ok {
+			// The curried shape gets its own migration message: it was once valid,
+			// so "does not match the contract" would not tell an author what to do.
+			if isCurriedShape(sig) {
+				return nil, fmt.Errorf("codegen: WithFilter %q: filter %q uses the removed curried shape func(args) func(T) R; rewrite as seed-first func([ctx,] subject, args...)", a.Name, a.FuncName)
+			}
 			return nil, fmt.Errorf("codegen: WithFilter %q: func %q does not match the seed-first filter contract func([ctx,] subject, args...) (R[, error])", a.Name, a.FuncName)
 		}
 		harvested[a.Name] = append(harvested[a.Name], filterEntry{

--- a/internal/codegen/filters.go
+++ b/internal/codegen/filters.go
@@ -264,91 +264,47 @@ func harvestFilters(dir string, pkgPaths []string, explicitAliases []FilterAlias
 		byPath[pkg.PkgPath] = pkg
 	}
 
-	harvested := map[string][]filterEntry{}
+	// Validate what only *packages.Package can tell us (load errors, dir context),
+	// then hand the plain types to the ONE harvest implementation. Every path that
+	// builds a filter table — go list, a WASM Bundle, or the Module's external
+	// importer — must agree on precedence, classification, and alias assignment, so
+	// there is exactly one place that decides them.
+	typesByPath := make(map[string]*types.Package, len(byPath))
 	for _, path := range pkgPaths {
-		pkg, ok := byPath[path]
-		if !ok {
-			return nil, fmt.Errorf("codegen: filter package %q not found in %s", path, dir)
+		if err := checkFilterPkg(byPath[path], path, dir, ""); err != nil {
+			return nil, err
 		}
-		if len(pkg.Errors) > 0 {
-			return nil, fmt.Errorf("codegen: filter package %q type resolution failed: %s", path, pkg.Errors[0])
-		}
-		if pkg.Types == nil {
-			return nil, fmt.Errorf("codegen: filter package %q has no type information", path)
-		}
-		alias := aliases[path]
-		scope := pkg.Types.Scope()
-		for _, name := range scope.Names() {
-			obj := scope.Lookup(name)
-			if !obj.Exported() {
-				continue
-			}
-			fn, ok := obj.(*types.Func)
-			if !ok {
-				continue
-			}
-			sig, ok := fn.Type().(*types.Signature)
-			if !ok {
-				continue
-			}
-			wantsCtx, ok := classifyFilter(sig)
-			if !ok {
-				// A non-conforming func (incl. the removed curried shape) is simply
-				// skipped during whole-package harvest, as before.
-				continue
-			}
-			tname := lowerFirst(name)
-			harvested[tname] = append(harvested[tname], filterEntry{
-				funcName: name,
-				wantsCtx: wantsCtx,
-				hasErr:   sig.Results().Len() == 2,
-				alias:    alias,
-				pkgPath:  path,
-			})
-		}
+		typesByPath[path] = byPath[path].Types
 	}
-
-	// Register explicit aliases AFTER whole-package harvest, in option order, so
-	// an alias can intentionally override a harvested same-named filter (last-wins).
+	// An alias package's failure is reported against the WithFilter that named it.
+	// "package X not found" is far less actionable when nothing else in the config
+	// mentions X — only the alias pulled it in.
 	for _, a := range explicitAliases {
-		pkg, ok := byPath[a.PkgPath]
-		if !ok {
-			return nil, fmt.Errorf("codegen: WithFilter %q: package %q not found in %s", a.Name, a.PkgPath, dir)
+		if err := checkFilterPkg(byPath[a.PkgPath], a.PkgPath, dir, a.Name); err != nil {
+			return nil, err
 		}
-		if len(pkg.Errors) > 0 {
-			return nil, fmt.Errorf("codegen: WithFilter %q: package %q type resolution failed: %s", a.Name, a.PkgPath, pkg.Errors[0])
-		}
-		if pkg.Types == nil {
-			return nil, fmt.Errorf("codegen: WithFilter %q: package %q has no type information", a.Name, a.PkgPath)
-		}
-		obj := pkg.Types.Scope().Lookup(a.FuncName)
-		if obj == nil {
-			return nil, fmt.Errorf("codegen: WithFilter %q: func %q not found in package %q", a.Name, a.FuncName, a.PkgPath)
-		}
-		fn, ok := obj.(*types.Func)
-		if !ok {
-			return nil, fmt.Errorf("codegen: WithFilter %q: %q in package %q is not a function", a.Name, a.FuncName, a.PkgPath)
-		}
-		sig, ok := fn.Type().(*types.Signature)
-		if !ok {
-			return nil, fmt.Errorf("codegen: WithFilter %q: %q in package %q has no signature", a.Name, a.FuncName, a.PkgPath)
-		}
-		wantsCtx, ok := classifyFilter(sig)
-		if !ok {
-			if isCurriedShape(sig) {
-				return nil, fmt.Errorf("codegen: WithFilter %q: filter %q uses the removed curried shape func(args) func(T) R; rewrite as seed-first func([ctx,] subject, args...)", a.Name, a.FuncName)
-			}
-			return nil, fmt.Errorf("codegen: WithFilter %q: func %q does not match the seed-first filter contract func([ctx,] subject, args...) (R[, error])", a.Name, a.FuncName)
-		}
-		harvested[a.Name] = append(harvested[a.Name], filterEntry{
-			funcName: a.FuncName,
-			wantsCtx: wantsCtx,
-			hasErr:   sig.Results().Len() == 2,
-			alias:    aliases[a.PkgPath],
-			pkgPath:  a.PkgPath,
-		})
+		typesByPath[a.PkgPath] = byPath[a.PkgPath].Types
 	}
-	return harvested, nil
+	return harvestFromTypes(typesByPath, pkgPaths, explicitAliases, aliases)
+}
+
+// checkFilterPkg reports the load-level failures only *packages.Package can see.
+// aliasName, when non-empty, frames the error against the WithFilter that named
+// the package rather than against the package alone.
+func checkFilterPkg(pkg *packages.Package, path, dir, aliasName string) error {
+	where := fmt.Sprintf("filter package %q", path)
+	if aliasName != "" {
+		where = fmt.Sprintf("WithFilter %q: package %q", aliasName, path)
+	}
+	switch {
+	case pkg == nil:
+		return fmt.Errorf("codegen: %s not found in %s", where, dir)
+	case len(pkg.Errors) > 0:
+		return fmt.Errorf("codegen: %s type resolution failed: %s", where, pkg.Errors[0])
+	case pkg.Types == nil:
+		return fmt.Errorf("codegen: %s has no type information", where)
+	}
+	return nil
 }
 
 // FilterInfo describes one resolved pipeline filter, for `gsx info`.

--- a/internal/codegen/filtertable_equiv_test.go
+++ b/internal/codegen/filtertable_equiv_test.go
@@ -1,0 +1,235 @@
+package codegen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestFilterTableFromExtMatchesGoList is the faithfulness harness for replacing
+// the filter table's packages.Load with a harvest from the external importer's
+// already-loaded types. The two must agree EXACTLY — same names, same winning
+// package, same ctx/err classification, and critically the same `_gsxf<i>` import
+// alias, since that alias is emitted into every .x.go.
+//
+// It exercises the properties that make the two paths capable of diverging:
+// last-wins precedence across packages, ctx-taking filters, (T, error) filters,
+// generics, and explicit WithFilter aliases pointing at a package that appears
+// nowhere else.
+func TestFilterTableFromExtMatchesGoList(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	root := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	repoRoot = filepath.Dir(repoRoot)
+	must := func(p, c string) {
+		t.Helper()
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/x\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	// `shout` is defined in BOTH a and b: last-wins must pick b.
+	must("a/a.go", "package a\n\nfunc Shout(s string) string { return s }\nfunc Only(s string) string { return s }\n")
+	must("b/b.go", "package b\n\nimport \"context\"\n\n"+
+		"func Shout(s string) string { return s }\n"+
+		"func Ctxy(ctx context.Context, s string) (string, error) { return s, nil }\n"+
+		"func Gen[T any](v []T) (T, error) { var z T; return z, nil }\n")
+	// aliasonly is referenced ONLY through an explicit WithFilter alias.
+	must("aliasonly/c.go", "package aliasonly\n\nfunc URLFor(s string) string { return s }\n")
+	must("views/v.gsx", "package views\n\ncomponent V(s string) {\n\t<p>{ s |> shout }</p>\n}\n")
+
+	filterPkgs := []string{stdImportPath, "example.com/x/a", "example.com/x/b"}
+	aliases := []FilterAlias{{Name: "url", PkgPath: "example.com/x/aliasonly", FuncName: "URLFor"}}
+
+	// Path 1: the standalone packages.Load harvest (the old behavior).
+	viaGoList, err := loadFilterTableMulti(root, dedupFilterPkgs(filterPkgs), aliases)
+	if err != nil {
+		t.Fatalf("loadFilterTableMulti: %v", err)
+	}
+
+	// Path 2: harvested from the external importer's loaded types.
+	m, err := Open(Options{ModuleRoot: root, ModulePath: "example.com/x", FilterPkgs: filterPkgs, Aliases: aliases})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.externalImporter(); err != nil {
+		t.Fatalf("externalImporter: %v", err)
+	}
+	viaTypes, err := m.filterTableFromExt(dedupFilterPkgs(filterPkgs))
+	if err != nil {
+		t.Fatalf("filterTableFromExt: %v", err)
+	}
+
+	if !reflect.DeepEqual(viaGoList, viaTypes) {
+		t.Errorf("filter tables diverge\n--- go list ---\n%s\n--- from types ---\n%s",
+			dumpTable(viaGoList), dumpTable(viaTypes))
+	}
+
+	// Sanity: the harness would be vacuous if the table were empty or if last-wins
+	// / aliases were not actually exercised.
+	if len(viaTypes) == 0 {
+		t.Fatal("empty table: harness proves nothing")
+	}
+	if e, ok := viaTypes["shout"]; !ok || e.pkgPath != "example.com/x/b" {
+		t.Errorf("last-wins not exercised: shout = %+v", e)
+	}
+	if e, ok := viaTypes["url"]; !ok || e.pkgPath != "example.com/x/aliasonly" {
+		t.Errorf("explicit alias not exercised: url = %+v", e)
+	}
+	if e, ok := viaTypes["ctxy"]; !ok || !e.wantsCtx || !e.hasErr {
+		t.Errorf("ctx/err classification not exercised: ctxy = %+v", e)
+	}
+}
+
+// TestFilterHarvestErrorsMatch pins the failure modes, not just the happy path.
+// The two harvests silently disagreed here: only the go-list copy recognized the
+// removed curried shape, so the SAME bad WithFilter produced a migration hint or
+// an unhelpful "does not match the contract" depending on which path ran. Now
+// both delegate to harvestFromTypes, so this asserts identical error text.
+func TestFilterHarvestErrorsMatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	cases := []struct {
+		name, src string
+		alias     FilterAlias
+		want      string
+	}{
+		{
+			name:  "curried",
+			src:   "package bad\n\nfunc Old(n int) func(string) string { return func(s string) string { return s } }\n",
+			alias: FilterAlias{Name: "old", PkgPath: "example.com/x/bad", FuncName: "Old"},
+			want:  "removed curried shape",
+		},
+		{
+			name:  "not_a_func",
+			src:   "package bad\n\nvar Old = 3\n",
+			alias: FilterAlias{Name: "old", PkgPath: "example.com/x/bad", FuncName: "Old"},
+			want:  "is not a function",
+		},
+		{
+			name:  "missing_func",
+			src:   "package bad\n\nfunc Other(s string) string { return s }\n",
+			alias: FilterAlias{Name: "old", PkgPath: "example.com/x/bad", FuncName: "Old"},
+			want:  "not found in package",
+		},
+		{
+			name:  "nonconforming",
+			src:   "package bad\n\nfunc Old() {}\n",
+			alias: FilterAlias{Name: "old", PkgPath: "example.com/x/bad", FuncName: "Old"},
+			want:  "seed-first filter contract",
+		},
+		{
+			// A broken ALIAS package must be reported against the WithFilter that
+			// named it — nothing else in the config mentions the package, so
+			// "filter package X failed" leaves the author no thread to pull.
+			name:  "broken_alias_pkg",
+			src:   "package bad\n\nfunc Old(s string) string { return undefinedIdent(s) }\n",
+			alias: FilterAlias{Name: "old", PkgPath: "example.com/x/bad", FuncName: "Old"},
+			want:  `WithFilter "old": package "example.com/x/bad" type resolution failed`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			repoRoot, _ := filepath.Abs("..")
+			repoRoot = filepath.Dir(repoRoot)
+			must := func(p, c string) {
+				full := filepath.Join(root, p)
+				if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			must("go.mod", "module example.com/x\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+			must("bad/bad.go", tc.src)
+
+			filterPkgs := []string{stdImportPath}
+			aliases := []FilterAlias{tc.alias}
+
+			_, goListErr := loadFilterTableMulti(root, dedupFilterPkgs(filterPkgs), aliases)
+
+			m, err := Open(Options{ModuleRoot: root, ModulePath: "example.com/x", FilterPkgs: filterPkgs, Aliases: aliases})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := m.externalImporter(); err != nil {
+				t.Fatalf("externalImporter: %v", err)
+			}
+			_, typesErr := m.filterTableFromExt(dedupFilterPkgs(filterPkgs))
+
+			if goListErr == nil || typesErr == nil {
+				t.Fatalf("expected both paths to error; goList=%v types=%v", goListErr, typesErr)
+			}
+			if goListErr.Error() != typesErr.Error() {
+				t.Errorf("error text diverges\n  go list: %v\nfrom types: %v", goListErr, typesErr)
+			}
+			if !strings.Contains(typesErr.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", typesErr, tc.want)
+			}
+		})
+	}
+}
+
+func dumpTable(tbl filterTable) string {
+	names := make([]string, 0, len(tbl))
+	for n := range tbl {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var sb strings.Builder
+	for _, n := range names {
+		e := tbl[n]
+		fmt.Fprintf(&sb, "%s -> %s.%s alias=%s ctx=%v err=%v\n", n, e.pkgPath, e.funcName, e.alias, e.wantsCtx, e.hasErr)
+	}
+	return sb.String()
+}
+
+// TestFilterTableFromExtRejectsBrokenPkg: packages.Load hands back PARTIAL Types
+// for a package that fails to type-check, so a from-types harvest would silently
+// yield a thinner table and the pipe would fail later as "unknown filter". The
+// go-list path errors; the types path must too.
+func TestFilterTableFromExtRejectsBrokenPkg(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	root := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	repoRoot = filepath.Dir(repoRoot)
+	must := func(p, c string) {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("go.mod", "module example.com/x\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	must("broken/b.go", "package broken\n\nfunc Shout(s string) string { return undefinedIdent(s) }\n")
+	must("views/v.gsx", "package views\n\ncomponent V(s string) {\n\t<p>{ s |> shout }</p>\n}\n")
+
+	filterPkgs := []string{stdImportPath, "example.com/x/broken"}
+	m, err := Open(Options{ModuleRoot: root, ModulePath: "example.com/x", FilterPkgs: filterPkgs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.externalImporter(); err != nil {
+		t.Fatalf("externalImporter: %v", err)
+	}
+	if _, err := m.filterTableFromExt(dedupFilterPkgs(filterPkgs)); err == nil {
+		t.Fatal("a broken filter package yielded a table instead of an error")
+	}
+}

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -127,29 +127,30 @@ type Options struct {
 // while keeping ext, pkgTypes, or pkgResults: that would orphan their positions.
 type Module struct {
 	opts              Options
-	overrides         map[string][]byte          // abs .gsx path -> in-memory source
-	ext               types.Importer             // lazily built external importer (stdlib + third-party)
-	extPkgs           map[string]*types.Package  // the types behind ext, kept for subprocess-free filter-table harvests
-	extLoads          int                        // count of external packages.Load calls (observability; test hook)
-	filterTbl         filterTable                // lazily built filter table (see cachedFilterTable)
-	filterTblErr      error                      // error from the filter-table load (cached alongside filterTbl)
-	filterTblDone     bool                       // true once the filter table has been loaded (success or error)
-	filterLoads       int                        // count of filter-table loads performed (observability; test hook)
-	dirFilterTbls     map[string]filterTable     // per-dir filter-table memo, keyed by canonical FilterPkgs key
-	perDirMergersErr  error                      // cached result of validatePerDirMergers
-	perDirMergersDone bool                       // true once the PerDir mergers have been validated
-	fset              *token.FileSet             // module-wide shared FileSet (see "FileSet" / "Growth" notes above)
-	pkgTypes          map[string]*types.Package  // abs dir -> checked *types.Package cache
-	pkgResults        map[string]*PackageResult  // abs dir -> cached full analysis result (Package path only)
-	depFacts          map[string]*depPropFacts   // abs dep dir -> cached imported prop facts (see importedPropFacts)
-	imports           map[string][]string        // dir -> its project-gsx dependency dirs (forward edges)
-	importedBy        map[string]map[string]bool // dep dir -> set of importer dirs (reverse edges)
-	dirty             map[string]bool            // dirs with a pending content change (consumed by applyDirty)
-	fsetBaseline      int                        // m.fset.Base() captured after the last packages.Load (growth measured since here)
-	fsetRebuildBytes  int                        // rebuild fset when fset.Base()-fsetBaseline exceeds this; 0 disables
-	rebuildCount      int                        // count of fset rebuilds performed (observability; exposed via rebuilds())
-	mu                sync.Mutex                 // guards overrides, ext, pkgTypes, pkgResults, depFacts, imports, importedBy, dirty
-	analysisMu        sync.Mutex                 // serializes Package/Generate/typesPackage (see concurrency contract)
+	overrides         map[string][]byte           // abs .gsx path -> in-memory source
+	ext               types.Importer              // lazily built external importer (stdlib + third-party)
+	extPkgs           map[string]*types.Package   // the types behind ext, kept for subprocess-free filter-table harvests
+	extErrs           map[string][]packages.Error // per-package load/type errors from the ext load (filter packages must not be silently partial)
+	extLoads          int                         // count of external packages.Load calls (observability; test hook)
+	filterTbl         filterTable                 // lazily built filter table (see cachedFilterTable)
+	filterTblErr      error                       // error from the filter-table load (cached alongside filterTbl)
+	filterTblDone     bool                        // true once the filter table has been loaded (success or error)
+	filterLoads       int                         // count of filter-table loads performed (observability; test hook)
+	dirFilterTbls     map[string]filterTable      // per-dir filter-table memo, keyed by canonical FilterPkgs key
+	perDirMergersErr  error                       // cached result of validatePerDirMergers
+	perDirMergersDone bool                        // true once the PerDir mergers have been validated
+	fset              *token.FileSet              // module-wide shared FileSet (see "FileSet" / "Growth" notes above)
+	pkgTypes          map[string]*types.Package   // abs dir -> checked *types.Package cache
+	pkgResults        map[string]*PackageResult   // abs dir -> cached full analysis result (Package path only)
+	depFacts          map[string]*depPropFacts    // abs dep dir -> cached imported prop facts (see importedPropFacts)
+	imports           map[string][]string         // dir -> its project-gsx dependency dirs (forward edges)
+	importedBy        map[string]map[string]bool  // dep dir -> set of importer dirs (reverse edges)
+	dirty             map[string]bool             // dirs with a pending content change (consumed by applyDirty)
+	fsetBaseline      int                         // m.fset.Base() captured after the last packages.Load (growth measured since here)
+	fsetRebuildBytes  int                         // rebuild fset when fset.Base()-fsetBaseline exceeds this; 0 disables
+	rebuildCount      int                         // count of fset rebuilds performed (observability; exposed via rebuilds())
+	mu                sync.Mutex                  // guards overrides, ext, pkgTypes, pkgResults, depFacts, imports, importedBy, dirty
+	analysisMu        sync.Mutex                  // serializes Package/Generate/typesPackage (see concurrency contract)
 }
 
 // defaultFsetRebuildBytes bounds the module-lifetime FileSet's project re-parse
@@ -297,20 +298,31 @@ func (m *Module) externalImporter() (types.Importer, error) {
 	// (resolver.go) which lists "github.com/gsxhq/gsx" first for the same reason.
 	loadPaths := append([]string{"github.com/gsxhq/gsx", stdImportPath}, m.opts.FilterPkgs...)
 	loadPaths = append(loadPaths, m.opts.LoadPkgs...)
+	// Explicit WithFilter aliases name packages that need not appear anywhere
+	// else. They must be in the load set for filterTableFromExt to classify their
+	// target func's signature without a second packages.Load.
+	for _, a := range m.opts.Aliases {
+		loadPaths = append(loadPaths, a.PkgPath)
+	}
 	loadPaths = append(loadPaths, "./...")
 	pkgs, err := packages.Load(cfg, loadPaths...)
 	if err != nil {
 		return nil, err
 	}
 	mp := map[string]*types.Package{}
+	errs := map[string][]packages.Error{}
 	packages.Visit(pkgs, nil, func(p *packages.Package) {
 		if p.Types != nil {
 			mp[p.PkgPath] = p.Types
+		}
+		if len(p.Errors) > 0 {
+			errs[p.PkgPath] = p.Errors
 		}
 	})
 	m.mu.Lock()
 	m.ext = mapImporter(mp)
 	m.extPkgs = mp
+	m.extErrs = errs
 	m.extLoads++
 	m.fsetBaseline = m.fset.Base()
 	m.mu.Unlock()
@@ -431,26 +443,38 @@ func (m *Module) classMergerFor(dir string) *ClassMergerRef {
 
 // filterTableFor returns the filter table that applies to dir.
 //
-// Without a PerDir override this is cachedFilterTable — one packages.Load per
-// Module, shared by every dir. With one, the table is harvested from the types
-// the external importer already loaded, so N dirs with N different filter sets
-// cost ONE load between them rather than N. That is the whole point of the
-// union/per-dir split: Options.LoadPkgs is loaded once, DirOptions.FilterPkgs
-// only narrows what that dir may see.
+// withExt says whether the caller is on a path that loads the external importer.
+// Every such caller (Generate, Package, typesPackage → analyze) already paid one
+// packages.Load that includes the gsx runtime, FilterPkgs, LoadPkgs, and the
+// Aliases' packages — so the table is HARVESTED from those types rather than
+// re-loaded. That kills a second `go list` per Module: filter-table loads were
+// running 1:1 with importer loads (148 vs 127 across the gen suite alone).
+//
+// buildPackageSkeletons passes withExt=false. That path is `gsx fmt`'s syntactic
+// fast lane, which deliberately never loads the importer (it is what took
+// `gsx fmt -l` from ~16s to 0.58s); harvesting from types there would ADD the
+// full "./..." load it exists to avoid. It keeps the standalone
+// loadFilterTableMulti, which loads only the filter packages.
+//
+// A PerDir override always harvests from types, forcing the importer if needed:
+// N dirs with N different filter sets then cost ONE load between them.
 //
 // A dir naming a filter package the importer never loaded is an error. It must
 // never degrade to an empty table — a corpus case that asserts "this filter is
 // rejected because its package is not whitelisted" would then pass while
 // testing nothing.
-func (m *Module) filterTableFor(dir string) (filterTable, error) {
+func (m *Module) filterTableFor(dir string, withExt bool) (filterTable, error) {
 	if m.opts.Bundle != nil {
 		return m.opts.Bundle.filters(), nil
 	}
-	d, ok := m.dirOptionsFor(dir)
-	if !ok || d.FilterPkgs == nil {
+	pkgs := m.opts.FilterPkgs
+	if d, ok := m.dirOptionsFor(dir); ok && d.FilterPkgs != nil {
+		pkgs, withExt = d.FilterPkgs, true
+	}
+	if !withExt {
 		return m.cachedFilterTable()
 	}
-	pkgs := dedupFilterPkgs(d.FilterPkgs)
+	pkgs = dedupFilterPkgs(pkgs)
 	key := strings.Join(pkgs, "\x00")
 
 	m.mu.Lock()
@@ -465,11 +489,7 @@ func (m *Module) filterTableFor(dir string) (filterTable, error) {
 	if _, err := m.externalImporter(); err != nil {
 		return nil, err
 	}
-	m.mu.Lock()
-	extPkgs := m.extPkgs
-	m.mu.Unlock()
-
-	tbl, err := loadFilterTableFromTypes(extPkgs, pkgs, m.opts.Aliases)
+	tbl, err := m.filterTableFromExt(pkgs)
 	if err != nil {
 		return nil, fmt.Errorf("codegen: filter table for %s: %w", dir, err)
 	}
@@ -477,6 +497,40 @@ func (m *Module) filterTableFor(dir string) (filterTable, error) {
 	m.dirFilterTbls[key] = tbl
 	m.mu.Unlock()
 	return tbl, nil
+}
+
+// filterTableFromExt harvests a filter table from the external importer's
+// already-loaded types. It reproduces harvestFilters' error semantics — a filter
+// package that is absent, or that failed to type-check, is an error rather than a
+// silently-thinner table — because packages.Load hands back partial Types for a
+// broken package and a missing filter would otherwise surface as a confusing
+// "unknown filter" diagnostic at the pipe site.
+func (m *Module) filterTableFromExt(pkgs []string) (filterTable, error) {
+	m.mu.Lock()
+	extPkgs, extErrs := m.extPkgs, m.extErrs
+	m.mu.Unlock()
+
+	check := func(path, aliasName string) error {
+		errs := extErrs[path]
+		if len(errs) == 0 {
+			return nil
+		}
+		if aliasName != "" {
+			return fmt.Errorf("codegen: WithFilter %q: package %q type resolution failed: %s", aliasName, path, errs[0])
+		}
+		return fmt.Errorf("codegen: filter package %q type resolution failed: %s", path, errs[0])
+	}
+	for _, p := range pkgs {
+		if err := check(p, ""); err != nil {
+			return nil, err
+		}
+	}
+	for _, a := range m.opts.Aliases {
+		if err := check(a.PkgPath, a.Name); err != nil {
+			return nil, err
+		}
+	}
+	return loadFilterTableFromTypes(extPkgs, pkgs, m.opts.Aliases)
 }
 
 // maybeRebuildFset rebuilds the FileSet (and ext/pkgTypes/pkgResults) when project re-parse
@@ -503,6 +557,7 @@ func (m *Module) rebuildFset() {
 	m.fset = token.NewFileSet()
 	m.ext = nil
 	m.extPkgs = nil
+	m.extErrs = nil
 	m.filterTbl, m.filterTblErr, m.filterTblDone = filterTable{}, nil, false
 	m.dirFilterTbls = map[string]filterTable{}
 	m.perDirMergersErr, m.perDirMergersDone = nil, false

--- a/internal/codegen/module_filtercache_test.go
+++ b/internal/codegen/module_filtercache_test.go
@@ -6,46 +6,81 @@ import (
 	"testing"
 )
 
-// TestFilterTableCachedAcrossRegens proves the filter table — a ~150ms
-// packages.Load — is harvested ONCE per Module and reused across every warm
-// regen, rather than reloaded on each analyze(). Before caching, every
-// gsx generate --watch cycle paid the full filter-package load, turning ~10ms
-// warm regens into ~150ms ones.
-func TestFilterTableCachedAcrossRegens(t *testing.T) {
+// TestGeneratePathDoesNoFilterTableLoad proves the Generate/Package path never
+// runs a standalone `go list` for the filter table. It used to run one per
+// Module, 1:1 with the external importer's own load — 148 filter loads against
+// 127 importer loads across the gen suite alone — even though the importer had
+// already loaded and type-checked those exact packages. The table is now
+// harvested from those types.
+//
+// The old version of this test asserted `filterTableLoads() == 1` and guarded a
+// weaker property (the table is not reloaded per warm regen). Zero is the
+// stronger claim and subsumes it.
+func TestGeneratePathDoesNoFilterTableLoad(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
 	m, root := setupChainModule(t)
 	comp := filepath.Join(root, "components")
 
-	// Cold + several warm regens of the same package.
 	for i := range 4 {
 		if _, _, err := m.Generate(comp); err != nil {
 			t.Fatalf("generate #%d: %v", i, err)
 		}
 	}
-	if got := m.filterTableLoads(); got != 1 {
-		t.Fatalf("filter table loaded %d times across 4 regens; want 1 (cache miss every cycle = the watch slowdown)", got)
+	if got := m.filterTableLoads(); got != 0 {
+		t.Fatalf("filter table loaded %d times; want 0 (harvest it from the importer's types)", got)
+	}
+	if got := m.externalLoads(); got != 1 {
+		t.Fatalf("externalLoads = %d; want 1", got)
 	}
 
-	// An edit-driven regen (content change → applyDirty → re-analyze) must also
-	// reuse the cached table — a .gsx edit cannot change the filter packages.
+	// An edit-driven regen (content change → applyDirty → re-analyze) must not
+	// introduce one either — a .gsx edit cannot change the filter packages.
 	card := filepath.Join(comp, "card.gsx")
 	m.SetOverride(card, []byte("package components\n\nimport \"example.com/x/util\"\n\ncomponent X(title string) {\n\t<div><util.Y label={ title }/></div>\n}\n"))
 	if _, _, err := m.Generate(comp); err != nil {
 		t.Fatal(err)
 	}
-	if got := m.filterTableLoads(); got != 1 {
-		t.Fatalf("filter table reloaded after a .gsx edit: loads=%d; want 1", got)
+	if got := m.filterTableLoads(); got != 0 {
+		t.Fatalf("filter table loaded after a .gsx edit: loads=%d; want 0", got)
 	}
 
-	// A FileSet rebuild drops derived caches, so the next analyze reloads it once.
+	// A FileSet rebuild drops ext + the harvested tables together. The next
+	// analyze re-loads the importer once and re-harvests from it — still no
+	// standalone filter load.
 	m.rebuildFset()
 	m.SetOverride(card, fmt.Appendf(nil, "package components\n\nimport \"example.com/x/util\"\n\ncomponent X(title string) {\n\t<p><util.Y label={ title }/></p>\n}\n"))
 	if _, _, err := m.Generate(comp); err != nil {
 		t.Fatal(err)
 	}
-	if got := m.filterTableLoads(); got != 2 {
-		t.Fatalf("filter table loads after rebuildFset = %d; want 2 (one reload post-rebuild)", got)
+	if el, fl := m.externalLoads(), m.filterTableLoads(); el != 2 || fl != 0 {
+		t.Fatalf("after rebuildFset: externalLoads=%d filterTableLoads=%d; want 2,0", el, fl)
+	}
+}
+
+// TestFmtPathKeepsStandaloneFilterLoad pins the other half of the split.
+// buildPackageSkeletons is `gsx fmt`'s syntactic fast lane: it deliberately
+// never loads the external importer (that is what took `gsx fmt -l` from ~16s to
+// 0.58s). Harvesting its table from types would force the full "./..." load it
+// exists to avoid, so it keeps the standalone loadFilterTableMulti — which loads
+// ONLY the filter packages — and caches it for the Module's lifetime.
+func TestFmtPathKeepsStandaloneFilterLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	m, root := setupChainModule(t)
+	comp := filepath.Join(root, "components")
+
+	for i := range 3 {
+		if _, err := m.buildPackageSkeletons(comp); err != nil {
+			t.Fatalf("buildPackageSkeletons #%d: %v", i, err)
+		}
+	}
+	if got := m.externalLoads(); got != 0 {
+		t.Fatalf("externalLoads = %d; want 0 (the fmt fast path must not go-list the world)", got)
+	}
+	if got := m.filterTableLoads(); got != 1 {
+		t.Fatalf("filterTableLoads = %d; want 1 (loaded once, then cached)", got)
 	}
 }

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -759,7 +759,7 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	}
 	// Per-dir: an imported sibling package resolves its OWN filter table here,
 	// because analyze is the recursion point for the import graph.
-	table, err := m.filterTableFor(dir)
+	table, err := m.filterTableFor(dir, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codegen/module_perf_test.go
+++ b/internal/codegen/module_perf_test.go
@@ -26,13 +26,13 @@ func TestWarmRegenDoesNoGoListReloads(t *testing.T) {
 	comp := filepath.Join(root, "components")
 	card := filepath.Join(comp, "card.gsx")
 
-	// Cold generate the whole chain: this is where the one allowed go-list pair
-	// (ext + filter) happens.
+	// Cold generate the whole chain: this is where the ONE allowed go-list happens.
+	// The filter table is harvested from that load's types, so it costs zero.
 	if _, _, err := m.Generate(pages); err != nil {
 		t.Fatalf("cold generate: %v", err)
 	}
-	if el, fl := m.externalLoads(), m.filterTableLoads(); el != 1 || fl != 1 {
-		t.Fatalf("after cold generate: externalLoads=%d filterTableLoads=%d; want 1,1", el, fl)
+	if el, fl := m.externalLoads(), m.filterTableLoads(); el != 1 || fl != 0 {
+		t.Fatalf("after cold generate: externalLoads=%d filterTableLoads=%d; want 1,0", el, fl)
 	}
 
 	// 10 edit-driven warm regens of the components package. Each is a real
@@ -44,8 +44,8 @@ func TestWarmRegenDoesNoGoListReloads(t *testing.T) {
 			t.Fatalf("warm regen #%d: %v", i, err)
 		}
 	}
-	if el, fl := m.externalLoads(), m.filterTableLoads(); el != 1 || fl != 1 {
-		t.Fatalf("after 10 warm regens: externalLoads=%d filterTableLoads=%d; want 1,1 "+
+	if el, fl := m.externalLoads(), m.filterTableLoads(); el != 1 || fl != 0 {
+		t.Fatalf("after 10 warm regens: externalLoads=%d filterTableLoads=%d; want 1,0 "+
 			"(a value > 1 means a per-edit go-list crept back in — the watch/LSP slowdown)", el, fl)
 	}
 
@@ -54,7 +54,7 @@ func TestWarmRegenDoesNoGoListReloads(t *testing.T) {
 	if _, _, err := m.Generate(pages); err != nil {
 		t.Fatalf("regen pages: %v", err)
 	}
-	if el, fl := m.externalLoads(), m.filterTableLoads(); el != 1 || fl != 1 {
-		t.Fatalf("after cross-package regen: externalLoads=%d filterTableLoads=%d; want 1,1", el, fl)
+	if el, fl := m.externalLoads(), m.filterTableLoads(); el != 1 || fl != 0 {
+		t.Fatalf("after cross-package regen: externalLoads=%d filterTableLoads=%d; want 1,0", el, fl)
 	}
 }

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -130,7 +130,7 @@ func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
 	for _, f := range gsxFiles {
 		jsx.ResolveScripts(f, bag) // best-effort; failure just means we may skip that file below
 	}
-	table, err := m.filterTableFor(dir)
+	table, err := m.filterTableFor(dir, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Every `codegen.Module` ran **two** `packages.Load` (`go list`) invocations, and the second re-loaded packages the first had already type-checked.

| | before | after |
|---|---|---|
| `gen` | 146.4s | **36.0s** |
| `internal/codegen` | 90.7s | **63.9s** |
| `internal/lsp` | 3.2s | **2.4s** |
| `make ci` | 119s | **89s** |
| `gsx fmt -l .` | 0.35s | 0.34s *(unchanged, as required)* |

Zero golden churn. `make ci` and `make lint` exit 0, `-race` clean.

## Finding it

I instrumented every `packages.Load` site rather than guessing (my last two guesses about this codebase's hot path were wrong by 20×). Across the `gen` suite:

```
PROF extImporter    calls=127 aggWall=18m10s
PROF filters        calls=148 aggWall=19m42s   ← re-loading what extImporter already loaded
PROF classmerger    calls=  3
PROF resolver       calls=  3
```

Filter-table loads ran **1:1 with importer loads**. `externalImporter` loads `FilterPkgs` into its importer; `cachedFilterTable` → `loadFilterTableMulti` then loaded those same packages again via a fresh `go list`.

## The change

Harvest the table from the types the importer already produced.

`externalImporter` now also loads the packages named by `Options.Aliases` (a `WithFilter` alias's package may appear nowhere else in the load set) and records **per-package load errors**. That last part matters: `packages.Load` returns *partial* `Types` for a package that failed to type-check, so without checking `p.Errors` a broken filter package would yield a silently thinner table and surface much later as a confusing `unknown filter` at the pipe site. `TestFilterTableFromExtRejectsBrokenPkg` pins that.

`buildPackageSkeletons` **keeps** the standalone load. It is `gsx fmt`'s syntactic fast lane and deliberately never loads the importer — that's what took `gsx fmt -l` from ~16s to 0.58s. Harvesting from types there would *add* the full `./...` load it exists to avoid. `filterTableFor(dir, withExt bool)` takes the flag explicitly rather than sniffing cache state, so which path a caller is on is stated, not inferred. `TestFmtPathKeepsStandaloneFilterLoad` asserts `externalLoads() == 0` there.

## The bug this surfaced

There were **two** harvest implementations. `bundle.go`'s own comment admitted it:

> `NOTE: harvestFromTypes duplicates the scope-iteration of harvestFilters […] Worth DRYing once the WASM path is settled.`

They had already drifted. Only the go-list copy recognized the removed **curried filter shape**, so the same bad `WithFilter` produced either a migration hint or an unhelpful "does not match the contract" — depending on which path happened to run. The existing suite caught this the moment I switched paths (`TestWithFilterCurriedMigrationDiagnostic`).

`harvestFilters` now validates what only `*packages.Package` can see (load errors, dir context) and **delegates** to `harvestFromTypes`. Precedence (last-wins), signature classification, and `_gsxf<i>` alias assignment all feed the emitted `.x.go`, so exactly one place decides them. Two harvests that disagree produce different generated code from the same input.

## Tests pin equivalence, not speed

- `TestFilterTableFromExtMatchesGoList` — the two harvests must produce `DeepEqual` tables, including the `_gsxf<i>` alias emitted into every `.x.go`. Exercises last-wins across packages, ctx-taking filters, `(T, error)` filters, generics, and an alias-only package. Asserts the harness isn't vacuous (empty table / unexercised last-wins → fail).
- `TestFilterHarvestErrorsMatch` — **byte-identical error text** across both paths for curried / not-a-func / missing-func / non-conforming / broken-alias-package. This is where they had actually diverged.
- `TestGeneratePathDoesNoFilterTableLoad` — `filterTableLoads() == 0` on the Generate path, including across warm regens and after `rebuildFset`. Replaces the old `== 1` assertion; zero is the stronger claim and subsumes it.
- `TestFmtPathKeepsStandaloneFilterLoad` — the fmt lane still never `go list`s the world.

Every new test was mutation-tested: break the source, confirm red, revert.

## Adversarial review

An independent reviewer probed table divergence (alias pkg == filter pkg, alias overriding a whole-package filter, in-module pkgs reachable via `./...`, dedup ordering), `packages.Visit` root-package coverage, `extErrs` poisoning from unrelated broken packages, fset sharing, Bundle/WASM, PerDir isolation, memo-key collisions, invalidation, and `-race`. **No correctness bugs.** It mutation-tested the new tests independently and confirmed each catches its bug.

It raised one nit, now fixed: a broken/missing **alias** package had regressed to the generic `filter package "X" …` framing. Nothing else in a config mentions that package — only the alias pulled it in — so the error is now reported against the `WithFilter` that named it, on both paths, with a regression test (`broken_alias_pkg`).

## Note on `make ci`

119s → 89s. The remaining wall time is set by the slowest package under `-j4` + parallel `go test ./...`. `internal/codegen` (63.9s) still opens ~116 temp Modules across its tests, each paying the one *remaining* importer load. Sharing a Module fixture across those tests is the next step, and is test-only.

https://claude.ai/code/session_011BLviYFuAN33mKbxoDn3jp