### PR TITLE
fmt: format js/css attribute-value literals + preserve multi-line-token interiors

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -802,6 +802,19 @@ vocabulary remains a design aspiration, not the current API.
 
 ## Tracked debts / deferrals
 
+- [ ] **External flat formatters miss the multi-line-token-interior fix** - the
+  built-in `gsx fmt` path re-indents `<script>`/`<style>` bodies and `` js`/css` ``
+  attribute values via LINE formatters, so a multi-line token (template literal,
+  block comment) interior is preserved verbatim. An external formatter supplied
+  via `gen.WithCSSFormatter`/`WithJSFormatter` is a flat `rawfmt.Formatter` (bytes,
+  no logical-line structure), so `printer.embeddedAttrLines`/`jsBodyDoc` fall back
+  to the physical-line split and re-indent token interiors (non-idempotent). Only
+  reachable through those options; the CLI passes nil and takes the fixed path.
+  Closing it means a line-returning external-formatter interface.
+- [ ] **Dead `Stages` branch in `embeddedAttrDoc`** - `internal/printer/printer.go`
+  keeps `braced := v.Braced || len(v.Stages) > 0` and a closer `|> stage` loop,
+  but the parser rejects whole-literal pipelines on `` js`/css` `` literals, so
+  `v.Stages` is always empty on that path. Harmless; remove or comment for clarity.
 - [ ] **Element literals inside `{{ }}` Go blocks** - a `<tag>`/`<>` element
   literal written in a body `{{ }}` Go block (`{{ x := <div/> }}`) is a
   positioned `unsupported-node` diagnostic ("element literals inside {{ }}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -227,6 +227,9 @@ present in the `.gsx` file. A CLI import mode overrides the
 bodies. Interpolation holes are preserved. If an embedded body cannot be
 formatted safely, that body is left unchanged.
 
+`` js` ``/`` css` `` **attribute** values are re-indented the same way as
+`<script>`/`<style>` bodies. Plain `"…"` string attributes are left verbatim.
+
 ### Check formatting in CI
 
 `-l` and `-d` exit `1` when any file differs, so either works as a CI check:

--- a/docs/superpowers/plans/2026-07-14-embedded-attr-literal-fmt-phase1.md
+++ b/docs/superpowers/plans/2026-07-14-embedded-attr-literal-fmt-phase1.md
@@ -1,0 +1,644 @@
+# Embedded-Attr JS/CSS Literal Formatting (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `gsx fmt` re-indent the body of a multi-line `js`…``/`css`…``/`js"…"`/`css"…"` **attribute value**, the way it already re-indents `<script>`/`<style>` element bodies.
+
+**Architecture:** Add an `*ast.EmbeddedAttr` case to the printer's `attrDoc` seam. For a JS/CSS literal whose body spans lines, extract its segments+holes, run the existing `jsfmt`/`cssfmt` re-indenter through a new `rawfmt.FormatString` (the placeholder→format→restore core, with a delimiter-escaping hook applied before hole restoration), then build a `pretty.Doc` that attaches the opening delimiter to the first body line, breaks intermediate lines at the attribute's own indent, and attaches the closing delimiter to the last line. Single-line values and non-JS/CSS (`f`…``) literals are untouched (verbatim, as today).
+
+**Tech Stack:** Go 1.26.1; `internal/rawfmt`, `internal/jsfmt`, `internal/cssfmt`, `internal/printer`, `internal/gsxfmt`; `internal/pretty` doc engine.
+
+## Global Constraints
+
+- Go pinned to `GO_VERSION` in `.github/workflows/ci.yml` (currently **1.26.1**) — a different minor re-introduces gofmt drift.
+- Runtime (root package) stays standard-library-only; this work is entirely in `internal/**` tooling, which may use `golang.org/x/tools` (none needed here).
+- **Re-indent only, never reflow** — a single-line value never becomes multi-line and token layout is never rewritten (this is what keeps JS ASI safe). Achieved for free by `jsfmt`/`cssfmt`, which only normalize leading indentation.
+- **No new config knob** — formatting is on whenever `p.jsFmt`/`p.cssFmt` is set, the same gate that governs `<script>`/`<style>` body formatting. `Fprint` supplies the defaults.
+- **Idempotence is the correctness gate.** `fmt(fmt(x)) == fmt(x)`. It holds because `jsfmt`/`cssfmt` *normalize* leading whitespace (strip + re-apply by brace depth), so the base indentation the pretty engine bakes into the value on pass 1 is stripped again on pass 2. The `internal/gsxfmt` corpus harness asserts this automatically (`corpus_test.go:164`).
+- **Faithful escaping** — delimiter / `@{` re-escaping reuses the existing `writeEmbeddedLiteralText`; never approximate it.
+- Run `make check` (inner loop) before declaring done; `make ci` mirrors GitHub CI.
+
+## File Structure
+
+- `internal/rawfmt/rawfmt.go` — MODIFY: extract `FormatString` (exported) from `Format`; add optional `escape func(string) string` applied before hole restoration.
+- `internal/rawfmt/rawfmt_test.go` — MODIFY/CREATE: unit tests for `FormatString` (escape-before-restore, sentinel safety, identity == old `Format`).
+- `internal/printer/printer.go` — MODIFY: `attrDoc` gains an `*ast.EmbeddedAttr` case; add helpers `embeddedAttrDoc`, `embeddedSegmentsMultiline`, `embeddedAttrBody`, `embeddedHoleString`, `embeddedAttrValueDoc`.
+- `internal/printer/embedded_attr_fmt_test.go` — CREATE: targeted `normPrint` assertions (indent, hole preserved, delimiter round-trip, single-line stays inline, braced+stages, CSS, fallback, x-data end-to-end).
+- `internal/gsxfmt/testdata/cases/embed_attr_*.txtar` — CREATE: golden cases (auto idempotence + reparse via the harness).
+- `docs/guide/**` (formatting page) — MODIFY: one concise line that `js`/css`` attribute values are re-indented like `<script>`/`<style>` bodies.
+
+---
+
+### Task 1: `rawfmt.FormatString` — format core with an escape hook
+
+**Files:**
+- Modify: `internal/rawfmt/rawfmt.go:69-83` (the `Format` function)
+- Test: `internal/rawfmt/rawfmt_test.go`
+
+**Interfaces:**
+- Consumes: existing unexported `buildPlaceholdered`, `safeFormat`, `restore`, `reindent` (same package).
+- Produces:
+  - `func FormatString(segments, holes []string, f Formatter, escape func(string) string) (string, bool)` — placeholder→format→(escape)→restore, returns the formatted source string (no re-indent). `escape` may be nil.
+  - `func Format(segments, holes []string, f Formatter) (pretty.Doc, bool)` — unchanged signature/behavior, now delegates to `FormatString(…, nil)` then `reindent`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/rawfmt/rawfmt_test.go`:
+
+```go
+func TestFormatStringEscapeBeforeRestore(t *testing.T) {
+	// identity formatter: returns input unchanged.
+	id := func(src []byte) ([]byte, error) { return src, nil }
+	// One hole between two segments; the segment text contains a `"` that the
+	// escaper must backslash — but the restored hole must NOT be escaped.
+	segments := []string{`say "hi" `, ` end`}
+	holes := []string{`@{name}`}
+	escape := func(s string) string { return strings.ReplaceAll(s, `"`, `\"`) }
+	got, ok := FormatString(segments, holes, id, escape)
+	if !ok {
+		t.Fatal("FormatString returned ok=false")
+	}
+	want := `say \"hi\" @{name} end`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "__gsxhole") {
+		t.Fatalf("sentinel leaked: %q", got)
+	}
+}
+
+func TestFormatStringNilEscapeMatchesRaw(t *testing.T) {
+	id := func(src []byte) ([]byte, error) { return src, nil }
+	got, ok := FormatString([]string{"a ", " b"}, []string{"@{x}"}, id, nil)
+	if !ok || got != "a @{x} b" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestFormatStringArityMismatch(t *testing.T) {
+	id := func(src []byte) ([]byte, error) { return src, nil }
+	if _, ok := FormatString([]string{"a"}, []string{"@{x}"}, id, nil); ok {
+		t.Fatal("expected ok=false on arity mismatch")
+	}
+}
+```
+
+Ensure `"strings"` is imported in the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/rawfmt/ -run TestFormatString -v`
+Expected: FAIL — `undefined: FormatString`.
+
+- [ ] **Step 3: Refactor `Format` and add `FormatString`**
+
+Replace `internal/rawfmt/rawfmt.go:69-83` (the `Format` function body) with:
+
+```go
+// FormatString runs the placeholder → format → (escape) → restore pipeline and
+// returns the formatted source with holes restored, WITHOUT re-indenting into a
+// Doc (the caller shapes it). escape, if non-nil, is applied to the formatted
+// text BEFORE hole restoration — used to re-escape an embedded literal's
+// delimiter. Escaping the whole placeholdered string is safe: the hole sentinels
+// are collision-free identifiers containing no escapable character, so escaping
+// never corrupts one, and the restored holes are inserted afterward and stay
+// unescaped. ok=false on arity mismatch, formatter error/panic, or a hole-restore
+// mismatch (the caller falls back to verbatim).
+func FormatString(segments, holes []string, f Formatter, escape func(string) string) (string, bool) {
+	if len(segments) != len(holes)+1 {
+		return "", false
+	}
+	placeholdered, prefix := buildPlaceholdered(segments, holes)
+	formatted, err := safeFormat(f, placeholdered)
+	if err != nil {
+		return "", false
+	}
+	out := string(formatted)
+	if escape != nil {
+		out = escape(out)
+	}
+	restored, ok := restore(out, prefix, holes)
+	if !ok {
+		return "", false
+	}
+	return restored, true
+}
+
+// Format renders a raw-text element body. segments and holes interleave with
+// len(segments) == len(holes)+1; each holes[i] is the already-rendered gsx
+// hole. Result ok=false → caller renders verbatim.
+func Format(segments, holes []string, f Formatter) (pretty.Doc, bool) {
+	restored, ok := FormatString(segments, holes, f, nil)
+	if !ok {
+		return pretty.Doc{}, false
+	}
+	return reindent(restored), true
+}
+```
+
+(Keep the existing doc comment above `Format` if it duplicates; the block above already carries it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/rawfmt/ -v`
+Expected: PASS (new tests + existing rawfmt tests).
+
+- [ ] **Step 5: Verify no regression in body formatting**
+
+Run: `go test ./internal/printer/ -run 'Script|Style' -v`
+Expected: PASS — `<script>`/`<style>` body formatting unchanged (still routes through `Format`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/rawfmt/rawfmt.go internal/rawfmt/rawfmt_test.go
+git commit -m "refactor(rawfmt): extract FormatString with pre-restore escape hook"
+```
+
+---
+
+### Task 2: Printer — format multi-line js``/css`` attribute values
+
+**Files:**
+- Modify: `internal/printer/printer.go` — `attrDoc` (`:530-532`, the `default` case) + new helpers.
+- Test: `internal/printer/embedded_attr_fmt_test.go` (create).
+
+**Interfaces:**
+- Consumes: `rawfmt.FormatString` (Task 1); existing `embeddedDelim`, `embeddedLangName`, `pipeStageStr`, `fmtExpr`, `markupInlineString`, `writeEmbeddedLiteralText` (all in package `printer`); `p.jsFmt`, `p.cssFmt`.
+- Produces: `(*printer).embeddedAttrDoc(v *ast.EmbeddedAttr) (pretty.Doc, bool)` and pure helpers `embeddedSegmentsMultiline`, `embeddedAttrBody`, `embeddedHoleString`, `embeddedAttrValueDoc`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/printer/embedded_attr_fmt_test.go`:
+
+```go
+package printer
+
+import (
+	"strings"
+	"testing"
+)
+
+// A multi-line js"…" attribute value: body one level under the attribute,
+// brace-nested deeper, closing delimiter attached to the last line.
+func TestEmbeddedAttrJSReindented(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nopen: false,\nitems() {\nreturn 1;\n}\n}\" class=\"c\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// <form> at depth 1 → attrs at depth 2. Opening `{` attaches to js".
+	if !strings.Contains(out, "x-data=js\"{") {
+		t.Fatalf("opening delimiter+brace should attach:\n%s", out)
+	}
+	// body one level under the attribute (2 tabs base + 1 jsfmt = 3 tabs).
+	if !strings.Contains(out, "\t\t\topen: false,") {
+		t.Fatalf("body not one level under attribute:\n%s", out)
+	}
+	if !strings.Contains(out, "\t\t\t\treturn 1;") {
+		t.Fatalf("nested body not two levels under attribute:\n%s", out)
+	}
+	// closing brace dedents to the attribute level and the delimiter attaches.
+	if !strings.Contains(out, "\t\t}\"") {
+		t.Fatalf("closing delimiter should attach at attribute indent:\n%s", out)
+	}
+	// following attribute survives.
+	if !strings.Contains(out, "class=\"c\"") {
+		t.Fatalf("trailing attribute lost:\n%s", out)
+	}
+}
+
+func TestEmbeddedAttrIdempotent(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nopen: false,\n}\"/>\n}\n"
+	once, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	twice, err := normPrint(t, once)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if once != twice {
+		t.Fatalf("not idempotent:\n--- once ---\n%s\n--- twice ---\n%s", once, twice)
+	}
+}
+
+func TestEmbeddedAttrHolePreserved(t *testing.T) {
+	src := "package p\n\ncomponent C(id string) {\n\t<form x-data=js\"{\nurl: '@{id}',\nk: 1,\n}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "@{id}") || strings.Contains(out, "__gsxhole") {
+		t.Fatalf("hole not preserved / sentinel leaked:\n%s", out)
+	}
+}
+
+// A body containing the literal's own delimiter must round-trip (escaped).
+func TestEmbeddedAttrDelimiterRoundTrip(t *testing.T) {
+	// js"…" value whose JS contains a double-quoted string → the inner `"` is
+	// escaped in source; after fmt it must still be escaped and re-parse.
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nmsg: \\\"hi\\\",\nk: 1,\n}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `msg: \"hi\",`) {
+		t.Fatalf("inner delimiter not re-escaped:\n%s", out)
+	}
+	// re-parse must succeed (idempotence test covers structural stability).
+	if _, err := normPrint(t, out); err != nil {
+		t.Fatalf("reparse failed: %v\n%s", err, out)
+	}
+}
+
+// A single-line js"…" value is left inline, unchanged.
+func TestEmbeddedAttrSingleLineStaysInline(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{open:false}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "x-data=js\"{open:false}\"") {
+		t.Fatalf("single-line value should stay inline:\n%s", out)
+	}
+}
+
+// CSS literal, backtick delimiter, multi-line.
+func TestEmbeddedAttrCSSReindented(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<div style=css`\ncolor: red;\nmargin: 0;\n`/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "\t\tcolor: red;") {
+		t.Fatalf("css body not re-indented under attribute:\n%s", out)
+	}
+}
+
+// End-to-end: the motivating Alpine x-data blob converted to js"…".
+func TestEmbeddedAttrXDataEndToEnd(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nopen: false,\nactive: -1,\nmoveActive(d) {\nif (!this.open) return;\n},\n}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"x-data=js\"{",
+		"\t\t\topen: false,",
+		"\t\t\tmoveActive(d) {",
+		"\t\t\t\tif (!this.open) return;",
+		"\t\t\t},",
+		"\t\t}\"",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/printer/ -run TestEmbeddedAttr -v`
+Expected: FAIL — values still emitted verbatim inline (e.g. `open: false` not re-indented; `x-data=js"{` not present because the whole value stays on one line via `attrInline`).
+
+- [ ] **Step 3: Add the helpers**
+
+Add near `writeEmbeddedAttrSegments` in `internal/printer/printer.go` (after `embeddedLiteralString`, ~`:1211`):
+
+```go
+// embeddedSegmentsMultiline reports whether an embedded literal's body spans
+// more than one source line (only then does fmt re-indent it; single-line values
+// stay inline, unchanged).
+func embeddedSegmentsMultiline(segs []ast.Markup) bool {
+	for _, n := range segs {
+		if t, ok := n.(*ast.Text); ok && strings.Contains(t.Value, "\n") {
+			return true
+		}
+	}
+	return false
+}
+
+// embeddedAttrBody splits an embedded-attribute literal's Segments into raw text
+// segments and rendered holes for rawfmt, mirroring nodesToBody but emitting the
+// TIGHT `@{expr}` hole form used inside attribute literals (not the spaced body
+// form). segments and holes interleave with len(segments) == len(holes)+1.
+func embeddedAttrBody(segs []ast.Markup) (segments, holes []string) {
+	var cur strings.Builder
+	for _, n := range segs {
+		switch v := n.(type) {
+		case *ast.Text:
+			cur.WriteString(v.Value)
+		case *ast.Interp:
+			segments = append(segments, cur.String())
+			cur.Reset()
+			holes = append(holes, embeddedHoleString(v))
+		default:
+			cur.WriteString(markupInlineString(n))
+		}
+	}
+	segments = append(segments, cur.String())
+	return segments, holes
+}
+
+// embeddedHoleString renders one `@{ expr |> stage }` hole tight (`@{expr}`),
+// matching writeEmbeddedAttrSegments.
+func embeddedHoleString(v *ast.Interp) string {
+	var b strings.Builder
+	b.WriteString("@{")
+	b.WriteString(fmtExpr(v.Expr))
+	for _, s := range v.Stages {
+		b.WriteString(" |> ")
+		b.WriteString(pipeStageStr(s))
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+// embeddedAttrValueDoc builds the Doc for a multi-line embedded-literal attribute
+// value. opener is the text up to and including the opening delimiter (e.g.
+// `x-data=js"` or `x-data={js"`); formatted is the re-indented body (leading and
+// trailing blank lines already trimmed); closer is the closing delimiter plus any
+// `|> stage` / `}` (e.g. `"` or `" |> f}`). The first body line attaches to the
+// opener, intermediate lines break at the attribute's own indent level (the
+// formatter's per-line leading tabs supply the brace-depth nesting), and the
+// closer attaches to the last line. Blank lines emit as bare "\n" so they never
+// carry trailing tabs (idempotence).
+func embeddedAttrValueDoc(opener, formatted, closer string) pretty.Doc {
+	lines := strings.Split(formatted, "\n")
+	parts := make([]pretty.Doc, 0, len(lines)*2+2)
+	parts = append(parts, pretty.Text(opener+lines[0]))
+	for _, ln := range lines[1:] {
+		ln = strings.TrimRight(ln, " \t")
+		if ln == "" {
+			parts = append(parts, pretty.Text("\n"))
+			continue
+		}
+		parts = append(parts, pretty.HardLine, pretty.Text(ln))
+	}
+	parts = append(parts, pretty.Text(closer))
+	return pretty.Concat(parts...)
+}
+
+// embeddedAttrDoc re-indents a multi-line js`/css` attribute value's body with
+// the configured JS/CSS formatter. ok=false (caller falls back to verbatim
+// inline) for a non-JS/CSS literal, a nil formatter, a single-line body, or any
+// formatter failure.
+func (p *printer) embeddedAttrDoc(v *ast.EmbeddedAttr) (pretty.Doc, bool) {
+	var f rawfmt.Formatter
+	switch v.Lang {
+	case ast.EmbeddedJS:
+		f = p.jsFmt
+	case ast.EmbeddedCSS:
+		f = p.cssFmt
+	default: // ast.EmbeddedText — f`…`: no sublanguage, nothing to format.
+		return pretty.Doc{}, false
+	}
+	if f == nil || !embeddedSegmentsMultiline(v.Segments) {
+		return pretty.Doc{}, false
+	}
+	segments, holes := embeddedAttrBody(v.Segments)
+	delim := embeddedDelim(v.DoubleQuoted)
+	escape := func(s string) string {
+		var b strings.Builder
+		writeEmbeddedLiteralText(&b, s, delim)
+		return b.String()
+	}
+	formatted, ok := rawfmt.FormatString(segments, holes, f, escape)
+	if !ok {
+		return pretty.Doc{}, false
+	}
+	formatted = strings.Trim(formatted, "\n")
+	if !strings.Contains(formatted, "\n") {
+		// Formatter collapsed the body to one line — keep the inline form.
+		return pretty.Doc{}, false
+	}
+	braced := v.Braced || len(v.Stages) > 0
+	var opener strings.Builder
+	opener.WriteString(v.Name)
+	opener.WriteString("=")
+	if braced {
+		opener.WriteString("{")
+	}
+	opener.WriteString(embeddedLangName(v.Lang))
+	opener.WriteByte(delim)
+	var closer strings.Builder
+	closer.WriteByte(delim)
+	for _, s := range v.Stages {
+		closer.WriteString(" |> ")
+		closer.WriteString(pipeStageStr(s))
+	}
+	if braced {
+		closer.WriteString("}")
+	}
+	return embeddedAttrValueDoc(opener.String(), formatted, closer.String()), true
+}
+```
+
+- [ ] **Step 4: Wire the seam in `attrDoc`**
+
+In `internal/printer/printer.go`, change the `default` case of `attrDoc` (`:530-531`) to first try the embedded path:
+
+```go
+	case *ast.EmbeddedAttr:
+		if doc, ok := p.embeddedAttrDoc(v); ok {
+			return doc
+		}
+		return pretty.Text(attrInline(a))
+	default:
+		return pretty.Text(attrInline(a))
+```
+
+(Insert the `case *ast.EmbeddedAttr:` immediately before `default:`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/printer/ -run TestEmbeddedAttr -v`
+Expected: PASS (all 7 tests).
+
+- [ ] **Step 6: Run the full printer suite (no regressions)**
+
+Run: `go test ./internal/printer/`
+Expected: PASS — including the existing `embedded`/`Script`/`Style`/idempotence/faithfulness suites.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/printer/printer.go internal/printer/embedded_attr_fmt_test.go
+git commit -m "feat(fmt): re-indent multi-line js\`/css\` attribute values"
+```
+
+---
+
+### Task 3: gsxfmt corpus goldens (idempotence + reparse for free)
+
+**Files:**
+- Create: `internal/gsxfmt/testdata/cases/embed_attr_js_multiline.txtar`
+- Create: `internal/gsxfmt/testdata/cases/embed_attr_css_multiline.txtar`
+- Create: `internal/gsxfmt/testdata/cases/embed_attr_js_hole.txtar`
+- Create: `internal/gsxfmt/testdata/cases/embed_attr_single_line_inline.txtar`
+- Test: `internal/gsxfmt/corpus_test.go` (harness, no edit — it globs the cases)
+
+**Interfaces:**
+- Consumes: the Task 2 printer behavior (the corpus routes nil formatters → `printer.Fprint` → default `jsfmt`/`cssfmt`).
+- Produces: pinned `fmt.golden` for each case; the harness asserts golden-match, idempotence (`:164`), and reparse (`:168`).
+
+- [ ] **Step 1: Write the case inputs (goldens filled by -update)**
+
+Create `internal/gsxfmt/testdata/cases/embed_attr_js_multiline.txtar`:
+
+```
+A multi-line js"…" attribute value is re-indented under its attribute: the
+opening delimiter+brace attach to the js" line, the body sits one level deeper
+(brace-nested deeper still), and the closing brace+delimiter dedent back to the
+attribute's indent. Re-indent only — no reflow.
+
+-- input.gsx --
+package p
+
+component C() {
+	<form x-data=js"{
+open: false,
+items() {
+return 1;
+}
+}" class="c"/>
+}
+```
+
+Create `internal/gsxfmt/testdata/cases/embed_attr_css_multiline.txtar`:
+
+```
+A multi-line css`…` attribute value is re-indented under its attribute, the same
+way a <style> body is.
+
+-- input.gsx --
+package p
+
+component C() {
+	<div style=css`
+color: red;
+margin: 0;
+`/>
+}
+```
+
+Create `internal/gsxfmt/testdata/cases/embed_attr_js_hole.txtar`:
+
+```
+A hole inside a multi-line js"…" attribute value survives re-indentation (the
+@{expr} form is preserved tight; no sentinel leaks).
+
+-- input.gsx --
+package p
+
+component C(id string) {
+	<form x-data=js"{
+url: '@{id}',
+k: 1,
+}"/>
+}
+```
+
+Create `internal/gsxfmt/testdata/cases/embed_attr_single_line_inline.txtar`:
+
+```
+A single-line js"…" attribute value stays inline, byte-for-byte — fmt never
+force-wraps an embedded literal.
+
+-- input.gsx --
+package p
+
+component C() {
+	<form x-data=js"{open:false}"/>
+}
+```
+
+- [ ] **Step 2: Run to verify the cases fail (missing golden)**
+
+Run: `go test ./internal/gsxfmt/ -run TestFmtCorpus`
+Expected: FAIL — `case ... has no fmt.golden — run with -update`.
+
+- [ ] **Step 3: Generate goldens**
+
+Run: `go test ./internal/gsxfmt/ -run TestFmtCorpus -update`
+Expected: writes `fmt.golden` into each new `.txtar`.
+
+- [ ] **Step 4: Inspect the goldens by eye**
+
+Run: `sed -n '/-- fmt.golden --/,$p' internal/gsxfmt/testdata/cases/embed_attr_js_multiline.txtar`
+Expected: the `x-data=js"{` line, body at 3 tabs, `return 1;` at 4 tabs, `}"` at 2 tabs, `class="c"` preserved. If wrong, the bug is in Task 2 — fix there and regenerate.
+
+- [ ] **Step 5: Verify without -update (golden + idempotence + reparse)**
+
+Run: `go test ./internal/gsxfmt/ -run TestFmtCorpus -v`
+Expected: PASS — each case matches its golden, is idempotent on its golden, and re-parses.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/gsxfmt/testdata/cases/embed_attr_*.txtar
+git commit -m "test(fmt): corpus goldens for js/css attribute-value re-indent"
+```
+
+---
+
+### Task 4: Docs + full verification
+
+**Files:**
+- Modify: the formatting page under `docs/guide/**` (find with grep in Step 1).
+- Verify: whole repo via `make check`.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: one documented sentence; a clean `make check`.
+
+- [ ] **Step 1: Find the formatting doc that mentions script/style body formatting**
+
+Run: `grep -rln "gsx fmt\|re-indent\|<script>\|formatter" docs/guide/ | head`
+Then open the formatting/tooling page.
+
+- [ ] **Step 2: Add one concise line**
+
+Add a single sentence near the `<script>`/`<style>` body-formatting note, e.g.:
+
+```markdown
+`js`…`` / `css`…`` **attribute** values are re-indented the same way as
+`<script>`/`<style>` bodies — a multi-line value's body is laid out one level
+under its attribute. Plain `"…"` string attributes are left verbatim.
+```
+
+If the surrounding prose uses literal `{{ }}`, wrap that block in `::: v-pre` (VitePress parses `{{ }}` as Vue interpolation).
+
+- [ ] **Step 3: Run the inner-loop verification**
+
+Run: `make check`
+Expected: build/vet/test both modules pass; `gofmt` + `gsx fmt` clean; examples drift clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guide
+git commit -m "docs: note js/css attribute-value re-indentation in gsx fmt"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 sections only):**
+- Seam `attrDoc` + `*ast.EmbeddedAttr` case → Task 2 Step 4. ✓
+- Single-line inline / multi-line re-indent → Task 2 (`embeddedSegmentsMultiline`), test `TestEmbeddedAttrSingleLineStaysInline`. ✓
+- Extract segments+holes (tight `@{expr}`) → `embeddedAttrBody`/`embeddedHoleString`, Task 2. ✓
+- Delimiter escaping before restore → `rawfmt.FormatString` escape hook (Task 1) + escaper closure (Task 2); tests `TestFormatStringEscapeBeforeRestore`, `TestEmbeddedAttrDelimiterRoundTrip`. ✓
+- Attr-anchored re-indent (attach first/last) → `embeddedAttrValueDoc`, Task 2; test `TestEmbeddedAttrJSReindented`. ✓
+- Whole-literal `|> stages` + braced form → `closer`/`opener` construction, Task 2. ✓
+- Fallback on formatter failure → `embeddedAttrDoc` returns `ok=false`; the `attrInline` fallback in Step 4. (Note: an unparseable body cannot easily be forced because `jsfmt`/`cssfmt` are lexer-based and rarely error; the `ok=false` path is still exercised by the non-JS/CSS and single-line early returns.) ✓
+- Idempotence gate → gsxfmt corpus harness + `TestEmbeddedAttrIdempotent`. ✓
+- No new config → nothing added; gated on `p.jsFmt`/`p.cssFmt`. ✓
+- Phase 2 (minify) → deliberately OUT of this plan (separate plan after Phase 1 lands).
+
+**Placeholder scan:** none — every code step carries full code; every run step carries a command + expected output.
+
+**Type consistency:** `FormatString(segments, holes []string, f Formatter, escape func(string) string) (string, bool)` used identically in Task 1 (def) and Task 2 (call). `embeddedAttrDoc` returns `(pretty.Doc, bool)`, consumed by the `attrDoc` case. `embeddedAttrValueDoc(opener, formatted, closer string)` matches its call. Helper names (`embeddedSegmentsMultiline`, `embeddedAttrBody`, `embeddedHoleString`) are consistent between definition and use.

--- a/docs/superpowers/plans/2026-07-14-embedded-fmt-verbatim-span-fix.md
+++ b/docs/superpowers/plans/2026-07-14-embedded-fmt-verbatim-span-fix.md
@@ -1,0 +1,295 @@
+# Fix: embedded-JS/CSS formatting corrupts multi-line-token interiors
+
+**Goal:** Stop `gsx fmt` from injecting indentation into the interior of multi-line JS/CSS tokens (template literals, block comments) when re-indenting `<script>`/`<style>` bodies AND `js`…``/`css`…`` attribute values. Restore idempotence and value-preservation for those bodies.
+
+**Root cause:** `internal/reindent.Reindent` is correct — an `Opaque` token (string/template/regex/comment) keeps its internal `\n`s as *content within one logical line*, so only the logical-line start is indented. But the **outer Doc-building layer** flattens that to a string and splits on **every** `\n` (`rawfmt.Format`→`reindent`, and `printer.embeddedAttrValueDoc`), emitting a managed `HardLine` (which adds base indent) for each physical line — including Opaque interiors. Verified: `x-data=js"{ html:` `` `<div>\nhi\n</div>` `` `}"` re-indents `hi`/`</div>` and is non-idempotent.
+
+**Fix:** thread **logical lines** from the tokenizer to the Doc builder. A logical line may contain internal `\n`s (Opaque content); emitted as ONE `pretty.Text`, the pretty engine writes those newlines verbatim with NO managed indent (`internal/pretty/print.go:57`), while a `HardLine` precedes only the logical-line start. This fixes both surfaces uniformly.
+
+**Scope:** built-in formatter path only (the `gsx fmt` CLI + `Fprint` default). External custom flat `rawfmt.Formatter`s (via `gen.WithCSSFormatter`, rare) keep current behavior — they carry no token info to fix.
+
+## Global Constraints
+
+- Go 1.26.1. Runtime root package stays std-lib-only (all changes are in `internal/**`).
+- **Idempotence is the gate:** `fmt(fmt(x)) == fmt(x)`, enforced automatically by the `internal/gsxfmt` corpus harness (`corpus_test.go:164`) and the printer idempotence suite.
+- **Value preservation:** a template literal / block comment interior must be emitted byte-identical to the author's (no injected/removed whitespace).
+- Never reflow; keep every newline (ASI safety unchanged).
+- Existing `<script>`/`<style>` and attribute behavior for NON-multi-line-token bodies must be unchanged (goldens byte-identical).
+- `make check` must pass.
+
+## File structure
+
+- `internal/reindent/reindent.go` — add `ReindentLines(src, a) ([]string, bool)`; `Reindent` delegates.
+- `internal/jsfmt/jsfmt.go`, `internal/cssfmt/cssfmt.go` — add `FormatLines(src, width) ([]string, bool)`.
+- `internal/rawfmt/rawfmt.go` — add `LineFormatter` type, `FormatLines` (Doc from logical lines, for `<script>`/`<style>`), `FormatStringLines` (escaped+restored logical lines, for attributes), `reindentLines`, `restoreLines`.
+- `internal/printer/printer.go` — printer gains `cssLineFmt, jsLineFmt rawfmt.LineFormatter`; `Fprint` sets them; `element()` (script/style) and `embeddedAttrDoc` prefer the line path; `embeddedAttrValueDoc` consumes `[]string` logical lines.
+- Tests + gsxfmt corpus cases (template literal, block comment) for all four surfaces.
+
+---
+
+### Task 1: `reindent.ReindentLines`
+
+**Files:** `internal/reindent/reindent.go`, `internal/reindent/reindent_test.go`
+
+- [ ] **Step 1 — failing test.** Add to `reindent_test.go` a test using the existing test adapter (see the existing `reindent_test.go` for the fake adapter pattern) asserting that a token stream containing an `Opaque` token whose `Text` spans lines (e.g. `` `<div>\nhi\n</div>` ``) returns it as ONE logical line (the returned slice element contains the internal `\n`s), while structural `Newline` tokens split lines. Also assert `strings.Join(ReindentLines(src,a), "\n") == Reindent(src,a)`.
+
+- [ ] **Step 2 — run, expect FAIL** (`undefined: ReindentLines`). `go test ./internal/reindent/ -run Lines -v`
+
+- [ ] **Step 3 — implement.** Add `ReindentLines` returning `[]string` (one per logical line), refactor `Reindent` to `join`:
+
+```go
+// ReindentLines is Reindent returning the re-indented LOGICAL lines rather than a
+// joined string. An Opaque token's internal newlines stay WITHIN a line (they are
+// content, not line boundaries), so a returned element may itself contain '\n'.
+// Reindent(src,a) == strings.Join(ReindentLines(src,a)) with "\n".
+func ReindentLines(src []byte, a Adapter) ([]string, bool) {
+	toks, ok := a.Tokenize(src)
+	if !ok {
+		return nil, false
+	}
+	var lines [][]Token
+	var cur []Token
+	for _, t := range toks {
+		if t.Class == Newline {
+			lines = append(lines, cur)
+			cur = nil
+			continue
+		}
+		cur = append(cur, t)
+	}
+	lines = append(lines, cur)
+
+	out := make([]string, 0, len(lines))
+	depth := 0
+	for _, line := range lines {
+		start, end := 0, len(line)
+		for start < end && line[start].Class == Space {
+			start++
+		}
+		for end > start && line[end-1].Class == Space {
+			end--
+		}
+		content := line[start:end]
+		if len(content) == 0 {
+			out = append(out, "")
+			continue
+		}
+		indent := depth
+		if content[0].Class == Close && indent > 0 {
+			indent--
+		}
+		var b strings.Builder
+		for i := 0; i < indent; i++ {
+			b.WriteByte('\t')
+		}
+		opens, closes := 0, 0
+		for _, t := range content {
+			b.WriteString(t.Text)
+			switch t.Class {
+			case Open:
+				opens++
+			case Close:
+				closes++
+			}
+		}
+		depth += opens - closes
+		if depth < 0 {
+			depth = 0
+		}
+		out = append(out, b.String())
+	}
+	return out, true
+}
+
+func Reindent(src []byte, a Adapter) (string, bool) {
+	lines, ok := ReindentLines(src, a)
+	if !ok {
+		return "", false
+	}
+	return strings.Join(lines, "\n"), true
+}
+```
+
+- [ ] **Step 4 — run, expect PASS**, and existing reindent tests still green: `go test ./internal/reindent/`
+- [ ] **Step 5 — commit** `refactor(reindent): add ReindentLines returning logical lines`
+
+---
+
+### Task 2: `jsfmt.FormatLines` / `cssfmt.FormatLines`
+
+**Files:** `internal/jsfmt/jsfmt.go`, `internal/cssfmt/cssfmt.go` (+ their `_test.go`)
+
+- [ ] **Step 1 — failing tests.** In each package, assert `FormatLines` returns logical lines and that a multi-line template literal (js) / multi-line `/* … */` comment (css) is a SINGLE returned line containing the internal `\n`s (i.e. `strings.Contains(line, "\n")`), while ordinary statements are separate lines.
+- [ ] **Step 2 — run, expect FAIL** (`undefined: FormatLines`).
+- [ ] **Step 3 — implement** (mirror the existing `Format`):
+
+```go
+// jsfmt
+func FormatLines(src []byte, width int) ([]string, bool) {
+	return reindent.ReindentLines(src, jsAdapter{})
+}
+```
+```go
+// cssfmt
+func FormatLines(src []byte, width int) ([]string, bool) {
+	return reindent.ReindentLines(src, cssAdapter{})
+}
+```
+- [ ] **Step 4 — run, expect PASS**; existing jsfmt/cssfmt tests green.
+- [ ] **Step 5 — commit** `feat(jsfmt,cssfmt): FormatLines returning logical lines`
+
+---
+
+### Task 3: `rawfmt` line-based Doc building
+
+**Files:** `internal/rawfmt/rawfmt.go`, `internal/rawfmt/rawfmt_test.go`
+
+**Interfaces produced:**
+- `type LineFormatter func(src []byte) (lines []string, ok bool)`
+- `func FormatLines(segments, holes []string, lf LineFormatter) (pretty.Doc, bool)` — body Doc for `<script>`/`<style>`.
+- `func FormatStringLines(segments, holes []string, lf LineFormatter, escape func(string) string) ([]string, bool)` — escaped + hole-restored logical lines, for attributes.
+
+- [ ] **Step 1 — failing tests.** In `rawfmt_test.go`:
+  - `TestFormatStringLinesKeepsOpaqueInterior`: a LineFormatter that returns `["a {", "html: `<div>\nhi\n</div>`", "}"]` (a line WITH an internal `\n`) and one hole; assert `FormatStringLines` returns the same logical-line count (the multi-line line stays ONE element), the hole is restored, no sentinel leaks, and the escape func was applied per line.
+  - `TestFormatLinesDocVerbatimInterior`: assert the Doc from `FormatLines` for a line containing an internal `\n` renders (via `pretty.Print`) with the interior line NOT gaining indent tabs (the char after the internal `\n` is not a tab).
+- [ ] **Step 2 — run, expect FAIL.**
+- [ ] **Step 3 — implement:**
+
+```go
+type LineFormatter func(src []byte) (lines []string, ok bool)
+
+// FormatStringLines runs placeholder → line-format → (escape per line) → restore
+// and returns the formatted LOGICAL lines with holes restored. escape (if non-nil)
+// is applied to each line before restoration (safe: sentinels contain no escapable
+// char). ok=false on arity/format/restore failure.
+func FormatStringLines(segments, holes []string, lf LineFormatter, escape func(string) string) ([]string, bool) {
+	if len(segments) != len(holes)+1 {
+		return nil, false
+	}
+	placeholdered, prefix := buildPlaceholdered(segments, holes)
+	lines, ok := lf([]byte(placeholdered))
+	if !ok {
+		return nil, false
+	}
+	if escape != nil {
+		for i := range lines {
+			lines[i] = escape(lines[i])
+		}
+	}
+	return restoreLines(lines, prefix, holes)
+}
+
+// restoreLines replaces each sentinel with its hole, verifying every sentinel
+// index appears EXACTLY once across all lines (a sentinel never spans a line
+// boundary). ok=false on any missing/duplicated sentinel or stray prefix.
+func restoreLines(lines []string, prefix string, holes []string) ([]string, bool) {
+	for i := range holes {
+		tok := sentinel(prefix, i)
+		count := 0
+		for _, ln := range lines {
+			count += strings.Count(ln, tok)
+		}
+		if count != 1 {
+			return nil, false
+		}
+		for j := range lines {
+			if strings.Contains(lines[j], tok) {
+				lines[j] = strings.Replace(lines[j], tok, holes[i], 1)
+				break
+			}
+		}
+	}
+	for _, ln := range lines {
+		if strings.Contains(ln, prefix) {
+			return nil, false
+		}
+	}
+	return lines, true
+}
+
+// FormatLines renders a <script>/<style> body from logical lines. Each logical
+// line becomes HardLine+Text; a line's internal newlines (Opaque content) are
+// emitted verbatim by Text — no managed indent — so template-literal/comment
+// interiors survive. ok=false → caller renders verbatim.
+func FormatLines(segments, holes []string, lf LineFormatter) (pretty.Doc, bool) {
+	lines, ok := FormatStringLines(segments, holes, lf, nil)
+	if !ok {
+		return pretty.Doc{}, false
+	}
+	return reindentLines(lines), true
+}
+
+// reindentLines is reindent for logical lines: trims leading/trailing blank
+// logical lines, then one HardLine+Text per line (blank → bare "\n"). TrimRight
+// on each logical line trims only its tail (the last physical line); Opaque
+// interior newlines/whitespace are preserved. Wrapped in Indent + trailing
+// HardLine, matching reindent's placement between the open and close tags.
+func reindentLines(lines []string) pretty.Doc {
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return pretty.Text("")
+	}
+	parts := make([]pretty.Doc, 0, len(lines)*2+1)
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			parts = append(parts, pretty.Text("\n"))
+			continue
+		}
+		parts = append(parts, pretty.HardLine, pretty.Text(strings.TrimRight(ln, " \t")))
+	}
+	return pretty.Concat(pretty.Indent(pretty.Concat(parts...)), pretty.HardLine)
+}
+```
+
+- [ ] **Step 4 — run, expect PASS**; existing rawfmt tests green (`Format`/`FormatString` untouched).
+- [ ] **Step 5 — commit** `feat(rawfmt): line-based Doc building preserves Opaque-token interiors`
+
+---
+
+### Task 4: printer — use the line path; fix both surfaces
+
+**Files:** `internal/printer/printer.go`, `internal/printer/embedded_attr_fmt_test.go`, `internal/printer/script_test.go`/`style_test.go` (assertions only if needed)
+
+- [ ] **Step 1 — failing tests.** Add to `embedded_attr_fmt_test.go`:
+  - `TestEmbeddedAttrTemplateLiteralVerbatim`: the `x-data=js"{ … html:` `` `<div>\nhi\n</div>` `` …}"` case — assert the interior `hi`/`</div>` lines are NOT re-indented (byte-check the template-literal substring is unchanged) AND idempotent (`normPrint(normPrint(x)) == normPrint(x)`).
+  - `TestScriptTemplateLiteralVerbatim` (in `script_test.go`): a `<script>` body with a multi-line template literal — interior preserved + idempotent.
+  These MUST fail on the current code (interior re-indented / non-idempotent).
+- [ ] **Step 2 — run, expect FAIL** with the drift shown.
+- [ ] **Step 3 — implement.**
+  - Add printer fields `cssLineFmt, jsLineFmt rawfmt.LineFormatter`.
+  - `Fprint` constructs the printer with the built-in LINE formatters set (and may leave flat `cssFmt/jsFmt` nil); `FprintWith` keeps setting the flat formatters with line formatters nil (external path unchanged). Add `defaultCSSLineFormatter(width)`/`defaultJSLineFormatter(width)` wrapping `cssfmt.FormatLines`/`jsfmt.FormatLines`.
+  - `element()` `<script>`: `if p.jsLineFmt != nil { if doc, ok := rawfmt.FormatLines(segments, holes, p.jsLineFmt); ok { … } } else if p.jsFmt != nil { rawfmt.Format(…) }`. Same for `<style>`/`p.cssLineFmt`.
+  - `embeddedAttrDoc`: select `lf := p.jsLineFmt`/`p.cssLineFmt` by lang. When a line formatter is present, call `rawfmt.FormatStringLines(segments, holes, lf, escape)` → `[]string` logical lines → pass to `embeddedAttrValueDoc`. When only a flat formatter is present (external), keep the current `FormatString`→split path.
+  - Change `embeddedAttrValueDoc` to accept `lines []string` (logical lines) instead of a flat `formatted` string. The block/inline decision keys on `lines[0] == ""` (a leading blank logical line = block). The inline/block bodies are built from the logical lines directly (each line → `HardLine`+`Text`; a line's internal `\n`s stay in its `Text`, verbatim). For the flat fallback, split the flat string on `\n` into `lines` (current behavior) before calling it.
+- [ ] **Step 4 — run, expect PASS** the new tests; then FULL `go test ./internal/printer/` (idempotence/faithfulness suites included). Fix any drift.
+- [ ] **Step 5 — commit** `fix(fmt): preserve multi-line-token interiors in js/css bodies and attrs`
+
+---
+
+### Task 5: corpus coverage (the user's explicit ask) + full verification
+
+**Files:** new `internal/gsxfmt/testdata/cases/*.txtar`; `make check`.
+
+- [ ] **Step 1 — add cases** (inputs authored with multi-line tokens; goldens via `-update`). At least:
+  - `embed_body_script_template_literal.txtar` — `<script>` body with a multi-line `` `…` `` template literal.
+  - `embed_body_style_block_comment.txtar` — `<style>` body with a multi-line `/* … */` comment.
+  - `embed_attr_js_template_literal.txtar` — `x-data=js"{ … `…\n…` … }"`.
+  - `embed_attr_css_block_comment.txtar` — `style=css`\n/* multi\nline */\ncolor: red;\n``.
+- [ ] **Step 2 — run, expect FAIL** (missing goldens). `go test ./internal/gsxfmt/ -run TestFmtCorpus`
+- [ ] **Step 3 — `-update`, then INSPECT** each golden: the multi-line-token interior must be byte-identical to the input's interior (no injected tabs). If a golden shows injected indentation, that's a Task-4 bug — fix it, don't hand-edit.
+- [ ] **Step 4 — run WITHOUT `-update`** (`-v`): golden-match + idempotence + reparse all green — the harness idempotence check is the real proof.
+- [ ] **Step 5 — `make check`** — clean.
+- [ ] **Step 6 — commit** `test(fmt): corpus for multi-line-token interiors (script/style/js-attr/css-attr)`
+
+## Self-review checklist
+- Opaque interior verbatim (no injected indent) — Tasks 4/5 tests + corpus.
+- Idempotence — gsxfmt harness auto-check on every new golden.
+- `<script>`/`<style>` non-token bodies unchanged — existing goldens byte-identical (diff them).
+- JS/CSS attr non-token bodies unchanged — existing `embed_attr_*` goldens byte-identical.
+- External flat-Formatter path unchanged (fallback branch retained).
+- `Reindent`/`Format`/`FormatString` public behavior unchanged (delegation only).

--- a/docs/superpowers/specs/2026-07-14-embedded-attr-literal-format-minify-design.md
+++ b/docs/superpowers/specs/2026-07-14-embedded-attr-literal-format-minify-design.md
@@ -109,20 +109,27 @@ and mirrors `<script>`/`<style>` body behavior.
    character, so escaping the whole placeholdered string cannot corrupt a
    sentinel. Restored holes (`@{expr}`) are inserted *after* escaping, so they stay
    unescaped real holes.
-4. **Attr-anchored re-indent (NEW variant of `rawfmt.reindent`)**: unlike the
-   body variant (which leads and trails with `HardLine` so `<script>`/`</script>`
-   sit on their own lines), the attribute variant:
-   - attaches the opening delimiter + first body line to the `name=js"` line (no
-     leading `HardLine`),
-   - indents body lines one level under the attribute (honoring the formatter's
-     brace-depth indentation),
-   - attaches the closing delimiter to the last body line (no trailing `HardLine`
-     before the delimiter).
+4. **Attr-anchored re-indent (NEW variant of `rawfmt.reindent`)** — TWO layouts,
+   chosen by the body's own structure (which the formatter preserves; the signal
+   is whether the formatted body starts with a newline):
+   - **Inline (content-adjacent)** — the body begins with content, e.g.
+     `js"{ … }"` whose `{`/`}` hug the delimiters. The opening delimiter + first
+     body line attach to the `name=js"` line (no leading `HardLine`), body lines
+     indent one level under the attribute via the formatter's own brace-depth
+     tabs (NO extra base `Indent`), and the closing delimiter attaches to the last
+     body line.
+   - **Block (body on its own lines)** — the body begins with a newline, e.g.
+     `css`\n…\n``, and (for flat declaration lists) the formatter emits no
+     brace-depth nesting. The delimiters stand alone on their own lines and the
+     body is wrapped in one base `Indent` (body one level under the attribute) —
+     the same shape as a `<script>`/`<style>` element body. Without this, a
+     brace-less CSS body would sit flush with the attribute and the closing
+     delimiter would glue to the last declaration.
 
-   Target layout (approved):
+   Target layouts (approved):
    ```
    	<form
-   		x-data=js"{
+   		x-data=js"{          ← inline: `{` attaches, body nested via braces
    			open: false,
    			active: -1,
    			items() {
@@ -131,6 +138,12 @@ and mirrors `<script>`/`<style>` body behavior.
    		}"
    		class="c"
    	>
+   	<div
+   		style=css`           ← block: delimiters alone, body +1 (like <style>)
+   			color: red;
+   			margin: 0;
+   		`
+   	/>
    ```
 5. **Whole-literal pipeline**: any `Stages` (`|> f`) append after the closing
    delimiter, as today.

--- a/docs/superpowers/specs/2026-07-14-embedded-attr-literal-format-minify-design.md
+++ b/docs/superpowers/specs/2026-07-14-embedded-attr-literal-format-minify-design.md
@@ -1,0 +1,235 @@
+# Format & minify `js``/`css`` attribute-value literals
+
+**Date:** 2026-07-14
+**Status:** Approved (design), ready for planning
+
+## Problem
+
+Embedded-literal **attribute values** — `name=js`…``, `name=css`…``, `name=js"…"`,
+`name=css"…"` — are the only place gsx knows an attribute value is JavaScript or
+CSS, yet they are the one place that knowledge is never used by the tooling:
+
+- **`gsx fmt`** emits their body **verbatim** (`internal/printer/printer.go:1118-1142`,
+  `writeEmbeddedAttrSegments` at `printer.go:1185-1202`). A multi-line
+  `x-data=js"{ … }"` blob keeps whatever indentation the author left, exactly as a
+  plain `"…"` string would. `<script>`/`<style>` **element bodies**, by contrast,
+  are re-indented during fmt (`printer.go:459-475`).
+- **minify** never touches them. The codegen minify walkers
+  (`internal/cssmin/file.go`, `internal/jsmin/file.go`) recurse into attributes
+  via `minifyAttrs`, which handles only `*ast.MarkupAttr` and `*ast.CondAttr` —
+  there is **no `*ast.EmbeddedAttr` case** (`cssmin/file.go:136-155`). So an
+  `onclick=js`…`` / `style=css`…`` body is streamed to the client un-minified.
+
+Motivating case: a large inline Alpine `x-data` object literal. Written as a
+plain `"…"` string it is opaque (whitespace is literal value — fmt cannot and must
+not touch it). Rewritten as `x-data=js"{ … }"` it becomes formattable *and*
+minifiable — but today neither happens.
+
+Non-problem for reference: a plain `"…"` static attribute is opaque HTML-ish text;
+its interior whitespace is part of the value. It is out of scope by design (see
+Non-goals).
+
+## Scope decision (locked)
+
+Formatting and minification apply **only** to `*ast.EmbeddedAttr` whose `Lang` is
+`EmbeddedJS` or `EmbeddedCSS`. Excluded, unchanged, verbatim:
+
+- Plain `"…"` static attribute values (`*ast.StaticAttr`) — opaque, whitespace is
+  literal value.
+- `f`…`` / `f"…"` literals (`Lang == EmbeddedText`) — generic interpolating
+  literal, no sublanguage, nothing to format/minify.
+
+The author opts in per-attribute by writing `js"…"` / `css"…"` (or the backtick
+forms).
+
+## Existing infrastructure reused (no new engines)
+
+| Concern | Reused component | Notes |
+|---|---|---|
+| JS re-indent | `internal/jsfmt` | tdewolff JS **lexer** (no parser); indents by brace depth; **keeps every newline → ASI never altered**; strings/templates/regex/comments opaque. |
+| CSS re-indent | `internal/cssfmt` | CSS tokenizer; indents by brace depth; changes nothing else. |
+| placeholder/format/restore | `internal/rawfmt` | `Format(segments, holes, Formatter) (pretty.Doc, bool)`; hole → sentinel → format → restore → re-indent. Already powers `<script>`/`<style>` bodies. |
+| JS minify (safe) | `internal/jsmin` | tdewolff lexer; strips comments+indentation, collapses intra-line whitespace, **keeps every newline (ASI-safe)**. |
+| CSS minify (safe) | `internal/cssmin` | whitespace/comment reductions only, hole-aware, never value rewrites. |
+| JS/CSS minify (full) | `internal/fullmin` | tdewolff **parser/AST** `js.Minify`/`css.Minify`; **removes newlines, ASI respected**; holeless blocks only. |
+| minify level selection | `gen/minify.go` (`MinifyLevel`), config `[minify]`, `GSX_MINIFY` | precedence option > env > config; public default `MinifyNone`. |
+
+The formatters (`jsfmt`/`cssfmt`) are bound in `FprintWith` as `p.jsFmt`/`p.cssFmt`
+(`printer.go:61-67`); a `nil` formatter leaves the body verbatim.
+
+## AST shape
+
+`ast.EmbeddedAttr` (`ast/ast.go:416-436`):
+
+- `Name string`
+- `Lang EmbeddedLang` (`EmbeddedJS` / `EmbeddedCSS` / `EmbeddedText`)
+- `Segments []Markup` — only `*ast.Text` (unescaped literal body) and `*ast.Interp`
+  (`@{ }` holes)
+- `Stages []PipeStage` — optional whole-literal `|>` pipeline
+- `DoubleQuoted bool`, `Braced bool` — delimiter / brace round-trip facts
+
+Critical fact confirmed from `writeEmbeddedLiteralText` (`printer.go:1221-1235`):
+**the AST stores the body UNESCAPED (real JS/CSS).** The delimiter (`` ` `` or `"`)
+and bare `@{` are re-escaped only on output. So the formatter/minifier operate on
+real source; escaping is purely an emission concern.
+
+---
+
+## Phase 1 — formatting (`gsx fmt`)
+
+### Seam
+
+`attrDoc` (`internal/printer/printer.go:530`) currently sends `*ast.EmbeddedAttr`
+to `default: return pretty.Text(attrInline(a))` (flat, single-line). Add an
+`*ast.EmbeddedAttr` case (guard `Lang ∈ {JS,CSS}` and the relevant `p.jsFmt`/
+`p.cssFmt != nil`).
+
+- **Single-line value** (body contains no newline): unchanged — inline exactly as
+  today (still normalizes hole whitespace via the existing path).
+- **Already-multi-line value**: produce a structured `pretty.Doc`.
+
+Re-indent only, **never force-wrap**: a single-line literal never becomes
+multi-line, and token layout inside is never reflowed. This is what keeps ASI safe
+and mirrors `<script>`/`<style>` body behavior.
+
+### Pipeline (reuses `rawfmt` core + two additions)
+
+1. **Extract** `Segments` → interleaved (`segments []string`, `holes []string`)
+   with `len(segments) == len(holes)+1`. Each `*ast.Text` → its unescaped body;
+   each `*ast.Interp` → its rendered `@{ expr }` string (expr formatted by the gsx
+   printer). This is the attribute analogue of `nodesToBody` (`printer.go:1307`),
+   which does the same for `<script>`/`<style>` children.
+2. **Format** the placeholdered source with `p.jsFmt`/`p.cssFmt` (via
+   `rawfmt`'s existing placeholder → format → restore machinery).
+3. **Delimiter escaping (NEW)** — applied to the formatted text **before** hole
+   restoration: escape the literal's own delimiter (`` ` `` for backtick forms,
+   `"` for the `"` forms) and bare `@{`, using the existing
+   `writeEmbeddedLiteralText` rule (odd-backslash-run aware). Safe because
+   `rawfmt`'s sentinels (`__gsxhole_N_`, valid identifiers) contain no escapable
+   character, so escaping the whole placeholdered string cannot corrupt a
+   sentinel. Restored holes (`@{expr}`) are inserted *after* escaping, so they stay
+   unescaped real holes.
+4. **Attr-anchored re-indent (NEW variant of `rawfmt.reindent`)**: unlike the
+   body variant (which leads and trails with `HardLine` so `<script>`/`</script>`
+   sit on their own lines), the attribute variant:
+   - attaches the opening delimiter + first body line to the `name=js"` line (no
+     leading `HardLine`),
+   - indents body lines one level under the attribute (honoring the formatter's
+     brace-depth indentation),
+   - attaches the closing delimiter to the last body line (no trailing `HardLine`
+     before the delimiter).
+
+   Target layout (approved):
+   ```
+   	<form
+   		x-data=js"{
+   			open: false,
+   			active: -1,
+   			items() {
+   				return q('a:not([x])');
+   			},
+   		}"
+   		class="c"
+   	>
+   ```
+5. **Whole-literal pipeline**: any `Stages` (`|> f`) append after the closing
+   delimiter, as today.
+
+### Failure / fallback
+
+Any formatter error, panic, arity mismatch, or hole-restore mismatch →
+`rawfmt.Format` returns `ok=false` → fall back to today's verbatim inline emission.
+Identical safety valve to the body path (`printer.go:460-475`,
+`rawfmt.go:69-83`).
+
+### Config
+
+On by default whenever `p.jsFmt`/`p.cssFmt` is set — the same gate that already
+governs `<script>`/`<style>` body formatting. **No new config knob.**
+
+### Idempotence
+
+`fmt(fmt(x)) == fmt(x)` is the correctness gate. The re-indent variant must land on
+a fixed point (blank lines emit as bare `Text("\n")` with no trailing tabs — the
+same idempotence discipline the existing `rawfmt.reindent` already documents and
+implements).
+
+---
+
+## Phase 2 — minify (generated output, codegen)
+
+### Seam
+
+`minifyAttrs` in `internal/cssmin/file.go:136-155` (and the JS analogue in
+`internal/jsmin/file.go`) handle `*ast.MarkupAttr` and `*ast.CondAttr` only. Add
+an `*ast.EmbeddedAttr` case: when `Lang` matches the pass (CSS for cssmin, JS for
+jsmin), minify the literal body and re-emit with delimiter-escaping (the **same**
+escaper as Phase 1).
+
+### Policy — mirror `<script>`/`<style>` exactly
+
+- **Safe pass** (`jsmin`/`cssmin`): keeps every newline (ASI-safe); strips
+  indentation / collapses intra-line whitespace. CSS is hole-aware; a JS literal
+  carrying any `@{ }` hole is **left un-minified** (ASI / hole-boundary whitespace
+  unsafe — same rule as holey `<script>` at `jsmin/file.go:98-105`).
+- **Full pass** (`fullmin`): tdewolff parser; **removes newlines**, ASI respected;
+  applied only to **holeless** literals. This is the path that answers "simple
+  minify = remove line breaks" — already correctness-preserving via a real parser,
+  no ASI-unsafe newline-stripping heuristic.
+
+### Config
+
+Runs at codegen, gated by the existing `MinifyLevel` (`gen/minify.go`), config
+`[minify]`, `GSX_MINIFY`. **No new config surface.** Precedence option > env >
+config, as today.
+
+---
+
+## Testing
+
+### Phase 1 (fmt) — `internal/gsxfmt/testdata/cases/*.txtar`
+
+One case per combination, plus idempotence verified by the corpus harness
+(`fmt.golden`, then re-run without `-update`):
+
+- `js` × {backtick, `"`} — multi-line, re-indented under the attribute.
+- `css` × {backtick, `"`} — multi-line.
+- hole present (`@{expr}`) inside a multi-line body — hole preserved, expr
+  formatted, surrounding JS re-indented.
+- single-line value stays inline (no forced wrap).
+- delimiter round-trip: a literal whose body contains its own delimiter and a bare
+  `@{` — escaping survives format.
+- fallback: a deliberately unparseable body degrades to verbatim (no crash).
+
+### Phase 2 (minify) — semantic corpus `internal/corpus/testdata/cases/**`
+
+`input.gsx` + `generated.x.go.golden` + `render.golden`:
+
+- `js"…"` / `css"…"` attribute literal minified in output; rendered HTML still
+  correct.
+- full-pass case: newlines removed on a holeless literal; render correct.
+- holey JS literal **left un-minified** (ASI safety) — pinned.
+- delimiter-escaping preserved through minify.
+
+### Unit
+
+- The delimiter-escaping-before-restore helper: sentinel-safety property (escaping
+  a placeholdered string never touches a sentinel).
+
+---
+
+## Non-goals
+
+- Detecting/formatting JS inside plain `"…"` string attributes (gsx cannot know a
+  string is JS; re-indenting would change literal value bytes).
+- Reflowing / line-wrapping JS or CSS (re-indent only).
+- Changing hole (`@{ }`) semantics or the whole-literal `|>` pipeline.
+- Any new config knob for either phase.
+- The tree-sitter multi-line-attribute fix (separate, already shipped) and any
+  CodeMirror / vscode-gsx grammar follow-ups.
+
+## Delivery
+
+One spec, **two sequenced phases**: implement + review Phase 1 (formatting) first
+(it unblocks readable source), then Phase 2 (minify). Each phase ships its own
+tests; the semantic and fmt corpora stay separate per the repo convention.

--- a/internal/cssfmt/cssfmt.go
+++ b/internal/cssfmt/cssfmt.go
@@ -60,6 +60,14 @@ func Format(src []byte, width int) ([]byte, error) {
 	return []byte(out), nil
 }
 
+// FormatLines is Format returning the re-indented LOGICAL lines. A multi-line
+// token (template literal, block comment) stays within ONE line, so the caller
+// can place each logical line at its depth without re-indenting the token's
+// interior. ok=false on a lex error → caller renders verbatim.
+func FormatLines(src []byte, width int) ([]string, bool) {
+	return reindent.ReindentLines(src, cssAdapter{})
+}
+
 var errUnterminated = stringError("cssfmt: unterminated string or comment")
 
 type stringError string

--- a/internal/cssfmt/cssfmt_test.go
+++ b/internal/cssfmt/cssfmt_test.go
@@ -121,3 +121,24 @@ func TestCSSLoneCRIsLineBreakNotFusion(t *testing.T) {
 		t.Fatalf("lone CR mishandled in CSS: %q", got)
 	}
 }
+
+func TestFormatLinesBlockCommentOneLine(t *testing.T) {
+	// A multi-line /* … */ comment must be a SINGLE logical line.
+	src := ".a {\n/* multi\nline\ncomment */\ncolor: red;\n}"
+	lines, ok := FormatLines([]byte(src), 80)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	found := false
+	for _, ln := range lines {
+		if strings.Contains(ln, "/* multi") {
+			if !strings.Contains(ln, "line") || !strings.Contains(ln, "comment */") {
+				t.Fatalf("comment split across lines: %q", ln)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("comment line not found in %q", lines)
+	}
+}

--- a/internal/gsxfmt/gsxfmt_test.go
+++ b/internal/gsxfmt/gsxfmt_test.go
@@ -54,7 +54,14 @@ func TestFormatParseErrorReturnsError(t *testing.T) {
 	}
 }
 
-func TestFormatPreservesMultilineEmbeddedAttrBody(t *testing.T) {
+// A multi-line embedded-attribute body is now re-indented by the configured
+// JS/CSS formatter (printer: format multi-line js`/css` attribute values),
+// superseding the verbatim-preservation behavior this test used to pin.
+// jsfmt/cssfmt treat these bodies as flat top-level content (no outer
+// nesting), so they get zero extra indent beyond the attribute's own depth;
+// the opening tag and children break in symmetry once an attribute value
+// forces a hard break.
+func TestFormatReindentsMultilineEmbeddedAttrBody(t *testing.T) {
 	src := "package p\n\n" +
 		"component C(open bool) {\n" +
 		"\t<div x-data=js`" + "\n" +
@@ -65,11 +72,12 @@ func TestFormatPreservesMultilineEmbeddedAttrBody(t *testing.T) {
 		"}\n"
 	want := "package p\n\n" +
 		"component C(open bool) {\n" +
-		"\t<div x-data=js`" + "\n" +
-		"\t\t{ open: @{open} }\n" +
-		"\t` style=css`" + "\n" +
-		"\t\tcolor : @{color}\n" +
-		"\t`>\n" +
+		"\t<div\n" +
+		"\t\tx-data=js`\n" +
+		"\t\t{ open: @{open} }`\n" +
+		"\t\tstyle=css`\n" +
+		"\t\tcolor : @{color}`\n" +
+		"\t>\n" +
 		"\t\tx\n" +
 		"\t</div>\n" +
 		"}\n"

--- a/internal/gsxfmt/gsxfmt_test.go
+++ b/internal/gsxfmt/gsxfmt_test.go
@@ -74,9 +74,11 @@ func TestFormatReindentsMultilineEmbeddedAttrBody(t *testing.T) {
 		"component C(open bool) {\n" +
 		"\t<div\n" +
 		"\t\tx-data=js`\n" +
-		"\t\t{ open: @{open} }`\n" +
+		"\t\t\t{ open: @{open} }\n" +
+		"\t\t`\n" +
 		"\t\tstyle=css`\n" +
-		"\t\tcolor : @{color}`\n" +
+		"\t\t\tcolor : @{color}\n" +
+		"\t\t`\n" +
 		"\t>\n" +
 		"\t\tx\n" +
 		"\t</div>\n" +

--- a/internal/gsxfmt/testdata/cases/embed_attr_css_block_comment.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_attr_css_block_comment.txtar
@@ -1,0 +1,27 @@
+A multi-line /* … */ comment inside a css`…` attribute value keeps its interior
+verbatim while declarations are re-indented under the attribute (block layout).
+
+-- input.gsx --
+package p
+
+component C() {
+	<div style=css`
+/* multi
+   line */
+color: red;
+margin: 0;
+`/>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	<div
+		style=css`
+			/* multi
+   line */
+			color: red;
+			margin: 0;
+		`
+	/>
+}

--- a/internal/gsxfmt/testdata/cases/embed_attr_css_multiline.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_attr_css_multiline.txtar
@@ -1,0 +1,22 @@
+A multi-line css`…` attribute value is re-indented under its attribute, the same
+way a <style> body is.
+
+-- input.gsx --
+package p
+
+component C() {
+	<div style=css`
+color: red;
+margin: 0;
+`/>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	<div
+		style=css`
+		color: red;
+		margin: 0;`
+	/>
+}

--- a/internal/gsxfmt/testdata/cases/embed_attr_css_multiline.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_attr_css_multiline.txtar
@@ -16,7 +16,8 @@ package p
 component C() {
 	<div
 		style=css`
-		color: red;
-		margin: 0;`
+			color: red;
+			margin: 0;
+		`
 	/>
 }

--- a/internal/gsxfmt/testdata/cases/embed_attr_js_hole.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_attr_js_hole.txtar
@@ -1,0 +1,23 @@
+A hole inside a multi-line js"…" attribute value survives re-indentation (the
+@{expr} form is preserved tight; no sentinel leaks).
+
+-- input.gsx --
+package p
+
+component C(id string) {
+	<form x-data=js"{
+url: '@{id}',
+k: 1,
+}"/>
+}
+-- fmt.golden --
+package p
+
+component C(id string) {
+	<form
+		x-data=js"{
+			url: '@{id}',
+			k: 1,
+		}"
+	/>
+}

--- a/internal/gsxfmt/testdata/cases/embed_attr_js_multiline.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_attr_js_multiline.txtar
@@ -1,0 +1,30 @@
+A multi-line js"…" attribute value is re-indented under its attribute: the
+opening delimiter+brace attach to the js" line, the body sits one level deeper
+(brace-nested deeper still), and the closing brace+delimiter dedent back to the
+attribute's indent. Re-indent only — no reflow.
+
+-- input.gsx --
+package p
+
+component C() {
+	<form x-data=js"{
+open: false,
+items() {
+return 1;
+}
+}" class="c"/>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	<form
+		x-data=js"{
+			open: false,
+			items() {
+				return 1;
+			}
+		}"
+		class="c"
+	/>
+}

--- a/internal/gsxfmt/testdata/cases/embed_attr_js_template_literal.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_attr_js_template_literal.txtar
@@ -1,0 +1,31 @@
+A multi-line JS template literal inside a js"…" attribute value keeps its
+interior verbatim while the surrounding object is re-indented under the attribute.
+
+-- input.gsx --
+package p
+
+component C() {
+	<form x-data=js"{
+render() {
+return `<div>
+  hi
+</div>`;
+},
+k: 1,
+}"/>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	<form
+		x-data=js"{
+			render() {
+				return `<div>
+  hi
+</div>`;
+			},
+			k: 1,
+		}"
+	/>
+}

--- a/internal/gsxfmt/testdata/cases/embed_attr_single_line_inline.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_attr_single_line_inline.txtar
@@ -1,0 +1,15 @@
+A single-line js"…" attribute value stays inline, byte-for-byte — fmt never
+force-wraps an embedded literal.
+
+-- input.gsx --
+package p
+
+component C() {
+	<form x-data=js"{open:false}"/>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	<form x-data=js"{open:false}"/>
+}

--- a/internal/gsxfmt/testdata/cases/embed_body_script_template_literal.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_body_script_template_literal.txtar
@@ -1,0 +1,26 @@
+A multi-line JS template literal inside a <script> body keeps its interior
+VERBATIM — the outer re-indent must not inject tabs into the template's value
+(that would corrupt the string and break idempotence).
+
+-- input.gsx --
+package p
+
+component C() {
+	<script>
+const t = `<div>
+  hi
+</div>`;
+document.body.innerHTML = t;
+</script>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	<script>
+		const t = `<div>
+  hi
+</div>`;
+		document.body.innerHTML = t;
+	</script>
+}

--- a/internal/gsxfmt/testdata/cases/embed_body_style_block_comment.txtar
+++ b/internal/gsxfmt/testdata/cases/embed_body_style_block_comment.txtar
@@ -1,0 +1,28 @@
+A multi-line /* … */ comment inside a <style> body keeps its interior verbatim.
+
+-- input.gsx --
+package p
+
+component C() {
+	<style>
+.a {
+/* multi
+   line
+   comment */
+color: red;
+}
+</style>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	<style>
+		.a {
+			/* multi
+   line
+   comment */
+			color: red;
+		}
+	</style>
+}

--- a/internal/jsfmt/jsfmt.go
+++ b/internal/jsfmt/jsfmt.go
@@ -29,6 +29,14 @@ func Format(src []byte, width int) ([]byte, error) {
 	return []byte(out), nil
 }
 
+// FormatLines is Format returning the re-indented LOGICAL lines. A multi-line
+// token (template literal, block comment) stays within ONE line, so the caller
+// can place each logical line at its depth without re-indenting the token's
+// interior. ok=false on a lex error → caller renders verbatim.
+func FormatLines(src []byte, width int) ([]string, bool) {
+	return reindent.ReindentLines(src, jsAdapter{})
+}
+
 type stringError string
 
 func (e stringError) Error() string { return string(e) }

--- a/internal/jsfmt/jsfmt_test.go
+++ b/internal/jsfmt/jsfmt_test.go
@@ -183,3 +183,25 @@ func TestCRLFNormalizedToLF(t *testing.T) {
 		t.Fatalf("CRLF not normalized to a single LF: %q", got)
 	}
 }
+
+func TestFormatLinesTemplateLiteralOneLine(t *testing.T) {
+	// A multi-line template literal must be a SINGLE logical line (its internal
+	// newlines are content), while ordinary statements are separate lines.
+	src := "var f = () => {\nreturn `<div>\nhi\n</div>`;\n}"
+	lines, ok := FormatLines([]byte(src), 80)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	found := false
+	for _, ln := range lines {
+		if strings.Contains(ln, "`<div>") {
+			if !strings.Contains(ln, "hi") || !strings.Contains(ln, "</div>`") {
+				t.Fatalf("template literal split across lines: %q", ln)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("template literal line not found in %q", lines)
+	}
+}

--- a/internal/printer/embedded_attr_fmt_test.go
+++ b/internal/printer/embedded_attr_fmt_test.go
@@ -126,3 +126,23 @@ func TestEmbeddedAttrXDataEndToEnd(t *testing.T) {
 		}
 	}
 }
+
+// A multi-line template literal inside a js"…" attribute value must have its
+// interior emitted VERBATIM (no injected indent) and be idempotent.
+func TestEmbeddedAttrTemplateLiteralVerbatim(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nhtml: `<div>\nhi\n</div>`,\nk: 1,\n}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "`<div>\nhi\n</div>`") {
+		t.Fatalf("template-literal interior re-indented (should be verbatim):\n%s", out)
+	}
+	twice, err := normPrint(t, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != twice {
+		t.Fatalf("not idempotent:\n--- once ---\n%s\n--- twice ---\n%s", out, twice)
+	}
+}

--- a/internal/printer/embedded_attr_fmt_test.go
+++ b/internal/printer/embedded_attr_fmt_test.go
@@ -1,0 +1,124 @@
+package printer
+
+import (
+	"strings"
+	"testing"
+)
+
+// A multi-line js"…" attribute value: body one level under the attribute,
+// brace-nested deeper, closing delimiter attached to the last line.
+func TestEmbeddedAttrJSReindented(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nopen: false,\nitems() {\nreturn 1;\n}\n}\" class=\"c\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// <form> at depth 1 → attrs at depth 2. Opening `{` attaches to js".
+	if !strings.Contains(out, "x-data=js\"{") {
+		t.Fatalf("opening delimiter+brace should attach:\n%s", out)
+	}
+	// body one level under the attribute (2 tabs base + 1 jsfmt = 3 tabs).
+	if !strings.Contains(out, "\t\t\topen: false,") {
+		t.Fatalf("body not one level under attribute:\n%s", out)
+	}
+	if !strings.Contains(out, "\t\t\t\treturn 1;") {
+		t.Fatalf("nested body not two levels under attribute:\n%s", out)
+	}
+	// closing brace dedents to the attribute level and the delimiter attaches.
+	if !strings.Contains(out, "\t\t}\"") {
+		t.Fatalf("closing delimiter should attach at attribute indent:\n%s", out)
+	}
+	// following attribute survives.
+	if !strings.Contains(out, "class=\"c\"") {
+		t.Fatalf("trailing attribute lost:\n%s", out)
+	}
+}
+
+func TestEmbeddedAttrIdempotent(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nopen: false,\n}\"/>\n}\n"
+	once, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	twice, err := normPrint(t, once)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if once != twice {
+		t.Fatalf("not idempotent:\n--- once ---\n%s\n--- twice ---\n%s", once, twice)
+	}
+}
+
+func TestEmbeddedAttrHolePreserved(t *testing.T) {
+	src := "package p\n\ncomponent C(id string) {\n\t<form x-data=js\"{\nurl: '@{id}',\nk: 1,\n}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "@{id}") || strings.Contains(out, "__gsxhole") {
+		t.Fatalf("hole not preserved / sentinel leaked:\n%s", out)
+	}
+}
+
+// A body containing the literal's own delimiter must round-trip (escaped).
+func TestEmbeddedAttrDelimiterRoundTrip(t *testing.T) {
+	// js"…" value whose JS contains a double-quoted string → the inner `"` is
+	// escaped in source; after fmt it must still be escaped and re-parse.
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nmsg: \\\"hi\\\",\nk: 1,\n}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `msg: \"hi\",`) {
+		t.Fatalf("inner delimiter not re-escaped:\n%s", out)
+	}
+	// re-parse must succeed (idempotence test covers structural stability).
+	if _, err := normPrint(t, out); err != nil {
+		t.Fatalf("reparse failed: %v\n%s", err, out)
+	}
+}
+
+// A single-line js"…" value is left inline, unchanged.
+func TestEmbeddedAttrSingleLineStaysInline(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{open:false}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "x-data=js\"{open:false}\"") {
+		t.Fatalf("single-line value should stay inline:\n%s", out)
+	}
+}
+
+// CSS literal, backtick delimiter, multi-line.
+func TestEmbeddedAttrCSSReindented(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<div style=css`\ncolor: red;\nmargin: 0;\n`/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "\t\tcolor: red;") {
+		t.Fatalf("css body not re-indented under attribute:\n%s", out)
+	}
+}
+
+// End-to-end: the motivating Alpine x-data blob converted to js"…".
+func TestEmbeddedAttrXDataEndToEnd(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<form x-data=js\"{\nopen: false,\nactive: -1,\nmoveActive(d) {\nif (!this.open) return;\n},\n}\"/>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"x-data=js\"{",
+		"\t\t\topen: false,",
+		"\t\t\tmoveActive(d) {",
+		"\t\t\t\tif (!this.open) return;",
+		"\t\t\t},",
+		"\t\t}\"",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/internal/printer/embedded_attr_fmt_test.go
+++ b/internal/printer/embedded_attr_fmt_test.go
@@ -90,15 +90,19 @@ func TestEmbeddedAttrSingleLineStaysInline(t *testing.T) {
 	}
 }
 
-// CSS literal, backtick delimiter, multi-line.
+// CSS literal, backtick delimiter, multi-line. Brace-less CSS gets the block
+// layout: opening backtick alone on the attribute line, body indented one
+// level under the attribute, closing backtick alone at the attribute's own
+// indent (never glued to the last declaration).
 func TestEmbeddedAttrCSSReindented(t *testing.T) {
 	src := "package p\n\ncomponent C() {\n\t<div style=css`\ncolor: red;\nmargin: 0;\n`/>\n}\n"
+	want := "package p\n\ncomponent C() {\n\t<div\n\t\tstyle=css`\n\t\t\tcolor: red;\n\t\t\tmargin: 0;\n\t\t`\n\t/>\n}\n"
 	out, err := normPrint(t, src)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "\t\tcolor: red;") {
-		t.Fatalf("css body not re-indented under attribute:\n%s", out)
+	if out != want {
+		t.Fatalf("css block layout mismatch:\ngot:\n%s\nwant:\n%s", out, want)
 	}
 }
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1264,21 +1264,41 @@ func embeddedHoleString(v *ast.Interp) string {
 }
 
 // embeddedAttrValueDoc builds the Doc for a multi-line embedded-literal attribute
-// value. opener is the text up to and including the opening delimiter (e.g.
-// `x-data=js"` or `x-data={js"`); formatted is the re-indented body (leading and
-// trailing blank lines already trimmed); closer is the closing delimiter plus any
-// `|> stage` / `}` (e.g. `"` or `" |> f}`). The first body line attaches to the
-// opener, intermediate lines break at the attribute's own indent level (the
-// formatter's per-line leading tabs supply the brace-depth nesting), and the
-// closer attaches to the last line. Blank lines emit as bare "\n" so they never
-// carry trailing tabs (idempotence).
+// value. opener is the text up to and including the opening delimiter; formatted
+// is the re-indented body from the formatter; closer is the closing delimiter
+// plus any `|> stage` / `}`.
+//
+// Two layouts, chosen by the body's own structure (which the formatter preserves):
+//   - Inline (content-adjacent, e.g. js"{ … }" whose `{`/`}` hug the delimiters):
+//     the opening delimiter attaches to the first body line and the closer to the
+//     last; body nesting comes from the formatter's own brace-depth tabs.
+//   - Block (body on its own lines, signalled by a leading newline, e.g.
+//     css`\n…\n`): the delimiters stand alone and the body is indented one level
+//     under the attribute — the same shape as a <script>/<style> element body.
+//
+// Blank lines emit as bare "\n" so they never carry trailing tabs (idempotence).
 func embeddedAttrValueDoc(opener, formatted, closer string) pretty.Doc {
-	lines := strings.Split(formatted, "\n")
+	block := strings.HasPrefix(formatted, "\n")
+	lines := strings.Split(strings.Trim(formatted, "\n"), "\n")
+	if block {
+		inner := make([]pretty.Doc, 0, len(lines)*2)
+		for _, ln := range lines {
+			if ln = strings.TrimRight(ln, " \t"); ln == "" {
+				inner = append(inner, pretty.Text("\n"))
+				continue
+			}
+			inner = append(inner, pretty.HardLine, pretty.Text(ln))
+		}
+		return pretty.Concat(
+			pretty.Text(opener),
+			pretty.Indent(pretty.Concat(inner...)),
+			pretty.HardLine, pretty.Text(closer),
+		)
+	}
 	parts := make([]pretty.Doc, 0, len(lines)*2+2)
 	parts = append(parts, pretty.Text(opener+lines[0]))
 	for _, ln := range lines[1:] {
-		ln = strings.TrimRight(ln, " \t")
-		if ln == "" {
+		if ln = strings.TrimRight(ln, " \t"); ln == "" {
 			parts = append(parts, pretty.Text("\n"))
 			continue
 		}
@@ -1316,14 +1336,11 @@ func (p *printer) embeddedAttrDoc(v *ast.EmbeddedAttr) (pretty.Doc, bool) {
 	if !ok {
 		return pretty.Doc{}, false
 	}
-	// Trim only a trailing newline artifact from the formatter. A LEADING
-	// newline is preserved deliberately: CSS/JS formatters emit one when the
-	// body's first line has no meaningful content to attach to the opening
-	// delimiter (e.g. a bare CSS declaration list, vs. a JS body that opens
-	// with a user-written `{`), and strings.Split below turns that leading
-	// "\n" into an empty lines[0] — which embeddedAttrValueDoc then leaves
-	// attached to the opener, forcing the first real line onto its own break.
-	formatted = strings.TrimRight(formatted, "\n")
+	// formatted is passed to embeddedAttrValueDoc UNTRIMMED: a leading newline
+	// is the signal it uses to pick the block layout (CSS/declaration-list
+	// bodies) over the inline layout (JS bodies whose `{` hugs the opening
+	// delimiter); embeddedAttrValueDoc trims both ends internally once that
+	// choice is made.
 	if !strings.Contains(formatted, "\n") {
 		// Formatter collapsed the body to one line — keep the inline form.
 		return pretty.Doc{}, false

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -36,19 +36,32 @@ import (
 // exceed width columns. width <= 0 uses pretty.DefaultPrintWidth; tabWidth <= 0
 // uses pretty.DefaultTabWidth.
 func Fprint(w io.Writer, f *ast.File, width, tabWidth int) error {
-	return FprintWith(w, f, width, tabWidth, defaultCSSFormatter(width), defaultJSFormatter(width))
+	// The built-in path uses LINE formatters (jsfmt/cssfmt FormatLines), which
+	// carry logical-line structure so a multi-line Opaque token (template literal
+	// / block comment) interior survives re-indentation verbatim.
+	return fprint(w, f, width, tabWidth, printer{
+		cssLineFmt: defaultCSSLineFormatter(width),
+		jsLineFmt:  defaultJSLineFormatter(width),
+	})
 }
 
-// FprintWith is Fprint with explicit CSS and JS formatters for <style>/<script>
-// bodies. A nil formatter leaves that body verbatim.
+// FprintWith is Fprint with explicit external CSS and JS formatters for
+// <style>/<script> bodies. A nil formatter leaves that body verbatim. External
+// flat formatters carry no token structure, so a multi-line-token interior in
+// their output is re-indented (the same limitation as before line formatters).
 func FprintWith(w io.Writer, f *ast.File, width, tabWidth int, cssFmt, jsFmt rawfmt.Formatter) error {
+	return fprint(w, f, width, tabWidth, printer{cssFmt: cssFmt, jsFmt: jsFmt})
+}
+
+func fprint(w io.Writer, f *ast.File, width, tabWidth int, p printer) error {
 	if width <= 0 {
 		width = pretty.DefaultPrintWidth
 	}
 	if tabWidth <= 0 {
 		tabWidth = pretty.DefaultTabWidth
 	}
-	p := printer{cssFmt: cssFmt, jsFmt: jsFmt, width: width, tabWidth: tabWidth}
+	p.width = width
+	p.tabWidth = tabWidth
 	doc := p.file(f)
 	if p.err != nil {
 		return p.err
@@ -57,23 +70,30 @@ func FprintWith(w io.Writer, f *ast.File, width, tabWidth int, cssFmt, jsFmt raw
 	return err
 }
 
-// defaultCSSFormatter binds the built-in cssfmt to the print width.
-func defaultCSSFormatter(width int) rawfmt.Formatter {
-	return func(src []byte) ([]byte, error) { return cssfmt.Format(src, width) }
+// defaultCSSLineFormatter / defaultJSLineFormatter bind the built-in
+// line-returning re-indenters to the print width.
+func defaultCSSLineFormatter(width int) rawfmt.LineFormatter {
+	return func(src []byte) ([]string, bool) { return cssfmt.FormatLines(src, width) }
 }
 
-func defaultJSFormatter(width int) rawfmt.Formatter {
-	return func(src []byte) ([]byte, error) { return jsfmt.Format(src, width) }
+func defaultJSLineFormatter(width int) rawfmt.LineFormatter {
+	return func(src []byte) ([]string, bool) { return jsfmt.FormatLines(src, width) }
 }
 
 // printer accumulates the first I/O-independent error encountered while
 // building the document.
 type printer struct {
-	err      error
-	cssFmt   rawfmt.Formatter // nil → no CSS formatting (style stays verbatim)
-	jsFmt    rawfmt.Formatter
-	width    int // print width fmtGoChunk/fmtGoExprParts measure Go fragments against
-	tabWidth int
+	err error
+	// External flat formatters (via FprintWith). A nil formatter leaves the body
+	// verbatim; they cannot preserve multi-line-token interiors.
+	cssFmt rawfmt.Formatter
+	jsFmt  rawfmt.Formatter
+	// Built-in line formatters (via Fprint), preferred when set: they carry
+	// logical-line structure so template-literal / block-comment interiors survive.
+	cssLineFmt rawfmt.LineFormatter
+	jsLineFmt  rawfmt.LineFormatter
+	width      int // print width fmtGoChunk/fmtGoExprParts measure Go fragments against
+	tabWidth   int
 }
 
 func (p *printer) fail(format string, args ...any) pretty.Doc {
@@ -457,20 +477,18 @@ func (p *printer) element(e *ast.Element) pretty.Doc {
 	close := pretty.Concat(pretty.Text("</"), pretty.Text(e.Tag), pretty.Text(">"))
 
 	if strings.EqualFold(e.Tag, "script") {
-		if p.jsFmt != nil && isExecutableScript(e) {
+		if isExecutableScript(e) {
 			segments, holes := nodesToBody(e.Children)
-			if doc, ok := rawfmt.Format(segments, holes, p.jsFmt); ok {
+			if doc, ok := p.jsBodyDoc(segments, holes); ok {
 				return pretty.Concat(openTag, doc, close)
 			}
 		}
 		return pretty.Concat(openTag, p.rawHoleChildren(e.Children), close)
 	}
 	if strings.EqualFold(e.Tag, "style") {
-		if p.cssFmt != nil {
-			segments, holes := nodesToBody(e.Children)
-			if doc, ok := rawfmt.Format(segments, holes, p.cssFmt); ok {
-				return pretty.Concat(openTag, doc, close)
-			}
+		segments, holes := nodesToBody(e.Children)
+		if doc, ok := p.cssBodyDoc(segments, holes); ok {
+			return pretty.Concat(openTag, doc, close)
 		}
 		return pretty.Concat(openTag, p.rawHoleChildren(e.Children), close)
 	}
@@ -1277,9 +1295,22 @@ func embeddedHoleString(v *ast.Interp) string {
 //     under the attribute — the same shape as a <script>/<style> element body.
 //
 // Blank lines emit as bare "\n" so they never carry trailing tabs (idempotence).
-func embeddedAttrValueDoc(opener, formatted, closer string) pretty.Doc {
-	block := strings.HasPrefix(formatted, "\n")
-	lines := strings.Split(strings.Trim(formatted, "\n"), "\n")
+func embeddedAttrValueDoc(opener string, lines []string, closer string) pretty.Doc {
+	// A leading blank logical line means the body opened on its own line → block
+	// layout (delimiters alone, body one level under). Then drop leading/trailing
+	// blank logical lines. Each logical line may carry internal newlines (an
+	// Opaque token — template literal / block comment); emitted as one Text they
+	// are verbatim (the pretty engine adds no managed indent inside a Text).
+	block := len(lines) > 0 && lines[0] == ""
+	for len(lines) > 0 && lines[0] == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return pretty.Text(opener + closer)
+	}
 	if block {
 		inner := make([]pretty.Doc, 0, len(lines)*2)
 		for _, ln := range lines {
@@ -1313,16 +1344,10 @@ func embeddedAttrValueDoc(opener, formatted, closer string) pretty.Doc {
 // inline) for a non-JS/CSS literal, a nil formatter, a single-line body, or any
 // formatter failure.
 func (p *printer) embeddedAttrDoc(v *ast.EmbeddedAttr) (pretty.Doc, bool) {
-	var f rawfmt.Formatter
-	switch v.Lang {
-	case ast.EmbeddedJS:
-		f = p.jsFmt
-	case ast.EmbeddedCSS:
-		f = p.cssFmt
-	default: // ast.EmbeddedText — f`…`: no sublanguage, nothing to format.
-		return pretty.Doc{}, false
+	if v.Lang != ast.EmbeddedJS && v.Lang != ast.EmbeddedCSS {
+		return pretty.Doc{}, false // ast.EmbeddedText — f`…`: no sublanguage.
 	}
-	if f == nil || !embeddedSegmentsMultiline(v.Segments) {
+	if !embeddedSegmentsMultiline(v.Segments) {
 		return pretty.Doc{}, false
 	}
 	segments, holes := embeddedAttrBody(v.Segments)
@@ -1332,17 +1357,14 @@ func (p *printer) embeddedAttrDoc(v *ast.EmbeddedAttr) (pretty.Doc, bool) {
 		writeEmbeddedLiteralText(&b, s, delim)
 		return b.String()
 	}
-	formatted, ok := rawfmt.FormatString(segments, holes, f, escape)
+	lines, ok := p.embeddedAttrLines(v.Lang, segments, holes, escape)
 	if !ok {
 		return pretty.Doc{}, false
 	}
-	// formatted is passed to embeddedAttrValueDoc UNTRIMMED: a leading newline
-	// is the signal it uses to pick the block layout (CSS/declaration-list
-	// bodies) over the inline layout (JS bodies whose `{` hugs the opening
-	// delimiter); embeddedAttrValueDoc trims both ends internally once that
-	// choice is made.
-	if !strings.Contains(formatted, "\n") {
-		// Formatter collapsed the body to one line — keep the inline form.
+	// Keep the inline form if the formatter collapsed the body to a single
+	// physical line (one logical line with no internal newline). A leading blank
+	// logical line (block signal) still counts as multi-line.
+	if len(lines) <= 1 && (len(lines) == 0 || !strings.Contains(lines[0], "\n")) {
 		return pretty.Doc{}, false
 	}
 	braced := v.Braced || len(v.Stages) > 0
@@ -1363,7 +1385,58 @@ func (p *printer) embeddedAttrDoc(v *ast.EmbeddedAttr) (pretty.Doc, bool) {
 	if braced {
 		closer.WriteString("}")
 	}
-	return embeddedAttrValueDoc(opener.String(), formatted, closer.String()), true
+	return embeddedAttrValueDoc(opener.String(), lines, closer.String()), true
+}
+
+// embeddedAttrLines formats an embedded-attribute body into re-indented LOGICAL
+// lines (a multi-line Opaque token stays within one line). It prefers the
+// built-in LineFormatter (set by Fprint); an external flat Formatter (via
+// FprintWith) falls back to the naive physical-line split, which cannot preserve
+// multi-line-token interiors — external custom formatters carry no token info.
+func (p *printer) embeddedAttrLines(lang ast.EmbeddedLang, segments, holes []string, escape func(string) string) ([]string, bool) {
+	var lf rawfmt.LineFormatter
+	var f rawfmt.Formatter
+	switch lang {
+	case ast.EmbeddedJS:
+		lf, f = p.jsLineFmt, p.jsFmt
+	case ast.EmbeddedCSS:
+		lf, f = p.cssLineFmt, p.cssFmt
+	}
+	if lf != nil {
+		return rawfmt.FormatStringLines(segments, holes, lf, escape)
+	}
+	if f != nil {
+		s, ok := rawfmt.FormatString(segments, holes, f, escape)
+		if !ok {
+			return nil, false
+		}
+		return strings.Split(s, "\n"), true
+	}
+	return nil, false
+}
+
+// jsBodyDoc / cssBodyDoc format a <script>/<style> body, preferring the built-in
+// LineFormatter (preserves multi-line-token interiors) over an external flat
+// Formatter. ok=false (no formatter or a formatter failure) → caller renders the
+// body verbatim.
+func (p *printer) jsBodyDoc(segments, holes []string) (pretty.Doc, bool) {
+	if p.jsLineFmt != nil {
+		return rawfmt.FormatLines(segments, holes, p.jsLineFmt)
+	}
+	if p.jsFmt != nil {
+		return rawfmt.Format(segments, holes, p.jsFmt)
+	}
+	return pretty.Doc{}, false
+}
+
+func (p *printer) cssBodyDoc(segments, holes []string) (pretty.Doc, bool) {
+	if p.cssLineFmt != nil {
+		return rawfmt.FormatLines(segments, holes, p.cssLineFmt)
+	}
+	if p.cssFmt != nil {
+		return rawfmt.Format(segments, holes, p.cssFmt)
+	}
+	return pretty.Doc{}, false
 }
 
 // writeEmbeddedLiteralText writes the literal text of an embedded (js/css/text)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -527,6 +527,11 @@ func (p *printer) attrDoc(a ast.Attr) pretty.Doc {
 			parts = append(parts, p.classPartDoc(part))
 		}
 		return wrapAttrValue(v.Name, pretty.Line, pretty.Group(pretty.Concat(parts...)))
+	case *ast.EmbeddedAttr:
+		if doc, ok := p.embeddedAttrDoc(v); ok {
+			return doc
+		}
+		return pretty.Text(attrInline(a))
 	default:
 		return pretty.Text(attrInline(a))
 	}
@@ -1208,6 +1213,140 @@ func embeddedLiteralString(lang ast.EmbeddedLang, nodes []ast.Markup, delim byte
 	writeEmbeddedAttrSegments(&b, nodes, delim)
 	b.WriteByte(delim)
 	return b.String()
+}
+
+// embeddedSegmentsMultiline reports whether an embedded literal's body spans
+// more than one source line (only then does fmt re-indent it; single-line values
+// stay inline, unchanged).
+func embeddedSegmentsMultiline(segs []ast.Markup) bool {
+	for _, n := range segs {
+		if t, ok := n.(*ast.Text); ok && strings.Contains(t.Value, "\n") {
+			return true
+		}
+	}
+	return false
+}
+
+// embeddedAttrBody splits an embedded-attribute literal's Segments into raw text
+// segments and rendered holes for rawfmt, mirroring nodesToBody but emitting the
+// TIGHT `@{expr}` hole form used inside attribute literals (not the spaced body
+// form). segments and holes interleave with len(segments) == len(holes)+1.
+func embeddedAttrBody(segs []ast.Markup) (segments, holes []string) {
+	var cur strings.Builder
+	for _, n := range segs {
+		switch v := n.(type) {
+		case *ast.Text:
+			cur.WriteString(v.Value)
+		case *ast.Interp:
+			segments = append(segments, cur.String())
+			cur.Reset()
+			holes = append(holes, embeddedHoleString(v))
+		default:
+			cur.WriteString(markupInlineString(n))
+		}
+	}
+	segments = append(segments, cur.String())
+	return segments, holes
+}
+
+// embeddedHoleString renders one `@{ expr |> stage }` hole tight (`@{expr}`),
+// matching writeEmbeddedAttrSegments.
+func embeddedHoleString(v *ast.Interp) string {
+	var b strings.Builder
+	b.WriteString("@{")
+	b.WriteString(fmtExpr(v.Expr))
+	for _, s := range v.Stages {
+		b.WriteString(" |> ")
+		b.WriteString(pipeStageStr(s))
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+// embeddedAttrValueDoc builds the Doc for a multi-line embedded-literal attribute
+// value. opener is the text up to and including the opening delimiter (e.g.
+// `x-data=js"` or `x-data={js"`); formatted is the re-indented body (leading and
+// trailing blank lines already trimmed); closer is the closing delimiter plus any
+// `|> stage` / `}` (e.g. `"` or `" |> f}`). The first body line attaches to the
+// opener, intermediate lines break at the attribute's own indent level (the
+// formatter's per-line leading tabs supply the brace-depth nesting), and the
+// closer attaches to the last line. Blank lines emit as bare "\n" so they never
+// carry trailing tabs (idempotence).
+func embeddedAttrValueDoc(opener, formatted, closer string) pretty.Doc {
+	lines := strings.Split(formatted, "\n")
+	parts := make([]pretty.Doc, 0, len(lines)*2+2)
+	parts = append(parts, pretty.Text(opener+lines[0]))
+	for _, ln := range lines[1:] {
+		ln = strings.TrimRight(ln, " \t")
+		if ln == "" {
+			parts = append(parts, pretty.Text("\n"))
+			continue
+		}
+		parts = append(parts, pretty.HardLine, pretty.Text(ln))
+	}
+	parts = append(parts, pretty.Text(closer))
+	return pretty.Concat(parts...)
+}
+
+// embeddedAttrDoc re-indents a multi-line js`/css` attribute value's body with
+// the configured JS/CSS formatter. ok=false (caller falls back to verbatim
+// inline) for a non-JS/CSS literal, a nil formatter, a single-line body, or any
+// formatter failure.
+func (p *printer) embeddedAttrDoc(v *ast.EmbeddedAttr) (pretty.Doc, bool) {
+	var f rawfmt.Formatter
+	switch v.Lang {
+	case ast.EmbeddedJS:
+		f = p.jsFmt
+	case ast.EmbeddedCSS:
+		f = p.cssFmt
+	default: // ast.EmbeddedText — f`…`: no sublanguage, nothing to format.
+		return pretty.Doc{}, false
+	}
+	if f == nil || !embeddedSegmentsMultiline(v.Segments) {
+		return pretty.Doc{}, false
+	}
+	segments, holes := embeddedAttrBody(v.Segments)
+	delim := embeddedDelim(v.DoubleQuoted)
+	escape := func(s string) string {
+		var b strings.Builder
+		writeEmbeddedLiteralText(&b, s, delim)
+		return b.String()
+	}
+	formatted, ok := rawfmt.FormatString(segments, holes, f, escape)
+	if !ok {
+		return pretty.Doc{}, false
+	}
+	// Trim only a trailing newline artifact from the formatter. A LEADING
+	// newline is preserved deliberately: CSS/JS formatters emit one when the
+	// body's first line has no meaningful content to attach to the opening
+	// delimiter (e.g. a bare CSS declaration list, vs. a JS body that opens
+	// with a user-written `{`), and strings.Split below turns that leading
+	// "\n" into an empty lines[0] — which embeddedAttrValueDoc then leaves
+	// attached to the opener, forcing the first real line onto its own break.
+	formatted = strings.TrimRight(formatted, "\n")
+	if !strings.Contains(formatted, "\n") {
+		// Formatter collapsed the body to one line — keep the inline form.
+		return pretty.Doc{}, false
+	}
+	braced := v.Braced || len(v.Stages) > 0
+	var opener strings.Builder
+	opener.WriteString(v.Name)
+	opener.WriteString("=")
+	if braced {
+		opener.WriteString("{")
+	}
+	opener.WriteString(embeddedLangName(v.Lang))
+	opener.WriteByte(delim)
+	var closer strings.Builder
+	closer.WriteByte(delim)
+	for _, s := range v.Stages {
+		closer.WriteString(" |> ")
+		closer.WriteString(pipeStageStr(s))
+	}
+	if braced {
+		closer.WriteString("}")
+	}
+	return embeddedAttrValueDoc(opener.String(), formatted, closer.String()), true
 }
 
 // writeEmbeddedLiteralText writes the literal text of an embedded (js/css/text)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -371,7 +371,15 @@ component C(id string) {
 	checkFormat(t, src, want)
 }
 
-func TestEmbeddedAttrMultilinePreservesBody(t *testing.T) {
+// A multi-line embedded-attribute body is now re-indented by the configured
+// JS formatter (Task 2: printer — format multi-line js`/css` attribute
+// values), superseding the pre-Task-2 verbatim-preservation behavior this
+// test used to pin. jsfmt treats `{ open: @{open} }` as a single flat
+// top-level block (no outer nesting), so it gets zero extra indent beyond
+// the attribute's own depth; the opening tag and children break in symmetry
+// per the existing ChildrenMultiline convention once the attribute value
+// forces a hard break.
+func TestEmbeddedAttrMultilineReindented(t *testing.T) {
 	src := `package p
 component C(open bool) {
 	<div x-data=js` + "`" + `
@@ -381,9 +389,12 @@ component C(open bool) {
 	want := `package p
 
 component C(open bool) {
-	<div x-data=js` + "`" + `
-		{ open: @{open} }
-	` + "`" + `>x</div>
+	<div
+		x-data=js` + "`" + `
+		{ open: @{open} }` + "`" + `
+	>
+		x
+	</div>
 }
 `
 	checkFormat(t, src, want)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -375,10 +375,13 @@ component C(id string) {
 // JS formatter (Task 2: printer — format multi-line js`/css` attribute
 // values), superseding the pre-Task-2 verbatim-preservation behavior this
 // test used to pin. jsfmt treats `{ open: @{open} }` as a single flat
-// top-level block (no outer nesting), so it gets zero extra indent beyond
-// the attribute's own depth; the opening tag and children break in symmetry
-// per the existing ChildrenMultiline convention once the attribute value
-// forces a hard break.
+// top-level block (no outer nesting), so it gets zero extra indent from
+// jsfmt itself — but the author wrote it on its own line (blank line before
+// `{`), which is exactly the block-layout signal (formatted body starts with
+// a newline): delimiters stand alone and the body is indented one level
+// under the attribute, same shape as the CSS declaration-list case. The
+// opening tag and children break in symmetry per the existing
+// ChildrenMultiline convention once the attribute value forces a hard break.
 func TestEmbeddedAttrMultilineReindented(t *testing.T) {
 	src := `package p
 component C(open bool) {
@@ -391,7 +394,8 @@ component C(open bool) {
 component C(open bool) {
 	<div
 		x-data=js` + "`" + `
-		{ open: @{open} }` + "`" + `
+			{ open: @{open} }
+		` + "`" + `
 	>
 		x
 	</div>

--- a/internal/printer/script_test.go
+++ b/internal/printer/script_test.go
@@ -88,3 +88,20 @@ func TestScriptIdempotent(t *testing.T) {
 		t.Fatalf("script fmt not idempotent:\n--- once ---\n%s\n--- twice ---\n%s", once, twice)
 	}
 }
+
+// A multi-line template literal inside a <script> body must be emitted verbatim
+// (interior not re-indented) and be idempotent.
+func TestScriptTemplateLiteralVerbatim(t *testing.T) {
+	src := "package p\n\ncomponent C() {\n\t<script>\nconst t = `<div>\nhi\n</div>`;\n</script>\n}\n"
+	out, err := normPrint(t, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "`<div>\nhi\n</div>`") {
+		t.Fatalf("script template-literal interior re-indented:\n%s", out)
+	}
+	twice, _ := normPrint(t, out)
+	if out != twice {
+		t.Fatalf("script not idempotent:\n--- once ---\n%s\n--- twice ---\n%s", out, twice)
+	}
+}

--- a/internal/rawfmt/rawfmt.go
+++ b/internal/rawfmt/rawfmt.go
@@ -56,6 +56,35 @@ func buildPlaceholdered(segments, holes []string) (text, prefix string) {
 // minifier options so wrappers (e.g. a prettier shell-out) drop in directly.
 type Formatter func(src []byte) ([]byte, error)
 
+// FormatString runs the placeholder → format → (escape) → restore pipeline and
+// returns the formatted source with holes restored, WITHOUT re-indenting into a
+// Doc (the caller shapes it). escape, if non-nil, is applied to the formatted
+// text BEFORE hole restoration — used to re-escape an embedded literal's
+// delimiter. Escaping the whole placeholdered string is safe: the hole sentinels
+// are collision-free identifiers containing no escapable character, so escaping
+// never corrupts one, and the restored holes are inserted afterward and stay
+// unescaped. ok=false on arity mismatch, formatter error/panic, or a hole-restore
+// mismatch (the caller falls back to verbatim).
+func FormatString(segments, holes []string, f Formatter, escape func(string) string) (string, bool) {
+	if len(segments) != len(holes)+1 {
+		return "", false
+	}
+	placeholdered, prefix := buildPlaceholdered(segments, holes)
+	formatted, err := safeFormat(f, placeholdered)
+	if err != nil {
+		return "", false
+	}
+	out := string(formatted)
+	if escape != nil {
+		out = escape(out)
+	}
+	restored, ok := restore(out, prefix, holes)
+	if !ok {
+		return "", false
+	}
+	return restored, true
+}
+
 // Format renders a raw-text element body. segments and holes interleave with
 // len(segments) == len(holes)+1; each holes[i] is the already-rendered gsx
 // source of an interpolation (e.g. "@{ fg }"). It returns (doc, true) on
@@ -67,15 +96,7 @@ type Formatter func(src []byte) ([]byte, error)
 // arity mismatch, Formatter error, recovered panic, or hole-restoration
 // mismatch. Format never itself fails fmt on parseable gsx.
 func Format(segments, holes []string, f Formatter) (pretty.Doc, bool) {
-	if len(segments) != len(holes)+1 {
-		return pretty.Doc{}, false
-	}
-	placeholdered, prefix := buildPlaceholdered(segments, holes)
-	formatted, err := safeFormat(f, placeholdered)
-	if err != nil {
-		return pretty.Doc{}, false
-	}
-	restored, ok := restore(string(formatted), prefix, holes)
+	restored, ok := FormatString(segments, holes, f, nil)
 	if !ok {
 		return pretty.Doc{}, false
 	}

--- a/internal/rawfmt/rawfmt.go
+++ b/internal/rawfmt/rawfmt.go
@@ -103,6 +103,103 @@ func Format(segments, holes []string, f Formatter) (pretty.Doc, bool) {
 	return reindent(restored), true
 }
 
+// LineFormatter formats a self-contained embedded-language source and returns the
+// re-indented LOGICAL lines: an Opaque token (template literal, block comment,
+// string) keeps its internal newlines WITHIN one line. ok=false on a lex error →
+// caller renders verbatim. Unlike Formatter (flat bytes), it carries the
+// logical-line structure the Doc builder needs to leave multi-line-token interiors
+// verbatim instead of re-indenting them.
+type LineFormatter func(src []byte) (lines []string, ok bool)
+
+// FormatStringLines runs placeholder → line-format → (escape per line) → restore
+// and returns the formatted LOGICAL lines with holes restored. escape (if
+// non-nil) is applied to each line BEFORE restoration; safe because hole sentinels
+// contain no escapable character and never span a line. ok=false on arity
+// mismatch, format failure, or a hole-restore mismatch.
+func FormatStringLines(segments, holes []string, lf LineFormatter, escape func(string) string) ([]string, bool) {
+	if len(segments) != len(holes)+1 {
+		return nil, false
+	}
+	placeholdered, prefix := buildPlaceholdered(segments, holes)
+	lines, ok := lf([]byte(placeholdered))
+	if !ok {
+		return nil, false
+	}
+	if escape != nil {
+		for i := range lines {
+			lines[i] = escape(lines[i])
+		}
+	}
+	return restoreLines(lines, prefix, holes)
+}
+
+// FormatLines renders a raw-text element body (<script>/<style>) from a
+// LineFormatter. Each logical line becomes HardLine+Text; a line's internal
+// newlines (Opaque content) are emitted verbatim by Text — no managed indent — so
+// template-literal / block-comment interiors survive re-indentation. ok=false →
+// caller renders verbatim.
+func FormatLines(segments, holes []string, lf LineFormatter) (pretty.Doc, bool) {
+	lines, ok := FormatStringLines(segments, holes, lf, nil)
+	if !ok {
+		return pretty.Doc{}, false
+	}
+	return reindentLines(lines), true
+}
+
+// reindentLines is reindent for LOGICAL lines. It trims leading/trailing blank
+// logical lines, then emits one HardLine+Text per line (blank → bare "\n").
+// TrimRight touches only each logical line's tail (its last physical line);
+// Opaque interior newlines and their whitespace are preserved. Wrapped in Indent
+// with a trailing HardLine, matching reindent's placement between the tags.
+func reindentLines(lines []string) pretty.Doc {
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return pretty.Text("")
+	}
+	parts := make([]pretty.Doc, 0, len(lines)*2+1)
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			parts = append(parts, pretty.Text("\n"))
+			continue
+		}
+		parts = append(parts, pretty.HardLine, pretty.Text(strings.TrimRight(ln, " \t")))
+	}
+	return pretty.Concat(pretty.Indent(pretty.Concat(parts...)), pretty.HardLine)
+}
+
+// restoreLines is restore for a slice of logical lines: each sentinel index must
+// appear EXACTLY once across all lines (a sentinel never spans a line boundary).
+// ok=false on any missing/duplicated sentinel or a stray prefix.
+func restoreLines(lines []string, prefix string, holes []string) ([]string, bool) {
+	for i := range holes {
+		tok := sentinel(prefix, i)
+		count := 0
+		for _, ln := range lines {
+			count += strings.Count(ln, tok)
+		}
+		if count != 1 {
+			return nil, false
+		}
+		for j := range lines {
+			if strings.Contains(lines[j], tok) {
+				lines[j] = strings.Replace(lines[j], tok, holes[i], 1)
+				break
+			}
+		}
+	}
+	for _, ln := range lines {
+		if strings.Contains(ln, prefix) {
+			return nil, false
+		}
+	}
+	return lines, true
+}
+
 // safeFormat calls f, converting a panic into an error so a buggy Formatter
 // (including a third-party plugin) degrades to verbatim instead of crashing fmt.
 func safeFormat(f Formatter, src string) (out []byte, err error) {

--- a/internal/rawfmt/rawfmt_test.go
+++ b/internal/rawfmt/rawfmt_test.go
@@ -3,6 +3,8 @@ package rawfmt
 import (
 	"strings"
 	"testing"
+
+	"github.com/gsxhq/gsx/internal/pretty"
 )
 
 func TestBuildPlaceholderedInterleaves(t *testing.T) {
@@ -123,5 +125,60 @@ func TestFormatStringArityMismatch(t *testing.T) {
 	id := func(src []byte) ([]byte, error) { return src, nil }
 	if _, ok := FormatString([]string{"a"}, []string{"@{x}"}, id, nil); ok {
 		t.Fatal("expected ok=false on arity mismatch")
+	}
+}
+
+func TestFormatStringLinesKeepsOpaqueInteriorAndHole(t *testing.T) {
+	// segments/holes whose body has a multi-line template literal AND a hole.
+	// The line formatter merges the backtick span into one logical line.
+	segs := []string{"a {\nhtml: `<div>\nhi\n</div>`,\nk: ", "\n}"}
+	holes := []string{"@{v}"}
+	idLines := func(src []byte) ([]string, bool) {
+		return mergeBacktick(strings.Split(string(src), "\n")), true
+	}
+	esc := func(s string) string { return s }
+	lines, ok := FormatStringLines(segs, holes, idLines, esc)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	joined := strings.Join(lines, "\x00")
+	if !strings.Contains(joined, "html: `<div>\nhi\n</div>`,") {
+		t.Fatalf("opaque interior not kept in one logical line: %q", lines)
+	}
+	if !strings.Contains(joined, "@{v}") || strings.Contains(joined, "__gsxhole") {
+		t.Fatalf("hole not restored / sentinel leaked: %q", lines)
+	}
+}
+
+// mergeBacktick merges physical lines so a `...` span spanning lines becomes one.
+func mergeBacktick(phys []string) []string {
+	var out []string
+	i := 0
+	for i < len(phys) {
+		line := phys[i]
+		for strings.Count(line, "`")%2 == 1 && i+1 < len(phys) {
+			i++
+			line += "\n" + phys[i]
+		}
+		out = append(out, line)
+		i++
+	}
+	return out
+}
+
+func TestFormatLinesDocLeavesInteriorVerbatim(t *testing.T) {
+	// One hole-free body whose single logical line carries an internal newline.
+	lf := func(src []byte) ([]string, bool) {
+		return mergeBacktick(strings.Split(string(src), "\n")), true
+	}
+	doc, ok := FormatLines([]string{"x `a\nb`"}, nil, lf)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	out := pretty.Print(doc, 80, pretty.DefaultTabWidth)
+	// The interior line "b" must NOT gain a leading tab (verbatim inside the
+	// template); the logical-line start "x `a" is indented by the engine.
+	if !strings.Contains(out, "a\nb`") {
+		t.Fatalf("interior re-indented (expected verbatim `a\\nb`): %q", out)
 	}
 }

--- a/internal/rawfmt/rawfmt_test.go
+++ b/internal/rawfmt/rawfmt_test.go
@@ -89,3 +89,39 @@ func TestBuildPlaceholderedAvoidsCollisionInHole(t *testing.T) {
 		t.Fatalf("hole not restored intact:\n%s", got)
 	}
 }
+
+func TestFormatStringEscapeBeforeRestore(t *testing.T) {
+	// identity formatter: returns input unchanged.
+	id := func(src []byte) ([]byte, error) { return src, nil }
+	// One hole between two segments; the segment text contains a `"` that the
+	// escaper must backslash — but the restored hole must NOT be escaped.
+	segments := []string{`say "hi" `, ` end`}
+	holes := []string{`@{name}`}
+	escape := func(s string) string { return strings.ReplaceAll(s, `"`, `\"`) }
+	got, ok := FormatString(segments, holes, id, escape)
+	if !ok {
+		t.Fatal("FormatString returned ok=false")
+	}
+	want := `say \"hi\" @{name} end`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "__gsxhole") {
+		t.Fatalf("sentinel leaked: %q", got)
+	}
+}
+
+func TestFormatStringNilEscapeMatchesRaw(t *testing.T) {
+	id := func(src []byte) ([]byte, error) { return src, nil }
+	got, ok := FormatString([]string{"a ", " b"}, []string{"@{x}"}, id, nil)
+	if !ok || got != "a @{x} b" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestFormatStringArityMismatch(t *testing.T) {
+	id := func(src []byte) ([]byte, error) { return src, nil }
+	if _, ok := FormatString([]string{"a"}, []string{"@{x}"}, id, nil); ok {
+		t.Fatal("expected ok=false on arity mismatch")
+	}
+}

--- a/internal/reindent/reindent.go
+++ b/internal/reindent/reindent.go
@@ -46,9 +46,27 @@ type Adapter interface {
 //
 // Blank lines (no content) emit just the newline — no tabs, no trailing space.
 func Reindent(src []byte, a Adapter) (string, bool) {
-	toks, ok := a.Tokenize(src)
+	lines, ok := ReindentLines(src, a)
 	if !ok {
 		return "", false
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// ReindentLines is Reindent returning the re-indented LOGICAL lines instead of a
+// joined string. An Opaque token's internal newlines stay WITHIN a line (they are
+// content, not line boundaries), so a returned element may itself contain '\n'.
+// A blank logical line is an empty string. Reindent(src, a) equals
+// strings.Join(ReindentLines(src, a), "\n").
+//
+// This split lets the outer Doc-building layer (rawfmt) place each logical line
+// at its depth WITHOUT re-indenting the interior physical lines of a multi-line
+// Opaque token (a template literal or block comment), which would corrupt the
+// token's value and break idempotence.
+func ReindentLines(src []byte, a Adapter) ([]string, bool) {
+	toks, ok := a.Tokenize(src)
+	if !ok {
+		return nil, false
 	}
 
 	// Split into logical lines on Newline tokens. Opaque tokens keep their
@@ -65,12 +83,9 @@ func Reindent(src []byte, a Adapter) (string, bool) {
 	}
 	lines = append(lines, cur)
 
-	var b strings.Builder
+	out := make([]string, 0, len(lines))
 	depth := 0
-	for li, line := range lines {
-		if li > 0 {
-			b.WriteByte('\n')
-		}
+	for _, line := range lines {
 		// Trim leading and trailing Space tokens.
 		start, end := 0, len(line)
 		for start < end && line[start].Class == Space {
@@ -81,12 +96,14 @@ func Reindent(src []byte, a Adapter) (string, bool) {
 		}
 		content := line[start:end]
 		if len(content) == 0 {
-			continue // blank line: newline only, no indent
+			out = append(out, "") // blank line: no indent
+			continue
 		}
 		indent := depth
 		if content[0].Class == Close && indent > 0 {
 			indent--
 		}
+		var b strings.Builder
 		for i := 0; i < indent; i++ {
 			b.WriteByte('\t')
 		}
@@ -104,6 +121,7 @@ func Reindent(src []byte, a Adapter) (string, bool) {
 		if depth < 0 {
 			depth = 0
 		}
+		out = append(out, b.String())
 	}
-	return b.String(), true
+	return out, true
 }

--- a/internal/reindent/reindent_test.go
+++ b/internal/reindent/reindent_test.go
@@ -111,3 +111,84 @@ func TestReindentLexFailureReportsFalse(t *testing.T) {
 		t.Fatal("expected ok=false on adapter lex failure")
 	}
 }
+
+// opaqueFake tokenizes like fake but treats a backtick-delimited run (which may
+// span newlines) as a single Opaque token whose internal newlines are content.
+type opaqueFake struct{}
+
+func (opaqueFake) Tokenize(src []byte) ([]Token, bool) {
+	s := string(src)
+	var toks []Token
+	i := 0
+	for i < len(s) {
+		switch c := s[i]; c {
+		case '`':
+			j := i + 1
+			for j < len(s) && s[j] != '`' {
+				j++
+			}
+			if j < len(s) {
+				j++ // include closing backtick
+			}
+			toks = append(toks, Token{Opaque, s[i:j]})
+			i = j
+		case '\n':
+			toks = append(toks, Token{Newline, "\n"})
+			i++
+		case ' ', '\t':
+			j := i
+			for j < len(s) && (s[j] == ' ' || s[j] == '\t') {
+				j++
+			}
+			toks = append(toks, Token{Space, s[i:j]})
+			i = j
+		case '{':
+			toks = append(toks, Token{Open, "{"})
+			i++
+		case '}':
+			toks = append(toks, Token{Close, "}"})
+			i++
+		default:
+			j := i
+			for j < len(s) && s[j] != '\n' && s[j] != ' ' && s[j] != '\t' && s[j] != '{' && s[j] != '}' && s[j] != '`' {
+				j++
+			}
+			toks = append(toks, Token{Other, s[i:j]})
+			i = j
+		}
+	}
+	return toks, true
+}
+
+func TestReindentLinesOpaqueInteriorStaysOneLine(t *testing.T) {
+	// A backtick literal spanning 3 physical lines inside a braced block.
+	in := "{\nx `a\nb\nc`\n}\n"
+	lines, ok := ReindentLines([]byte(in), opaqueFake{})
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	// Logical lines: "{", "\tx `a\nb\nc`", "}", "" — the opaque token keeps its
+	// internal newlines within ONE logical line (indented only at its start).
+	want := []string{"{", "\tx `a\nb\nc`", "}", ""}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines %q, want %d %q", len(lines), lines, len(want), want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Fatalf("line %d: got %q want %q (all: %q)", i, lines[i], want[i], lines)
+		}
+	}
+}
+
+func TestReindentLinesJoinEqualsReindent(t *testing.T) {
+	for _, in := range []string{"{\nx `a\nb`\n}\n", "a\n{\nb\n}\n", "{\n}\n"} {
+		lines, ok := ReindentLines([]byte(in), opaqueFake{})
+		if !ok {
+			t.Fatalf("%q: ok=false", in)
+		}
+		flat, _ := Reindent([]byte(in), opaqueFake{})
+		if strings.Join(lines, "\n") != flat {
+			t.Fatalf("%q: join(lines)=%q != Reindent=%q", in, strings.Join(lines, "\n"), flat)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two related pieces for `gsx fmt`:

### 1. Format `js`…``/`css`…`` **attribute-value** literals
`gsx fmt` now re-indents a multi-line embedded-literal attribute value's body, the way it already does `<script>`/`<style>` element bodies. Two layouts, chosen by the body's own structure:
- **Inline** (content-adjacent, e.g. `x-data=js"{ … }"`) — the opening `{` attaches to the `js"` line, body nested by the object braces, closing `}"` on its own line.
- **Block** (body on its own lines, e.g. `style=css`\n…\n``) — delimiters stand alone, body indented one level under the attribute (like a `<style>` body).

Plain `"…"` string attributes and `f`…`` literals stay **verbatim** (opaque). Single-line embedded literals stay inline. No new config knob — on whenever the built-in formatters are active.

### 2. Preserve multi-line-token interiors (correctness fix)
Re-indenting a JS/CSS body that contains a **multi-line token** (template literal `` `<div>\n…</div>` ``, block comment `/* …\n… */`) previously injected indentation into the token's interior — corrupting the shipped JS string and breaking idempotence. This was a **pre-existing** bug in the `<script>`/`<style>` body path and it also affected the new attribute path.

Root cause: the core `internal/reindent` correctly keeps an Opaque token's internal newlines as *content within one logical line*, but the outer Doc-building layer split the formatted body on **every** physical `\n` and added managed indent to each. Fix: thread **logical lines** from the tokenizer to the Doc builder (`reindent.ReindentLines` → `jsfmt`/`cssfmt.FormatLines` → `rawfmt.LineFormatter`/`FormatLines`/`FormatStringLines` → `printer`). A logical line's internal newlines are emitted as one `pretty.Text` — verbatim, no managed indent — while a `HardLine` precedes only the logical-line start. Fixes **both** surfaces uniformly.

External custom flat formatters (`gen.WithCSSFormatter`/`WithJSFormatter`) keep prior behavior — they carry no token structure (tracked in ROADMAP).

## Testing
- New `internal/gsxfmt` corpus cases pin the layout AND (via the harness) **idempotence + reparse**: js/css attr multi-line, hole, single-line-inline, and multi-line-token interiors for all four surfaces (`embed_attr_*`, `embed_body_*`).
- Printer/reindent/jsfmt/cssfmt/rawfmt unit tests, including template-literal-verbatim + idempotence on both surfaces.
- `make check` clean (both modules, examples drift, gofmt + gsx fmt, golangci-lint).
- Independent adversarial review (probe-based): Ready to merge.

## Notes
- Sibling: tree-sitter multi-line double-quoted attribute value fix — gsxhq/tree-sitter-gsx#7.
- Follow-ups captured in `docs/ROADMAP.md` (external-formatter interior fix; dead `Stages` branch).

https://claude.ai/code/session_017vX3ysmU4SWSqk7GXp3SEp