### PR TITLE
fix(fmt): multi-statement {{ }} Go blocks break to block style

### DIFF
--- a/internal/gsxfmt/testdata/cases/goblock-literal.txtar
+++ b/internal/gsxfmt/testdata/cases/goblock-literal.txtar
@@ -1,11 +1,12 @@
-A multi-line `{{ }}` block whose statements embed a js` literal. The block is
+A multi-statement `{{ }}` block whose statements embed a js` literal. The block is
 not, on its own, parseable Go (a js` literal is not a Go token), so the plain
 statement path relays it verbatim and never normalizes the author's ragged
 indent. The literal-aware path splits the block, formats it through gofmt behind
 one placeholder per literal, and splices the literals back — hole expression
-reformatted (`@{detail}`), literal text/prefix/delimiter intact. gofmt owns the
-statement layout: the composite fields land one tab in, the trailing `}` and the
-following assignment return to the block's base column.
+reformatted (`@{detail}`), literal text/prefix/delimiter intact. A multi-statement
+block breaks: `{{` alone on its line, the statements one level deeper (gofmt owns
+their internal layout — the composite fields another tab in), `}}` alone at the
+block's column.
 
 -- input.gsx --
 package ui
@@ -23,9 +24,11 @@ component Page(detail string) {
 package ui
 
 component Page(detail string) {
-	{{ containerAttrs := gsx.Attrs{
-		{Key: "@suggest-datetime.window", Value: js`suggest(@{detail})`},
-	}
-	_ = containerAttrs }}
+	{{
+		containerAttrs := gsx.Attrs{
+			{Key: "@suggest-datetime.window", Value: js`suggest(@{detail})`},
+		}
+		_ = containerAttrs
+	}}
 	<div { containerAttrs... }>x</div>
 }

--- a/internal/gsxfmt/testdata/cases/goblock_multiline_block.txtar
+++ b/internal/gsxfmt/testdata/cases/goblock_multiline_block.txtar
@@ -1,0 +1,26 @@
+A multi-statement `{{ }}` block breaks: `{{` alone on its line, every statement
+indented one level deeper, `}}` alone on its own line at the block's column.
+Applies regardless of how the author wrote it (ragged / one-line-with-semicolons).
+
+-- input.gsx --
+package p
+
+component C() {
+	{{
+	x := 1
+	y := x + 2
+	_ = y
+	}}
+	<div>{ x }</div>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	{{
+		x := 1
+		y := x + 2
+		_ = y
+	}}
+	<div>{ x }</div>
+}

--- a/internal/gsxfmt/testdata/cases/goblock_multiline_semicolons.txtar
+++ b/internal/gsxfmt/testdata/cases/goblock_multiline_semicolons.txtar
@@ -1,0 +1,22 @@
+A `{{ }}` block the author wrote as a single line with semicolon-separated
+statements still breaks to block style: gofmt splits the statements onto their
+own lines, so the block is multi-statement and lays out `{{` / body+1 / `}}`.
+
+-- input.gsx --
+package p
+
+component C() {
+	{{ x := 1; y := x + 2; _ = y }}
+	<div>{ x }</div>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	{{
+		x := 1
+		y := x + 2
+		_ = y
+	}}
+	<div>{ x }</div>
+}

--- a/internal/gsxfmt/testdata/cases/goblock_single_inline.txtar
+++ b/internal/gsxfmt/testdata/cases/goblock_single_inline.txtar
@@ -1,0 +1,16 @@
+A single-statement `{{ }}` block stays inline: `{{ stmt }}`.
+
+-- input.gsx --
+package p
+
+component C() {
+	{{ x := 1 }}
+	<div>{ x }</div>
+}
+-- fmt.golden --
+package p
+
+component C() {
+	{{ x := 1 }}
+	<div>{ x }</div>
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -770,25 +770,48 @@ func pipeStageStr(s ast.PipeStage) string {
 }
 
 func (p *printer) goBlock(b *ast.GoBlock) pretty.Doc {
-	body := p.goBlockBody(b.Code)
-	return pretty.Concat(pretty.Text("{{ "), body, pretty.Text(" }}"))
+	s := p.goBlockCode(b.Code)
+	// A single-statement block stays inline: `{{ stmt }}`.
+	if !strings.Contains(s, "\n") {
+		return pretty.Concat(pretty.Text("{{ "), pretty.Text(s), pretty.Text(" }}"))
+	}
+	// A multi-statement block breaks like a Go block body: `{{` alone on its line,
+	// the statements indented one level deeper, `}}` alone on its own line at the
+	// block's column. Raw-string interior newlines stay embedded in their segment.
+	segs := splitOutsideRawStrings(s)
+	inner := make([]pretty.Doc, 0, len(segs)*2)
+	for _, seg := range segs {
+		if strings.TrimSpace(seg) == "" {
+			// A blank line between statements: a bare newline, no managed indent
+			// (so it never carries trailing tabs — idempotence).
+			inner = append(inner, pretty.Text("\n"))
+			continue
+		}
+		inner = append(inner, pretty.HardLine, pretty.Text(strings.TrimRight(seg, " \t")))
+	}
+	return pretty.Concat(
+		pretty.Text("{{"),
+		pretty.Indent(pretty.Concat(inner...)),
+		pretty.BreakParent,
+		pretty.HardLine, pretty.Text("}}"),
+	)
 }
 
-// goBlockBody lays out the statements of a `{{ }}` block. A block carrying an
-// embedded f`/js`/css` literal is not, on its own, parseable Go — fmtStmts'
-// go/format call rejects it and relays the raw text verbatim, so the block's
-// indentation is never normalized. goBlockBody restores parseability with the
-// same placeholder round-trip fmtGoExprParts uses (formatGoParts), so gofmt lays
-// the statements out and the literals splice back in, hole expressions
+// goBlockCode returns the canonical statement text of a `{{ }}` block. A block
+// carrying an embedded f`/js`/css` literal is not, on its own, parseable Go —
+// fmtStmts' go/format call rejects it and relays the raw text verbatim, so the
+// block's indentation is never normalized. goBlockCode restores parseability with
+// the same placeholder round-trip fmtGoExprParts uses (formatGoParts), so gofmt
+// lays the statements out and the literals splice back in, hole expressions
 // reformatted. A block with no embedded literal (fmtGoBlockCode finds no value
 // part, or the literal split fails) falls back to the plain fmtStmts path. Both
-// paths yield a canonical body string fed through multiline, which lays its
-// newlines out at the block's current indent.
-func (p *printer) goBlockBody(code string) pretty.Doc {
+// paths yield a canonical body string that goBlock lays out at the block's
+// indent (inline for a single statement, one level deeper for several).
+func (p *printer) goBlockCode(code string) string {
 	if s, ok := p.fmtGoBlockCode(code); ok {
-		return multiline(s)
+		return s
 	}
-	return multiline(fmtStmts(code))
+	return fmtStmts(code)
 }
 
 // goBlockWrapperPrefix/Suffix wrap a GoBlock's statements in a synthetic


### PR DESCRIPTION
## What

`gsx fmt` now breaks a multi-statement `{{ }}` Go block onto multiple lines:

```gsx
{{
	x := 1
	y := x + 2
	_ = y
}}
```

`{{` alone on its line, the statements indented one level deeper, `}}` alone at the block's column — matching how a Go block body reads. Single-statement blocks stay inline (`{{ stmt }}`).

The break is driven purely by whether the canonical statement text (gofmt/literal-aware round-trip) is multi-line, so it covers ragged multi-line input **and** one-line semicolon-separated input alike (gofmt splits the latter onto separate lines first).

## How

- `goBlockBody` → `goBlockCode`: returns the canonical statement *string* instead of a `pretty.Doc`.
- `goBlock`: inline for single-statement; for multi-statement, lays segments out via `HardLine` + `Indent` (raw-string interior newlines stay embedded in their segment; blank lines emit a bare newline so no trailing tabs → idempotent).

## Tests

New fmt-corpus cases (`internal/gsxfmt/testdata/cases/`):
- `goblock_single_inline` — single statement stays inline
- `goblock_multiline_block` — ragged multi-statement → block style
- `goblock_multiline_semicolons` — one-line `;`-separated → block style
- `goblock-literal` golden re-based to block style

`make check` passes. Validated on one-learning-gsx (`gsx fmt -w ui/`): 46 files reformatted, `gsx fmt -l` idempotent-clean. Formatter-only change — no codegen/semantic-corpus drift.

https://claude.ai/code/session_017vX3ysmU4SWSqk7GXp3SEp