### PR TITLE
fix(fmt): collapse the newline before a hole alone inside parens

### DIFF
--- a/internal/goexprshape/shape.go
+++ b/internal/goexprshape/shape.go
@@ -163,22 +163,36 @@ func isSpace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
-// collapseHoleWhitespace returns a copy of src where, for every hole whose
-// immediately-following non-whitespace byte is a REAL (not inside a comment)
-// closing bracket, the whitespace after it is collapsed to a single space (if
-// it contains a newline). Returns each hole's new Start offset in the returned
-// string, in the same order as holes.
+// collapseHoleWhitespace returns a copy of src where whitespace runs touching a
+// hole are collapsed to a single space, under two separate rules. Returns each
+// hole's new Start offset in the returned string, in the same order as holes.
 //
-// Only the whitespace AFTER a hole is ever touched. Go's automatic semicolon
-// insertion fires on the token that ENDS a line, and a placeholder identifier
-// ending a line directly before a closing bracket picks up a semicolon that
-// breaks the parse (`(\nHOLE\n)` becomes `(HOLE;)`). The whitespace between an
-// opening bracket and a hole cannot cause that: the token ending that line is
-// the opening bracket itself, which is not in ASI's trigger set. Collapsing it
-// anyway would be worse than useless — go/printer reads the line break between
-// a composite literal's `{` and its first element to decide whether the literal
-// prints on one line, so erasing it drags the first element up onto the brace
-// line and silently reflows the author's source.
+// AFTER a hole, whenever the next non-whitespace byte is a REAL (not inside a
+// comment) closing bracket. This one is about parsing. Go's automatic semicolon
+// insertion fires on the token that ENDS a line, so a placeholder identifier
+// ending a line directly before a closing bracket picks up a semicolon and
+// `(\nHOLE\n)` becomes `(HOLE;)`, which does not parse.
+//
+// BEFORE a hole, only when the hole is ALONE INSIDE PARENS — the previous
+// non-whitespace byte is a real "(" and the next one is a real ")". This one is
+// about layout, and it is deliberately narrow.
+//
+// A hole is presented to gofmt as a placeholder identifier exactly as wide as
+// the value will render flat (see internal/printer's fmtGoExprParts). That is a
+// promise that the value occupies one line. `(\n\tHOLE )` breaks the promise:
+// the following key:value pair now starts a new SOURCE line, so go/printer emits
+// an alignment cell for it (nodes.go:271) even though it joins the line back up
+// — and gsx fmt's own decorative-paren output has exactly this shape, so the
+// padding reappears and grows on every run. Collapsing restores the inline view.
+//
+// It must NOT extend to "(", "[" or "{" generally. go/printer reads the line
+// break between a composite literal's "{" and its first element to decide
+// whether the literal prints on one line (nodes.go:145), and the same break
+// between a call's "(" and its first argument for the argument list. Erasing
+// those drags the first element up onto the bracket line and silently reflows
+// the author's source. A hole sitting alone between "(" and ")" has no list to
+// lay out: it is a parenthesized single expression, and gofmt joins it either
+// way.
 //
 // Processes holes in ascending Start order (left to right), tracking a
 // cumulative shift so far. This is the opposite of the naive-looking
@@ -211,14 +225,33 @@ func collapseHoleWhitespace(src string, holes []Hole) (string, []int) {
 		for after < len(s) && isSpace(s[after]) {
 			after++
 		}
-		afterWS := s[end:after]
-		collapseAfter := after < len(s) && isCloseBracket(s[after]) && !insideAny(comments, after-shift) && containsNewline(afterWS)
-		offsets[i] = start
-		if !collapseAfter {
+		before := start
+		for before > 0 && isSpace(s[before-1]) {
+			before--
+		}
+		beforeWS, afterWS := s[before:start], s[end:after]
+
+		closerOK := after < len(s) && !insideAny(comments, after-shift)
+		collapseAfter := closerOK && isCloseBracket(s[after]) && containsNewline(afterWS)
+		// Alone inside parens: "(" directly before and ")" directly after.
+		inParens := before > 0 && s[before-1] == '(' && !insideAny(comments, before-1-shift) &&
+			closerOK && s[after] == ')'
+		collapseBefore := inParens && containsNewline(beforeWS)
+
+		if !collapseBefore && !collapseAfter {
+			offsets[i] = start
 			continue
 		}
-		s = s[:end] + " " + s[after:]
-		shift += 1 - (after - end)
+		newBefore, newAfter := beforeWS, afterWS
+		if collapseBefore {
+			newBefore = " "
+		}
+		if collapseAfter {
+			newAfter = " "
+		}
+		s = s[:before] + newBefore + s[start:end] + newAfter + s[after:]
+		offsets[i] = before + len(newBefore)
+		shift += (len(newBefore) + (end - start) + len(newAfter)) - (after - before)
 	}
 	return s, offsets
 }

--- a/internal/goexprshape/shape_test.go
+++ b/internal/goexprshape/shape_test.go
@@ -116,9 +116,11 @@ func TestSanitizeCollapsesBracketAdjacentNewlines(t *testing.T) {
 	holes := []Hole{{Start: start, End: start + 1}}
 
 	got, gotHoles := Sanitize(src, holes)
-	// Only the newline AFTER the hole is collapsed: the one after `(` is left
-	// alone, because an opening bracket cannot trigger semicolon insertion.
-	want := "package p\nvar x = []T{\n\t{icon: (\n\t\tH ), page: P{}},\n}\n"
+	// The hole is alone inside parens, so BOTH sides collapse: the after-side to
+	// keep semicolon insertion from breaking the parse, the before-side to keep
+	// gofmt seeing the value inline (otherwise `page` looks like it starts a new
+	// source line and picks up an alignment cell).
+	want := "package p\nvar x = []T{\n\t{icon: ( H ), page: P{}},\n}\n"
 	if got != want {
 		t.Errorf("Sanitize:\n got %q\nwant %q", got, want)
 	}
@@ -149,16 +151,57 @@ func TestSanitizeLeavesStatementSeparatingNewline(t *testing.T) {
 	}
 }
 
-// The newline between an opening bracket and a hole must survive Sanitize: an
-// opening bracket never ends a line in a way that triggers semicolon insertion,
-// and go/printer reads that break to decide whether a composite literal prints
-// on one line. Collapsing it reflows the author's source.
-func TestSanitizeKeepsNewlineAfterOpeningBracket(t *testing.T) {
+// The newline between a composite literal's `{` and its first element must
+// survive Sanitize: go/printer reads that break to decide whether the literal
+// prints on one line. Collapsing it drags the first element up onto the brace
+// line and reflows the author's source.
+func TestSanitizeKeepsNewlineAfterOpeningBrace(t *testing.T) {
 	src := "package p\nvar x = []gsx.Node{\n\tH,\n\tI,\n}\n"
 	h := strings.Index(src, "H")
 	i := strings.Index(src, "I")
 	got, _ := Sanitize(src, []Hole{{Start: h, End: h + 1}, {Start: i, End: i + 1}})
 	if got != src {
 		t.Errorf("Sanitize collapsed a newline after an opening bracket:\n got %q\nwant %q", got, src)
+	}
+}
+
+// The before-hole collapse is narrow: it fires only when the hole is alone
+// inside parens. go/printer reads the break between a composite literal's `{`
+// (or a call's `(`) and its first element to lay the list out; erasing it
+// reflows the author's source.
+func TestSanitizeBeforeCollapseIsParenOnly(t *testing.T) {
+	tests := []struct {
+		name, src, want string
+	}{{
+		name: "composite-literal brace: newline preserved",
+		src:  "package p\nvar x = []gsx.Node{\n\tH,\n}\n",
+		want: "package p\nvar x = []gsx.Node{\n\tH,\n}\n",
+	}, {
+		// `{` before and `}` after, but a brace is not a paren.
+		name: "sole composite-literal element: only the after side collapses",
+		src:  "package p\nvar x = []gsx.Node{\n\tH\n}\n",
+		want: "package p\nvar x = []gsx.Node{\n\tH }\n",
+	}, {
+		name: "call argument list: newline preserved",
+		src:  "package p\nvar x = Wrap(\n\tH,\n\ty,\n)\n",
+		want: "package p\nvar x = Wrap(\n\tH,\n\ty,\n)\n",
+	}, {
+		name: "hole alone inside parens: both sides collapse",
+		src:  "package p\nvar x = S{a: (\n\tH\n)}\n",
+		want: "package p\nvar x = S{a: ( H )}\n",
+	}, {
+		// A "(" that is really a comment's last byte is not a real paren.
+		name: "paren inside a comment is not a real paren",
+		src:  "package p\nvar x = Wrap(a, // (\n\tH)\n",
+		want: "package p\nvar x = Wrap(a, // (\n\tH)\n",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := strings.Index(tt.src, "H")
+			got, _ := Sanitize(tt.src, []Hole{{Start: start, End: start + 1}})
+			if got != tt.want {
+				t.Errorf("Sanitize:\n got %q\nwant %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/gsxfmt/testdata/cases/element_paren_wrap_no_align_drift.txtar
+++ b/internal/gsxfmt/testdata/cases/element_paren_wrap_no_align_drift.txtar
@@ -1,0 +1,27 @@
+Two items in one gofmt alignment section, each with an element that paren-wraps.
+
+Re-formatting fmt's own output must not drift. The decorative paren puts the
+element alone on its line, which makes `page` start a new SOURCE line. gofmt then
+emits an alignment cell for `page:` even though it joins the line back up, and the
+padding grows on every run. Collapsing the newline between `(` and the hole keeps
+gofmt's view of the value inline — which is exactly what the flat-width
+placeholder already promises it.
+
+-- input.gsx --
+package ui
+
+var nav = []item{
+	{label: "Team View", icon: <UsersIcon/>, page: TeamViewPage{}, pathMatch: "/team", nonVendor: true},
+	{label: "Search", icon: <SearchIcon/>, page: ListPage{}, pathMatch: "/list/", excludeQuery: "entity_type"},
+}
+-- fmt.golden --
+package ui
+
+var nav = []item{
+	{label: "Team View", icon: (
+		<UsersIcon/>
+	), page: TeamViewPage{}, pathMatch: "/team", nonVendor: true},
+	{label: "Search", icon: (
+		<SearchIcon/>
+	), page: ListPage{}, pathMatch: "/list/", excludeQuery: "entity_type"},
+}


### PR DESCRIPTION
## Regression introduced by #58

`gsx fmt` is not idempotent on its own paren-wrapped output. `page:` grows an alignment cell on every run:

```go
	), page: ListPage{}, pathMatch: "/list/", excludeQuery: "entity_type"},     // pass 1
	), page:   ListPage{}, pathMatch: "/list/", excludeQuery: "entity_type"},   // pass 2
```

Found by re-running `gsx fmt` twice over the file that started this whole thread.

## Cause

A hole is handed to gofmt as a placeholder identifier exactly as wide as the value renders **flat** (`fmtGoExprParts`). That is a promise that the value occupies one line, and gofmt's column arithmetic depends on it.

#58 stopped collapsing the whitespace *before* a hole. So `gsx fmt`'s own decorative-paren output re-enters as:

```go
{label: "Search", icon: (
	HOLE ), page: ListPage{}, ...}
```

`page` now starts a new **source** line. go/printer's `exprList` emits an alignment cell (`vtab`) for a `key: value` pair that begins a new line (`nodes.go:271`) — even though it joins the line back up, because the literal still fits. The `vtab` becomes padding once the tabwriter aligns it against the neighbouring items in the same section, and the padding is re-read as source on the next run.

## Fix

#58 was right that the collapse must **not** apply to a composite literal's `{`: go/printer reads that break to decide whether the literal prints on one line (`nodes.go:145`), and erasing it drags the first element onto the brace line. The same holds for a call's `(` and its argument list.

But a hole sitting **alone between `(` and `)`** has no list to lay out — it is a parenthesized single expression, which gofmt joins either way — and that is exactly the shape this printer's decorative paren produces.

So the before-collapse is restored, narrowed to that one shape: the previous non-whitespace byte is a real `(` **and** the next is a real `)`. Composite-literal braces and call argument lists keep their breaks, so #58's regression stays fixed.

Verified directly against `go/format`:

| gofmt input | output |
|---|---|
| `icon: (\n\tHOLE ), page: …` | `icon: (HOLE), page:` **`   `** `…` |
| `icon: ( HOLE ), page: …` | `icon: (HOLE), page: …` |

`TestSanitizeBeforeCollapseIsParenOnly` pins the boundary: composite-literal brace preserved, call argument list preserved, a `(` inside a comment not treated as a real paren, and the paren-alone shape collapsed on both sides.

## What caught it

The fmt corpus, the moment the case existed — the harness's per-case idempotence check rejects a golden that isn't a fixed point, so `-update` refused to bless it.

Nothing else could have. #57's no-verbatim-fallback property sees `ok=true` here. The printer's corpus idempotence property only covers `internal/corpus` inputs, and this shape isn't among them. And alignment drift is invisible to a faithfulness or re-parse check — the AST is identical, the output re-parses, it is merely wrong.

No existing golden shifted; the fix is surgical. `make ci` and `make lint` pass, and the originally-reported file is now idempotent under repeated `gsx fmt`.

https://claude.ai/code/session_01NtNWQzQeJjfABhPckkD5qg