### PR TITLE
fix(lsp): unused imports from analyze's skeletons — no go list on the hot path

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -598,6 +598,19 @@ vocabulary remains a design aspiration, not the current API.
   statement-form design. Spec `2026-07-03-pipe-error-any-stage-design.md`.
 - [ ] **Pipeline extensions** - initialism-aware filter naming;
   pipeline-as-filter-argument; ambient `mapEach` (deferred / out of scope).
+- [ ] **`externalImporter` preload gap: package imported only from a `.gsx`
+  import line** - `externalImporter` (`internal/codegen/module.go`) preloads
+  its importer graph once, from `"./..."` + the gsx runtime + the std filter
+  package + configured `FilterPkgs`/`LoadPkgs`. A package reachable only via a
+  `.gsx` file's own `import` line (not from any of those roots) is never in
+  that preload, so `go/types` cannot load it: `mapImporter.Import` fails,
+  producing a spurious `could not import <path>` **error** diagnostic, and the
+  LSP's `Package()` cannot resolve the import's real name and conservatively
+  keeps it even when it's genuinely unused (see
+  `docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md`'s
+  Divergence A). The CLI (`gsx fmt` / `Module.UnusedImports`) is unaffected -
+  it resolves names via a targeted `go list`, not the type-checker's importer
+  graph.
 - [x] **Class parts inside component cond-attr branches now support
   `(R, error)`** - CLOSED (2026-07-03). `AttrsCond`'s thunks return
   `(Attrs, error)` - one uniform lowering, the statement form deleted - and

--- a/docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md
+++ b/docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md
@@ -107,12 +107,36 @@ The fix: `importNamesFromTypes` skips any `imp` with `imp.Complete() == false` b
 the map, so an unresolvable import's real name is never guessed — it is simply absent, and
 `unusedImportsCore`'s `if !ok { continue }` conservatively keeps it, exactly like a nil `pkg`.
 
-**Accepted trade-off (documented, not a bug):** an import that is BOTH genuinely unused AND
-outside the importer graph with a name differing from its path base is now **kept** by `Package()`
-even though `Module.UnusedImports` (which resolves names via a real, targeted `go list`, not a
-guess) still correctly removes it. The two surfaces legitimately diverge on this one shape —
-under-removal in the LSP is the safe direction; deleting a used import is not. See
-`TestModuleAndPackageDivergeOnUnresolvableNameNeBase` in `internal/codegen/unused_imports_lsp_test.go`.
+**Accepted trade-off (documented, not a bug) — Divergence A:** any unused *default* import outside
+analyze's importer graph is now **kept** by `Package()`, even though `Module.UnusedImports` (which
+resolves names via a real, targeted `go list`, not a guess) still correctly removes it. This is
+broader than "name differs from path base" — the trigger is `Complete() == false`, which fires for
+**any** import outside the importer graph, including one whose name equals its base (verified:
+`container/ring`, `hash/crc64`, `text/tabwriter`, `net/rpc`, `container/heap`). The two surfaces
+legitimately diverge on this whole class of imports — under-removal in the LSP is the safe
+direction; deleting a used import is not. See `TestModuleAndPackageDivergeOnUnresolvableNameNeBase`
+(name != base) and `TestPackageKeepsUnusedImportOutsideImporterGraph` (name == base) in
+`internal/codegen/unused_imports_lsp_test.go`.
+
+An out-of-graph import also surfaces a spurious `could not import <path>` **error** diagnostic
+today (e.g. `could not import text/tabwriter (cached importer: "text/tabwriter" not loaded)`) —
+this is a pre-existing `externalImporter` limitation (its one-shot preload never reaches a package
+referenced only from a `.gsx` import line), not introduced by this design, and out of scope here;
+see `docs/ROADMAP.md`.
+
+**Divergence B (the opposite direction, and it is safe):** `Package()` can also **remove** an
+import `Module.UnusedImports` **keeps** — the reverse of Divergence A. An unused sibling gsx
+package imported only via `.gsx` files (no `.go` files in that directory, e.g. `import
+"testmod/foo"` where `foo/` is gsx-only) routes through `moduleImporter` (not `externalImporter`):
+analyze type-checks it from its skeletons like any project package, so `importNamesFromTypes`
+resolves its real name and `Package()` correctly reports it unused. `Module.UnusedImports`, having
+no type information, asks `go list -f NeedName` for the same path; `go list` cannot name a package
+with zero `.go` files (verified: `no Go files in <dir>`) and the CLI conservatively **keeps** it.
+This is safe because it only ever fires on a genuinely unused import: `Package()` still correctly
+KEEPS a sibling gsx import that IS used, in every shape tested (tag `<foo.Box/>`, a plain
+`foo.Helper()` call inside an interpolation, and the other used-shapes in the corpus/test suite).
+See `TestPackageRemovesUnusedSiblingGsxImportModuleKeeps` and
+`TestPackageKeepsUsedSiblingGsxImport` in `internal/codegen/unused_imports_lsp_test.go`.
 
 This is still strictly more robust than `detectUnusedImports`, which returned nil for the whole
 package on any unrelated error.
@@ -147,10 +171,16 @@ per invocation and has no type information. Unchanged.
   (default import, aliased import, blank `_`, dot `.`, sunk import). A default import whose real
   name differs from its path base AND is outside the importer graph (`math/rand/v2`) is
   deliberately **excluded** from this parity set — see the next bullet.
-- **Documented divergence (name≠base, unresolvable):** `TestModuleAndPackageDivergeOnUnresolvableNameNeBase`
-  asserts `Package()` conservatively *keeps* an unused, unresolvable `math/rand/v2` while
-  `Module.UnusedImports` correctly *removes* it via `go list` — the one input shape where the two
-  surfaces are allowed to disagree, per the trade-off above.
+- **Documented divergence A (out of importer graph, unresolvable):**
+  `TestModuleAndPackageDivergeOnUnresolvableNameNeBase` (name != base, `math/rand/v2`) and
+  `TestPackageKeepsUnusedImportOutsideImporterGraph` (name == base, `container/ring`) assert
+  `Package()` conservatively *keeps* an unused, out-of-graph import while `Module.UnusedImports`
+  correctly *removes* it via `go list` — see the Divergence A trade-off above.
+- **Documented divergence B (sibling gsx-only import, the opposite direction):**
+  `TestPackageRemovesUnusedSiblingGsxImportModuleKeeps` asserts `Package()` *removes* an unused
+  `.gsx`-only sibling import that `Module.UnusedImports` *keeps* (go list cannot name a package with
+  no `.go` files); `TestPackageKeepsUsedSiblingGsxImport` asserts the safety property — the same
+  import, used via a plain function call, is never reported unused.
 - **No `go list` on the hot path (deterministic, not timing-based):** a test-only counter
   incremented in `resolvePackageNames`; assert it stays **0** across `Package()`, and is
   non-zero for the CLI `Module.UnusedImports` path (proving the test can actually observe it).

--- a/docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md
+++ b/docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md
@@ -1,0 +1,128 @@
+# LSP unused imports: syntactic classifier, no `go list` on the hot path
+
+## Problem
+
+`gsx` has two unused-import implementations, and the LSP is wired to the fragile one.
+
+| Surface | Source of "unused imports" | Robustness |
+|---|---|---|
+| CLI `gsx fmt` | `Module.UnusedImports` → `classifyUnusedImports` (syntactic, per-file) | Robust |
+| LSP formatting + `source.organizeImports` | `PackageResult.UnusedImports` ← `detectUnusedImports` (`results.go:104`), set at `module.go:637` | Fragile |
+
+`detectUnusedImports` correlates raw `go/types` errors with import specs by file+line, and
+**returns `nil` the moment it sees any error that is not a cleanly position-correlated
+`"imported and not used"`** (`results.go:125`). A clean single-file package is fine; a real
+multi-file package's skeleton always carries other benign/suppressed type errors, so it bails
+to `nil`. Then `internal/lsp/format.go:44` and `internal/lsp/codeaction.go:50` both see a nil
+`Unused`, the organized text equals the buffer, and both handlers return `[]` — the LSP
+silently offers nothing.
+
+Verified: on a real multi-file package `detectUnusedImports` → `nil`, while
+`Module.UnusedImports` on the same package correctly returns `[context, io]`, and
+`gsxfmt.FormatWith` given those refs strips both. Every piece works except the heuristic
+feeding the LSP.
+
+## The rejected fix
+
+The obvious patch is to call the syntactic classifier from `Package()`:
+
+```go
+if unused, _, err := m.UnusedImports(dir); err == nil {
+	res.UnusedImports = unused
+}
+```
+
+**This must not land.** Three independent defects, all reproduced:
+
+1. **Self-deadlock (Critical).** `Package()` acquires `m.analysisMu` (`module.go:583`) and holds
+   it via `defer`. `m.UnusedImports` → `buildPackageSkeletons` re-acquires the same mutex
+   (`unused_imports_syntactic.go:120`). `sync.Mutex` is not reentrant. Both
+   `./internal/codegen` and `./internal/lsp` hang to the test timeout.
+2. **`go list` on the LSP hot path (Critical for perf).** `resolvePackageNames` calls
+   `packages.Load` (a `go list` subprocess), uncached. Measured on a 6-file package:
+   **158 µs** with no candidate, **19.3 ms** when an unused *default* import exists — a 122×
+   regression, on exactly the scenario being fixed, once per debounced analysis.
+3. **Duplicated work.** `buildPackageSkeletons` re-parses the package and rebuilds the filter
+   table and prop fields — all of which `analyze` just did — and re-runs
+   `maybeRebuildFset`/`applyDirty` mid-`Package`.
+
+Plus: `detectUnusedImports` and its only other caller `pickImportByPath` go unused, so
+`make lint` fails.
+
+## Design: compute it inside `analyze`, from data it already has
+
+`analyze`'s per-file loop (`module_importer.go:840-885`) already holds, for each `.gsx` path:
+its per-file `imps []importSpec`, its parsed skeleton `gf *goast.File`, and
+`sunkImports[path]`. That is precisely a `fileSkeleton`. Capture the mapping there — no extra
+parse, no lock, no `applyDirty` re-entry.
+
+After type-checking, compute unused imports from those skeletons using the **same**
+`skeletonUsedNames` + `classifyUnusedImports` the CLI trusts, and store on `analyzed`.
+`Package()` then reads the field.
+
+### Resolving candidates without `go list`
+
+`classifyUnusedImports` returns *candidates*: default imports whose path base is not
+referenced, whose real package name must be known before they can be called unused
+(`math/rand/v2` declares package `rand`). The CLI resolves these with a `NeedName`
+`packages.Load` because it deliberately never type-checks.
+
+`analyze` **has already type-checked the package**. `types.Package.Imports()` lists every
+directly-imported package — *including unused ones* — with its declared name. Verified:
+
+```
+pkg.Imports() for a file where BOTH imports are unused:
+  path="context"        name="context"
+  path="math/rand/v2"   name="rand"
+```
+
+`emit.go:374` already reads declared names this way. So the LSP path resolves candidates from
+`a.pkg.Imports()` and never shells out.
+
+### Behavior when the type-check fails
+
+If `pkg` is nil or its import list is incomplete, the name map is empty and every candidate is
+**conservatively kept** (`if !ok { continue }`, mirroring `Module.UnusedImports`). Imports with
+an explicit alias, and default imports whose base *is* referenced, are still classified
+syntactically. This is strictly more robust than `detectUnusedImports`, which returned nil for
+the whole package.
+
+## Implementation
+
+- `internal/codegen/module_importer.go`
+  - In the per-file loop, build `skelByGsx map[string]fileSkeleton{skel: gf, imps: imps, sunk: sunkImports[path]}`.
+  - After type-checking, set `a.unusedImports = unusedFromSkeletons(skelByGsx, fset, pkg)`.
+  - `analyzed` gains `unusedImports map[string][]UnusedImport`.
+- `internal/codegen/unused_imports_syntactic.go`
+  - Add `importNamesFromTypes(pkg *types.Package) map[string]string` (path → declared name; nil pkg → empty map).
+  - Add `unusedFromSkeletons(byGsx map[string]fileSkeleton, gsxFset *token.FileSet, pkg *types.Package) map[string][]UnusedImport` — the shared core: per file, `skeletonUsedNames` → `classifyUnusedImports` → resolve candidates from the name map.
+  - `Module.UnusedImports` (CLI, no types) keeps `resolvePackageNames`; refactor it to call `unusedFromSkeletons`-shaped logic with a name map from `packages.Load` so the two surfaces share one classifier body.
+- `internal/codegen/module.go`
+  - `res.UnusedImports = a.unusedImports`. No call to `m.UnusedImports`.
+- `internal/codegen/results.go`
+  - Delete `detectUnusedImports` and `pickImportByPath` (dead; `make lint` enforces).
+
+`Module.UnusedImports` keeps its own skeleton pass and its `packages.Load` — the CLI runs once
+per invocation and has no type information. Unchanged.
+
+## Testing
+
+- **Regression (the bug):** a multi-file package whose skeleton carries other type errors AND has
+  unused imports → `Package().UnusedImports` is non-empty. This is the exact case
+  `detectUnusedImports` returned nil for. It must go through `Package()` — the gap that let the
+  deadlock through.
+- **Deadlock guard:** the same `Package()` test hangs if the lock bug returns; the package
+  `-timeout` catches it.
+- **Parity:** `Package(dir).UnusedImports` equals `Module.UnusedImports(dir)` across fixtures
+  (default import, aliased import, blank `_`, dot `.`, name≠base, sunk import).
+- **No `go list` on the hot path (deterministic, not timing-based):** a test-only counter
+  incremented in `resolvePackageNames`; assert it stays **0** across `Package()`, and is
+  non-zero for the CLI `Module.UnusedImports` path (proving the test can actually observe it).
+- **name ≠ base:** an unused `math/rand/v2` is detected via types alone.
+- `make ci` and `make lint` green.
+
+## Non-goals
+
+- Caching `resolvePackageNames` for the CLI. `gsx fmt` opens one `Module` per run; a per-module
+  path→name cache is a separate, unrelated win.
+- Changing `Module.UnusedImports`' public signature or the CLI's behavior.

--- a/docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md
+++ b/docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md
@@ -79,13 +79,43 @@ pkg.Imports() for a file where BOTH imports are unused:
 `emit.go:374` already reads declared names this way. So the LSP path resolves candidates from
 `a.pkg.Imports()` and never shells out.
 
-### Behavior when the type-check fails
+### Behavior when the type-check fails, or an import is unresolved
 
-If `pkg` is nil or its import list is incomplete, the name map is empty and every candidate is
-**conservatively kept** (`if !ok { continue }`, mirroring `Module.UnusedImports`). Imports with
-an explicit alias, and default imports whose base *is* referenced, are still classified
-syntactically. This is strictly more robust than `detectUnusedImports`, which returned nil for
-the whole package.
+If `pkg` is nil, the name map is empty and every candidate is **conservatively kept**
+(`if !ok { continue }`, mirroring `Module.UnusedImports`). Imports with an explicit alias, and
+default imports whose base *is* referenced, are still classified syntactically.
+
+**Per-import gating is required, and it is `Complete()`, not "the import list is incomplete."**
+`pkg.Imports()` lists every direct import whether or not `pkg` overall type-checked cleanly, but
+an individual entry can itself be a placeholder: when an import path is outside analyze's own
+importer graph (`moduleImporter`/`externalImporter` — e.g. reachable only from this one `.gsx`
+file, not from the gsx runtime, the std filter package, or any other Go file in the module),
+`go/types` cannot load it but still needs *some* `*types.Package` to keep type-checking the rest
+of the file. It fabricates one, **named after the import path's last segment** (verified:
+`"math/rand/v2"` → placeholder name `"v2"`, real declared name `"rand"`), and leaves it
+`Complete() == false`. Earlier text in this section claimed this case yields an *empty* name map
+and a conservative keep — that was wrong: `importNamesFromTypes` used to add every entry from
+`pkg.Imports()` unconditionally, so the map got populated with the **fabricated, wrong** name.
+
+That is the false positive an adversarial review caught (Critical): with `math/rand/v2` used as
+`rand.IntN(3)`, `classifyUnusedImports` makes it a removal candidate because its path base `"v2"`
+is unreferenced; resolving that candidate's name from the fabricated `"v2"` (instead of the real
+`"rand"`) makes the live reference invisible, and `Package()` reports a USED import unused — the
+LSP then deletes it via `gsxfmt.FormatWith`.
+
+The fix: `importNamesFromTypes` skips any `imp` with `imp.Complete() == false` before adding it to
+the map, so an unresolvable import's real name is never guessed — it is simply absent, and
+`unusedImportsCore`'s `if !ok { continue }` conservatively keeps it, exactly like a nil `pkg`.
+
+**Accepted trade-off (documented, not a bug):** an import that is BOTH genuinely unused AND
+outside the importer graph with a name differing from its path base is now **kept** by `Package()`
+even though `Module.UnusedImports` (which resolves names via a real, targeted `go list`, not a
+guess) still correctly removes it. The two surfaces legitimately diverge on this one shape —
+under-removal in the LSP is the safe direction; deleting a used import is not. See
+`TestModuleAndPackageDivergeOnUnresolvableNameNeBase` in `internal/codegen/unused_imports_lsp_test.go`.
+
+This is still strictly more robust than `detectUnusedImports`, which returned nil for the whole
+package on any unrelated error.
 
 ## Implementation
 
@@ -94,7 +124,7 @@ the whole package.
   - After type-checking, set `a.unusedImports = unusedFromSkeletons(skelByGsx, fset, pkg)`.
   - `analyzed` gains `unusedImports map[string][]UnusedImport`.
 - `internal/codegen/unused_imports_syntactic.go`
-  - Add `importNamesFromTypes(pkg *types.Package) map[string]string` (path → declared name; nil pkg → empty map).
+  - Add `importNamesFromTypes(pkg *types.Package) map[string]string` (path → declared name; nil pkg → empty map; entries with `imp.Complete() == false` are skipped — see "Behavior when the type-check fails, or an import is unresolved" above).
   - Add `unusedFromSkeletons(byGsx map[string]fileSkeleton, gsxFset *token.FileSet, pkg *types.Package) map[string][]UnusedImport` — the shared core: per file, `skeletonUsedNames` → `classifyUnusedImports` → resolve candidates from the name map.
   - `Module.UnusedImports` (CLI, no types) keeps `resolvePackageNames`; refactor it to call `unusedFromSkeletons`-shaped logic with a name map from `packages.Load` so the two surfaces share one classifier body.
 - `internal/codegen/module.go`
@@ -114,11 +144,28 @@ per invocation and has no type information. Unchanged.
 - **Deadlock guard:** the same `Package()` test hangs if the lock bug returns; the package
   `-timeout` catches it.
 - **Parity:** `Package(dir).UnusedImports` equals `Module.UnusedImports(dir)` across fixtures
-  (default import, aliased import, blank `_`, dot `.`, name≠base, sunk import).
+  (default import, aliased import, blank `_`, dot `.`, sunk import). A default import whose real
+  name differs from its path base AND is outside the importer graph (`math/rand/v2`) is
+  deliberately **excluded** from this parity set — see the next bullet.
+- **Documented divergence (name≠base, unresolvable):** `TestModuleAndPackageDivergeOnUnresolvableNameNeBase`
+  asserts `Package()` conservatively *keeps* an unused, unresolvable `math/rand/v2` while
+  `Module.UnusedImports` correctly *removes* it via `go list` — the one input shape where the two
+  surfaces are allowed to disagree, per the trade-off above.
 - **No `go list` on the hot path (deterministic, not timing-based):** a test-only counter
   incremented in `resolvePackageNames`; assert it stays **0** across `Package()`, and is
   non-zero for the CLI `Module.UnusedImports` path (proving the test can actually observe it).
-- **name ≠ base:** an unused `math/rand/v2` is detected via types alone.
+- **Critical false-positive regression:** `TestPackageUnusedImportsDoesNotDeleteUsedRandV2` — a
+  `.gsx` file that USES `math/rand/v2` as `rand.IntN(3)`, where that import is unresolvable via
+  analyze's importer graph, must not have it reported unused by `Package()`. Fails before the
+  `Complete()` gate, passes after.
+- **Headline case still removed:** `context` and `io`, both fully resolvable
+  (`Complete() == true`, since the gsx runtime itself imports them), unused, are still reported
+  unused by `Package()` via types alone (`TestPackageUnusedImportsHeadlineCaseStillRemoved`) — the
+  `Complete()` gate must not over-correct into never removing anything.
+- **Unresolvable candidate is kept, not misclassified as "correctly unused by luck":**
+  `TestPackageUnusedImportsKeepsUnresolvableCandidate` (renamed from
+  `TestPackageUnusedImportsNameNeBaseViaTypes`, which pinned the old, coincidentally-right-for-the-
+  wrong-reason behavior).
 - `make ci` and `make lint` green.
 
 ## Non-goals

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -634,7 +634,11 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 	}
 	res.Diags = a.bag.Sorted()
 	res.CrossIndex, res.NavIndex = buildCrossNav(a.compByKey, a.objKey, a.gsxFset, a.skelFset, a.info, a.pkg)
-	res.UnusedImports = detectUnusedImports(a.typeErrs, a.importSpecs, a.gsxFset)
+	// Unused imports come from analyze's syntactic classifier (unusedFromSkeletons,
+	// computed alongside the type-check) — the same classifier the `gsx fmt` CLI
+	// trusts (Module.UnusedImports) — never from correlating raw type-error
+	// positions. See docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md.
+	res.UnusedImports = a.unusedImports
 	m.mu.Lock()
 	m.pkgResults[dir] = res
 	m.mu.Unlock()

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -634,7 +634,15 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 	}
 	res.Diags = a.bag.Sorted()
 	res.CrossIndex, res.NavIndex = buildCrossNav(a.compByKey, a.objKey, a.gsxFset, a.skelFset, a.info, a.pkg)
-	res.UnusedImports = detectUnusedImports(a.typeErrs, a.importSpecs, a.gsxFset)
+	// Unused imports (consumed only by the LSP's formatting/organizeImports) come
+	// from the syntactic classifier — the same one the `gsx fmt` CLI trusts —
+	// rather than detectUnusedImports. The type-error correlation returns nil the
+	// moment the package's raw type errors include anything beyond clean
+	// unused-import errors, which is the norm in a real multi-file package, so the
+	// LSP would silently offer no organizeImports action / no import removal.
+	if unused, _, err := m.UnusedImports(dir); err == nil {
+		res.UnusedImports = unused
+	}
 	m.mu.Lock()
 	m.pkgResults[dir] = res
 	m.mu.Unlock()

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -634,15 +634,7 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 	}
 	res.Diags = a.bag.Sorted()
 	res.CrossIndex, res.NavIndex = buildCrossNav(a.compByKey, a.objKey, a.gsxFset, a.skelFset, a.info, a.pkg)
-	// Unused imports (consumed only by the LSP's formatting/organizeImports) come
-	// from the syntactic classifier — the same one the `gsx fmt` CLI trusts —
-	// rather than detectUnusedImports. The type-error correlation returns nil the
-	// moment the package's raw type errors include anything beyond clean
-	// unused-import errors, which is the norm in a real multi-file package, so the
-	// LSP would silently offer no organizeImports action / no import removal.
-	if unused, _, err := m.UnusedImports(dir); err == nil {
-		res.UnusedImports = unused
-	}
+	res.UnusedImports = detectUnusedImports(a.typeErrs, a.importSpecs, a.gsxFset)
 	m.mu.Lock()
 	m.pkgResults[dir] = res
 	m.mu.Unlock()

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -656,6 +656,7 @@ type analyzed struct {
 	importSpecs        []importSpec                   // hoisted .gsx import specs (for unused-import detection)
 	typeErrs           []types.Error                  // raw type errors from checkSkeletonPackage
 	signatureConflicts []signatureConflict            // same-name different-signature component collisions (block emission)
+	unusedImports      map[string][]UnusedImport      // .gsx abs path -> unused imports (Package's LSP surface; see unusedFromSkeletons)
 
 	// sunkImports maps a .gsx file path to the import SPECS (line+path keys)
 	// the type-checker PROVED were used only by a requalification-failed
@@ -799,6 +800,15 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	sunkImports := map[string]map[sunkImportKey]bool{}
 	var allImportSpecs []importSpec
 	factsByFile := map[string]*fileFacts{}
+	// skelByGsx captures exactly what unused_imports_syntactic.go's
+	// buildPackageSkeletons builds from a SEPARATE, importer-free parse: this
+	// loop already has each file's skeleton AST, hoisted import specs, and
+	// sunk set (sunkImports[path], pre-confirmation — same as
+	// buildPackageSkeletons' own, which never confirms via type errors
+	// either). Reusing it after type-checking (unusedFromSkeletons, below)
+	// means Package()'s unused-import detection costs no extra parse, no
+	// extra lock, and no re-entry into applyDirty.
+	skelByGsx := map[string]fileSkeleton{}
 	skelErr := false
 	// inferNames is the ONE package-wide inference-probe-helper name
 	// allocator shared by every file's buildSkeleton call below (see
@@ -886,6 +896,7 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 		factsByXGo[absXpath] = ff
 		ctrlOffByXGo[absXpath] = ctrlOff
 		inferByXGo[absXpath] = infReg
+		skelByGsx[path] = fileSkeleton{skel: gf, imps: imps, sunk: sunkImports[path]}
 	}
 	if skelErr {
 		gsxFiles = map[string]*gsxast.File{} // package-level skip: Generate's loop emits nothing
@@ -1217,6 +1228,13 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 		}
 	}
 
+	// Unused imports for the LSP surface (Package's PackageResult.UnusedImports),
+	// computed from the skeletons this loop already built and the package
+	// already type-checked above — no extra parse, no lock, no packages.Load.
+	// See unusedFromSkeletons' doc and the design doc
+	// (docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md).
+	unusedImports := unusedFromSkeletons(skelByGsx, fset, pkg)
+
 	return &analyzed{
 		pkgName:            pkgName,
 		gsxFiles:           gsxFiles,
@@ -1244,6 +1262,7 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 		typeErrs:           typeErrs,
 		sunkImports:        confirmedSunk,
 		signatureConflicts: sigConflicts,
+		unusedImports:      unusedImports,
 	}, nil
 }
 

--- a/internal/codegen/results.go
+++ b/internal/codegen/results.go
@@ -4,7 +4,6 @@ import (
 	goast "go/ast"
 	"go/token"
 	"go/types"
-	"strings"
 
 	gsxast "github.com/gsxhq/gsx/ast"
 	"github.com/gsxhq/gsx/internal/diag"
@@ -77,59 +76,4 @@ type PackageResult struct {
 type UnusedImport struct {
 	Name string
 	Path string
-}
-
-// pickImportByPath disambiguates several imports sharing one .gsx line using the
-// path go/types names in the error (`"<path>" imported ...`). Falls back to the
-// first spec if the path is not found.
-func pickImportByPath(specs []importSpec, msg string) importSpec {
-	if i := strings.IndexByte(msg, '"'); i >= 0 {
-		if j := strings.IndexByte(msg[i+1:], '"'); j >= 0 {
-			path := msg[i+1 : i+1+j]
-			for _, s := range specs {
-				if s.path == path {
-					return s
-				}
-			}
-		}
-	}
-	return specs[0]
-}
-
-// detectUnusedImports correlates raw go/types type errors (from
-// checkSkeletonPackage) with the hoisted .gsx import specs to identify unused
-// imports, using the conservative logic: returns nil if any error is not a clean
-// unused-import error, or when there are no type errors (nothing unused). Never
-// removes imports under uncertainty.
-func detectUnusedImports(typeErrs []types.Error, imports []importSpec, gsxFset *token.FileSet) map[string][]UnusedImport {
-	if len(typeErrs) == 0 || len(imports) == 0 {
-		return nil
-	}
-	type posKey struct {
-		file string
-		line int
-	}
-	byPos := map[posKey][]importSpec{}
-	for _, imp := range imports {
-		if !imp.pos.IsValid() {
-			continue // unresolved position: cannot correlate safely
-		}
-		p := gsxFset.Position(imp.pos)
-		k := posKey{p.Filename, p.Line}
-		byPos[k] = append(byPos[k], imp)
-	}
-	out := map[string][]UnusedImport{}
-	for _, e := range typeErrs {
-		ep := e.Fset.Position(e.Pos)
-		specs, ok := byPos[posKey{ep.Filename, ep.Line}]
-		if !ok || !strings.Contains(e.Msg, "imported and not used") {
-			return nil // not a clean unused-import error → analysis unreliable, remove nothing
-		}
-		spec := specs[0]
-		if len(specs) > 1 {
-			spec = pickImportByPath(specs, e.Msg)
-		}
-		out[ep.Filename] = append(out[ep.Filename], UnusedImport{Name: spec.name, Path: spec.path})
-	}
-	return out
 }

--- a/internal/codegen/unused_imports_lsp_test.go
+++ b/internal/codegen/unused_imports_lsp_test.go
@@ -1,0 +1,162 @@
+package codegen
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/diag"
+)
+
+// TestPackageUnusedImportsSurvivesOtherError is the regression test for the LSP
+// unused-imports bug (see docs/superpowers/specs/2026-07-09-lsp-unused-imports-
+// design.md): a real multi-file package whose skeleton carries an UNRELATED type
+// error (a.gsx's undefined "Nope") alongside a genuinely unused import in a
+// SIBLING file (b.gsx's "bytes") must still report that unused import via
+// m.Package(dir).UnusedImports.
+//
+// This is the exact case the old detectUnusedImports (results.go, now deleted)
+// returned nil for: it bailed to nil the moment it saw any type error that did
+// not cleanly position-correlate to an "imported and not used" message, which
+// is the norm for a real multi-file package. Going through Package() (not
+// Module.UnusedImports directly) is deliberate: it's the entry point the
+// self-deadlocking rejected patch (commit 42335ee) broke, and the only path the
+// LSP's format/organizeImports handlers actually call.
+func TestPackageUnusedImportsSurvivesOtherError(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"a.gsx": "package testmod\n\nimport \"strings\"\n\ncomponent A() {\n\t<p>{strings.ToUpper(\"x\")}</p>\n\t<p>{Nope()}</p>\n}\n",
+		"b.gsx": "package testmod\n\nimport \"bytes\"\n\ncomponent B() {\n\t<p>hi</p>\n}\n",
+	})
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: confirm the unrelated error is actually present, else this test
+	// isn't exercising the scenario it claims to.
+	foundUnrelated := false
+	for _, d := range pr.Diags {
+		if d.Severity == diag.Error && strings.Contains(d.Message, "undefined: Nope") {
+			foundUnrelated = true
+		}
+	}
+	if !foundUnrelated {
+		t.Fatalf("expected an unrelated type error (undefined: Nope) in diags, got %+v", pr.Diags)
+	}
+	bPath := filepath.Join(dir, "b.gsx")
+	unused := pr.UnusedImports[bPath]
+	if len(unused) != 1 || unused[0].Path != "bytes" {
+		t.Errorf("want b.gsx's bytes reported unused despite a.gsx's unrelated type error; got %+v (all=%+v)", unused, pr.UnusedImports)
+	}
+	aPath := filepath.Join(dir, "a.gsx")
+	if u := pr.UnusedImports[aPath]; len(u) != 0 {
+		t.Errorf("a.gsx's strings IS used (strings.ToUpper); must not be reported unused, got %+v", u)
+	}
+}
+
+// TestPackageParityWithModuleUnusedImports proves Package(dir).UnusedImports
+// (the LSP surface, now computed from analyze's already-type-checked skeletons)
+// agrees exactly with Module.UnusedImports(dir) (the CLI's independent
+// packages.Load-based syntactic classifier) across every import-spec shape:
+// plain default, aliased, blank `_`, dot `.`, a name that differs from its
+// path's base (math/rand/v2 declares package "rand"), and a genuinely used
+// import (must be absent from both).
+func TestPackageParityWithModuleUnusedImports(t *testing.T) {
+	cases := map[string]map[string]string{
+		"default": {
+			"a.gsx": "package testmod\n\nimport \"bytes\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+		},
+		"aliased": {
+			"a.gsx": "package testmod\n\nimport al \"bytes\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+		},
+		"blank": {
+			"a.gsx": "package testmod\n\nimport _ \"bytes\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+		},
+		"dot": {
+			"a.gsx": "package testmod\n\nimport . \"bytes\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+		},
+		"name_ne_base": {
+			"a.gsx": "package testmod\n\nimport \"math/rand/v2\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+		},
+		"used": {
+			"a.gsx": "package testmod\n\nimport \"strings\"\n\ncomponent A() {\n\t<p>{strings.ToUpper(\"x\")}</p>\n}\n",
+		},
+	}
+	for name, files := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir, m := openTestModule(t, files)
+			pr, err := m.Package(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			syn, _, err := m.UnusedImports(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertSameRemovalSet(t, dir, pr.UnusedImports, syn)
+		})
+	}
+}
+
+// TestPackageUnusedImportsDoesNotCallGoList is the deterministic (not timing-
+// based) proof that Package() never shells out to `go list`: resolvePackageNames
+// is the only place that calls packages.Load for name resolution, and
+// resolvePackageNamesCalls counts its invocations. The package under test has
+// an unused DEFAULT import ("bytes") — exactly the shape whose candidate
+// resolution used to trigger a packages.Load in the rejected patch (measured
+// 19.3ms vs 158us). Package() must resolve it from a.pkg.Imports() instead, so
+// the counter must not move.
+//
+// The zero-assertion alone would be vacuous if resolvePackageNames were simply
+// dead code, so this also drives Module.UnusedImports (the CLI path) over the
+// SAME package afterwards and asserts the counter DOES move there — proving
+// the instrumentation can actually observe a call.
+func TestPackageUnusedImportsDoesNotCallGoList(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"a.gsx": "package testmod\n\nimport \"bytes\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+	})
+
+	before := resolvePackageNamesCalls.Load()
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := resolvePackageNamesCalls.Load(); got != before {
+		t.Errorf("Package() called resolvePackageNames (go list) %d time(s); want 0 — LSP hot path must resolve names from types alone", got-before)
+	}
+	if u := pr.UnusedImports[filepath.Join(dir, "a.gsx")]; len(u) != 1 || u[0].Path != "bytes" {
+		t.Errorf("want bytes reported unused via types alone, got %+v", u)
+	}
+
+	// The CLI path, over the same package, DOES resolve via packages.Load —
+	// proving the counter is wired to something Package() could have hit.
+	if _, _, err := m.UnusedImports(dir); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolvePackageNamesCalls.Load(); got == before {
+		t.Errorf("Module.UnusedImports never called resolvePackageNames; counter is not observing real calls (test would be vacuous)")
+	}
+}
+
+// TestPackageUnusedImportsNameNeBaseViaTypes covers the case
+// resolvePackageNames exists to handle for the CLI: a default import whose real
+// package name differs from its path's last segment (math/rand/v2 declares
+// package "rand", not "v2"). Package() must resolve this correctly from
+// a.pkg.Imports() (populated by the skeleton type-check) without calling
+// resolvePackageNames at all.
+func TestPackageUnusedImportsNameNeBaseViaTypes(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"a.gsx": "package testmod\n\nimport \"math/rand/v2\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+	})
+	before := resolvePackageNamesCalls.Load()
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := pr.UnusedImports[filepath.Join(dir, "a.gsx")]
+	if len(u) != 1 || u[0].Path != "math/rand/v2" {
+		t.Errorf(`want math/rand/v2 (declared package "rand", base "v2") reported unused via types alone; got %+v`, u)
+	}
+	if got := resolvePackageNamesCalls.Load(); got != before {
+		t.Errorf("go list (resolvePackageNames) was called %d time(s); want types-only resolution", got-before)
+	}
+}

--- a/internal/codegen/unused_imports_lsp_test.go
+++ b/internal/codegen/unused_imports_lsp_test.go
@@ -252,6 +252,100 @@ func TestPackageUnusedImportsDoesNotDeleteUsedRandV2(t *testing.T) {
 	}
 }
 
+// TestPackageKeepsUnusedImportOutsideImporterGraph pins the REAL shape of
+// Divergence A (see the design doc's "Behavior when the type-check fails, or
+// an import is unresolved" section): ANY unused default import whose package
+// is outside analyze's importer graph (externalImporter's one-shot preload of
+// the gsx runtime + std filter package + FilterPkgs/LoadPkgs + "./..." — see
+// externalImporter's doc in module.go) is kept by Package(), not just the
+// name != path-base shape TestModuleAndPackageDivergeOnUnresolvableNameNeBase
+// covers. container/ring is unused, outside the importer graph (reachable only
+// from this one .gsx file), AND its declared package name ("ring") equals its
+// path base ("ring") — so importNamesFromTypes' Complete() gate, not a
+// name-mismatch, is what makes it unresolvable here. Module.UnusedImports
+// (CLI, go list) has no such gate and correctly removes it.
+func TestPackageKeepsUnusedImportOutsideImporterGraph(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"a.gsx": "package testmod\n\nimport \"container/ring\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+	})
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aPath := filepath.Join(dir, "a.gsx")
+	if u := pr.UnusedImports[aPath]; len(u) != 0 {
+		t.Errorf("Package(): want container/ring conservatively KEPT (outside importer graph, name==base), got reported unused: %+v", u)
+	}
+	syn, _, err := m.UnusedImports(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	su := syn[aPath]
+	if len(su) != 1 || su[0].Path != "container/ring" {
+		t.Errorf(`Module.UnusedImports: want container/ring reported unused (resolved via go list); got %+v`, su)
+	}
+}
+
+// TestPackageRemovesUnusedSiblingGsxImportModuleKeeps pins Divergence B: the
+// opposite direction from every other test in this file. main.gsx imports a
+// sibling gsx-only package ("testmod/foo", no .go files) and never references
+// it. Package() (LSP) type-checks foo from its skeleton via moduleImporter —
+// unlike stdlib/third-party packages, sibling gsx packages route through the
+// warm skeleton graph, not externalImporter — so it resolves foo's real name
+// ("foo") from types and correctly reports the import unused. Module.UnusedImports
+// (CLI) asks `go list -f NeedName` for the same path, which fails ("no Go
+// files in .../foo": verified empirically) since go list cannot resolve a
+// package with zero .go files; the candidate is therefore unresolvable and the
+// CLI conservatively KEEPS it. This is the one shape where Package() is MORE
+// aggressive than the CLI, not less — see TestPackageKeepsUsedSiblingGsxImport
+// for the safety property that makes this acceptable (Package() never removes
+// a sibling import that IS used).
+func TestPackageRemovesUnusedSiblingGsxImportModuleKeeps(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"foo/box.gsx": "package foo\n\ncomponent Box() {\n\t<div>box</div>\n}\n",
+		"main.gsx":    "package testmod\n\nimport \"testmod/foo\"\n\ncomponent Main() {\n\t<p>hi</p>\n}\n",
+	})
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.gsx")
+	u := pr.UnusedImports[mainPath]
+	if len(u) != 1 || u[0].Path != "testmod/foo" {
+		t.Errorf(`Package(): want testmod/foo (unused sibling gsx import, resolved via types) reported unused; got %+v`, u)
+	}
+	syn, _, err := m.UnusedImports(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	su := syn[mainPath]
+	if len(su) != 0 {
+		t.Errorf(`Module.UnusedImports: want testmod/foo conservatively KEPT (go list cannot resolve a .gsx-only sibling with no .go files); got reported unused: %+v`, su)
+	}
+}
+
+// TestPackageKeepsUsedSiblingGsxImport is the safety property for
+// Divergence B: when the same sibling gsx-only import IS used — here via a
+// plain Go function call (foo.Helper()) inside an interpolation, not merely a
+// component tag — Package() must NOT report it unused. Divergence B only ever
+// makes Package() remove a GENUINELY unused sibling import (matching the
+// adversarial review's finding that it was verified safe across tag, plain
+// call, and other used-shapes); it must never misclassify a used one.
+func TestPackageKeepsUsedSiblingGsxImport(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"foo/box.gsx": "package foo\n\nfunc Helper() string { return \"x\" }\n\ncomponent Box() {\n\t<div>box</div>\n}\n",
+		"main.gsx":    "package testmod\n\nimport \"testmod/foo\"\n\ncomponent Main() {\n\t<p>{ foo.Helper() }</p>\n}\n",
+	})
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainPath := filepath.Join(dir, "main.gsx")
+	if u := pr.UnusedImports[mainPath]; len(u) != 0 {
+		t.Errorf("Package(): testmod/foo IS used (foo.Helper()) but reported unused (would be deleted by the LSP): %+v", u)
+	}
+}
+
 // TestPackageUnusedImportsHeadlineCaseStillRemoved guards against the
 // Complete()-gating fix over-correcting into never removing anything: context
 // and io are both genuinely unused here AND fully resolvable

--- a/internal/codegen/unused_imports_lsp_test.go
+++ b/internal/codegen/unused_imports_lsp_test.go
@@ -56,10 +56,14 @@ func TestPackageUnusedImportsSurvivesOtherError(t *testing.T) {
 // TestPackageParityWithModuleUnusedImports proves Package(dir).UnusedImports
 // (the LSP surface, now computed from analyze's already-type-checked skeletons)
 // agrees exactly with Module.UnusedImports(dir) (the CLI's independent
-// packages.Load-based syntactic classifier) across every import-spec shape:
-// plain default, aliased, blank `_`, dot `.`, a name that differs from its
-// path's base (math/rand/v2 declares package "rand"), and a genuinely used
-// import (must be absent from both).
+// packages.Load-based syntactic classifier) across every import-spec shape
+// where the two ARE expected to agree: plain default, aliased, blank `_`, dot
+// `.`, and a genuinely used import (must be absent from both).
+//
+// A default import whose real name differs from its path base
+// (math/rand/v2 declares package "rand", base "v2") is deliberately NOT a case
+// here: see TestModuleAndPackageDivergeOnUnresolvableNameNeBase below, which
+// documents and asserts that the two surfaces now legitimately DISAGREE on it.
 func TestPackageParityWithModuleUnusedImports(t *testing.T) {
 	cases := map[string]map[string]string{
 		"default": {
@@ -73,9 +77,6 @@ func TestPackageParityWithModuleUnusedImports(t *testing.T) {
 		},
 		"dot": {
 			"a.gsx": "package testmod\n\nimport . \"bytes\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
-		},
-		"name_ne_base": {
-			"a.gsx": "package testmod\n\nimport \"math/rand/v2\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
 		},
 		"used": {
 			"a.gsx": "package testmod\n\nimport \"strings\"\n\ncomponent A() {\n\t<p>{strings.ToUpper(\"x\")}</p>\n}\n",
@@ -94,6 +95,52 @@ func TestPackageParityWithModuleUnusedImports(t *testing.T) {
 			}
 			assertSameRemovalSet(t, dir, pr.UnusedImports, syn)
 		})
+	}
+}
+
+// TestModuleAndPackageDivergeOnUnresolvableNameNeBase documents and asserts
+// the one input shape where Package() (LSP) and Module.UnusedImports (CLI) now
+// legitimately disagree, as a direct consequence of this file's Complete()
+// fix: a default import whose real package name differs from its path base
+// AND is outside the type-checker's own importer graph (math/rand/v2, unused,
+// declares package "rand", path base "v2").
+//
+//   - Module.UnusedImports resolves the candidate's real name via
+//     resolvePackageNames — a fresh, targeted `go list` (NeedName-only) that
+//     always finds the real name regardless of what analyze's importer graph
+//     happens to already contain. It correctly resolves "rand" and reports the
+//     (unused) import removed.
+//   - Package() resolves candidate names from the already-type-checked
+//     *types.Package (importNamesFromTypes) with NO extra go-list call, for
+//     LSP hot-path performance. Here go/types never loaded math/rand/v2 (nothing
+//     else in the importer graph — the gsx runtime, the std filter package, the
+//     module's other Go files — reaches it), so it fabricates an incomplete
+//     placeholder named after the path base ("v2"), which importNamesFromTypes
+//     now deliberately skips (Complete()==false) rather than trust as a guess.
+//     The candidate is therefore unresolvable and conservatively KEPT.
+//
+// This is the documented, accepted trade-off: under-removal (LSP keeps a
+// genuinely unused import it can't safely name-resolve) is safe; the
+// alternative — trusting the fabricated name — is what let the LSP delete a
+// USED import (see TestPackageUnusedImportsDoesNotDeleteUsedRandV2).
+func TestModuleAndPackageDivergeOnUnresolvableNameNeBase(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"a.gsx": "package testmod\n\nimport \"math/rand/v2\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+	})
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u := pr.UnusedImports[filepath.Join(dir, "a.gsx")]; len(u) != 0 {
+		t.Errorf("Package(): want math/rand/v2 conservatively KEPT (unresolvable via types), got reported unused: %+v", u)
+	}
+	syn, _, err := m.UnusedImports(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	su := syn[filepath.Join(dir, "a.gsx")]
+	if len(su) != 1 || su[0].Path != "math/rand/v2" {
+		t.Errorf(`Module.UnusedImports: want math/rand/v2 (resolved to "rand" via go list) reported unused; got %+v`, su)
 	}
 }
 
@@ -137,13 +184,28 @@ func TestPackageUnusedImportsDoesNotCallGoList(t *testing.T) {
 	}
 }
 
-// TestPackageUnusedImportsNameNeBaseViaTypes covers the case
-// resolvePackageNames exists to handle for the CLI: a default import whose real
-// package name differs from its path's last segment (math/rand/v2 declares
-// package "rand", not "v2"). Package() must resolve this correctly from
-// a.pkg.Imports() (populated by the skeleton type-check) without calling
-// resolvePackageNames at all.
-func TestPackageUnusedImportsNameNeBaseViaTypes(t *testing.T) {
+// TestPackageUnusedImportsKeepsUnresolvableCandidate covers the false-positive
+// this file's Critical fix removes. math/rand/v2 is outside the type-checker's
+// own importer graph (moduleImporter/externalImporter never load it here: it's
+// reached only from this .gsx file, not from the gsx runtime, the std filter
+// package, or any other Go file in the module), so go/types cannot resolve it
+// and fabricates an incomplete placeholder package NAMED AFTER THE PATH'S LAST
+// SEGMENT ("v2") — not its real declared name ("rand"). That guessed name used
+// to be trusted outright (importNamesFromTypes had no Complete() gate), which
+// happened to give the RIGHT answer here only because the import is genuinely
+// unused: "v2" is absent from the used-set for the same reason "rand" would
+// have been. TestPackageUnusedImportsDoesNotDeleteUsedRandV2 (in the same
+// file) proves that agreement was a coincidence, not a correct mechanism — the
+// moment the import IS used (`rand.IntN(3)`), the guessed name still isn't in
+// the used-set and the old code deleted a working import.
+//
+// The corrected contract: an import whose package is !Complete() has no
+// resolvable real name from types alone, so Package() conservatively KEEPS it
+// (matching resolvePackageNames' own "absent path ⇒ keep" contract for the CLI
+// path) — even though it is, in fact, unused. This is the documented
+// under-removal trade-off; see importNamesFromTypes' doc comment and
+// docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md.
+func TestPackageUnusedImportsKeepsUnresolvableCandidate(t *testing.T) {
 	dir, m := openTestModule(t, map[string]string{
 		"a.gsx": "package testmod\n\nimport \"math/rand/v2\"\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
 	})
@@ -153,8 +215,68 @@ func TestPackageUnusedImportsNameNeBaseViaTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 	u := pr.UnusedImports[filepath.Join(dir, "a.gsx")]
-	if len(u) != 1 || u[0].Path != "math/rand/v2" {
-		t.Errorf(`want math/rand/v2 (declared package "rand", base "v2") reported unused via types alone; got %+v`, u)
+	if len(u) != 0 {
+		t.Errorf(`want math/rand/v2 conservatively KEPT (unresolvable via types alone, real name "rand" != fabricated "v2"); got reported unused: %+v`, u)
+	}
+	if got := resolvePackageNamesCalls.Load(); got != before {
+		t.Errorf("go list (resolvePackageNames) was called %d time(s); want types-only resolution", got-before)
+	}
+}
+
+// TestPackageUnusedImportsDoesNotDeleteUsedRandV2 is the Critical regression
+// test: before the Complete()-gating fix, importNamesFromTypes trusted
+// go/types' fabricated placeholder name for an import outside the importer
+// graph — the path's last segment ("v2" for "math/rand/v2"), not its real
+// declared name ("rand"). classifyUnusedImports makes math/rand/v2 a removal
+// CANDIDATE because its path base "v2" is never referenced (the source
+// references it as "rand"), and the old code then resolved that candidate's
+// name to the same wrong "v2", which is ALSO absent from the used-set — so a
+// live `rand.IntN(3)` reference was invisible and Package() reported the
+// import unused. The LSP's format/organizeImports handlers act on exactly that
+// signal and would delete a working import, leaving `rand.IntN(3)` undefined.
+//
+// This must FAIL before the fix (verified) and PASS after it.
+func TestPackageUnusedImportsDoesNotDeleteUsedRandV2(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"a.gsx": "package testmod\n\nimport \"math/rand/v2\"\n\ncomponent A() {\n\t<p>{rand.IntN(3)}</p>\n}\n",
+	})
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := pr.UnusedImports[filepath.Join(dir, "a.gsx")]
+	for _, imp := range u {
+		if imp.Path == "math/rand/v2" {
+			t.Fatalf("math/rand/v2 is USED (rand.IntN(3)) but Package() reported it unused (would be deleted by the LSP): unused=%+v", u)
+		}
+	}
+}
+
+// TestPackageUnusedImportsHeadlineCaseStillRemoved guards against the
+// Complete()-gating fix over-correcting into never removing anything: context
+// and io are both genuinely unused here AND fully resolvable
+// (types.Package.Complete()==true, since the gsx runtime itself imports both,
+// so they are always in analyze's importer graph) — Package() must still
+// report them unused via types alone, exactly as before the fix.
+func TestPackageUnusedImportsHeadlineCaseStillRemoved(t *testing.T) {
+	dir, m := openTestModule(t, map[string]string{
+		"a.gsx": "package testmod\n\nimport (\n\t\"context\"\n\t\"io\"\n)\n\ncomponent A() {\n\t<p>hi</p>\n}\n",
+	})
+	before := resolvePackageNamesCalls.Load()
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := pr.UnusedImports[filepath.Join(dir, "a.gsx")]
+	if len(u) != 2 {
+		t.Fatalf("want both context and io reported unused via types alone; got %+v", u)
+	}
+	gotPaths := map[string]bool{}
+	for _, imp := range u {
+		gotPaths[imp.Path] = true
+	}
+	if !gotPaths["context"] || !gotPaths["io"] {
+		t.Errorf("want context and io both reported unused; got %+v", u)
 	}
 	if got := resolvePackageNamesCalls.Load(); got != before {
 		t.Errorf("go list (resolvePackageNames) was called %d time(s); want types-only resolution", got-before)

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -4,8 +4,10 @@ import (
 	goast "go/ast"
 	goparser "go/parser"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gsxhq/gsx/internal/diag"
 	"github.com/gsxhq/gsx/internal/jsx"
@@ -175,10 +177,21 @@ func (m *Module) buildPackageSkeletons(dir string) (*packageSkeletons, error) {
 	return out, nil
 }
 
+// resolvePackageNamesCalls counts invocations of resolvePackageNames — the
+// only place in the unused-import classifier that shells out to `go list`
+// (packages.Load). Test-only instrumentation (see
+// TestPackageUnusedImportsDoesNotCallGoList) proving deterministically, not by
+// timing, that the LSP's Package() path never hits it: candidate names are
+// resolved from the already-type-checked *types.Package instead (see
+// importNamesFromTypes). The CLI path (Module.UnusedImports) has no type
+// information and keeps calling this.
+var resolvePackageNamesCalls atomic.Int64
+
 // resolvePackageNames returns the real package name for each import path, via a
 // NeedName-only load (no type-checking, no dependency resolution). Unresolvable
 // paths are simply absent from the result, so the caller keeps those imports.
 func (m *Module) resolvePackageNames(paths []string) map[string]string {
+	resolvePackageNamesCalls.Add(1)
 	out := map[string]string{}
 	if len(paths) == 0 {
 		return out
@@ -194,6 +207,88 @@ func (m *Module) resolvePackageNames(paths []string) map[string]string {
 		}
 	}
 	return out
+}
+
+// importNamesFromTypes returns pkg's direct-import path -> declared package
+// name, straight from the already-type-checked *types.Package — no
+// packages.Load, no subprocess. types.Package.Imports() lists every directly
+// imported package INCLUDING unused ones (verified: an unused "math/rand/v2"
+// still appears, with name "rand"), which is exactly the candidate-resolution
+// signal unusedFromSkeletons needs. A nil pkg (type-check failed before
+// producing one) yields an empty map, so every candidate is conservatively
+// kept by the caller — mirroring resolvePackageNames' own "absent path ⇒ keep"
+// contract.
+func importNamesFromTypes(pkg *types.Package) map[string]string {
+	out := map[string]string{}
+	if pkg == nil {
+		return out
+	}
+	for _, imp := range pkg.Imports() {
+		out[imp.Path()] = imp.Name()
+	}
+	return out
+}
+
+// unusedImportsCore is the ONE classifier body shared by both unused-import
+// surfaces (Module.UnusedImports for the CLI, unusedFromSkeletons for the
+// LSP's Package()): per file, skeletonUsedNames -> classifyUnusedImports finds
+// definitely-unused imports and removal CANDIDATES (default imports whose path
+// base isn't referenced), then resolveNames is called exactly once with every
+// candidate path across the whole package, and each candidate's real name is
+// checked against the file's used set before it is reported unused. An
+// unresolvable candidate path (resolveNames' result has no entry) is
+// conservatively kept, never removed.
+func unusedImportsCore(byGsx map[string]fileSkeleton, gsxFset *token.FileSet, resolveNames func(paths []string) map[string]string) map[string][]UnusedImport {
+	out := map[string][]UnusedImport{}
+	usedByFile := map[string]map[string]bool{}
+	type pending struct {
+		gsxPath string
+		imp     importSpec
+	}
+	var candidates []pending
+	candPaths := map[string]bool{}
+	for gsxPath, fs := range byGsx {
+		used := skeletonUsedNames(fs.skel)
+		usedByFile[gsxPath] = used
+		unused, cands := classifyUnusedImports(used, fs.imps, fs.sunk, gsxFset)
+		if len(unused) > 0 {
+			out[gsxPath] = unused
+		}
+		for _, c := range cands {
+			candidates = append(candidates, pending{gsxPath, c})
+			candPaths[c.path] = true
+		}
+	}
+	if len(candPaths) == 0 {
+		return out
+	}
+	paths := make([]string, 0, len(candPaths))
+	for p := range candPaths {
+		paths = append(paths, p)
+	}
+	names := resolveNames(paths)
+	for _, p := range candidates {
+		realName, ok := names[p.imp.path]
+		if !ok {
+			continue // unresolvable → conservative keep
+		}
+		if !usedByFile[p.gsxPath][realName] {
+			out[p.gsxPath] = append(out[p.gsxPath], UnusedImport{Name: p.imp.name, Path: p.imp.path})
+		}
+	}
+	return out
+}
+
+// unusedFromSkeletons is the LSP-facing entry point for unused-import
+// detection: given the per-file skeletons analyze already built and the
+// package it already type-checked, it classifies unused imports via
+// unusedImportsCore, resolving candidate names from pkg (importNamesFromTypes)
+// instead of a fresh packages.Load — no extra parse, no lock, no subprocess.
+// See Module.Package's use of a.unusedImports and the design doc
+// (docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md).
+func unusedFromSkeletons(byGsx map[string]fileSkeleton, gsxFset *token.FileSet, pkg *types.Package) map[string][]UnusedImport {
+	names := importNamesFromTypes(pkg)
+	return unusedImportsCore(byGsx, gsxFset, func([]string) map[string]string { return names })
 }
 
 // UnusedImports returns, per .gsx file (abs path) in dir, the imports the file
@@ -214,41 +309,6 @@ func (m *Module) UnusedImports(dir string) (map[string][]UnusedImport, []diag.Di
 	if err != nil {
 		return nil, nil, err
 	}
-	out := map[string][]UnusedImport{}
-	usedByFile := map[string]map[string]bool{}
-	type pending struct {
-		gsxPath string
-		imp     importSpec
-	}
-	var candidates []pending
-	candPaths := map[string]bool{}
-	for gsxPath, fs := range ps.byGsx {
-		used := skeletonUsedNames(fs.skel)
-		usedByFile[gsxPath] = used
-		unused, cands := classifyUnusedImports(used, fs.imps, fs.sunk, ps.gsxFset)
-		if len(unused) > 0 {
-			out[gsxPath] = unused
-		}
-		for _, c := range cands {
-			candidates = append(candidates, pending{gsxPath, c})
-			candPaths[c.path] = true
-		}
-	}
-	if len(candPaths) > 0 {
-		paths := make([]string, 0, len(candPaths))
-		for p := range candPaths {
-			paths = append(paths, p)
-		}
-		names := m.resolvePackageNames(paths)
-		for _, p := range candidates {
-			realName, ok := names[p.imp.path]
-			if !ok {
-				continue // unresolvable → conservative keep
-			}
-			if !usedByFile[p.gsxPath][realName] {
-				out[p.gsxPath] = append(out[p.gsxPath], UnusedImport{Name: p.imp.name, Path: p.imp.path})
-			}
-		}
-	}
+	out := unusedImportsCore(ps.byGsx, ps.gsxFset, m.resolvePackageNames)
 	return out, ps.goParseDiags, nil
 }

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -218,12 +218,42 @@ func (m *Module) resolvePackageNames(paths []string) map[string]string {
 // producing one) yields an empty map, so every candidate is conservatively
 // kept by the caller — mirroring resolvePackageNames' own "absent path ⇒ keep"
 // contract.
+//
+// Completeness gates every entry (imp.Complete()). When an import path is not
+// in the type-checker's own importer graph (moduleImporter/externalImporter —
+// e.g. it is reachable only via the .gsx source, not via the gsx runtime, the
+// std filter package, or the module's other Go files), go/types cannot load
+// it, but it still needs a placeholder *types.Package to keep type-checking
+// the rest of the file. It fabricates one named after the import PATH'S LAST
+// SEGMENT (verified: "math/rand/v2" → placeholder name "v2", real declared
+// name "rand") and leaves it incomplete. Trusting that guessed name is exactly
+// the banned "simple heuristic": it makes classifyUnusedImports' candidate
+// check compare the file's used-name set against "v2" instead of "rand", so a
+// live `rand.IntN(3)` reference is invisible and the import is reported
+// unused — the LSP then deletes a working import out from under the user.
+// Skipping incomplete imports here means their real name is simply
+// unresolvable from types alone, so unusedImportsCore's `!ok → continue`
+// conservatively keeps them — the same "absent path ⇒ keep" contract
+// resolvePackageNames already provides for the CLI path.
+//
+// Accepted trade-off: a candidate import that is BOTH genuinely unused AND
+// outside the importer graph (so its real name can only be a guess) is now
+// KEPT by the LSP even though `Module.UnusedImports`/`gsx fmt` (which resolves
+// names via a real `go list`, not a guess) still correctly removes it. This
+// under-removal is deliberate and asymmetric: failing to flag a genuinely
+// unused import is a missed cleanup opportunity; deleting a used one breaks
+// the user's build. See docs/superpowers/specs/2026-07-09-lsp-unused-imports-
+// design.md.
 func importNamesFromTypes(pkg *types.Package) map[string]string {
 	out := map[string]string{}
 	if pkg == nil {
 		return out
 	}
 	for _, imp := range pkg.Imports() {
+		if !imp.Complete() {
+			// Fabricated path-base placeholder — not a fact, do not trust it.
+			continue
+		}
 		out[imp.Path()] = imp.Name()
 	}
 	return out

--- a/internal/codegen/unused_imports_syntactic.go
+++ b/internal/codegen/unused_imports_syntactic.go
@@ -219,31 +219,30 @@ func (m *Module) resolvePackageNames(paths []string) map[string]string {
 // kept by the caller — mirroring resolvePackageNames' own "absent path ⇒ keep"
 // contract.
 //
-// Completeness gates every entry (imp.Complete()). When an import path is not
-// in the type-checker's own importer graph (moduleImporter/externalImporter —
-// e.g. it is reachable only via the .gsx source, not via the gsx runtime, the
-// std filter package, or the module's other Go files), go/types cannot load
-// it, but it still needs a placeholder *types.Package to keep type-checking
-// the rest of the file. It fabricates one named after the import PATH'S LAST
-// SEGMENT (verified: "math/rand/v2" → placeholder name "v2", real declared
-// name "rand") and leaves it incomplete. Trusting that guessed name is exactly
-// the banned "simple heuristic": it makes classifyUnusedImports' candidate
-// check compare the file's used-name set against "v2" instead of "rand", so a
-// live `rand.IntN(3)` reference is invisible and the import is reported
-// unused — the LSP then deletes a working import out from under the user.
-// Skipping incomplete imports here means their real name is simply
-// unresolvable from types alone, so unusedImportsCore's `!ok → continue`
-// conservatively keeps them — the same "absent path ⇒ keep" contract
-// resolvePackageNames already provides for the CLI path.
-//
-// Accepted trade-off: a candidate import that is BOTH genuinely unused AND
-// outside the importer graph (so its real name can only be a guess) is now
-// KEPT by the LSP even though `Module.UnusedImports`/`gsx fmt` (which resolves
-// names via a real `go list`, not a guess) still correctly removes it. This
-// under-removal is deliberate and asymmetric: failing to flag a genuinely
-// unused import is a missed cleanup opportunity; deleting a used one breaks
-// the user's build. See docs/superpowers/specs/2026-07-09-lsp-unused-imports-
-// design.md.
+// Completeness gates every entry (imp.Complete()). An import path outside the
+// type-checker's own importer graph (moduleImporter/externalImporter — e.g. it
+// is reachable only via the .gsx source, not via the gsx runtime, the std
+// filter package, FilterPkgs/LoadPkgs, or "./..." — see externalImporter's
+// doc) cannot be loaded by go/types, but it still needs a placeholder
+// *types.Package to keep type-checking the rest of the file. It fabricates
+// one named after the import PATH'S LAST SEGMENT (verified: "math/rand/v2" →
+// placeholder name "v2", real declared name "rand") and leaves it incomplete.
+// This is NOT limited to the name != path-base shape: ANY unused default
+// import outside the importer graph gets this treatment, including one whose
+// name equals its base (verified: container/ring). Trusting the guessed name
+// is exactly the banned "simple heuristic": it would make
+// classifyUnusedImports' candidate check compare the file's used-name set
+// against the fabricated name instead of the real one, so a live reference
+// (e.g. `rand.IntN(3)`) is invisible and the import is reported unused — the
+// LSP then deletes a working import out from under the user. Skipping
+// incomplete imports here means the caller (unusedImportsCore's
+// `!ok → continue`) conservatively KEEPS every such import — the same
+// "absent path ⇒ keep" contract resolvePackageNames already provides for the
+// CLI path. One consequence: `Module.UnusedImports`/`gsx fmt` (which resolves
+// names via a real `go list`, not a guess) may remove an import that Package()
+// keeps. See docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md
+// for the full divergence matrix, including the (safe) opposite direction —
+// Package() removing an unused sibling gsx-only import `go list` cannot name.
 func importNamesFromTypes(pkg *types.Package) map[string]string {
 	out := map[string]string{}
 	if pkg == nil {

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -213,6 +213,23 @@ func TestBuildPackageSkeletonsNoExternalLoad(t *testing.T) {
 // LSP side's candidate-name resolution (which needs a.pkg.Imports()) diverges
 // from the CLI's independent packages.Load, and this test's job is comparing
 // the two syntactic classifiers, not re-litigating that edge.
+//
+// Known blind spot (confirmed by adversarial review): this skip fires
+// precisely on the class of input where the two name sources diverge — an
+// import path outside analyze's own importer graph produces a go/types
+// "could not import" error (error severity, message not "imported and not
+// used"), which trips this guard and skips the whole case before
+// assertSameRemovalSet ever runs. Concretely, adding a math/rand/v2-shaped
+// case (default import, real name != path base, unresolvable via the
+// importer graph) to the cases map above would silently no-op, not exercise
+// anything — this oracle structurally cannot see that divergence. That gap
+// is deliberately NOT closed here; it is covered directly, with an oracle
+// that does not depend on a.pkg's completeness, by
+// TestPackageUnusedImportsDoesNotDeleteUsedRandV2 (the Critical false-positive
+// this divergence caused), TestPackageUnusedImportsKeepsUnresolvableCandidate,
+// TestPackageUnusedImportsHeadlineCaseStillRemoved, and
+// TestModuleAndPackageDivergeOnUnresolvableNameNeBase (all in
+// unused_imports_lsp_test.go).
 func anyErrorDiagCodegen(diags []diag.Diagnostic) bool {
 	for _, d := range diags {
 		if d.Severity == diag.Error && !strings.Contains(d.Message, "imported and not used") {

--- a/internal/codegen/unused_imports_syntactic_test.go
+++ b/internal/codegen/unused_imports_syntactic_test.go
@@ -199,19 +199,20 @@ func TestBuildPackageSkeletonsNoExternalLoad(t *testing.T) {
 // Error, full stop): an unused import is ITSELF surfaced as a go/types
 // "<path>" imported and not used error (verified empirically — see
 // module_importer.go's analyze loop, which adds every type error to the bag
-// as diag.Error with no special-casing for this message). detectUnusedImports
-// (results.go) treats that EXACT class of error as the safe, expected case —
-// it returns the populated map when EVERY type error matches "imported and
-// not used"; it returns nil (removes nothing) only when some OTHER error is
-// present. The old type-check-based analyzeUnusedImports (pre-Task-1, see
-// commit 56c4787) read pr.UnusedImports directly with no Diags gate at all,
-// confirming this: the "unused import" diagnostic was never meant to block
-// removal. So the oracle's documented divergence is specifically "some
-// unrelated (non-unused-import) error exists, ⇒ oracle removes nothing" —
-// gating on ANY error diagnostic (including the unused-import ones the two
-// detectors are supposed to agree on) would skip the interp/allunused cases
-// this test exists to exercise. Matching on the message substring mirrors
-// detectUnusedImports' own criterion exactly (results.go:120).
+// as diag.Error with no special-casing for this message), and that class of
+// error is expected/harmless for this oracle comparison. Since the syntactic
+// classifier now backs BOTH Module.UnusedImports (CLI) and Package()'s
+// UnusedImports (LSP; see unusedFromSkeletons/unusedImportsCore) — neither
+// gates on unrelated type errors the way the old, now-deleted
+// detectUnusedImports did (that heuristic bailed to nil the instant it saw any
+// error that wasn't a clean "imported and not used", which is exactly the
+// regression TestPackageUnusedImportsSurvivesOtherError in
+// unused_imports_lsp_test.go pins) — this skip is expected to be a no-op for
+// every case below. It is kept as a defensive guard: an unrelated error can
+// still mean the type-checked package (a.pkg) is incomplete enough that the
+// LSP side's candidate-name resolution (which needs a.pkg.Imports()) diverges
+// from the CLI's independent packages.Load, and this test's job is comparing
+// the two syntactic classifiers, not re-litigating that edge.
 func anyErrorDiagCodegen(diags []diag.Diagnostic) bool {
 	for _, d := range diags {
 		if d.Severity == diag.Error && !strings.Contains(d.Message, "imported and not used") {

--- a/internal/codegen/unused_imports_test.go
+++ b/internal/codegen/unused_imports_test.go
@@ -65,10 +65,19 @@ func TestUnusedImportsGateOnBrokenImport(t *testing.T) {
 	}
 }
 
-// TestUnusedImportsGateOnOtherError: when the package has a NON-import type
-// error, UnusedImports stays empty even though an unused import is present —
-// removing under uncertainty is unsafe.
-func TestUnusedImportsGateOnOtherError(t *testing.T) {
+// TestUnusedImportsSurvivesOtherError: when the package has a NON-import type
+// error (an undefined symbol), a genuinely unused import elsewhere in the file
+// is STILL reported — the syntactic classifier (see
+// docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md) determines
+// "unused" from the skeleton's own referenced names, not from correlating
+// go/types error positions, so an unrelated error cannot suppress it.
+//
+// This intentionally reverses the old detectUnusedImports behavior (deleted;
+// see results.go's former doc): that type-error-correlation heuristic bailed to
+// nil the moment it saw ANY error that wasn't a clean "imported and not used"
+// — exactly this scenario — which is why the LSP silently offered no
+// organizeImports/format-strip action on any real multi-file package.
+func TestUnusedImportsSurvivesOtherError(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	repoRoot, _ := filepath.Abs("../..")
@@ -86,7 +95,9 @@ func TestUnusedImportsGateOnOtherError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n := len(pr.UnusedImports); n != 0 {
-		t.Errorf("expected NO removals under an unrelated error, got %+v", pr.UnusedImports)
+	gsxPath := filepath.Join(dir, "card.gsx")
+	unused := pr.UnusedImports[gsxPath]
+	if len(unused) != 1 || unused[0].Path != "strings" {
+		t.Errorf("want strings reported unused despite the unrelated Nope() error, got %+v", unused)
 	}
 }


### PR DESCRIPTION
The language server silently never removed unused imports: `<leader>gi` (`source.organizeImports`) and format-on-save both did nothing, on any real package.

## Root cause

gsx had **two** unused-import implementations, and the LSP was wired to the fragile one.

| Surface | Source | Robustness |
|---|---|---|
| CLI `gsx fmt` | `Module.UnusedImports` → `classifyUnusedImports` (syntactic, per-file) | Robust |
| LSP formatting + `organizeImports` | `PackageResult.UnusedImports` ← `detectUnusedImports` | Fragile |

`detectUnusedImports` correlated raw `go/types` errors with import specs by file+line and **returned `nil` the moment it saw any error that wasn't a cleanly position-correlated `"imported and not used"`**. A clean single-file package is fine; a real multi-file package's skeleton always carries other benign/suppressed type errors, so it bailed to `nil`, and both handlers returned `[]`.

## Why the obvious patch was rejected

Calling `m.UnusedImports(dir)` from `Package()` fails three ways, all reproduced:

1. **Self-deadlock.** `Package()` holds `m.analysisMu`; `m.UnusedImports` → `buildPackageSkeletons` re-acquires it. `sync.Mutex` isn't reentrant — both `./internal/codegen` and `./internal/lsp` hang to the test timeout.
2. **`go list` on the LSP hot path.** `resolvePackageNames` calls `packages.Load`, uncached: **158 µs → 19.3 ms** per analysis on a package with an unused *default* import — i.e. exactly the case being fixed, once per debounced keystroke.
3. **Duplicated work** — a second parse pass, filter table, prop fields, and `applyDirty` re-entry, all of which `analyze` just did.

Plus `detectUnusedImports`/`pickImportByPath` go dead, so `make lint` fails.

## The fix

`analyze` already builds, per `.gsx` file, exactly what the classifier needs: the skeleton AST, its `importSpecs`, and its sunk-import set. Capture that mapping in the existing loop (no extra parse), and after type-checking run the **same** `skeletonUsedNames` + `classifyUnusedImports` the CLI trusts. `Package()` reads the field.

Candidate package names (a default import whose name ≠ path base, e.g. `math/rand/v2` → `rand`) come from the **type-checker** — `types.Package.Imports()` lists every direct import, unused ones included, with its declared name — instead of a subprocess. `emit.go` already reads names this way.

**Zero `packages.Load` on the `Package()` path**, guarded by a deterministic counter test that also asserts the counter *moves* for the CLI path, so the zero isn't vacuous. `Module.UnusedImports` (CLI, no type info) keeps `go list`, unchanged.

`detectUnusedImports` and `pickImportByPath` deleted.

## A Critical caught by adversarial review

`go/types` **fabricates a placeholder package named after the path base** for any import outside `analyze`'s importer graph:

```
path="context"        name="context"   Complete=true    <- real
path="math/rand/v2"   name="v2"        Complete=false   <- FABRICATED (path base!)
```

Trusting `imp.Name()` meant a **used** `math/rand/v2` was reported unused and the LSP **deleted compiling code**. That is precisely the path-base guess CLAUDE.md bans, arriving via the stdlib. Fixed by gating on `imp.Complete()`; `context`/`io` are `Complete=true`, so the headline case is untouched.

## Documented divergences (pinned by tests)

Review then proved the first safety claim wrong in both scope and direction. Both are now tested and documented:

- **A.** *Any* unused default import outside the importer graph — not just name ≠ base — is **kept** by the LSP and removed by `gsx fmt` (`container/ring`, `text/tabwriter`). Safe direction. **Pre-existing, not a regression**: `detectUnusedImports` also returned `nil` for these, since they emit `could not import`, not `imported and not used`. Recorded in `docs/ROADMAP.md` as an `externalImporter` preload gap.
- **B.** An unused `.gsx`-only sibling package import is **removed** by the LSP and kept by `gsx fmt` (`go list` can't resolve a dir with no `.go` files). Here the LSP is *more* correct; verified it keeps that import in every used shape.

## Verification

- Driving the **real** language server over stdio on a multi-file package with unused `context`/`io`: both `source.organizeImports` and `textDocument/formatting` now return an edit stripping them.
- `make ci` ✅ · `make lint` ✅ · `go test -race` ✅ (codegen + lsp) · no hangs.
- The deadlock cannot recur: nothing reachable from `Package()` acquires `analysisMu` or calls `buildPackageSkeletons`/`packages.Load`.

Complies with main's new CLAUDE.md rule on `packages.Load` cost — and pins it with a test.

Spec: `docs/superpowers/specs/2026-07-09-lsp-unused-imports-design.md`

https://claude.ai/code/session_019iePKYNP1kgfX1MHBbCk8s
