### PR TITLE
docs: align package import example

### DIFF
--- a/docs/guide/syntax/basic-syntax.md
+++ b/docs/guide/syntax/basic-syntax.md
@@ -9,11 +9,9 @@ Begin with a package declaration and import any packages used by your Go code. Y
 ```gsx
 package views
 
-import "time"
+import "github.com/gsxhq/gsx"
 
-func formatDate(t time.Time) string {
-	return t.Format("2006-01-02")
-}
+func wrap(n gsx.Node) gsx.Node { return n }
 ```
 
 ## Declare a component


### PR DESCRIPTION
## Summary

- replace the unrelated `time` helper in the package/import example
- import `github.com/gsxhq/gsx` and use `gsx.Node`, matching the rule explained immediately above the snippet

## Verification

- built the VitePress site with `GSX_DOCS_SRC` pointing at this checkout
- `git diff --check`
