### PR TITLE
ci: pin Go 1.27 RC1 compatibility lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,28 +117,27 @@ jobs:
       - name: Run lint
         run: make lint
 
-  go-tip:
-    name: go tip (generic-method tests)
+  go-1-27-rc1:
+    name: Go 1.27 RC1 (generic-method tests)
     runs-on: ubuntu-latest
     continue-on-error: true
-    # Non-blocking tip lane: runs the go1.27-gated generic-method tests under
-    # gotip with skip promoted to failure. continue-on-error keeps tip breakage
-    # from blocking merges; the lane exists so the generic-method path is
-    # actually executed somewhere before GO_VERSION reaches 1.27.
+    # Non-blocking next-release lane: runs the go1.27-gated generic-method tests
+    # with skip promoted to failure. continue-on-error keeps release-candidate
+    # breakage from blocking merges; the lane exists so the generic-method path
+    # is actually executed somewhere before GO_VERSION reaches 1.27.
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Cache gotip SDK
+      - name: Cache Go 1.27 RC1 SDK
         uses: actions/cache@v4
         with:
-          path: ~/sdk/gotip
-          key: gotip-${{ runner.os }}-${{ github.run_number }}
-          restore-keys: gotip-${{ runner.os }}-
-      - name: Install gotip
+          path: ~/sdk/go1.27rc1
+          key: go1.27rc1-${{ runner.os }}-${{ runner.arch }}
+      - name: Install Go 1.27 RC1
         run: |
-          go install golang.org/dl/gotip@latest
-          gotip download
-      - name: Run generic-method tests under tip
-        run: make test-gotip
+          go install golang.org/dl/go1.27rc1@latest
+          go1.27rc1 download
+      - name: Run generic-method tests under Go 1.27 RC1
+        run: make test-go127rc1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # gsx developer tasks. Use tabs for recipe indentation.
-.PHONY: test check lint cover cover-html examples ci ci-gomod ci-playground ci-examples ci-format ci-tailwind-example ci-tailwind-example-drift reload-probe test-gotip
+.PHONY: test check lint cover cover-html examples ci ci-gomod ci-playground ci-examples ci-format ci-tailwind-example ci-tailwind-example-drift reload-probe test-go127rc1
 
 # COUNT is the go-test cache control. -count=1 disables the test cache so every
 # run re-executes — the authoritative behaviour `ci` uses to mirror GitHub CI.
@@ -102,13 +102,13 @@ cover-html: cover
 examples:
 	go run ./cmd/gsx-examples
 
-# Runs the go1.27-gated generic-methods tests under the gotip toolchain, with
+# Runs the go1.27-gated generic-methods tests under the Go 1.27 RC1 toolchain, with
 # skip promoted to FAILURE (GSX_REQUIRE_GENERIC_METHODS=1) so the lane can
-# never green-light while silently testing nothing. Requires gotip:
-#   go install golang.org/dl/gotip@latest && gotip download
-test-gotip:
-	@command -v gotip >/dev/null 2>&1 || { \
-		echo "gotip not found — install with:"; \
-		echo "  go install golang.org/dl/gotip@latest && gotip download"; \
+# never green-light while silently testing nothing. Requires go1.27rc1:
+#   go install golang.org/dl/go1.27rc1@latest && go1.27rc1 download
+test-go127rc1:
+	@command -v go1.27rc1 >/dev/null 2>&1 || { \
+		echo "go1.27rc1 not found — install with:"; \
+		echo "  go install golang.org/dl/go1.27rc1@latest && go1.27rc1 download"; \
 		exit 1; }
-	GSX_REQUIRE_GENERIC_METHODS=1 gotip test ./internal/codegen -run 'Go127|GenericMethod' -count=1 -v
+	GOTOOLCHAIN=local GSX_REQUIRE_GENERIC_METHODS=1 go1.27rc1 test ./internal/codegen -run 'Go127|GenericMethod' -count=1 -v


### PR DESCRIPTION
## Summary

- replace the moving `gotip` compatibility lane with the released `go1.27rc1` wrapper and SDK
- cache the RC SDK by runner OS and architecture
- rename the Make target and force `GOTOOLCHAIN=local` so the RC wrapper cannot silently select another configured toolchain

## Verification

- `go install golang.org/dl/go1.27rc1@latest`
- `go1.27rc1 download`
- `GOCACHE=/tmp/gsx-go127rc1-cache make test-go127rc1`
- `git diff --check`