### PR TITLE
test(gen): wait for watch startup generation

### DIFF
--- a/gen/watch_integration_test.go
+++ b/gen/watch_integration_test.go
@@ -50,6 +50,9 @@ func TestRunWatch_RegeneratesOnGsxChange(t *testing.T) {
 	// Wait for the watcher to announce it is ready (start event appears first,
 	// then the cold-generate startup cycle is emitted).
 	waitFor(t, 60*time.Second, func() bool { return strings.Contains(out.String(), `"event":"start"`) })
+	// Do not let the startup cycle satisfy the post-edit wait below. Under load,
+	// the test goroutine can observe start before runWatch emits generated.
+	waitFor(t, 60*time.Second, func() bool { return countGenerated(out.String(), true) >= 1 })
 	// Capture the generated count after startup so we can detect the regen.
 	priorCount := countGenerated(out.String(), true)
 


### PR DESCRIPTION
## Summary

- wait for the watcher's initial successful generation before recording the regeneration baseline
- prevent the startup event from being mistaken for the post-edit generation
- leave watcher production behavior and test deadlines unchanged

## Root cause

`runWatchWithStop` emits `start` before it emits the cold-start `generated` cycle. `TestRunWatch_RegeneratesOnGsxChange` waited only for `start`, so under CI load it could record `priorCount == 0`, edit `page.gsx`, and then treat the original startup generation as the expected regeneration. It would immediately read the still-old `page.x.go`, matching the main CI failure that retained `<h1>one</h1>`.

The neighboring debounce integration test already waits for the startup generation before taking its baseline; this change applies the same synchronization to the failing test.

## Validation

- observed the original failure in main CI run 29286532496
- `GOMAXPROCS=2 go test ./gen -run '^TestRunWatch_RegeneratesOnGsxChange$' -count=100`
- `make ci`