### PR TITLE
docs(spec): boolean attribute semantics — WHATWG-driven default + gsx.Toggle override

### DIFF
--- a/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
@@ -1,0 +1,509 @@
+# Boolean Attribute Semantics — Design
+
+Status: **draft, awaiting review**
+Supersedes: `2026-06-18-gsx-templating-design.md` §"Boolean attributes are type-driven"
+Evidence: `internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar`
+
+## Problem
+
+gsx decides presence-vs-value from the **Go type**: a `bool`-typed
+`name={ expr }` becomes a boolean attribute (bare when true, omitted when
+false). The 2026-06-18 spec rejected templ's `?=` on that basis — "gsx knows
+the value's type at compile time, so it emits boolean-attr code directly".
+
+The premise is wrong. The type answers *what value the author has*; it cannot
+answer *whether HTML wants presence or a string*. Only the attribute **name**
+answers that, and HTML has two classes with **opposite** requirements:
+
+- **Boolean attributes** (`required`, `checked`, `disabled`, …) — presence
+  alone means true and the **value is ignored**. `required="false"` is
+  required. Only **absence** is false, so no string can express false.
+- **Enumerated attributes** (`aria-*`, `contenteditable`, `draggable`,
+  `spellcheck`, and every `data-*`) — the **string is** the value. `="true"` /
+  `="false"` are the required forms; a bare name yields `=""`, which is not a
+  valid token and falls back to the default.
+
+One Go `bool`, two opposite correct renderings. gsx applies presence to both
+and is right for exactly one class:
+
+| source | renders | |
+| --- | --- | --- |
+| `<input required={false}/>` — static `bool` | `<input/>` | correct |
+| `<Mixed[bool] req={false}/>` — `T string \| bool` | `required="false"` | **required** |
+| bag `{required: Flag(false)}` — named bool | `required="false"` | **required** |
+| bag `{required: anyFalse}` — `var anyFalse any = false` | `<input/>` | correct |
+| `<div aria-hidden={true}/>` | `<div aria-hidden/>` | `=""` invalid → **not hidden** |
+| `<div aria-hidden={strconv.FormatBool(h)}/>` | `aria-hidden="true"` | correct |
+| `<div contenteditable={false}/>` | `<div/>` | **inverted** — inherits editable |
+| `<img draggable={false}/>` | `<img/>` | **inverted** — still draggable |
+
+`contenteditable` and `draggable` are inherited-or-default-on: `="false"` is
+what *blocks* editing inside an editable ancestor and what *stops* an image
+dragging. Omitting them means the author writes `false` and the browser does
+`true`.
+
+Two further defects share one root cause:
+
+1. **Type-parameter divergence.** `classify(t) == catBool` gates the `BoolAttr`
+   emit, so a `T string | bool` type parameter classifies as `catAnyMixed` and
+   falls to `AttrAny` → `required="false"`.
+2. **Named-bool bag divergence.** `attrs.go` asserts `kv.Value.(bool)` — an
+   *exact* type assertion — so a `type Flag bool` falls to `toStr` → `"false"`.
+
+**Root cause: EXACT vs UNDERLYING dispatch, not type erasure.** The control row
+above proves it — a plain `bool` boxed in an `any` renders *correctly*, because
+the assertion sees the dynamic type. gsx runs two classifiers that disagree:
+
+```
+static  (codegen)  classify(t) → t.Underlying() via go/types  →  Flag → catBool ✓
+runtime (writer)   anyRenderString / kv.Value.(bool)          →  EXACT types only ✗
+```
+
+Only a **named** bool and a **type parameter** fall through. This is `gsx.Val`'s
+documented contract, mirrored deliberately by `anyRenderString`.
+
+## Goals
+
+- **Correctness is the default.** Standard HTML renders correctly with no
+  annotation.
+- Both attribute classes expressible; either direction forceable.
+- Static and dynamic (bag) paths agree by construction, for every type.
+- No project-wide invisible state.
+
+## Non-goals
+
+- Configuration. See §Rejected alternatives.
+- Truthiness. Unlike Lit, `?=` takes a `bool`, not "any value, evaluated for
+  truthiness".
+- Knowing which attributes are *enumerated*. Only the boolean list exists;
+  everything not in it stringifies, which is correct for enumerated attributes
+  and for arbitrary `data-*`.
+- Changing spread syntax or the `{ if cond { attr } }` in-tag conditional form.
+
+## Surface syntax
+
+```
+name?={ expr }    → toggle, any name (expr must be bool-typed)
+name={ boolExpr } → name in the boolean list ? toggle : "true"/"false"
+name={ strExpr }  → always the string
+name              → bare; toggle
+```
+
+```go
+<input required={ p.Req } />          // list name → <input required> / <input>
+<div aria-expanded={ p.Open } />      // not listed → aria-expanded="false"
+<img draggable={ false } />           // → draggable="false"
+<my-toggle active?={ p.On } />        // custom element → forced toggle
+```
+
+### Forcing either direction
+
+Both overrides already exist; only one is new syntax. **The list is consulted
+only for bool-typed values**, which is what makes the second row work — a string
+never reaches the list lookup.
+
+| want | write | works because |
+| --- | --- | --- |
+| toggle on a non-list name | `active?={ b }` | `?=` forces it |
+| string on a list name | `required={ strconv.FormatBool(b) }` | the value isn't bool |
+
+This also handles HTML's hybrid attributes for free: `hidden={ true }` → bare
+`hidden`, `hidden={ "until-found" }` → `hidden="until-found"`; `download={ true }`
+→ bare `download`, `download={ "a.txt" }` → `download="a.txt"`.
+
+### Grammar — no reservation required
+
+`isAttrNameByte` (`parser/markup.go`) admits `A-Za-z0-9_:@.-` only; `?` has
+**never** been legal in a source attribute name, so `?=` is unambiguous and
+claims no namespace. tree-sitter's `attribute_name`
+(`/[A-Za-z_@:][A-Za-z0-9_@:.\-]*/`) already agrees.
+
+`validAttrName` (`attrs.go`) *does* admit `?`, but it governs **runtime bag
+keys**, not source. `Toggle` places the marker in the value and leaves the key
+untouched (§Runtime), so the key namespace is not claimed either.
+`validAttrName` is unchanged.
+
+Binding rule: `?` must **immediately** follow the name, after which the existing
+whitespace-tolerant `=` lookahead applies unchanged.
+
+```
+required?={b}   ok        required? = {b}   ok  (existing '=' ws tolerance)
+required?= {b}  ok        required ?={b}    error — '?' must abut the name
+required?       error     — "'?' requires a value; did you mean bare `required`?"
+```
+
+### AST
+
+Add `Toggle bool` to `ast.ExprAttr` rather than a new node type. Attributes are
+consumed at many codegen/LSP/fmt sites; a flag on the existing node keeps every
+one working and follows the `Element.IsComponent` stamp precedent. The formatter
+reads it to re-emit `?=`.
+
+## The boolean-attribute list
+
+**Semantic, not advisory** — it decides. That is safe *because* `?=` exists: a
+list gap is recoverable at the call site (`newattr?={b}`) without waiting for a
+gsx release, so an incomplete list is never a dead end.
+
+### Derivation
+
+Ported from the WHATWG **index of attributes**, taking every entry whose type is
+"Boolean attribute". Do not hand-write it from memory. Approximate size ~30:
+`allowfullscreen`, `async`, `autofocus`, `autoplay`, `checked`, `controls`,
+`default`, `defer`, `disabled`, `download`, `formnovalidate`, `inert`, `ismap`,
+`itemscope`, `loop`, `multiple`, `muted`, `nomodule`, `novalidate`, `open`,
+`playsinline`, `readonly`, `required`, `reversed`, `selected`, …
+
+**Verify during implementation; do not trust the list above.** Two known traps:
+
+- **`hidden`** is *enumerated* in current HTML (`until-found` / `hidden` / `""`),
+  not boolean — but the empty string maps to the hidden state, so listing it
+  still behaves correctly for bool values (§Forcing either direction). Decide
+  deliberately and record why.
+- **`contenteditable`, `draggable`, `spellcheck`** look boolean and are **not** —
+  they are enumerated. They must NOT be listed; listing them reproduces the
+  inverted rows in §Problem.
+
+Record the spec URL and a refresh policy beside the list.
+
+### Where it lives
+
+Codegen owns it, exactly as it owns `navNames`/`imageNames`/`srcsetNames`, and
+threads it into `Spread` as a `[]string` literal. One source of truth, consulted
+by both the static and dynamic paths.
+
+## Runtime: `gsx.Toggle`
+
+```go
+// Toggle marks a bag value as carrying boolean-attribute (presence) semantics
+// regardless of the attribute name: Spread writes a bare ` name` when true and
+// nothing when false. It is the runtime carrier of the `?=` declaration, needed
+// only for names outside the boolean-attribute list — a plain bool on a listed
+// name already toggles.
+type Toggle bool
+```
+
+A named `bool` type, so `Toggle(expr)` is a conversion; boxing a bool into `any`
+does not allocate (runtime `staticuint64s`).
+
+### `AttrAnyToggle`
+
+```go
+// AttrAnyToggle writes one complete attribute whose name IS a boolean attribute
+// (codegen resolved the list at generate time) but whose value type is only known
+// at runtime. A bool-kinded value writes presence — ` name` or nothing — and any
+// other value writes ` name="escaped"`. Generated code emits it for a catAnyMixed
+// value on a listed name, so `<input required={req}/>` with T = string | bool is
+// correct at both instantiations.
+func (gw *Writer) AttrAnyToggle(name string, v any)
+```
+
+It owns the whole span — the leading space, the name, and the optional `="…"` —
+which is what lets it omit a name that codegen would otherwise have baked into a
+static string.
+
+### `Spread`
+
+`Spread` grows a `boolNames []string` parameter beside the existing name sets,
+preserving the property that policy comes from the caller.
+
+| bag value, key `required` | renders |
+| --- | --- |
+| `Toggle(true)` / `Toggle(false)` | ` required` / *(omitted)* |
+| `false` — plain bool, listed name | *(omitted)* — **unchanged from today** |
+| `Flag(false)` — named bool, listed name | *(omitted)* — divergence fixed |
+| `"false"` — string | `required="false"` |
+| `false` — plain bool, key `data-open` | `data-open="false"` — the fix |
+
+**Placement.** `Toggle` is checked after the force-owned `excluded` skip but
+**before** the `imageNames`/`srcsetNames`/`navNames` switch. The rule: `Toggle`
+declares the attribute has no value, and an attribute with no value cannot carry
+a URL, so the URL sinks are not skipped but *inapplicable*. Checking it in
+`default` would route `Toggle(true)` on `href` to `URLVal` → `href="true"`,
+fabricating a value declared absent.
+
+The plain-bool list lookup lives in the `default` branch (no listed name is also
+a URL name, so it cannot reach the sinks).
+
+The key is never modified, so last-wins dedup, `Get`/`Has`, class-merge and
+caller-wins precedence keep working: `required?={true}` overrides an earlier
+`required={false}` because both are key `"required"`.
+
+### Prerequisite: unify the dispatch tables
+
+`Flag(false)` on a listed name only reaches the list lookup if the runtime can
+see "underlying bool". Today four tables disagree — proven:
+
+```
+uintptr     Val="ERR"     anyRenderString="5"     toStr="5"     ← Val is the outlier
+[]string    Val="ERR"     anyRenderString="ERR"   toStr="a b"   ← toStr is the outlier
+```
+
+| table | dispatch | quirk |
+| --- | --- | --- |
+| `classify` (codegen) | **underlying**, via go/types | correct for named types |
+| `anyRenderString` | exact | has `uintptr`, no `[]string` |
+| `valNode.Render` | exact | **no `uintptr`**, has `Node`/`[]Node` |
+| `toStr` | exact | has `[]string`, numerics via `fmt.Sprint` |
+
+`val.go` claims parity with the inline path ("gw.Text mirrors emitRender") but
+inline `{ x }` with a `uintptr` renders `"5"` while `gsx.Val(x)` errors — the
+documented invariant is already broken.
+
+Unify onto one runtime table **before** this work, as its own PR. It is
+independently valuable, it shrinks this change to a single recognition site
+rather than a fifth table, and it has an obvious differential test: for every
+value, `classify` / `Val` / `anyRenderString` / `toStr` must agree.
+
+**A string return is not sufficient.** Three consumers now need the *kind*, not
+just the text — `AttrAnyToggle` and `Spread` must know "is this bool-kinded" to
+choose presence, and `Val` must know "is this escape-free" to keep PR #122's
+`gw.S` win rather than routing numerics back through the escape pass. So the
+table returns a kind alongside the string:
+
+```go
+func anyRenderVal(v any) (s string, k valKind, ok bool)   // kindString, kindBool, kindNumber, …
+```
+
+One table, four consumers: `Val` (kind → `S` vs `Text`), `TextAny`/`AttrAny`,
+`AttrAnyToggle` (kindBool → presence), `Spread` (kindBool + listed name →
+presence). `toStr` takes the string and ignores the kind.
+
+**Matching must be by underlying type**, or `Flag(false)` never reaches the list
+lookup at all. Per the repo's correctness-first/optimize-simple rule, the general
+path is the default and the fast path must be proven equivalent to it: a
+`reflect.Kind` classification is the correct general behaviour, with the existing
+exact-type switch retained **as a fast path** for the predeclared types, and a
+differential test asserting the two agree on every case. Reflect is then only
+reached on the miss path — named types — so `bool`/`string`/`int` never pay for
+it.
+
+## Codegen lowering
+
+| site | condition | emit |
+| --- | --- | --- |
+| element, `?=` | `catBool` | `gw.BoolAttr(name, bool(expr))` |
+| element, `?=` | otherwise | error `toggle-requires-bool` |
+| element, `=` | `catBool`, listed | `gw.BoolAttr(name, bool(expr))` |
+| element, `=` | `catBool`, not listed | stringify `"true"`/`"false"` |
+| element, `=` | `catAnyMixed`, listed | `gw.AttrAnyToggle(name, expr)` |
+| element, `=` | `catAnyMixed`, not listed | existing ` name="` + `AttrAny` |
+| element, `=` | any other non-`catBool` | existing stringify path |
+| bare `name` | — | `gw.BoolAttr(name, true)` |
+| component, `?=`, matched field | — | **open** (§Risks 1) |
+| component, `?=`, fallthrough | `catBool` | bag entry `gsx.Toggle(expr)` |
+| component, `=`, fallthrough | — | bag entry as-is; `Spread` consults the list |
+
+The `catBool` gate moves from "→ BoolAttr" to "→ consult the list".
+
+### Defect 1: `catAnyMixed` on a listed name
+
+An earlier draft claimed defect 1 "dissolves" under `=`-means-stringify. It does
+not — that reasoning would leave `<Mixed[bool] req={false}/>` rendering
+`required="false"` (required) with no escape, since `?=` demands an all-bool
+constraint. Refusing the construct with a diagnostic was also considered and
+rejected: it respects neither the author's intention nor the HTML spec, merely
+declining to serve them.
+
+**Resolution: defer only the boolness, never the name.** The list lookup stays
+**static** — codegen has the literal attribute name, so it resolves membership at
+generate time and only the *value's* type is unknown until runtime:
+
+```go
+// name IS listed and the value is catAnyMixed:
+_gsxgw.S("<input")
+_gsxgw.AttrAnyToggle("required", req)   // bool at runtime → presence; else ="…"
+_gsxgw.S("/>")
+
+// name is NOT listed: unchanged, name stays baked into the static string
+_gsxgw.S("<input data-x=\"")
+_gsxgw.AttrAny(v)
+_gsxgw.S("\"/>")
+```
+
+So `boolNames` never threads into a static attribute write, and `AttrAnyToggle`
+is emitted only where it can matter. Both instantiations then render correctly
+with **no annotation**:
+
+```go
+component Mixed[T string | bool](req T) { <input required={req} /> }
+
+<Mixed[bool]   req={false} />   → <input/>              // bool → presence
+<Mixed[bool]   req={true}  />   → <input required/>
+<Mixed[string] req={"foo"} />   → <input required="foo"/>
+```
+
+`?=` is therefore *unnecessary* here rather than unavailable, and stays an error
+on a non-all-bool constraint: `?=` means "always toggle", which a `string`
+instantiation cannot honour.
+
+`?=` on a listed name (`required?={b}`) is allowed and silent — redundant but
+explicit and self-documenting, like `int64(x)` on an `int64`.
+
+## Diagnostics
+
+The old "did you mean `checked?=`" advisory is **gone** — `checked={b}` now just
+works. Two remain:
+
+1. `toggle-requires-bool` — `?=` on a non-bool value, including a type parameter
+   whose constraint is not all-bool terms.
+2. **Custom-element bool hint.** `<my-toggle active={b}/>` — a *hyphenated* tag
+   (a custom element, which gsx already identifies) carrying a bool-valued
+   attribute **not** in the list now renders `active="false"`, silently changing
+   from today's bare `active`. gsx cannot know the element's intent, so warn:
+   "custom-element attribute with a bool value renders as a string; use
+   `active?={ b }` for a toggle". Scoped to hyphenated tags so it stays silent on
+   `data-*`/`aria-*`, where stringifying is correct.
+
+Diagnostics live in the analyzer, never the formatter.
+
+## Security
+
+No new sink. `?=` and a listed name both write a bare name through the existing
+`BoolAttr`, which emits ` ` + name and never a value, so no escaping context is
+entered.
+
+`Toggle` short-circuits the URL/image/srcset sinks (§Spread), which is safe
+*because* it emits no value: sanitizers police a value, and there is none. This
+is a narrowing, not a bypass — the only reachable output is ` ` + a
+`validAttrName`-checked name. The inverse placement would be the unsafe one.
+
+The change **removes** a security-adjacent defect: `contenteditable={false}` and
+`draggable={false}` currently render as their opposite.
+
+## Rejected alternatives
+
+**Pure `?=` (author declares everything; no list).** Chosen briefly, then
+reversed. The list-as-semantics objection — "a missing entry ships wrong HTML" —
+only holds for a list *without* an override. With `?=`, a gap is fixable at the
+call site. Meanwhile pure `?=` puts a permanent annotation obligation on the most
+common case, failing silently to `checked="false"` (which the browser reads as
+checked) every time an author forgets. A ~30-entry closed list is a smaller
+liability than a forever-obligation on every author and call site.
+
+**Config (`gsx.toml` boolean-attribute table).** Rejected: `?=` already covers
+every name a list cannot know, per call site, visible in the file you are
+reading. A config table adds project-wide invisible state — a reviewer of one
+file cannot see that `gsx.toml` redefined what `open` means.
+
+**Bag key suffix (`"required?"`).** Rejected: `lastValidAttrIndexes` and `Get`
+compare keys exactly, so `"required"` and `"required?"` are distinct keys in
+dedup, lookup, exclusion and class-merge. A caller override would emit **both**
+(`<input required="false" required>`), and browsers take the first — silently
+losing the override. It also collides with real names (`?` is legal in HTML
+attribute names per WHATWG) and is stringly-typed. No framework does this: Lit's
+`?disabled` is a **prefix** consumed at template-parse time, templ's
+`noshade?={x}` a **suffix operator** — in both, `?` never reaches a runtime key.
+
+## Migration
+
+Smaller than under pure `?=`, because listed names keep today's behavior.
+
+1. **Bags with listed names — no change.** `gsx.Attrs{{Key: "disabled", Value:
+   true}}` still renders bare `disabled`. The riskiest step of the pure-`?=`
+   plan (a silent, compiler-invisible sweep of every hand-written bag) is gone.
+2. **Non-listed names with bool values now stringify** — `data-open={b}`,
+   `aria-expanded={b}`. This *is* the fix; no author action, but goldens,
+   `examples/` and docs change.
+3. **Custom elements using non-standard bool attribute names** need `?=`
+   (`<my-toggle active?={b}/>`). Silent behavior change, caught by the
+   custom-element hint (§Diagnostics 2).
+4. `val.go` is unaffected: `Val(true)` renders text `"true"`, unchanged.
+
+Sweep `../structpages` and `../one-learning` for cases 2 and 3.
+
+## Testing
+
+`?=` is attribute-position only; per CLAUDE.md the contexts each need a case.
+
+**Semantic corpus** — `input.gsx` + `generated.x.go.golden` + `render.golden`:
+
+- listed name, `=`, bool true/false → toggle
+- non-listed name, `=`, bool → `="true"`/`="false"` (the reversal)
+- enumerated regression: `aria-expanded`, `aria-hidden`, `contenteditable`,
+  `draggable`, `spellcheck`, `data-*`
+- listed name, `=`, **string** value → `="false"` (force-stringify)
+- `hidden={true}` → bare; `hidden={"until-found"}` → `="until-found"`
+- `?=` on a non-listed name → toggle; on a listed name → toggle, no diagnostic
+- element `?=` true/false
+- **`catAnyMixed` on a listed name** (`AttrAnyToggle`): `Mixed[bool] req={false}`
+  → `<input/>`, `req={true}` → `<input required/>`, `Mixed[string] req={"foo"}`
+  → `required="foo"` — all three from one component, no annotation
+- `catAnyMixed` on a **non**-listed name → unchanged ` data-x="…"` emission
+- named bool through `AttrAnyToggle` (underlying-bool match, not exact)
+- component `?=` fallthrough → `Toggle` in bag → `BoolAttr`
+- component `?=` on a matched field (per §Risks 1)
+- bare attribute unchanged
+- in-tag conditional: `<input { if r { required?={b} } }/>`
+- spread override: `required={false}` then `required?={true}` → single ` required`
+- bag: `Toggle(true/false)`, plain `bool` listed/non-listed, named `Flag(false)`,
+  string
+- `?=` on non-bool → `toggle-requires-bool`; on `T string | bool` → diagnostic
+- `required?` with no value → parse error
+- custom-element hint fires on `<my-toggle active={b}/>`, silent on `<div data-x={b}/>`
+- **update `bool_exact_dispatch_required.txtar`** — its goldens flip; it becomes
+  the regression test for this design
+
+**Formatter corpus** — `?=` round-trips; `required? = {b}` normalizes to
+`required?={b}`; idempotence.
+
+**Runtime unit tests** — `Toggle` through `Spread` (true/false, dedup/override,
+precedence against a plain-bool entry, `Toggle` on a URL key renders bare); plain
+bool listed vs non-listed; named bool on a listed name.
+
+Regenerate with `-update` (rewrites `coverage.golden`; a forgotten manifest bump
+fails the suite), then verify without. `make ci` before merge.
+
+## Docs
+
+- `docs/guide/` — attributes page: the four-line rule, the two force directions,
+  one sentence of rationale. Concise; rationale lives here, not the guide.
+  Literal `{{ }}` in prose needs `::: v-pre`.
+- `docs/ROADMAP.md` — record the 2026-06-18 reversal and why.
+
+## Sibling projects
+
+- **`../tree-sitter-gsx`** — add a `toggle_attribute` rule beside
+  `expr_attribute` (`grammar.js:350`); `attribute_name` needs no change.
+  Regenerate, add corpus entries, run the snippet gate.
+- **`../vscode-gsx`** — `syntaxes/gsx.tmLanguage.src.yaml` → regenerate `.json`.
+  Bump `package.json`, tag `vX.Y.Z` to release.
+- **`../gsxhq.github.io`** — CodeMirror mode in
+  `.vitepress/theme/GsxPlayground.vue`; playground WASM rebuilds with a hash
+  cache-bust. `/guide` is a gitignored synced copy — edit gsx `docs/guide`.
+
+`make lint` and `make ci` gate the gsx side.
+
+## Process
+
+Per CLAUDE.md: this spec → implementation plan → subagent-driven execution with
+per-task reviews → one **independent adversarial reviewer** (throwaway probe
+programs, not diff reading) before merge. Feature work in a git worktree.
+
+**Sequencing:** dispatch unification PR → this change.
+
+## Risks / open questions
+
+1. **Bool on a component tag — the one open decision.** Covers `?=` and bare
+   together. Presence is meaningless for a Go struct field, so `<Modal
+   open?={b}/>` with a declared `bool` field has no coherent reading. Lean:
+   **error on a matched field, `Toggle(b)` into the bag on fallthrough**. Bare is
+   the harder half — `<Badge on/>` on a `gsx.Node` field silently means the text
+   `true` (`gsx.Val(true)`), so bare already carries both readings. Options: (a)
+   leave it, documenting the fork; (b) reject bare on a `gsx.Node` field; (c)
+   reject bare on components entirely — the only option where bare means
+   *presence* everywhere with no exceptions, and the largest migration. Resolve
+   before planning.
+2. **The bare-bool fork is unpinned** — needs its own corpus case.
+3. **List accuracy is now load-bearing.** Derive from the WHATWG index, not
+   memory; decide `hidden` deliberately; keep `contenteditable`/`draggable`/
+   `spellcheck` out. Mitigated but not eliminated by `?=`.
+4. **`?=` on an enumerated attribute** (`aria-expanded?={b}`) produces the
+   invalid bare form. Detecting it needs a second (enumerated) list; deferred —
+   the author explicitly asked for the override.
+5. **`AttrAnyToggle` restructures a static emission site.** Resolved in design
+   (§Defect 1), but it is the one place where an attribute's name leaves the
+   static string and becomes a runtime argument, so the coalescer, `//line`
+   directives, and the attr-hoisting paths all see a shape they have not seen
+   before. Worth an explicit probe during implementation rather than trusting the
+   goldens alone.

--- a/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
@@ -121,23 +121,65 @@ means presence, and `download="true"` would be a *filename*. Listing it costs
 nothing, because the list only consults bool values — `download={"a.txt"}` still
 renders `download="a.txt"`.
 
+### Structure: derived and curated must be separate lists
+
+The mechanical part and the judgement part are **two lists, never one**. Merged,
+the next refresh from the spec silently drops `hidden` and `hidden={false}` starts
+hiding elements again — the regeneration would look clean and reintroduce the bug.
+
+```go
+// booleanAttrs is the WHATWG index's "Boolean attribute" rows, derived
+// mechanically (§Derivation). Regenerate wholesale; contains no judgement.
+var booleanAttrs = []string{"allowfullscreen", "async", "autofocus", /* … */}
+
+// presenceOnlyExtras are attributes the index does NOT type as "Boolean
+// attribute" but for which no string means false, so only absence can express
+// it. Hand-curated; each entry carries its reason; MUST survive a regeneration
+// of booleanAttrs.
+var presenceOnlyExtras = map[string]string{
+	"hidden":   `invalid value default is the Hidden state — hidden="false" HIDES the element`,
+	"download": `typed Text — download="true" would be a filename`,
+}
+```
+
+A third list exists **only as a test**, not runtime code — a guard against a
+future "fix" that re-adds an attribute which looks boolean but has a valid
+`"false"`, reviving the inverted render this design exists to remove:
+
+```go
+// notPresenceOnly must never appear in the effective list.
+var notPresenceOnly = []string{"contenteditable", "draggable", "spellcheck"}
+```
+
+The extras list is exactly two. `translate` (`yes`/`no`) and `autocapitalize`
+(`on`/`off`/…) use non-boolean keywords, so a bool does not apply and the author
+writes the string; `popover`'s bare form means `auto`, which is not what `={true}`
+implies. Only `hidden` and `download` are cases where a bool genuinely means
+presence while the type column disagrees.
+
 ### Derivation
 
 **Do not hand-copy the WHATWG index, and do not trust a fetched summary.** Two
 independent fetches of the attributes index during design contradicted each other
 (one reported `required`/`selected`/`multiple` as Boolean, the other as absent);
-the page is large enough that extraction truncates silently.
+the page is large enough that extraction truncates silently, and a truncated
+answer is indistinguishable from a complete one.
 
 Implementation must instead:
 
 1. Parse the index table programmatically, taking rows whose Value is exactly
-   "Boolean attribute".
+   "Boolean attribute". **Scope to the current index only** — the obsolete-features
+   table also carries boolean-typed attributes (`nowrap`, `compact`, `declare`),
+   which a naive parse will sweep in.
 2. **Review every row against the false-string test** — the type column is a
-   proxy, not the rule. Add `hidden` and `download`; keep `contenteditable`,
-   `draggable`, `spellcheck` out.
+   proxy, not the rule.
 3. Cross-check against two independent implementations that maintain the same
-   list — Vue's `isBooleanAttr` (`@vue/shared`) and React's property table.
-4. Record the spec URL, the derivation date, and a refresh policy beside the list.
+   list — Vue's `isBooleanAttr` (`@vue/shared`) and React's property table. A
+   disagreement is a signal to re-read the spec text for that attribute, not to
+   pick a majority.
+4. Record the spec URL and the derivation date beside `booleanAttrs`, and pin the
+   derived list in a test so a refresh shows up as a reviewable diff rather than
+   a silent behaviour change.
 
 ### Where it lives
 
@@ -390,6 +432,12 @@ No fmt corpus (no syntax change). No sibling-repo work.
 - **`hidden={false}` → omitted, NOT `hidden="false"`** — the invalid-value-default
   trap; `hidden={"until-found"}` → `="until-found"`
 - `download={true}` → bare; `download={"a.txt"}` → `="a.txt"`
+- **`notPresenceOnly` guard** — assert `contenteditable`, `draggable`,
+  `spellcheck` are absent from the effective list; this is the test that stops a
+  future refresh or "fix" reviving the inverted render
+- **`presenceOnlyExtras` survives regeneration** — assert `hidden` and `download`
+  are in the effective list even though `booleanAttrs` does not contain them
+- `booleanAttrs` pinned, so a spec refresh is a reviewable diff
 - listed name, **string** value → `="foo"` (the CSS-selector guarantee)
 - `gsx.Toggle(true/false)` on a listed and a non-listed name
 - `catAnyMixed` on a listed name (`AttrAnyToggle`): `Mixed[bool] req={false}` →

--- a/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
@@ -4,6 +4,10 @@ Status: **draft, awaiting review**
 Supersedes: `2026-06-18-gsx-templating-design.md` §"Boolean attributes are type-driven"
 Evidence: `internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar`
 
+**This is not a syntax change.** No new operator, no grammar change, no parser or
+AST change, no formatter work, and no sibling-repo updates. The fix is a
+name-keyed policy table plus one exported runtime type.
+
 ## Problem
 
 gsx decides presence-vs-value from the **Go type**: a `bool`-typed
@@ -15,16 +19,14 @@ The premise is wrong. The type answers *what value the author has*; it cannot
 answer *whether HTML wants presence or a string*. Only the attribute **name**
 answers that, and HTML has two classes with **opposite** requirements:
 
-- **Boolean attributes** (`required`, `checked`, `disabled`, …) — presence
-  alone means true and the **value is ignored**. `required="false"` is
-  required. Only **absence** is false, so no string can express false.
-- **Enumerated attributes** (`aria-*`, `contenteditable`, `draggable`,
-  `spellcheck`, and every `data-*`) — the **string is** the value. `="true"` /
-  `="false"` are the required forms; a bare name yields `=""`, which is not a
-  valid token and falls back to the default.
+- **Presence-only attributes** (`required`, `checked`, `disabled`, …) — presence
+  alone means true and the **value is ignored**. Only **absence** is false.
+- **Value attributes** (`aria-*`, `contenteditable`, `draggable`, `spellcheck`,
+  every `data-*`) — the **string is** the value. `="true"`/`="false"` are the
+  required forms; a bare name yields `=""`, usually invalid.
 
-One Go `bool`, two opposite correct renderings. gsx applies presence to both
-and is right for exactly one class:
+One Go `bool`, two opposite correct renderings. gsx applies presence to both and
+is right for exactly one class:
 
 | source | renders | |
 | --- | --- | --- |
@@ -33,26 +35,16 @@ and is right for exactly one class:
 | bag `{required: Flag(false)}` — named bool | `required="false"` | **required** |
 | bag `{required: anyFalse}` — `var anyFalse any = false` | `<input/>` | correct |
 | `<div aria-hidden={true}/>` | `<div aria-hidden/>` | `=""` invalid → **not hidden** |
-| `<div aria-hidden={strconv.FormatBool(h)}/>` | `aria-hidden="true"` | correct |
 | `<div contenteditable={false}/>` | `<div/>` | **inverted** — inherits editable |
 | `<img draggable={false}/>` | `<img/>` | **inverted** — still draggable |
 
-`contenteditable` and `draggable` are inherited-or-default-on: `="false"` is
-what *blocks* editing inside an editable ancestor and what *stops* an image
-dragging. Omitting them means the author writes `false` and the browser does
-`true`.
-
-Two further defects share one root cause:
-
-1. **Type-parameter divergence.** `classify(t) == catBool` gates the `BoolAttr`
-   emit, so a `T string | bool` type parameter classifies as `catAnyMixed` and
-   falls to `AttrAny` → `required="false"`.
-2. **Named-bool bag divergence.** `attrs.go` asserts `kv.Value.(bool)` — an
-   *exact* type assertion — so a `type Flag bool` falls to `toStr` → `"false"`.
+`contenteditable` and `draggable` are inherited-or-default-on: `="false"` is what
+*blocks* editing inside an editable ancestor and what *stops* an image dragging.
+Omitting them means the author writes `false` and the browser does `true`.
 
 **Root cause: EXACT vs UNDERLYING dispatch, not type erasure.** The control row
-above proves it — a plain `bool` boxed in an `any` renders *correctly*, because
-the assertion sees the dynamic type. gsx runs two classifiers that disagree:
+proves it — a plain `bool` boxed in an `any` renders *correctly*, because the
+assertion sees the dynamic type. gsx runs two classifiers that disagree:
 
 ```
 static  (codegen)  classify(t) → t.Underlying() via go/types  →  Flag → catBool ✓
@@ -64,143 +56,185 @@ documented contract, mirrored deliberately by `anyRenderString`.
 
 ## Goals
 
-- **Correctness is the default.** Standard HTML renders correctly with no
-  annotation.
-- Both attribute classes expressible; either direction forceable.
-- Static and dynamic (bag) paths agree by construction, for every type.
-- No project-wide invisible state.
+- **Correct HTML by default**, with no annotation.
+- **Never block the author.** `required="foo"` stays expressible — it is a valid
+  CSS selector target (`[required="foo"]`), and gsx is not the HTML police.
+- One override mechanism that **travels**: element, component prop, and bag.
+- Static and dynamic paths agree by construction, for every type.
 
 ## Non-goals
 
+- New syntax. See §Rejected alternatives.
 - Configuration. See §Rejected alternatives.
-- Truthiness. Unlike Lit, `?=` takes a `bool`, not "any value, evaluated for
-  truthiness".
-- Knowing which attributes are *enumerated*. Only the boolean list exists;
-  everything not in it stringifies, which is correct for enumerated attributes
-  and for arbitrary `data-*`.
-- Changing spread syntax or the `{ if cond { attr } }` in-tag conditional form.
+- Knowing which attributes are *enumerated*. Only the presence-only list exists;
+  everything else stringifies, which is correct for enumerated and `data-*`.
+- Truthiness. `Toggle` takes a `bool`, not "any value, evaluated for truthiness".
 
-## Surface syntax
+## The rule
 
 ```
-name?={ expr }    → toggle, any name (expr must be bool-typed)
-name={ boolExpr } → name in the boolean list ? toggle : "true"/"false"
-name={ strExpr }  → always the string
-name              → bare; toggle
+name={ boolExpr }        → listed name ? presence : "true"/"false"
+name={ strExpr }         → always the string          (the list only sees bools)
+name={ gsx.Toggle(b) }   → presence, any name         (the override)
+name                     → bare; presence
 ```
 
 ```go
-<input required={ p.Req } />          // list name → <input required> / <input>
-<div aria-expanded={ p.Open } />      // not listed → aria-expanded="false"
-<img draggable={ false } />           // → draggable="false"
-<my-toggle active?={ p.On } />        // custom element → forced toggle
+<input required={ p.Req } />               // listed → <input required> / <input>
+<div aria-expanded={ p.Open } />           // not listed → aria-expanded="false"
+<input required={ "foo" } />               // string → required="foo"  (CSS selector)
+<my-toggle active={ gsx.Toggle(b) } />     // custom element → forced presence
 ```
 
-### Forcing either direction
+## The presence-only list
 
-Both overrides already exist; only one is new syntax. **The list is consulted
-only for bool-typed values**, which is what makes the second row work — a string
-never reaches the list lookup.
+**Semantic** — it decides. Safe because `Toggle` recovers any gap at the call
+site, without waiting for a gsx release.
 
-| want | write | works because |
-| --- | --- | --- |
-| toggle on a non-list name | `active?={ b }` | `?=` forces it |
-| string on a list name | `required={ strconv.FormatBool(b) }` | the value isn't bool |
+### Membership: is there a string that means false?
 
-This also handles HTML's hybrid attributes for free: `hidden={ true }` → bare
-`hidden`, `hidden={ "until-found" }` → `hidden="until-found"`; `download={ true }`
-→ bare `download`, `download={ "a.txt" }` → `download="a.txt"`.
+The WHATWG "Value" column is only a **proxy for the real question, and it is
+wrong in both directions.** The criterion is:
 
-### Grammar — no reservation required
+> **Is there a string that means false?**
+> No → only absence can express it → **list it**.
+> Yes → stringify.
 
-`isAttrNameByte` (`parser/markup.go`) admits `A-Za-z0-9_:@.-` only; `?` has
-**never** been legal in a source attribute name, so `?=` is unambiguous and
-claims no namespace. tree-sitter's `attribute_name`
-(`/[A-Za-z_@:][A-Za-z0-9_@:.\-]*/`) already agrees.
+| attribute | WHATWG Value | string meaning false? | list |
+| --- | --- | --- | --- |
+| `required`, `checked`, `disabled`, `selected`, `readonly`, `multiple`, `autofocus`, `async`, `defer`, `open`, … | Boolean attribute | **no** — value ignored | ✅ |
+| `hidden` | *enumerated* (`until-found`/`hidden`/`""`) | **no** — see below | ✅ *despite type* |
+| `download` | *Text* (filename) | **no** — `"false"` is a filename | ✅ *despite type* |
+| `contenteditable` | enumerated `true`/`false`/`plaintext-only`/`""` | **yes** | ❌ |
+| `draggable`, `spellcheck` | enumerated `true`/`false` | **yes** | ❌ |
+| `aria-*` | enumerated `true`/`false` | **yes** | ❌ |
+| `data-*` | author-defined | **yes** | ❌ |
 
-`validAttrName` (`attrs.go`) *does* admit `?`, but it governs **runtime bag
-keys**, not source. `Toggle` places the marker in the value and leaves the key
-untouched (§Runtime), so the key namespace is not claimed either.
-`validAttrName` is unchanged.
+**`hidden` is the proof that the type column lies.** Its *invalid value default*
+is the **Hidden** state ([spec](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute)),
+so `hidden="false"` **hides the element**. Treating it as enumerated — the type
+column's answer — would make `hidden={false}` render `hidden="false"` and hide
+the element the author asked to show. It must be listed.
 
-Binding rule: `?` must **immediately** follow the name, after which the existing
-whitespace-tolerant `=` lookahead applies unchanged.
-
-```
-required?={b}   ok        required? = {b}   ok  (existing '=' ws tolerance)
-required?= {b}  ok        required ?={b}    error — '?' must abut the name
-required?       error     — "'?' requires a value; did you mean bare `required`?"
-```
-
-### AST
-
-Add `Toggle bool` to `ast.ExprAttr` rather than a new node type. Attributes are
-consumed at many codegen/LSP/fmt sites; a flag on the existing node keeps every
-one working and follows the `Element.IsComponent` stamp precedent. The formatter
-reads it to re-emit `?=`.
-
-## The boolean-attribute list
-
-**Semantic, not advisory** — it decides. That is safe *because* `?=` exists: a
-list gap is recoverable at the call site (`newattr?={b}`) without waiting for a
-gsx release, so an incomplete list is never a dead end.
+`download` is the same shape from the other side: typed `Text`, but a bool value
+means presence, and `download="true"` would be a *filename*. Listing it costs
+nothing, because the list only consults bool values — `download={"a.txt"}` still
+renders `download="a.txt"`.
 
 ### Derivation
 
-Ported from the WHATWG **index of attributes**, taking every entry whose type is
-"Boolean attribute". Do not hand-write it from memory. Approximate size ~30:
-`allowfullscreen`, `async`, `autofocus`, `autoplay`, `checked`, `controls`,
-`default`, `defer`, `disabled`, `download`, `formnovalidate`, `inert`, `ismap`,
-`itemscope`, `loop`, `multiple`, `muted`, `nomodule`, `novalidate`, `open`,
-`playsinline`, `readonly`, `required`, `reversed`, `selected`, …
+**Do not hand-copy the WHATWG index, and do not trust a fetched summary.** Two
+independent fetches of the attributes index during design contradicted each other
+(one reported `required`/`selected`/`multiple` as Boolean, the other as absent);
+the page is large enough that extraction truncates silently.
 
-**Verify during implementation; do not trust the list above.** Two known traps:
+Implementation must instead:
 
-- **`hidden`** is *enumerated* in current HTML (`until-found` / `hidden` / `""`),
-  not boolean — but the empty string maps to the hidden state, so listing it
-  still behaves correctly for bool values (§Forcing either direction). Decide
-  deliberately and record why.
-- **`contenteditable`, `draggable`, `spellcheck`** look boolean and are **not** —
-  they are enumerated. They must NOT be listed; listing them reproduces the
-  inverted rows in §Problem.
-
-Record the spec URL and a refresh policy beside the list.
+1. Parse the index table programmatically, taking rows whose Value is exactly
+   "Boolean attribute".
+2. **Review every row against the false-string test** — the type column is a
+   proxy, not the rule. Add `hidden` and `download`; keep `contenteditable`,
+   `draggable`, `spellcheck` out.
+3. Cross-check against two independent implementations that maintain the same
+   list — Vue's `isBooleanAttr` (`@vue/shared`) and React's property table.
+4. Record the spec URL, the derivation date, and a refresh policy beside the list.
 
 ### Where it lives
 
 Codegen owns it, exactly as it owns `navNames`/`imageNames`/`srcsetNames`, and
-threads it into `Spread` as a `[]string` literal. One source of truth, consulted
-by both the static and dynamic paths.
+threads it into `Spread` as a `[]string` literal. One source of truth for both
+the static and dynamic paths.
 
-## Runtime: `gsx.Toggle`
+## `gsx.Toggle` — the override
 
 ```go
-// Toggle marks a bag value as carrying boolean-attribute (presence) semantics
-// regardless of the attribute name: Spread writes a bare ` name` when true and
-// nothing when false. It is the runtime carrier of the `?=` declaration, needed
-// only for names outside the boolean-attribute list — a plain bool on a listed
-// name already toggles.
+// Toggle forces boolean-attribute (presence) semantics on any attribute name,
+// bypassing the presence-only list: true writes a bare ` name`, false writes
+// nothing. It exists for names the HTML spec cannot know — web components,
+// Datastar — where a plain bool would otherwise stringify.
+//
+// It is a value, not syntax, so the same expression works on an element, as a
+// component prop, and in a hand-written bag.
 type Toggle bool
 ```
 
-A named `bool` type, so `Toggle(expr)` is a conversion; boxing a bool into `any`
-does not allocate (runtime `staticuint64s`).
+A named `bool`, so `Toggle(expr)` is a conversion and the Go compiler enforces
+bool-ness — no diagnostic needed. Boxing a bool into `any` does not allocate
+(runtime `staticuint64s`).
+
+### Overriding, direct and through components
+
+The override **rides in the value's type**, so the component pass-down column is
+*identical* to the direct column — there is no separate component mechanism:
+
+| want | on an element | through a component | why |
+| --- | --- | --- | --- |
+| correct HTML (default) | `required={b}` | `<Comp required={b}/>` | leaf name decides |
+| force the string | `required="foo"` | `<Comp required={"foo"}/>` | list only sees bools |
+| force presence | `active={gsx.Toggle(b)}` | `<Comp active={gsx.Toggle(b)}/>` | `Toggle` rides in the bag |
+
+This is the leaf-decides principle gsx already applies to class-merge and the URL
+sinks: **a component tag binds a value; the element decides the HTML.** So
+`<Modal open={b}/>` just sets a `bool` prop, and whether it renders as presence
+depends entirely on which element the component puts it on — `required` →
+presence, `aria-hidden` → `"false"`. Correct for both, with the same call site.
+
+## Codegen lowering
+
+| site | condition | emit |
+| --- | --- | --- |
+| element | `catBool`, listed | `gw.BoolAttr(name, bool(expr))` |
+| element | `catBool`, not listed | stringify `"true"`/`"false"` |
+| element | `catAnyMixed`, listed | `gw.AttrAnyToggle(name, expr)` (§Defect 1) |
+| element | `catAnyMixed`, not listed | existing ` name="` + `AttrAny` |
+| element | `Toggle`-typed | `gw.BoolAttr(name, bool(expr))` |
+| element | any other | existing stringify path |
+| bare `name` | — | `gw.BoolAttr(name, true)` |
+| component prop | — | bind the value; **no HTML decision here** |
+| component fallthrough | — | bag entry as-is; `Spread` resolves at the leaf |
+
+### Defect 1: `catAnyMixed` on a listed name
+
+`T string | bool` is not `catBool`, so the list would never be consulted and
+`<Mixed[bool] req={false}/>` would render `required="false"` — required.
+
+**Resolution: defer only the boolness, never the name.** Codegen has the literal
+name, so it resolves list membership at generate time; only the value's type is
+unknown until runtime:
+
+```go
+_gsxgw.S("<input")
+_gsxgw.AttrAnyToggle("required", req)   // bool at runtime → presence; else ="…"
+_gsxgw.S("/>")
+```
+
+`boolNames` therefore never threads into a static attribute write. Both
+instantiations are correct with **no annotation**:
+
+```go
+component Mixed[T string | bool](req T) { <input required={req} /> }
+
+<Mixed[bool]   req={false} />   → <input/>
+<Mixed[bool]   req={true}  />   → <input required/>
+<Mixed[string] req={"foo"} />   → <input required="foo"/>
+```
+
+This is exactly the flexibility `?=` could not provide (§Rejected alternatives).
+
+## Runtime
 
 ### `AttrAnyToggle`
 
 ```go
-// AttrAnyToggle writes one complete attribute whose name IS a boolean attribute
-// (codegen resolved the list at generate time) but whose value type is only known
+// AttrAnyToggle writes one complete attribute whose name IS presence-only
+// (codegen resolved the list at generate time) but whose value type is known only
 // at runtime. A bool-kinded value writes presence — ` name` or nothing — and any
-// other value writes ` name="escaped"`. Generated code emits it for a catAnyMixed
-// value on a listed name, so `<input required={req}/>` with T = string | bool is
-// correct at both instantiations.
+// other value writes ` name="escaped"`.
 func (gw *Writer) AttrAnyToggle(name string, v any)
 ```
 
-It owns the whole span — the leading space, the name, and the optional `="…"` —
-which is what lets it omit a name that codegen would otherwise have baked into a
-static string.
+It owns the whole span — leading space, name, optional `="…"` — which is what
+lets it omit a name codegen would otherwise bake into a static string.
 
 ### `Spread`
 
@@ -220,14 +254,11 @@ preserving the property that policy comes from the caller.
 declares the attribute has no value, and an attribute with no value cannot carry
 a URL, so the URL sinks are not skipped but *inapplicable*. Checking it in
 `default` would route `Toggle(true)` on `href` to `URLVal` → `href="true"`,
-fabricating a value declared absent.
-
-The plain-bool list lookup lives in the `default` branch (no listed name is also
-a URL name, so it cannot reach the sinks).
+fabricating a value declared absent. The plain-bool list lookup lives in
+`default` (no listed name is also a URL name).
 
 The key is never modified, so last-wins dedup, `Get`/`Has`, class-merge and
-caller-wins precedence keep working: `required?={true}` overrides an earlier
-`required={false}` because both are key `"required"`.
+caller-wins precedence keep working.
 
 ### Prerequisite: unify the dispatch tables
 
@@ -250,122 +281,51 @@ uintptr     Val="ERR"     anyRenderString="5"     toStr="5"     ← Val is the o
 inline `{ x }` with a `uintptr` renders `"5"` while `gsx.Val(x)` errors — the
 documented invariant is already broken.
 
-Unify onto one runtime table **before** this work, as its own PR. It is
-independently valuable, it shrinks this change to a single recognition site
-rather than a fifth table, and it has an obvious differential test: for every
-value, `classify` / `Val` / `anyRenderString` / `toStr` must agree.
+Unify onto one table **before** this work, as its own PR. It is independently
+valuable, it shrinks this change to a single recognition site rather than a fifth
+table, and it has an obvious differential test: for every value, `classify` /
+`Val` / `anyRenderString` / `toStr` must agree.
 
-**A string return is not sufficient.** Three consumers now need the *kind*, not
-just the text — `AttrAnyToggle` and `Spread` must know "is this bool-kinded" to
-choose presence, and `Val` must know "is this escape-free" to keep PR #122's
-`gw.S` win rather than routing numerics back through the escape pass. So the
-table returns a kind alongside the string:
+**A string return is not sufficient.** Three consumers need the *kind*:
+`AttrAnyToggle` and `Spread` to choose presence, and `Val` to keep PR #122's
+`gw.S` win rather than routing numerics back through the escape pass.
 
 ```go
 func anyRenderVal(v any) (s string, k valKind, ok bool)   // kindString, kindBool, kindNumber, …
 ```
 
-One table, four consumers: `Val` (kind → `S` vs `Text`), `TextAny`/`AttrAny`,
-`AttrAnyToggle` (kindBool → presence), `Spread` (kindBool + listed name →
-presence). `toStr` takes the string and ignores the kind.
-
-**Matching must be by underlying type**, or `Flag(false)` never reaches the list
-lookup at all. Per the repo's correctness-first/optimize-simple rule, the general
-path is the default and the fast path must be proven equivalent to it: a
-`reflect.Kind` classification is the correct general behaviour, with the existing
-exact-type switch retained **as a fast path** for the predeclared types, and a
-differential test asserting the two agree on every case. Reflect is then only
-reached on the miss path — named types — so `bool`/`string`/`int` never pay for
-it.
-
-## Codegen lowering
-
-| site | condition | emit |
-| --- | --- | --- |
-| element, `?=` | `catBool` | `gw.BoolAttr(name, bool(expr))` |
-| element, `?=` | otherwise | error `toggle-requires-bool` |
-| element, `=` | `catBool`, listed | `gw.BoolAttr(name, bool(expr))` |
-| element, `=` | `catBool`, not listed | stringify `"true"`/`"false"` |
-| element, `=` | `catAnyMixed`, listed | `gw.AttrAnyToggle(name, expr)` |
-| element, `=` | `catAnyMixed`, not listed | existing ` name="` + `AttrAny` |
-| element, `=` | any other non-`catBool` | existing stringify path |
-| bare `name` | — | `gw.BoolAttr(name, true)` |
-| component, `?=`, matched field | — | **open** (§Risks 1) |
-| component, `?=`, fallthrough | `catBool` | bag entry `gsx.Toggle(expr)` |
-| component, `=`, fallthrough | — | bag entry as-is; `Spread` consults the list |
-
-The `catBool` gate moves from "→ BoolAttr" to "→ consult the list".
-
-### Defect 1: `catAnyMixed` on a listed name
-
-An earlier draft claimed defect 1 "dissolves" under `=`-means-stringify. It does
-not — that reasoning would leave `<Mixed[bool] req={false}/>` rendering
-`required="false"` (required) with no escape, since `?=` demands an all-bool
-constraint. Refusing the construct with a diagnostic was also considered and
-rejected: it respects neither the author's intention nor the HTML spec, merely
-declining to serve them.
-
-**Resolution: defer only the boolness, never the name.** The list lookup stays
-**static** — codegen has the literal attribute name, so it resolves membership at
-generate time and only the *value's* type is unknown until runtime:
-
-```go
-// name IS listed and the value is catAnyMixed:
-_gsxgw.S("<input")
-_gsxgw.AttrAnyToggle("required", req)   // bool at runtime → presence; else ="…"
-_gsxgw.S("/>")
-
-// name is NOT listed: unchanged, name stays baked into the static string
-_gsxgw.S("<input data-x=\"")
-_gsxgw.AttrAny(v)
-_gsxgw.S("\"/>")
-```
-
-So `boolNames` never threads into a static attribute write, and `AttrAnyToggle`
-is emitted only where it can matter. Both instantiations then render correctly
-with **no annotation**:
-
-```go
-component Mixed[T string | bool](req T) { <input required={req} /> }
-
-<Mixed[bool]   req={false} />   → <input/>              // bool → presence
-<Mixed[bool]   req={true}  />   → <input required/>
-<Mixed[string] req={"foo"} />   → <input required="foo"/>
-```
-
-`?=` is therefore *unnecessary* here rather than unavailable, and stays an error
-on a non-all-bool constraint: `?=` means "always toggle", which a `string`
-instantiation cannot honour.
-
-`?=` on a listed name (`required?={b}`) is allowed and silent — redundant but
-explicit and self-documenting, like `int64(x)` on an `int64`.
+**Matching must be by underlying type**, or `Flag(false)` never reaches the
+lookup. Per the repo's correctness-first/optimize-simple rule, the general path
+is the default and the fast path must be proven equivalent: `reflect.Kind`
+classification is the correct general behaviour, with the existing exact-type
+switch retained **as a fast path**, and a differential test asserting they agree
+on every case. Reflect is then reached only on the miss path — named types — so
+`bool`/`string`/`int` never pay for it.
 
 ## Diagnostics
 
-The old "did you mean `checked?=`" advisory is **gone** — `checked={b}` now just
-works. Two remain:
+One. `Toggle` is `type Toggle bool`, so the Go compiler rejects a non-bool
+argument — no `toggle-requires-bool` diagnostic is needed.
 
-1. `toggle-requires-bool` — `?=` on a non-bool value, including a type parameter
-   whose constraint is not all-bool terms.
-2. **Custom-element bool hint.** `<my-toggle active={b}/>` — a *hyphenated* tag
-   (a custom element, which gsx already identifies) carrying a bool-valued
-   attribute **not** in the list now renders `active="false"`, silently changing
-   from today's bare `active`. gsx cannot know the element's intent, so warn:
-   "custom-element attribute with a bool value renders as a string; use
-   `active?={ b }` for a toggle". Scoped to hyphenated tags so it stays silent on
-   `data-*`/`aria-*`, where stringifying is correct.
+**Custom-element hint.** `<my-toggle active={b}/>` — a *hyphenated* tag (a custom
+element, which gsx already identifies) carrying a bool-valued attribute **not** in
+the list now renders `active="false"`, silently changing from today's bare
+`active`. gsx cannot know the element's intent, so warn: "custom-element
+attribute with a bool value renders as a string; use `gsx.Toggle(b)` for
+presence". Scoped to hyphenated tags so it stays silent on `data-*`/`aria-*`,
+where stringifying is correct.
 
 Diagnostics live in the analyzer, never the formatter.
 
 ## Security
 
-No new sink. `?=` and a listed name both write a bare name through the existing
-`BoolAttr`, which emits ` ` + name and never a value, so no escaping context is
-entered.
+No new sink. A listed name and `Toggle` both write a bare name through the
+existing `BoolAttr`, which emits ` ` + name and never a value, so no escaping
+context is entered.
 
 `Toggle` short-circuits the URL/image/srcset sinks (§Spread), which is safe
-*because* it emits no value: sanitizers police a value, and there is none. This
-is a narrowing, not a bypass — the only reachable output is ` ` + a
+*because* it emits no value: sanitizers police a value, and there is none. This is
+a narrowing, not a bypass — the only reachable output is ` ` + a
 `validAttrName`-checked name. The inverse placement would be the unsafe one.
 
 The change **removes** a security-adjacent defect: `contenteditable={false}` and
@@ -373,106 +333,90 @@ The change **removes** a security-adjacent defect: `contenteditable={false}` and
 
 ## Rejected alternatives
 
-**Pure `?=` (author declares everything; no list).** Chosen briefly, then
-reversed. The list-as-semantics objection — "a missing entry ships wrong HTML" —
-only holds for a list *without* an override. With `?=`, a gap is fixable at the
-call site. Meanwhile pure `?=` puts a permanent annotation obligation on the most
-common case, failing silently to `checked="false"` (which the browser reads as
-checked) every time an author forgets. A ~30-entry closed list is a smaller
-liability than a forever-obligation on every author and call site.
+**`?=` syntax (templ's operator).** Chosen twice during design, then rejected —
+`Toggle` obsoletes it on every axis:
 
-**Config (`gsx.toml` boolean-attribute table).** Rejected: `?=` already covers
-every name a list cannot know, per call site, visible in the file you are
-reading. A config table adds project-wide invisible state — a reviewer of one
-file cannot see that `gsx.toml` redefined what `open` means.
+- **It cannot travel.** An override must reach the leaf, because the leaf makes
+  the decision. `Toggle` is a value, so it crosses component boundaries, rides in
+  bags, and survives generics. `?=` is an annotation on a source position and can
+  be passed nowhere — so it needed `Toggle` as a runtime carrier *anyway*. It was
+  always sugar over the mechanism.
+- **It punishes flexible components.** `?=` demands a static bool, so
+  `open?={"foo"}` must error. A component author who wants a flexible prop (a type
+  parameter, a value they do not want to constrain) therefore cannot use `?=` and
+  falls back to `open={var}` — the default path. The syntax serves only the author
+  who already knows it is a bool *and* is off-list, which is exactly what
+  `Toggle(b)` covers.
+- **It costs the whole syntax protocol** — parser, AST, formatter + fmt corpus,
+  tree-sitter, vscode-gsx, CodeMirror — for sugar.
+
+**Config (`gsx.toml` list table).** Rejected: `Toggle` already covers every name a
+list cannot know, per call site, visible in the file you are reading. A config
+table adds project-wide invisible state — a reviewer of one file cannot see that
+`gsx.toml` redefined what `open` means.
 
 **Bag key suffix (`"required?"`).** Rejected: `lastValidAttrIndexes` and `Get`
 compare keys exactly, so `"required"` and `"required?"` are distinct keys in
 dedup, lookup, exclusion and class-merge. A caller override would emit **both**
 (`<input required="false" required>`), and browsers take the first — silently
-losing the override. It also collides with real names (`?` is legal in HTML
-attribute names per WHATWG) and is stringly-typed. No framework does this: Lit's
-`?disabled` is a **prefix** consumed at template-parse time, templ's
-`noshade?={x}` a **suffix operator** — in both, `?` never reaches a runtime key.
+losing the override.
+
+**Name-list only, no override.** Rejected: a list gap would ship wrong HTML with
+no author recourse. `Toggle` is what makes the list safe to make semantic.
 
 ## Migration
 
-Smaller than under pure `?=`, because listed names keep today's behavior.
-
 1. **Bags with listed names — no change.** `gsx.Attrs{{Key: "disabled", Value:
-   true}}` still renders bare `disabled`. The riskiest step of the pure-`?=`
-   plan (a silent, compiler-invisible sweep of every hand-written bag) is gone.
+   true}}` still renders bare `disabled`.
 2. **Non-listed names with bool values now stringify** — `data-open={b}`,
    `aria-expanded={b}`. This *is* the fix; no author action, but goldens,
    `examples/` and docs change.
-3. **Custom elements using non-standard bool attribute names** need `?=`
-   (`<my-toggle active?={b}/>`). Silent behavior change, caught by the
-   custom-element hint (§Diagnostics 2).
+3. **Custom elements using off-list bool attribute names** need
+   `{gsx.Toggle(b)}`. Silent behavior change, caught by the custom-element hint.
 4. `val.go` is unaffected: `Val(true)` renders text `"true"`, unchanged.
 
 Sweep `../structpages` and `../one-learning` for cases 2 and 3.
 
 ## Testing
 
-`?=` is attribute-position only; per CLAUDE.md the contexts each need a case.
+No fmt corpus (no syntax change). No sibling-repo work.
 
 **Semantic corpus** — `input.gsx` + `generated.x.go.golden` + `render.golden`:
 
-- listed name, `=`, bool true/false → toggle
-- non-listed name, `=`, bool → `="true"`/`="false"` (the reversal)
+- listed name, bool true/false → presence
+- non-listed name, bool → `="true"`/`="false"` (the reversal)
 - enumerated regression: `aria-expanded`, `aria-hidden`, `contenteditable`,
   `draggable`, `spellcheck`, `data-*`
-- listed name, `=`, **string** value → `="false"` (force-stringify)
-- `hidden={true}` → bare; `hidden={"until-found"}` → `="until-found"`
-- `?=` on a non-listed name → toggle; on a listed name → toggle, no diagnostic
-- element `?=` true/false
-- **`catAnyMixed` on a listed name** (`AttrAnyToggle`): `Mixed[bool] req={false}`
-  → `<input/>`, `req={true}` → `<input required/>`, `Mixed[string] req={"foo"}`
-  → `required="foo"` — all three from one component, no annotation
-- `catAnyMixed` on a **non**-listed name → unchanged ` data-x="…"` emission
-- named bool through `AttrAnyToggle` (underlying-bool match, not exact)
-- component `?=` fallthrough → `Toggle` in bag → `BoolAttr`
-- component `?=` on a matched field (per §Risks 1)
+- **`hidden={false}` → omitted, NOT `hidden="false"`** — the invalid-value-default
+  trap; `hidden={"until-found"}` → `="until-found"`
+- `download={true}` → bare; `download={"a.txt"}` → `="a.txt"`
+- listed name, **string** value → `="foo"` (the CSS-selector guarantee)
+- `gsx.Toggle(true/false)` on a listed and a non-listed name
+- `catAnyMixed` on a listed name (`AttrAnyToggle`): `Mixed[bool] req={false}` →
+  `<input/>`, `req={true}` → `<input required/>`, `Mixed[string] req={"foo"}` →
+  `required="foo"` — one component, three renders, no annotation
+- `catAnyMixed` on a non-listed name → unchanged emission
+- named bool (`Flag(false)`) on a listed name, static and through a bag
+- component pass-down: `<Comp required={b}/>` → presence at an `input`;
+  the same prop landing on `aria-hidden` → `="false"`
 - bare attribute unchanged
-- in-tag conditional: `<input { if r { required?={b} } }/>`
-- spread override: `required={false}` then `required?={true}` → single ` required`
-- bag: `Toggle(true/false)`, plain `bool` listed/non-listed, named `Flag(false)`,
-  string
-- `?=` on non-bool → `toggle-requires-bool`; on `T string | bool` → diagnostic
-- `required?` with no value → parse error
+- spread override: `required={false}` then `Toggle(true)` → single ` required`
 - custom-element hint fires on `<my-toggle active={b}/>`, silent on `<div data-x={b}/>`
 - **update `bool_exact_dispatch_required.txtar`** — its goldens flip; it becomes
-  the regression test for this design
-
-**Formatter corpus** — `?=` round-trips; `required? = {b}` normalizes to
-`required?={b}`; idempotence.
+  this design's regression test
 
 **Runtime unit tests** — `Toggle` through `Spread` (true/false, dedup/override,
 precedence against a plain-bool entry, `Toggle` on a URL key renders bare); plain
-bool listed vs non-listed; named bool on a listed name.
+bool listed vs non-listed; named bool on a listed name; `AttrAnyToggle` kinds.
 
-Regenerate with `-update` (rewrites `coverage.golden`; a forgotten manifest bump
-fails the suite), then verify without. `make ci` before merge.
+Regenerate with `-update` (rewrites `coverage.golden`), then verify without.
+`make ci` before merge.
 
 ## Docs
 
-- `docs/guide/` — attributes page: the four-line rule, the two force directions,
-  one sentence of rationale. Concise; rationale lives here, not the guide.
-  Literal `{{ }}` in prose needs `::: v-pre`.
+- `docs/guide/` — attributes page: the four-line rule and the two overrides.
+  Concise; rationale lives here, not the guide.
 - `docs/ROADMAP.md` — record the 2026-06-18 reversal and why.
-
-## Sibling projects
-
-- **`../tree-sitter-gsx`** — add a `toggle_attribute` rule beside
-  `expr_attribute` (`grammar.js:350`); `attribute_name` needs no change.
-  Regenerate, add corpus entries, run the snippet gate.
-- **`../vscode-gsx`** — `syntaxes/gsx.tmLanguage.src.yaml` → regenerate `.json`.
-  Bump `package.json`, tag `vX.Y.Z` to release.
-- **`../gsxhq.github.io`** — CodeMirror mode in
-  `.vitepress/theme/GsxPlayground.vue`; playground WASM rebuilds with a hash
-  cache-bust. `/guide` is a gitignored synced copy — edit gsx `docs/guide`.
-
-`make lint` and `make ci` gate the gsx side.
 
 ## Process
 
@@ -484,26 +428,16 @@ programs, not diff reading) before merge. Feature work in a git worktree.
 
 ## Risks / open questions
 
-1. **Bool on a component tag — the one open decision.** Covers `?=` and bare
-   together. Presence is meaningless for a Go struct field, so `<Modal
-   open?={b}/>` with a declared `bool` field has no coherent reading. Lean:
-   **error on a matched field, `Toggle(b)` into the bag on fallthrough**. Bare is
-   the harder half — `<Badge on/>` on a `gsx.Node` field silently means the text
-   `true` (`gsx.Val(true)`), so bare already carries both readings. Options: (a)
-   leave it, documenting the fork; (b) reject bare on a `gsx.Node` field; (c)
-   reject bare on components entirely — the only option where bare means
-   *presence* everywhere with no exceptions, and the largest migration. Resolve
-   before planning.
-2. **The bare-bool fork is unpinned** — needs its own corpus case.
-3. **List accuracy is now load-bearing.** Derive from the WHATWG index, not
-   memory; decide `hidden` deliberately; keep `contenteditable`/`draggable`/
-   `spellcheck` out. Mitigated but not eliminated by `?=`.
-4. **`?=` on an enumerated attribute** (`aria-expanded?={b}`) produces the
-   invalid bare form. Detecting it needs a second (enumerated) list; deferred —
-   the author explicitly asked for the override.
-5. **`AttrAnyToggle` restructures a static emission site.** Resolved in design
-   (§Defect 1), but it is the one place where an attribute's name leaves the
-   static string and becomes a runtime argument, so the coalescer, `//line`
-   directives, and the attr-hoisting paths all see a shape they have not seen
-   before. Worth an explicit probe during implementation rather than trusting the
-   goldens alone.
+1. **List accuracy is load-bearing.** Derive it per §Derivation — programmatically,
+   reviewed against the false-string test, cross-checked against two independent
+   implementations. Mitigated but not eliminated by `Toggle`.
+2. **`AttrAnyToggle` restructures a static emission site.** It is the one place
+   where an attribute's name leaves the static string and becomes a runtime
+   argument, so the coalescer, `//line` directives and the attr-hoisting paths all
+   see a shape they have not seen before. Probe it explicitly rather than trusting
+   goldens.
+3. **`Toggle` on an enumerated attribute** (`aria-hidden={gsx.Toggle(b)}`) produces
+   the invalid bare form. Not blocked, per §Goals — the author asked. Detecting it
+   would need a second (enumerated) list; deferred.
+4. **`reflect` on the runtime path.** Confined to the miss path, but benchmark the
+   named-bool bag case before merge; the spread path is hot.

--- a/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md
@@ -337,12 +337,21 @@ func anyRenderVal(v any) (s string, k valKind, ok bool)   // kindString, kindBoo
 ```
 
 **Matching must be by underlying type**, or `Flag(false)` never reaches the
-lookup. Per the repo's correctness-first/optimize-simple rule, the general path
-is the default and the fast path must be proven equivalent: `reflect.Kind`
-classification is the correct general behaviour, with the existing exact-type
-switch retained **as a fast path**, and a differential test asserting they agree
-on every case. Reflect is then reached only on the miss path — named types — so
-`bool`/`string`/`int` never pay for it.
+lookup. `reflect.Kind` classification is the correct general behaviour, so it is
+**the implementation** — one table, no special cases, nothing to keep in sync.
+
+**Do not pre-build a fast path.** An earlier draft specified keeping the existing
+exact-type switch in front of reflect "so `bool`/`string`/`int` never pay for it".
+That is a guess wearing architecture's clothes: it assumes a cost nobody has
+measured, on a path nobody has profiled, and it is exactly the fast-path-reasoned-
+correct-in-isolation shape the repo's correctness-first/optimize-simple rule
+exists to prevent.
+
+The order is: ship the correct general version, **then measure** the spread and
+attribute paths. If the numbers justify an exact-type fast path, add it as an
+optimisation — proven byte-identical to the general path by a differential test
+over every case, exactly as `gw.S` was earned in PR #122. If they don't, the
+simpler code stands.
 
 ## Diagnostics
 
@@ -487,5 +496,9 @@ programs, not diff reading) before merge. Feature work in a git worktree.
 3. **`Toggle` on an enumerated attribute** (`aria-hidden={gsx.Toggle(b)}`) produces
    the invalid bare form. Not blocked, per §Goals — the author asked. Detecting it
    would need a second (enumerated) list; deferred.
-4. **`reflect` on the runtime path.** Confined to the miss path, but benchmark the
-   named-bool bag case before merge; the spread path is hot.
+4. **`reflect` cost is unmeasured — and stays that way until it is implemented.**
+   Not a design input. Ship the correct general version, benchmark the spread and
+   attribute paths, and let the numbers decide whether an exact-type fast path is
+   worth its complexity (§Prerequisite). Do not pre-optimise on a guess; PR #122
+   is the precedent — the "obvious" `IntInto` optimisation measured 2.2× *slower*
+   on the common case, and only benchmarking found the change that actually won.

--- a/internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar
+++ b/internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar
@@ -1,7 +1,7 @@
 # DEFECT PIN — documents current (wrong) behaviour, not desired behaviour.
 # Evidence for docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md.
-# The goldens below flip when `?=` / gsx.Toggle land; this case is then their
-# regression test.
+# The goldens below flip when the presence-only list + gsx.Toggle land; this case
+# is then their regression test.
 #
 # TWO CLASSES OF ATTRIBUTE NEED OPPOSITE TREATMENT FROM THE SAME GO TYPE.
 #
@@ -37,10 +37,11 @@
 #   required={req}       → `required` is a standard boolean attribute → toggle
 #   aria-hidden={hidden} → not one → "true", no strconv call at all
 #
-# `?=` is then reserved for names a spec list cannot know — web components,
-# Datastar — and `required={strconv.FormatBool(b)}` forces the string back on a
-# listed name, because the list is consulted only for BOOL-typed values.
-# Correctness is the default; annotation is the exception.
+# `gsx.Toggle(b)` is then reserved for names a spec list cannot know — web
+# components, Datastar — and `required={strconv.FormatBool(b)}` forces the string
+# back on a listed name, because the list is consulted only for BOOL-typed values.
+# Correctness is the default; the override is the exception, and it is a VALUE
+# rather than syntax so it survives being passed through a component into a bag.
 #
 # ROOT CAUSE — EXACT vs UNDERLYING dispatch, NOT "type erasure". Boxing is a red
 # herring: `anyFalse` is a plain `var anyFalse any = false` and renders

--- a/internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar
+++ b/internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar
@@ -1,0 +1,222 @@
+# DEFECT PIN — documents current (wrong) behaviour, not desired behaviour.
+# Evidence for docs/superpowers/specs/2026-07-16-gsx-bool-attr-semantics-design.md.
+# The goldens below flip when `?=` / gsx.Toggle land; this case is then their
+# regression test.
+#
+# TWO CLASSES OF ATTRIBUTE NEED OPPOSITE TREATMENT FROM THE SAME GO TYPE.
+#
+# `required` is a REAL boolean attribute: presence alone makes the field
+# required and the VALUE IS IGNORED. `required="false"` is required.
+# `required="true"` is required. `required=""` is required. Only ABSENCE is not
+# required — so PRESENCE is the only correct form, and no string can express
+# false.
+#
+# `aria-hidden` is an ENUMERATED attribute: the STRING IS the value, and the
+# only valid tokens are "true"/"false". `aria-hidden="true"` is the required
+# form. A bare `aria-hidden` yields `aria-hidden=""`, which is not a valid
+# token, so it falls back to the default (undefined) — i.e. NOT hidden.
+#
+# One Go `bool`; opposite correct renderings. The type cannot carry that, so
+# gsx's type-driven rule applies presence to both and is right for exactly one:
+#
+#   <Plain req={false} />         → <input/>           correct — static bool
+#   <Mixed[bool] req={false} />   → required="false"   WRONG → required
+#   bag {required: Flag(false)}   → required="false"   WRONG → required
+#   bag {required: anyFalse}      → <input/>           correct — see ROOT CAUSE
+#   <div aria-hidden={true} />    → <div aria-hidden/> WRONG → aria-hidden="" is
+#                                                      invalid → NOT hidden
+#   <div aria-hidden={strconv.FormatBool(hidden)} />
+#                                 → aria-hidden="true" correct — THE REQUIRED FORM
+#                                                      for an enumerated attribute
+#
+# THE ERGONOMIC PATH FOR ENUMERATED ATTRIBUTES IS TO FORMAT THE BOOL. The last
+# row is how you write it correctly today, and it is the shape the fix makes
+# automatic. Under the design (§Surface syntax) the attribute NAME decides, and
+# neither of the two common cases needs an annotation:
+#
+#   required={req}       → `required` is a standard boolean attribute → toggle
+#   aria-hidden={hidden} → not one → "true", no strconv call at all
+#
+# `?=` is then reserved for names a spec list cannot know — web components,
+# Datastar — and `required={strconv.FormatBool(b)}` forces the string back on a
+# listed name, because the list is consulted only for BOOL-typed values.
+# Correctness is the default; annotation is the exception.
+#
+# ROOT CAUSE — EXACT vs UNDERLYING dispatch, NOT "type erasure". Boxing is a red
+# herring: `anyFalse` is a plain `var anyFalse any = false` and renders
+# CORRECTLY, because Spread's `kv.Value.(bool)` sees the DYNAMIC type and a
+# boxed `bool` is still exactly `bool`. What breaks is the mismatch between the
+# two classifiers gsx runs:
+#
+#   static  (codegen)  classify(t) → t.Underlying() via go/types  →  Flag → catBool ✓
+#   runtime (writer)   anyRenderString / kv.Value.(bool)          →  EXACT types only ✗
+#
+# So a NAMED bool (`Flag`) and a TYPE PARAMETER (`T string | bool`) are the only
+# things that fall through — and they fall through to stringification:
+#
+#   row 2: _gsxgw.AttrAny(req) → AttrString → anyRenderString  `case bool:` misses T
+#   row 3: Spread              → kv.Value.(bool)               exact assertion, attrs.go:344
+#
+# This is gsx.Val's DOCUMENTED contract, not an oversight — val.go says named
+# scalar types "are NOT matched by the type switch ... even though { x } inline
+# classifies them by underlying type", and anyRenderString says it mirrors that
+# contract deliberately. The divergence is by design; what is missing is any way
+# for the author to declare the intent the exact-type switch cannot recover.
+#
+# WHY THERE IS NO WORKAROUND FOR `required`. Formatting the bool — the very
+# escape hatch that makes the last row correct for `aria-hidden` — cannot work
+# here, because THERE IS NO STRING THAT MEANS FALSE for a real boolean
+# attribute. Only absence means false. So the two classes do not merely differ,
+# they have disjoint escape hatches, and rows 2–3 have none:
+#   - Row 2: the constraint `T string | bool` contains bool, but gsx must pick at
+#     runtime and has no syntax to be told "this instantiation is a toggle".
+#     Nothing the author writes at the call site changes the emitted AttrAny.
+#   - Row 3: `Flag(false)` IS handled correctly one line away (row 1) — same
+#     value, same attribute, opposite meaning, decided only by whether it passed
+#     through a bag.
+# HOW THE DESIGN FIXES EACH ROW.
+#   row 3 — the boolean-attribute list makes `required` toggle by default, but
+#     `Flag(false)` only REACHES that lookup once the runtime can see "underlying
+#     bool". Unifying the four dispatch tables is therefore a prerequisite, not a
+#     cleanup.
+#   rows 5/6 — `aria-hidden` is not on the list, so `={hidden}` stringifies to
+#     "true" with no annotation, and row 6's manual strconv becomes unnecessary.
+#   row 2 — fixed by deferring only the BOOLNESS, never the name. Codegen has the
+#     literal name, so it resolves list membership statically and emits
+#     `AttrAnyToggle("required", req)`, which owns the whole span and can omit a
+#     name that would otherwise be baked into the static string. Both
+#     instantiations then render correctly with no annotation: Mixed[bool]
+#     req={false} → <input/>, Mixed[string] req={"foo"} → required="foo".
+#   row 1/4 — already correct; they are the controls that localise the defect.
+-- input.gsx --
+package views
+
+import (
+	"strconv"
+
+	"github.com/gsxhq/gsx"
+)
+
+type Flag bool
+
+var anyFalse any = false
+
+component Plain(req bool) {
+	<input required={req} />
+}
+
+component Mixed[T string | bool](req T) {
+	<input required={req} />
+}
+
+component Sink(extra gsx.Attrs) {
+	<input { extra... } />
+}
+
+component Aria(hidden bool) {
+	<div aria-hidden={hidden} />
+	<div aria-hidden={strconv.FormatBool(hidden)} />
+}
+
+component Page() {
+	<Plain req={false} />
+	<Mixed[bool] req={false} />
+	<Sink extra={gsx.Attrs{{Key: "required", Value: Flag(false)}}} />
+	<Sink extra={gsx.Attrs{{Key: "required", Value: anyFalse}}} />
+	<Aria hidden={true} />
+}
+-- invoke --
+Page()
+-- diagnostics.golden --
+-- render.golden --
+<input/><input required="false"/><input required="false"/><input/><div aria-hidden/><div aria-hidden="true"/>
+-- generated.x.go.golden --
+// Code generated by gsx; DO NOT EDIT.
+
+package views
+
+import (
+	"strconv"
+
+	_gsxctx "context"
+	"github.com/gsxhq/gsx"
+	_gsxrt "github.com/gsxhq/gsx"
+	_gsxio "io"
+)
+
+type Flag bool
+
+var anyFalse any = false
+
+//line input.gsx:13:1
+func Plain(req bool) _gsxrt.Node {
+	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
+		_gsxgw := _gsxrt.W(_gsxw)
+//line input.gsx:14:2
+		_gsxgw.S("<input")
+		_gsxgw.BoolAttr("required", bool(req))
+		_gsxgw.S("/>")
+		return _gsxgw.Err()
+	})
+}
+
+//line input.gsx:17:1
+func Mixed[T string | bool](req T) _gsxrt.Node {
+	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
+		_gsxgw := _gsxrt.W(_gsxw)
+//line input.gsx:18:2
+		_gsxgw.S("<input required=\"")
+		_gsxgw.AttrAny(req)
+		_gsxgw.S("\"/>")
+		return _gsxgw.Err()
+	})
+}
+
+//line input.gsx:21:1
+func Sink(extra gsx.Attrs) _gsxrt.Node {
+	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
+		_gsxgw := _gsxrt.W(_gsxw)
+//line input.gsx:22:2
+		_gsxv0 := extra
+		_gsxgw.S("<input")
+		_gsxgw.ClassMerged(_gsxrt.DefaultClassMerge, _gsxv0.Class())
+		_gsxgw.StyleMerged("", _gsxv0.Style())
+		_gsxgw.Spread(ctx, _gsxv0, []string{"action", "cite", "data", "formaction", "href", "manifest", "ping", "poster", "xlink:href"}, []string{"background", "src"}, []string{"imagesrcset", "srcset"}, nil, []string{"class", "style"})
+		_gsxgw.S("/>")
+		return _gsxgw.Err()
+	})
+}
+
+//line input.gsx:25:1
+func Aria(hidden bool) _gsxrt.Node {
+	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
+		_gsxgw := _gsxrt.W(_gsxw)
+//line input.gsx:26:2
+		_gsxgw.S("<div")
+		_gsxgw.BoolAttr("aria-hidden", bool(hidden))
+		_gsxgw.S("/>")
+//line input.gsx:27:2
+		_gsxgw.S("<div aria-hidden=\"")
+		_gsxgw.AttrValue(string(strconv.FormatBool(hidden)))
+		_gsxgw.S("\"/>")
+		return _gsxgw.Err()
+	})
+}
+
+//line input.gsx:30:1
+func Page() _gsxrt.Node {
+	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
+		_gsxgw := _gsxrt.W(_gsxw)
+//line input.gsx:31:2
+		_gsxgw.Node(ctx, Plain(false))
+//line input.gsx:32:2
+		_gsxgw.Node(ctx, Mixed[bool](false))
+//line input.gsx:33:2
+		_gsxgw.Node(ctx, Sink(gsx.Attrs{{Key: "required", Value: Flag(false)}}))
+//line input.gsx:34:2
+		_gsxgw.Node(ctx, Sink(gsx.Attrs{{Key: "required", Value: anyFalse}}))
+//line input.gsx:35:2
+		_gsxgw.Node(ctx, Aria(true))
+		return _gsxgw.Err()
+	})
+}

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -8,6 +8,7 @@ attrmap/spread_undefined_error	diag render
 attrmap/tuple_map_compose	diag(error)
 attrs/attr_error_autounwrap	diag gen render
 attrs/attr_error_autounwrap_nested	diag gen render
+attrs/bool_exact_dispatch_required	diag gen render
 attrs/cond_attr_bool_off	diag render
 attrs/cond_attr_bool_on	diag render
 attrs/cond_attr_else_if_other	diag render
@@ -895,4 +896,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 897 cases (render: 770, error: 89, gen-pinned: 518)
+TOTAL: 898 cases (render: 771, error: 89, gen-pinned: 519)


### PR DESCRIPTION
**Spec only. No code changes. And — after review — not a syntax change either.**

## The premise that broke

The [2026-06-18 templating spec](docs/superpowers/specs/2026-06-18-gsx-templating-design.md) rejected templ's `?=` on an explicit basis — *"gsx knows the value's type at compile time, so it emits boolean-attr code directly"*. True, and not sufficient. The type answers **what value the author has**; it can't answer **whether HTML wants presence or a string**. Only the attribute *name* does, and HTML has two classes with **opposite** requirements.

Rendered with every value `false`, only `checked` is right today:

| source | renders | |
|---|---|---|
| `<input required={false}/>` | `<input/>` | correct |
| `<div aria-expanded={false}/>` | `<div/>` | loses the collapsed state |
| `<div contenteditable={false}/>` | `<div/>` | **inverted** |
| `<img draggable={false}/>` | `<img/>` | **inverted** |

`contenteditable` and `draggable` are inherited-or-default-on: `="false"` is precisely what *blocks* editing inside an editable ancestor and what *stops* an image dragging. Omitting them means the author writes `false` and the browser does `true`.

## The design

```
name={ boolExpr }        → listed name ? presence : "true"/"false"
name={ strExpr }         → always the string        (the list only sees bools)
name={ gsx.Toggle(b) }   → presence, any name       (the override)
name                     → bare; presence
```

The name decides by default, so **correct HTML needs no annotation**. `gsx.Toggle` (`type Toggle bool`) forces presence on names the spec can't know — web components, Datastar. Passing a string forces the value back, so **`required="foo"` stays expressible** for `[required="foo"]` CSS selectors; gsx isn't the HTML police.

## Why no `?=`

The operator was proposed, then dropped. **An override has to travel**, because the leaf makes the decision — `Toggle` is a value, so it crosses component boundaries, rides in bags, and survives generics. `?=` is an annotation on a source position and can be passed nowhere, so it needed `Toggle` as a runtime carrier *anyway*. It was always sugar over the mechanism.

It also punishes the authors it should serve: `?=` demands a static bool, so `open?={"foo"}` must error — a component author wanting a flexible prop can't use it and falls back to `open={var}`, the default path. It serves only the author who already knows it's a bool *and* is off-list, which is exactly what `Toggle(b)` covers.

Dropping it removes parser/AST work, the formatter and fmt corpus, and all three sibling repos from the plan.

## The membership rule — the WHATWG type column lies

This one surprised me. The "Value" column is only a **proxy**, wrong in both directions. The real criterion:

> **Is there a string that means false?** No → only absence can express it → list it. Yes → stringify.

- **`hidden`** is typed *enumerated*, but its [invalid value default is the **Hidden** state](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute) — so `hidden="false"` **hides the element**. It must be listed, or `hidden={false}` hides what the author asked to show.
- **`download`** is typed *Text*, but `download="true"` is a *filename*. Must be listed.
- **`contenteditable`/`draggable`/`spellcheck`** look boolean and aren't — `"false"` is a valid keyword. Must **not** be listed.

Derivation is therefore an implementation task with a method, not a copy: two independent fetches of the WHATWG index **contradicted each other** (one reported `required`/`selected`/`multiple` as Boolean, the other as absent) because the page truncates silently. Parse the table programmatically, review every row against the false-string test, cross-check against Vue's `isBooleanAttr` and React's property table.

## The pin

`attrs/bool_exact_dispatch_required.txtar` documents current *wrong* behaviour — green now, goldens flip when the fix lands, then it's the regression test.

It also localises the root cause, which is **not type erasure**: a plain `bool` boxed in an `any` renders *correctly*, because the assertion sees the dynamic type. gsx runs two classifiers that disagree —

```
static  (codegen)  classify(t) → t.Underlying() via go/types  →  Flag → catBool ✓
runtime (writer)   anyRenderString / kv.Value.(bool)          →  EXACT types only ✗
```

— so only **named bools** and **type parameters** fall through. Unifying the four dispatch tables is a prerequisite, not a cleanup; they've already drifted (`Val` errors on `uintptr` while inline `{x}` and `toStr` render `"5"`).

`make ci` and `make lint` pass clean.

https://claude.ai/code/session_01USSEvedSyjrgFaCsqTMKGz