### PR TITLE
infra: cap Artifact Registry growth from playground deploys

### DIFF
--- a/.github/workflows/deploy-playground-server.yml
+++ b/.github/workflows/deploy-playground-server.yml
@@ -3,6 +3,17 @@ name: Deploy playground server
 on:
   push:
     branches: [main]
+    # The image bakes the whole repo (Dockerfile does `COPY . /gsx`) because the
+    # playground compiles visitor code against the live gsx module. So a parser or
+    # codegen change does need a redeploy — only paths that cannot reach the
+    # running compiler belong here.
+    paths-ignore:
+      - 'docs/**'
+      - 'skills/**'
+      - '**.md'
+      - 'LICENSE'
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@
 #
 # Usage (from the repo root):
 #   gcloud builds submit --config cloudbuild.yaml \
-#     --substitutions _IMAGE=gcr.io/$PROJECT_ID/gsx-playground .
+#     --substitutions _IMAGE=us-central1-docker.pkg.dev/$PROJECT_ID/gsx/gsx-playground .
 steps:
   - name: gcr.io/cloud-builders/docker
     args:

--- a/playground/server/cleanup-policy.json
+++ b/playground/server/cleanup-policy.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "keep-recent-deploys",
+    "action": { "type": "Keep" },
+    "mostRecentVersions": { "keepCount": 5 }
+  },
+  {
+    "name": "delete-stale",
+    "action": { "type": "Delete" },
+    "condition": { "olderThan": "1d" }
+  }
+]

--- a/playground/server/deploy.md
+++ b/playground/server/deploy.md
@@ -41,7 +41,7 @@ gcloud iam service-accounts create "$SA" --project "$PROJECT" \
 
 # Deploy under the zero-permission SA.
 gcloud run deploy "$SERVICE" --project "$PROJECT" --region "$REGION" \
-  --image "gcr.io/$PROJECT/$SERVICE" \
+  --image "$REGION-docker.pkg.dev/$PROJECT/gsx/$SERVICE" \
   --service-account "${SA}@${PROJECT}.iam.gserviceaccount.com" \
   --allow-unauthenticated \
   --memory 1Gi --cpu 1 --concurrency 4 --timeout 30 \
@@ -101,7 +101,8 @@ Run these from the **gsx repo root**:
 PROJECT=<your-gcp-project-id>
 REGION=us-central1           # free-tier eligible
 SERVICE=gsx-playground
-IMAGE="gcr.io/$PROJECT/$SERVICE"
+REPO=gsx                     # Artifact Registry repo (see "Image retention" below)
+IMAGE="$REGION-docker.pkg.dev/$PROJECT/$REPO/$SERVICE"
 
 # 1. Build the container image with Cloud Build.
 gcloud builds submit --config cloudbuild.yaml \
@@ -158,5 +159,40 @@ gcloud run services describe "$SERVICE" --region "$REGION" --project "$PROJECT"
 
 ## Re-deploying
 
-After code changes, repeat steps 1 and 2 above.  Cloud Build tags overwrite the
-previous image and Cloud Run performs a zero-downtime rollout.
+After code changes, repeat steps 1 and 2 above.  Cloud Run performs a
+zero-downtime rollout.
+
+CI (`.github/workflows/deploy-playground-server.yml`) tags each image with the
+commit sha, so images do **not** overwrite one another — every deploy adds one.
+See "Image retention" below.
+
+## Image retention
+
+Each deploy pushes a new `:$GITHUB_SHA` image (~100 MB of unique layers). Left
+alone, Artifact Registry grows without bound. Two things hold it down:
+
+1. **A cleanup policy on the `gsx` repo** (`cleanup-policy.json`). It keeps the
+   5 most recent versions unconditionally and deletes anything older than a day.
+   `Keep` rules take precedence over `Delete`, so the serving image can never be
+   pruned — even if nobody deploys for a month. The cost is that traffic can only
+   be rolled back about five deploys.
+
+   Apply or update it with:
+
+   ```bash
+   gcloud artifacts repositories set-cleanup-policies gsx \
+     --location=us-central1 \
+     --policy=playground/server/cleanup-policy.json \
+     --no-dry-run
+   ```
+
+   Swap `--no-dry-run` for `--dry-run` to have Artifact Registry log what it
+   *would* delete without deleting it. Policies run asynchronously (roughly
+   daily), so they do not reclaim space the instant they are applied.
+
+2. **A `paths-ignore` filter on the deploy workflow.** The Dockerfile does
+   `COPY . /gsx` because the playground compiles visitor code against the live
+   gsx module — so a parser or codegen change genuinely does need a redeploy, and
+   only inert paths (`docs/`, `skills/`, `*.md`) may be ignored. Never narrow
+   this to `playground/**`; that would leave the playground running a stale
+   compiler.


### PR DESCRIPTION
The playground deploy workflow fired on **every** push to `main`, pushed a `:$GITHUB_SHA` image (~100 MB of unique layers), and nothing ever deleted one. 70 of the 72 images in the `gsx` repo were created in nine days. A forgotten legacy `gcr.io` repo held another 1.2 GB.

## Changes

- **Artifact Registry cleanup policy** (`playground/server/cleanup-policy.json`) — keep the 5 most recent versions, delete anything older than 1d. `Keep` rules outrank `Delete`, so the serving image can never be pruned even if nobody deploys for a month. Committed as a file rather than left as click-ops.
- **`paths-ignore` on the deploy workflow** for inert paths only. The Dockerfile does `COPY . /gsx` because the playground compiles visitor code against the live gsx module, so a parser/codegen change genuinely *does* need a redeploy. Narrowing this to `paths: playground/**` would silently serve a stale compiler — there is a comment saying so.
- **`deploy.md` / `cloudbuild.yaml`** documented the retired `gcr.io` flow, which is how the legacy repo accumulated. Repointed at Artifact Registry, and corrected the claim that "tags overwrite the previous image" — CI tags by sha, so they accumulate.

## Already applied to `jackie-space`

These landed out-of-band alongside this PR:

| | Before | After |
|---|---|---|
| `gsx` images | 72 | 5 |
| `gcr.io` repo | 1.2 GB | deleted |
| Cloud Run revisions | 82 | 5 |
| Cleanup policy | none | keep 5, delete >1d |

Also added a project-scoped £5/month budget alert.

## Verification

- Guarded the serving image digest against the purge list, then hit `/render`: **HTTP 200 after a 9s cold start**. Since `min-instances` is 0, that cold start proves Cloud Run re-pulled the image successfully.
- Workflow YAML and policy JSON both parse; the committed policy matches what is live in GCP (`keepCount: 5`, `olderThan: 86400s`).
- Measured the filter against history: **29 of the last 97 `main` commits** would skip deploy (~30%), and asserted that **zero** skipped commits touch `*.go`, `*.gsx`, `*.txtar`, `Dockerfile`, or `go.mod/sum`.

Note: Artifact Registry `sizeBytes` still reports the old figure — layer GC is asynchronous and the size metric is cached — so the reclaimed bytes are not yet confirmable, though the object counts are.

https://claude.ai/code/session_01J6UvJEoS6k3DSQhb9v1xou