### PR TITLE
feat(fmt): close a composite literal in block form when it opens in block form

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -258,6 +258,40 @@ the print width. Write it inline and it stays inline; write it multi-line and it
 stays multi-line. (A block-level child, e.g. a nested element, still forces the
 enclosing body to break regardless, so the document hierarchy stays visible.)
 
+The same principle reaches the Go you embed. **A composite literal whose opening
+`{` ends a line gets its closing `}` on a line of its own**, so a literal written
+in block form closes in block form:
+
+```go
+items: []navItem{
+    {label: "Admin", page: AdminPage{}, adminOnly: true},
+    {
+        label: "Export", page: ExportPage{}, nonVendor: true },
+}
+```
+
+becomes
+
+```go
+items: []navItem{
+    {label: "Admin", page: AdminPage{}, adminOnly: true},
+    {
+        label: "Export", page: ExportPage{}, nonVendor: true,
+    },
+}
+```
+
+Braces are all-or-nothing; fields are not. The `Admin` item keeps its `{` inline,
+so it stays entirely inline, and the `Export` item's fields stay packed on the
+one line the author wrote them on — `gsx fmt` never introduces a break *between*
+fields.
+
+This is the one place `gsx fmt` adds a rule gofmt does not have: gofmt honours a
+break after `{` but never propagates it to the matching `}`. Everything after
+that break — the terminating comma, the indentation, the key alignment — is still
+gofmt's. And the output is a gofmt fixed point: run `gofmt` over it and nothing
+moves. `gsx fmt` extends gofmt here; it never fights it.
+
 **Import handling.** `gsx fmt` has two import modes, mirroring gopls's own
 gofmt/goimports split:
 

--- a/internal/gsxfmt/testdata/cases/blockform_close_brace_follows_open.txtar
+++ b/internal/gsxfmt/testdata/cases/blockform_close_brace_follows_open.txtar
@@ -1,0 +1,38 @@
+A composite literal whose `{` opens a line closes on its own line too. gofmt
+never does this: go/printer decides the `}` break solely from whether the SOURCE
+already put `}` on a later line (nodes.go:294), so `{\n\ta: 1}` stays welded shut.
+
+Braces are block-form all-or-nothing; fields are not. The Analytics and Admin
+items keep their `{` inline, so they stay entirely inline. The Import / Export
+item's fields stay packed on one line, because gsx fmt never breaks BETWEEN
+fields — only the closing brace moves.
+
+-- input.gsx --
+package ui
+
+var appShellNavSections = []appShellNavSection{
+	{
+		label: "TOOLS",
+		items: []appShellNavItem{
+			{
+				label: "Import / Export", page: ImportExportPage{}, pathMatch: "/import-export/", nonVendor: true, vendorVisible: func(u *db.UserInfo) bool { return u.HasGrantPrefix("", "import") }, },
+			{label: "Analytics", page: DashboardLanding{}, pathMatch: "/dashboard/", nonVendor: true},
+			{label: "Admin", page: AdminDashboardPage{}, pathMatch: "/admin/", adminOnly: true},
+		},
+	},
+}
+-- fmt.golden --
+package ui
+
+var appShellNavSections = []appShellNavSection{
+	{
+		label: "TOOLS",
+		items: []appShellNavItem{
+			{
+				label: "Import / Export", page: ImportExportPage{}, pathMatch: "/import-export/", nonVendor: true, vendorVisible: func(u *db.UserInfo) bool { return u.HasGrantPrefix("", "import") },
+			},
+			{label: "Analytics", page: DashboardLanding{}, pathMatch: "/dashboard/", nonVendor: true},
+			{label: "Admin", page: AdminDashboardPage{}, pathMatch: "/admin/", adminOnly: true},
+		},
+	},
+}

--- a/internal/gsxfmt/testdata/cases/blockform_comma_in_block_comment.txtar
+++ b/internal/gsxfmt/testdata/cases/blockform_comma_in_block_comment.txtar
@@ -1,0 +1,17 @@
+The comma that decides "is there already a terminating comma" must be a real Go
+token. A comma inside a /*…*/ comment between the last element and the closing
+brace is not one — treating it as a terminating comma would emit `1 /*,*/\n}`,
+where Go's automatic semicolon insertion puts a `;` after `1` and the literal
+stops parsing.
+
+-- input.gsx --
+package ui
+
+var a = []int{
+	1 /* , */}
+-- fmt.golden --
+package ui
+
+var a = []int{
+	1, /* , */
+}

--- a/internal/gsxfmt/testdata/cases/blockform_existing_trailing_comma.txtar
+++ b/internal/gsxfmt/testdata/cases/blockform_existing_trailing_comma.txtar
@@ -1,0 +1,15 @@
+When the source already ends the last element with a comma, only the newline is
+inserted — never a second comma. A bare newline is what gsx fmt inserts here, and
+gofmt then reprints the terminating comma itself.
+
+-- input.gsx --
+package ui
+
+var a = []int{
+	1, 2, 3,}
+-- fmt.golden --
+package ui
+
+var a = []int{
+	1, 2, 3,
+}

--- a/internal/gsxfmt/testdata/cases/blockform_gochunk_no_elements.txtar
+++ b/internal/gsxfmt/testdata/cases/blockform_gochunk_no_elements.txtar
@@ -1,0 +1,24 @@
+The rule applies to EVERY Go region, not just those containing gsx elements.
+A Go declaration chunk with no element in it goes through the same pre-pass, so a
+file does not get two different composite-literal layouts depending on whether an
+element happens to appear somewhere in the decl.
+
+-- input.gsx --
+package ui
+
+var defaults = map[string]string{
+	"a": "1", "b": "2"}
+
+component Index() {
+	<p>hi</p>
+}
+-- fmt.golden --
+package ui
+
+var defaults = map[string]string{
+	"a": "1", "b": "2",
+}
+
+component Index() {
+	<p>hi</p>
+}

--- a/internal/gsxfmt/testdata/cases/blockform_nested_literals.txtar
+++ b/internal/gsxfmt/testdata/cases/blockform_nested_literals.txtar
@@ -1,0 +1,27 @@
+Nested literals each get their own closing-brace break, innermost first. The
+insertions are applied right to left so a nested `}` never invalidates its
+parent's offset.
+
+`inline` keeps its `{` on the value's line, so it is left alone even though it
+sits inside a literal that is being block-formed.
+
+-- input.gsx --
+package ui
+
+var cfg = Config{
+	outer: Outer{
+		inner: Inner{
+			a: 1, b: 2}},
+	inline: Inline{c: 3},
+}
+-- fmt.golden --
+package ui
+
+var cfg = Config{
+	outer: Outer{
+		inner: Inner{
+			a: 1, b: 2,
+		},
+	},
+	inline: Inline{c: 3},
+}

--- a/internal/gsxfmt/testdata/cases/complit_keyed_fields_align.txtar
+++ b/internal/gsxfmt/testdata/cases/complit_keyed_fields_align.txtar
@@ -1,7 +1,10 @@
 gofmt owns the layout of embedded Go: it preserves the author's line breaks and
 column-aligns keyed composite-literal fields. Fields the author put on one line
 stay on one line (nonVendor + vendorVisible); fields on their own lines get
-aligned. gsx fmt never introduces a break here.
+aligned. gsx fmt never introduces a break BETWEEN fields.
+
+The one break gsx fmt does add is the closing brace's: the literal's `{` opens a
+line, so its `}` gets one too (see the blockform_* cases).
 
 -- input.gsx --
 package ui
@@ -27,5 +30,6 @@ var sections = []appShellNavItem{
 		pathMatch: "/import-export/",
 		nonVendor: true, vendorVisible: func(u *db.UserInfo) bool {
 			return u.HasGrantPrefix("", "import")
-		}},
+		},
+	},
 }

--- a/internal/printer/blockform.go
+++ b/internal/printer/blockform.go
@@ -1,0 +1,109 @@
+package printer
+
+import (
+	goast "go/ast"
+	goparser "go/parser"
+	goscanner "go/scanner"
+	gotoken "go/token"
+	"sort"
+)
+
+// blockFormBraces returns src with a line break inserted before the closing
+// brace of every composite literal whose opening brace is followed by a line
+// break — so a literal the author chose to write in block form closes in block
+// form too.
+//
+// gofmt does not do this. go/printer's exprList (go/printer/nodes.go) makes
+// three independent decisions from the ORIGINAL source positions:
+//
+//   - all entries print on one line iff the `{` line, the first element's line,
+//     and the last element's end line are the same (nodes.go:145);
+//   - line breaks BETWEEN elements are copied from the source, never invented;
+//   - the `}` gets its own line, and a terminating comma, iff the source already
+//     put it on a line after the last element (nodes.go:294).
+//
+// So gofmt honours a break after `{` but never propagates it to the matching
+// `}`, and `{\n\ta: 1}` stays welded shut. This pass supplies only the missing
+// third break; it never touches the second, so fields the author packed onto one
+// line stay packed. gofmt then owns everything downstream — the terminating
+// comma, the indentation, the key alignment.
+//
+// The result is a gofmt FIXED POINT: once `}` sits on its own line, rule three
+// above reproduces it. So this pass adds a rule on top of gofmt without ever
+// fighting it, and running it on its own output is a no-op.
+//
+// The inserted text is ",\n", not "\n", unless a terminating comma is already
+// present. A bare newline before `}` would let Go's automatic semicolon
+// insertion put a `;` after the last element, and the literal would stop parsing.
+//
+// src must be a complete Go file. On any parse error it is returned unchanged:
+// this is a layout nicety, never a reason for gsx fmt to fail.
+func blockFormBraces(src string) string {
+	fset := gotoken.NewFileSet()
+	file, err := goparser.ParseFile(fset, "", src, goparser.SkipObjectResolution)
+	if err != nil {
+		return src
+	}
+
+	type insertion struct {
+		offset int
+		text   string
+	}
+	var inserts []insertion
+
+	goast.Inspect(file, func(n goast.Node) bool {
+		lit, ok := n.(*goast.CompositeLit)
+		if !ok || lit.Incomplete || len(lit.Elts) == 0 {
+			return true
+		}
+		lbrace := fset.Position(lit.Lbrace)
+		first := fset.Position(lit.Elts[0].Pos())
+		if lbrace.Line == first.Line {
+			return true // author kept `{` and the first element together
+		}
+		lastEnd := fset.Position(lit.Elts[len(lit.Elts)-1].End())
+		rbrace := fset.Position(lit.Rbrace)
+		if rbrace.Line > lastEnd.Line {
+			return true // `}` already opens its own line
+		}
+		text := ",\n"
+		if hasCommaToken(src[lastEnd.Offset:rbrace.Offset]) {
+			text = "\n"
+		}
+		inserts = append(inserts, insertion{offset: rbrace.Offset, text: text})
+		return true
+	})
+	if len(inserts) == 0 {
+		return src
+	}
+
+	// Apply right to left so each insertion's offset stays valid: an edit only
+	// shifts text after it, and a nested literal's `}` always precedes its
+	// parent's.
+	sort.Slice(inserts, func(i, j int) bool { return inserts[i].offset > inserts[j].offset })
+	out := src
+	for _, in := range inserts {
+		out = out[:in.offset] + in.text + out[in.offset:]
+	}
+	return out
+}
+
+// hasCommaToken reports whether src contains a comma as a real Go token — not
+// one inside a string literal, rune literal, or comment. The span between a
+// composite literal's last element and its closing brace is short, but it can
+// hold a /*…*/ comment, and a comma inside one is not a terminating comma.
+func hasCommaToken(src string) bool {
+	fset := gotoken.NewFileSet()
+	f := fset.AddFile("", fset.Base(), len(src))
+	var sc goscanner.Scanner
+	sc.Init(f, []byte(src), func(gotoken.Position, string) {}, goscanner.ScanComments)
+	for {
+		_, tok, _ := sc.Scan()
+		switch tok {
+		case gotoken.EOF:
+			return false
+		case gotoken.COMMA:
+			return true
+		}
+	}
+}

--- a/internal/printer/blockform_test.go
+++ b/internal/printer/blockform_test.go
@@ -1,0 +1,93 @@
+package printer
+
+import (
+	"go/format"
+	"testing"
+)
+
+func TestBlockFormBraces(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{{
+		name: "brace opens a line, so it closes one",
+		src:  "package p\n\nvar x = T{\n\ta: 1}\n",
+		want: "package p\n\nvar x = T{\n\ta: 1,\n}\n",
+	}, {
+		name: "inline literal is left alone",
+		src:  "package p\n\nvar x = T{a: 1}\n",
+		want: "package p\n\nvar x = T{a: 1}\n",
+	}, {
+		name: "already block-form is a no-op (idempotence)",
+		src:  "package p\n\nvar x = T{\n\ta: 1,\n}\n",
+		want: "package p\n\nvar x = T{\n\ta: 1,\n}\n",
+	}, {
+		name: "existing terminating comma gets a newline, not a second comma",
+		src:  "package p\n\nvar x = T{\n\ta: 1,}\n",
+		want: "package p\n\nvar x = T{\n\ta: 1,\n}\n",
+	}, {
+		// A comma inside a comment is not a terminating comma. Treating it as one
+		// would emit `1 /*,*/\n}` — ASI puts a `;` after 1 and the literal dies.
+		// The comma is inserted at the brace, i.e. after the comment; gofmt then
+		// reflows it to `1, /* , */`.
+		name: "comma inside a block comment is not a terminating comma",
+		src:  "package p\n\nvar x = []int{\n\t1 /* , */}\n",
+		want: "package p\n\nvar x = []int{\n\t1 /* , */,\n}\n",
+	}, {
+		// The last element ends a line but the `}` does not open one — the break
+		// must still be inserted, since the `{` opened a line.
+		name: "multi-line last element still gets the closing break",
+		src:  "package p\n\nvar x = T{\n\tf: func() {\n\t\tg()\n\t}}\n",
+		want: "package p\n\nvar x = T{\n\tf: func() {\n\t\tg()\n\t},\n}\n",
+	}, {
+		name: "empty literal is untouched",
+		src:  "package p\n\nvar x = T{\n}\n",
+		want: "package p\n\nvar x = T{\n}\n",
+	}, {
+		// Never a reason for gsx fmt to fail: unparseable Go passes through.
+		name: "unparseable source passes through unchanged",
+		src:  "package p\n\nvar x = T{{{\n",
+		want: "package p\n\nvar x = T{{{\n",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := blockFormBraces(tt.src); got != tt.want {
+				t.Errorf("blockFormBraces:\n got %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Everything blockFormBraces emits must still be valid Go — the inserted comma
+// exists precisely to keep automatic semicolon insertion from breaking the
+// literal — and must be a gofmt FIXED POINT, so the pass adds a rule on top of
+// gofmt without ever fighting it.
+func TestBlockFormBracesOutputIsGofmtFixedPoint(t *testing.T) {
+	srcs := []string{
+		"package p\n\nvar x = T{\n\ta: 1}\n",
+		"package p\n\nvar x = []int{\n\t1 /* , */}\n",
+		"package p\n\nvar x = Config{\n\touter: Outer{\n\t\tinner: Inner{\n\t\t\ta: 1}},\n\tinline: I{c: 3},\n}\n",
+		"package p\n\nvar x = T{\n\tf: func() {\n\t\tg()\n\t}}\n",
+	}
+	for _, src := range srcs {
+		rewritten := blockFormBraces(src)
+		out, err := format.Source([]byte(rewritten))
+		if err != nil {
+			t.Errorf("gofmt rejected blockFormBraces output for %q: %v\n%s", src, err, rewritten)
+			continue
+		}
+		again, err := format.Source(out)
+		if err != nil {
+			t.Errorf("gofmt rejected its own output for %q: %v", src, err)
+			continue
+		}
+		if string(again) != string(out) {
+			t.Errorf("gofmt is not stable on blockFormBraces output for %q", src)
+		}
+		// And the pass itself is a no-op on gofmt's output: no oscillation.
+		if got := blockFormBraces(string(out)); got != string(out) {
+			t.Errorf("blockFormBraces re-fires on gofmt's output for %q:\n got %q\nwant %q", src, got, out)
+		}
+	}
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1251,7 +1251,7 @@ func fmtGoChunk(src string) string {
 	// Format the chunk as a VALID FILE, not a fragment: go/format.Source's
 	// fragment mode strips a fixed byte count off its output, which shears a
 	// //go:build comment that go/printer hoisted above the injected clause.
-	out, err := format.Source([]byte(goExprWrapper + src))
+	out, err := format.Source([]byte(blockFormBraces(goExprWrapper + src)))
 	if err != nil {
 		return strings.TrimSpace(src)
 	}
@@ -1443,7 +1443,11 @@ func (p *printer) fmtGoExprParts(parts []ast.GoPart) ([]ast.GoPart, []goexprshap
 	sanitized, sanHoles := goexprshape.Sanitize(goExprWrapper+src.String(), shapeHoles)
 	shapes := goexprshape.Classify(sanitized, sanHoles)
 
-	out, err := format.Source([]byte(sanitized))
+	// blockFormBraces only ever inserts text before a composite literal's `}`,
+	// so it cannot move a hole across a token boundary, reorder holes, or change
+	// any hole's classification — shapes stays valid, and the placeholders are
+	// still found in output order by the re-split below.
+	out, err := format.Source([]byte(blockFormBraces(sanitized)))
 	if err != nil {
 		return nil, shapes, false
 	}


### PR DESCRIPTION
## The rule

> If a composite literal's opening `{` ends a line, its closing `}` gets a line of its own.

```go
// input                                          // gsx fmt
items: []navItem{                                 items: []navItem{
    {label: "Admin", page: AdminPage{}},              {label: "Admin", page: AdminPage{}},
    {                                                 {
        label: "Export", nonVendor: true },               label: "Export", nonVendor: true,
}                                                     },
                                                  }
```

Braces are all-or-nothing; **fields are not**. `Admin` keeps its `{` inline so it stays entirely inline. `Export`'s fields stay packed on the one line the author wrote them on — this never introduces a break *between* fields.

## Why gofmt doesn't do this

`go/printer.exprList` makes three independent decisions, all from the *original* source positions:

| decision | source | behavior |
|---|---|---|
| all entries on one line | `nodes.go:145` | iff `{` line == first element line == last element end line |
| breaks between elements | loop | copied from source, never invented |
| `}` on its own line + terminating comma | `nodes.go:294` | iff the source **already** put `}` on a later line |

So gofmt honours a break after `{` but never propagates it to the matching `}`, and `{\n\ta: 1}` stays welded shut. This PR supplies only the missing third break.

## Implementation

`blockFormBraces` — a pre-pass on the Go source before `go/format` sees it. gofmt then owns everything downstream: the terminating comma, the indentation, the key alignment.

Two things it has to get right:

- **The inserted text is `,\n`, not `\n`** — unless a terminating comma is already there. A bare newline before `}` lets Go's automatic semicolon insertion put a `;` after the last element and the literal stops parsing. Same ASI family as #57 and #58.
- **"Already has a comma" means a real `COMMA` token**, found with `go/scanner`. A comma inside a `/*…*/` comment between the last element and the brace is not a terminating comma; treating it as one emits `1 /*,*/\n}` and the literal dies.

Nested literals are handled by applying insertions right to left, so a nested `}` never invalidates its parent's offset.

Applied to **every** Go region — `fmtGoChunk` as well as `fmtGoExprParts` — so a file can't end up with two different composite-literal layouts depending on whether a gsx element happens to appear somewhere in the decl.

## The safety property

The output is a **gofmt fixed point**: once `}` sits on its own line, gofmt's rule three above reproduces it. So the pass adds a rule on top of gofmt without ever fighting it, and running it on its own output is a no-op. `TestBlockFormBracesOutputIsGofmtFixedPoint` pins exactly that — gofmt accepts the rewritten source, gofmt is stable on it, and the pass doesn't re-fire on gofmt's output.

`gsx fmt -l .` over the repo reports no drift.

## Tests

Five fmt-corpus cases: the rule itself, nesting, an existing terminating comma, a comma inside a block comment, and an element-free Go chunk (proving the rule isn't limited to element-bearing regions). Plus `blockform_test.go` for the unit-level edges — empty literal, inline literal, multi-line last element, and unparseable Go passing through untouched (this is a layout nicety, never a reason for `gsx fmt` to fail).

`complit_keyed_fields_align.golden` shifts by exactly one closing brace, which is the corpus doing its job; its prose is updated.

`make ci` and `make lint` pass. Docs updated in `docs/guide/cli.md` alongside the existing "your line breaks are preserved" section.

https://claude.ai/code/session_01NtNWQzQeJjfABhPckkD5qg