### PR TITLE
fix(codegen): gsx generate is not idempotent when a .gsx has no component

### DIFF
--- a/internal/codegen/idempotent_xgo_test.go
+++ b/internal/codegen/idempotent_xgo_test.go
@@ -1,0 +1,111 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Generating twice must produce the same result. The first run leaves a .x.go on
+// disk; the second must not type-check that file IN ADDITION to the in-memory
+// skeleton built for the same .gsx, or every declaration in it is seen twice.
+//
+// The skeleton is registered under the .x.go path, and the loop that adds the
+// package's hand-written .go files skips paths that already have a skeleton. It
+// skipped them by testing `compsByXGo[absPath] != nil` — but that map's value is
+// a SLICE of components, and a .gsx that declares no `component` stores a nil
+// slice under a present key. Such a file's real .x.go was therefore parsed
+// alongside its own skeleton, and `func f` was redeclared.
+//
+// A .gsx with an element-valued `var` and a plain func has no component, which
+// is why this shape and not a component-bearing one exposes it.
+func TestGenerateTwiceWithXGoOnDisk(t *testing.T) {
+	t.Parallel()
+	repoRoot, _ := filepath.Abs("../..")
+	tmp := t.TempDir()
+	writeFile(t, tmp, "go.mod", "module gsxidem\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	dir := filepath.Join(tmp, "views")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No `component` anywhere: comps is a nil slice for this file.
+	src := `package views
+
+import "github.com/gsxhq/gsx"
+
+var xx = <p>hi</p>
+
+func f() gsx.Node { return xx }
+`
+	if err := os.WriteFile(filepath.Join(dir, "views.gsx"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gen := func(pass string) {
+		t.Helper()
+		res, err := GenerateDirs(tmp, []string{dir}, Options{FilterPkgs: []string{stdImportPath}}, nil)
+		if err != nil {
+			t.Fatalf("%s: generate: %v", pass, err)
+		}
+		dr := res[dir]
+		if hasDiagErrors(dr.Diags) {
+			t.Fatalf("%s: unexpected errors: %v", pass, dr.Diags)
+		}
+		// Write the generated .x.go, exactly as the CLI does, so the next pass
+		// sees it on disk.
+		for gsxPath, b := range dr.Files {
+			xgo := strings.TrimSuffix(gsxPath, ".gsx") + ".x.go"
+			if err := os.WriteFile(xgo, b, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	gen("first pass")  // no .x.go on disk
+	gen("second pass") // .x.go on disk — must not be type-checked twice
+}
+
+// A .gsx that DOES declare a component stores a non-nil comps slice, so the
+// buggy `!= nil` guard happened to skip its .x.go. Pinning it guards against a
+// fix that swings the other way and starts double-parsing component files.
+func TestGenerateTwiceWithXGoOnDiskComponentFile(t *testing.T) {
+	t.Parallel()
+	repoRoot, _ := filepath.Abs("../..")
+	tmp := t.TempDir()
+	writeFile(t, tmp, "go.mod", "module gsxidem2\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	dir := filepath.Join(tmp, "views")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := `package views
+
+component C() {
+	<b>c</b>
+}
+
+func helper() string { return "x" }
+`
+	if err := os.WriteFile(filepath.Join(dir, "views.gsx"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gen := func(pass string) {
+		t.Helper()
+		res, err := GenerateDirs(tmp, []string{dir}, Options{FilterPkgs: []string{stdImportPath}}, nil)
+		if err != nil {
+			t.Fatalf("%s: generate: %v", pass, err)
+		}
+		dr := res[dir]
+		if hasDiagErrors(dr.Diags) {
+			t.Fatalf("%s: unexpected errors: %v", pass, dr.Diags)
+		}
+		for gsxPath, b := range dr.Files {
+			xgo := strings.TrimSuffix(gsxPath, ".gsx") + ".x.go"
+			if err := os.WriteFile(xgo, b, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	gen("first pass")
+	gen("second pass")
+}

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -946,6 +946,14 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	// (helperXgoPath). Hand-written .x.go files (e.g. gsxshared.x.go) and
 	// orphaned .x.go files (from a deleted .gsx) are intentionally included —
 	// they are visible to the type-checker as on-disk .go files.
+	//
+	// The skeleton test is KEY PRESENCE, not a non-nil value. compsByXGo's value
+	// is the file's component slice, and a .gsx that declares no `component` at
+	// all — say an element-valued `var` beside a plain func — stores a nil slice
+	// under a present key. Testing the value let that file's real .x.go be parsed
+	// alongside its own skeleton, so every declaration in it existed twice and
+	// the second `gsx generate` failed with "redeclared in this block".
+	//
 	// goImportPaths collects the imports of the hand-written .go files so the import
 	// graph (recordImports) also tracks sibling gsx packages reached only through a
 	// companion .go (e.g. a model.go), not just through .gsx-hoisted imports.
@@ -953,7 +961,7 @@ func (m *Module) analyze(dir string, mi *moduleImporter) (*analyzed, error) {
 	if bp, berr := build.ImportDir(dir, 0); berr == nil {
 		for _, name := range bp.GoFiles {
 			absPath := filepath.Join(dir, name)
-			if compsByXGo[absPath] != nil || absPath == helperXgoPath {
+			if _, hasSkeleton := compsByXGo[absPath]; hasSkeleton || absPath == helperXgoPath {
 				continue // already represented as a synthetic overlay
 			}
 			src, readErr := os.ReadFile(absPath)


### PR DESCRIPTION
## The bug

`gsx generate` succeeds once, then fails on every run after:

```
$ gsx generate -no-cache .     # first run: clean
$ gsx generate -no-cache .     # second run:
t.gsx:7:6: error:   other declaration of f
t.gsx:9:6: error: f redeclared in this block
```

Minimal reproduction — no cache, no editor, no LSP:

```go
package main

import "github.com/gsxhq/gsx"

var xx = <p>hi</p>              // an element-valued var
func f() gsx.Node { return xx } // …plus a plain func, and NO component
```

Reported from a real `gsx init` project where the LSP appeared to hold stale diagnostics. It doesn't — this reproduces from a clean shell.

## Root cause

Each `.gsx` gets an in-memory skeleton, parsed under that file's `.x.go` path. The loop that adds the package's hand-written `.go` files then skips any path a skeleton already covers:

```go
if compsByXGo[absPath] != nil || absPath == helperXgoPath {
    continue // already represented as a synthetic overlay
}
```

`compsByXGo` is `map[string][]*gsxast.Component`. Its value is the file's **component slice** — and a `.gsx` that declares no `component` stores a **nil slice under a present key**. So for a component-free `.gsx`, the guard was false, its real `.x.go` was parsed *alongside its own skeleton*, and every declaration in it existed twice.

The guard's own comment already said "compsByXGo **keys**". The two other readers of that map (`module_importer.go:1132`, `:1205`) already test key presence with `comps, ok := compsByXGo[fname]`. Only this one tested the value.

Fix: test key presence.

## Why it looked like something else

**Why a component masked it.** Any `component` in the file makes `comps` non-nil, so the guard fired and the `.x.go` was correctly skipped. Only component-free `.gsx` files are affected.

**Why the first run always passed.** No `.x.go` on disk yet — nothing to double-parse.

**Why it looked like a stale cache.** Because generate *errors*, it never rewrites the `.x.go`. Users see generated output from an older edit still sitting there. `gsx clean --cache` does **not** fix it (verified); deleting the `.x.go` does. The cache is innocent.

## Tests

`TestGenerateTwiceWithXGoOnDisk` generates, writes the `.x.go` exactly as the CLI does, and generates again. It fails on `main` with the exact error above, and passes with this change — verified by restoring the old guard and watching it fail.

Its sibling `TestGenerateTwiceWithXGoOnDiskComponentFile` pins the component-bearing shape, which the buggy guard happened to get right, so a fix cannot swing the other way and start double-parsing component files.

Verified end to end against the reporting project: three consecutive `gsx generate` runs are clean, the `.x.go` is regenerated rather than left stale, and `go build ./...` succeeds.

`make ci` and `make lint` pass.

https://claude.ai/code/session_01NtNWQzQeJjfABhPckkD5qg