### PR TITLE
perf(runtime): skip the escape pass on bool and numeric writes

### DIFF
--- a/internal/codegen/emit.go
+++ b/internal/codegen/emit.go
@@ -2468,7 +2468,10 @@ func emitRender(b *bytes.Buffer, expr string, t types.Type, rt rtImports, n ast.
 	case catFloat:
 		fmt.Fprintf(b, "\t\t_gsxgw.FloatInto(_gsxnum[:], float64(%s))\n", expr)
 	case catBool:
-		fmt.Fprintf(b, "\t\t_gsxgw.Text(%s.FormatBool(bool(%s)))\n", rt.sc(), expr)
+		// S, not Text: FormatBool yields only "true"/"false", neither of which
+		// carries a byte htmlReplacer rewrites, so escaping is a no-op on every
+		// possible value (same reasoning as the IntInto/FloatInto arms above).
+		fmt.Fprintf(b, "\t\t_gsxgw.S(%s.FormatBool(bool(%s)))\n", rt.sc(), expr)
 	case catStringer:
 		fmt.Fprintf(b, "\t\t_gsxgw.Text((%s).String())\n", expr)
 	case catNode:

--- a/internal/corpus/testdata/cases/imports/shadow_strconv.txtar
+++ b/internal/corpus/testdata/cases/imports/shadow_strconv.txtar
@@ -41,7 +41,7 @@ func Uses(_gsxp UsesProps) _gsxrt.Node {
 //line input.gsx:6:2
 		_gsxgw.S("<b>")
 //line input.gsx:6:5
-		_gsxgw.Text(_gsxsc.FormatBool(bool(b)))
+		_gsxgw.S(_gsxsc.FormatBool(bool(b)))
 //line input.gsx:6:10
 		_gsxgw.Text(string(strconv))
 		_gsxgw.S("</b>")

--- a/internal/corpus/testdata/cases/pipelines/default_generic.txtar
+++ b/internal/corpus/testdata/cases/pipelines/default_generic.txtar
@@ -42,7 +42,7 @@ func Summary(_gsxp SummaryProps) _gsxrt.Node {
 		_gsxgw.IntInto(_gsxnum[:], int64(_gsxstd.Default((count), 12)))
 		_gsxgw.S("|")
 //line input.gsx:4:30
-		_gsxgw.Text(_gsxsc.FormatBool(bool(_gsxstd.Default((enabled), true))))
+		_gsxgw.S(_gsxsc.FormatBool(bool(_gsxstd.Default((enabled), true))))
 		_gsxgw.S("|")
 //line input.gsx:4:59
 		_gsxgw.Text(string(_gsxstd.Default((title), "Untitled")))

--- a/val.go
+++ b/val.go
@@ -45,34 +45,40 @@ func (n valNode) Render(ctx context.Context, w io.Writer) error {
 		gw.Text(string(t))
 	case fmt.Stringer:
 		gw.Text(t.String())
+	// The bool and numeric kinds below write via gw.S, not gw.Text: strconv's
+	// output charset here (decimal digits, '-', '+', '.', 'e', and the Inf/NaN
+	// and true/false letters) contains no byte htmlReplacer rewrites, so the
+	// escape pass is a no-op on every possible value and the emitted bytes are
+	// identical either way. This mirrors the same reasoning IntInto/FloatInto
+	// document. Do NOT extend gw.S to the string/[]byte/Stringer cases above —
+	// those carry arbitrary author content and must escape.
 	case bool:
-		// gw.Text mirrors emitRender: catBool uses _gsxgw.Text(strconv.FormatBool(...)).
-		gw.Text(strconv.FormatBool(t))
+		gw.S(strconv.FormatBool(t))
 	case int:
-		gw.Text(strconv.FormatInt(int64(t), 10))
+		gw.S(strconv.FormatInt(int64(t), 10))
 	case int8:
-		gw.Text(strconv.FormatInt(int64(t), 10))
+		gw.S(strconv.FormatInt(int64(t), 10))
 	case int16:
-		gw.Text(strconv.FormatInt(int64(t), 10))
+		gw.S(strconv.FormatInt(int64(t), 10))
 	case int32:
-		gw.Text(strconv.FormatInt(int64(t), 10))
+		gw.S(strconv.FormatInt(int64(t), 10))
 	case int64:
-		gw.Text(strconv.FormatInt(t, 10))
+		gw.S(strconv.FormatInt(t, 10))
 	case uint:
-		gw.Text(strconv.FormatUint(uint64(t), 10))
+		gw.S(strconv.FormatUint(uint64(t), 10))
 	case uint8:
-		gw.Text(strconv.FormatUint(uint64(t), 10))
+		gw.S(strconv.FormatUint(uint64(t), 10))
 	case uint16:
-		gw.Text(strconv.FormatUint(uint64(t), 10))
+		gw.S(strconv.FormatUint(uint64(t), 10))
 	case uint32:
-		gw.Text(strconv.FormatUint(uint64(t), 10))
+		gw.S(strconv.FormatUint(uint64(t), 10))
 	case uint64:
-		gw.Text(strconv.FormatUint(t, 10))
+		gw.S(strconv.FormatUint(t, 10))
 	case float32:
 		// emitRender always uses bitsize 64: FormatFloat(float64(x), 'g', -1, 64).
-		gw.Text(strconv.FormatFloat(float64(t), 'g', -1, 64))
+		gw.S(strconv.FormatFloat(float64(t), 'g', -1, 64))
 	case float64:
-		gw.Text(strconv.FormatFloat(t, 'g', -1, 64))
+		gw.S(strconv.FormatFloat(t, 'g', -1, 64))
 	default:
 		return fmt.Errorf("gsx.Val: value of type %T is not renderable in a gsx.Node prop", n.v)
 	}


### PR DESCRIPTION
`gsx.Val` and `emitRender`'s `catBool` arm wrote bools and numbers through `gw.Text`, paying a `strings.Replacer` scan that can never match. strconv's output for those kinds contains no byte `htmlReplacer` rewrites — decimal digits, `-`, `+`, `.`, `e`, and the Inf/NaN and true/false letters — so the escape is a no-op on **every possible value**. They now write via `gw.S`.

This is the reasoning `gw.IntInto`/`FloatInto` already document in their own doc comments; these two call sites just weren't taking advantage of it.

## Output is unchanged

Regenerating the entire corpus moves **two `.x.go` goldens** (the emitted call) and **zero `render.golden`**. That's the property that makes this safe — the emitted call changed, not a single rendered byte.

## Measurements

M3 Ultra, `io.Discard`:

| case | before | after |
|---|---|---|
| bool | 7.59 ns, 0 alloc | **3.24 ns, 0 alloc** |
| int 42 | 6.98 ns, 0 alloc | **3.79 ns, 0 alloc** |
| int 1234567890123 | 27.2 ns, 1 alloc/16 B | **21.7 ns, 1 alloc/16 B** |
| float 3.14159 | 47.9 ns, 1 alloc/8 B | **37.9 ns, 1 alloc/8 B** |

## Why not IntInto

Measured and rejected for `gsx.Val`. `IntInto` exists to amortize one scratch buffer across many numbers in a render — the generated-code shape, where `_gsxnum` is declared once per render function and it genuinely wins (a 6-number loop: 100.2 ns/3 allocs via `Text` vs 63.7 ns/1 alloc via `IntInto`). But `Val` renders one value per call, so the buffer never amortizes, and it forfeits `strconv.FormatInt`'s zero-alloc small-integer cache: **15.48 ns and +1 alloc** for `int 42`, against 6.98 ns and zero allocs today. A 2.2× regression on the common case.

## Scope

`string`/`[]byte`/`Stringer` stay on `gw.Text` — arbitrary author content, must escape. `holeStringExpr`'s `Format*` sites also stay: their result is concatenated into a value that gets escaped as a whole, so the escape isn't a no-op there.

The coalescer is unaffected — it only merges `S("<literal>")` and explicitly breaks a run on a non-literal arg, exactly as it already did for `Text(...)`.

`make ci` and `make lint` both pass clean.

https://claude.ai/code/session_01USSEvedSyjrgFaCsqTMKGz