### PR TITLE
fix(codegen): three verbatim-ABI analyzer fixes surfaced migrating a real project

### DIFF
--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -1042,6 +1042,22 @@ func emitProbes(sb *strings.Builder, nodes []gsxast.Markup, table funcTables, re
 						}
 					}
 				})
+				// The class-part probes above reference each part's VALUE expr, but a
+				// conditional class part's `: cond` guard and a value-form CF part's
+				// if/switch control are emitted verbatim by codegen with no harvest —
+				// so a var used ONLY in a component-tag class cond (e.g. a loop index
+				// in `<C class={ "first": i == 0 }/>`) would be a synthetic "declared
+				// and not used". The leaf-element branch already emits this liveness
+				// (see walkLivenessAttrExprs below); the component branch must too. An
+				// element enters exactly one branch, so there is no double emission.
+				// These yield empty-bodied `if cond {}` / `switch {}` blocks (not
+				// _gsxuse calls), leaving the k-th probe → k-th node harvest alignment
+				// undisturbed, and record ctrlOff entries for LSP go-to-definition.
+				walkLivenessAttrExprs(t.Attrs, func(cf *gsxast.ValueCF) {
+					emitValueCFControl(sb, fset, cf, ctrlOff)
+				}, func(node gsxast.Node, cond string, condPos token.Pos) {
+					emitCondLiveness(sb, fset, node, cond, condPos, ctrlOff)
+				})
 				// Probe ExprAttr values nested in a component cond-attr branch
 				// (`{ if C { attr={expr} } }`) with _gsxuseq, AFTER the parts probes —
 				// matching collectExprs's walkBranchAttrExprs pass exactly (Then→Else,

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -930,6 +930,21 @@ func emitProbes(sb *strings.Builder, nodes []gsxast.Markup, table funcTables, re
 					if err := targetRegistry.emitBinding(sb, t, fset); err != nil {
 						return err
 					}
+				} else if t.TypeArgs != "" {
+					// A component tag's authored type arguments are consumed by the
+					// target-discovery binding (emitBinding, above), but the shipping
+					// skeleton lowers the call positionally and never re-emits them —
+					// so an import referenced ONLY inside a markup type-argument (e.g.
+					// <comp.Check[cons.Foo] .../>) would be a synthetic "imported and
+					// not used". Reference the whole authored type-argument list as a
+					// function-result type list (which is exactly a comma-separated
+					// list of type expressions, so nested generics and multiple args
+					// need no ad-hoc splitting), anchored at TypeArgsPos so any
+					// undefined-type diagnostic maps back to the authored bytes. The
+					// blank var is neither a _gsxuse nor _gsxuseq call, so the k-th
+					// probe → k-th node harvest alignment is undisturbed.
+					emitSkeletonLine(sb, fset, t.TypeArgsPos)
+					fmt.Fprintf(sb, "var _ func() (%s)\n", t.TypeArgs)
 				}
 				// Probe simple ExprAttr values (child-prop values) with _gsxuse so harvest
 				// records their RAW types into resolved[ea]. This is emitted for ALL child

--- a/internal/codegen/component_positional_plan.go
+++ b/internal/codegen/component_positional_plan.go
@@ -790,11 +790,20 @@ func planComponentTypeArguments(target componentTargetFact, instance types.Insta
 }
 
 func validateTypeArgumentSpelling(expr string, want types.Type, target componentTargetFact, pkg *types.Package, fset *token.FileSet, txn *generatedImportTxn) error {
-	if len(txn.work.order) == txn.baseLen && target.expr != nil && target.expr.Pos().IsValid() {
-		parsed, err := goparser.ParseExpr(expr)
-		if err != nil {
-			return err
-		}
+	parsed, err := goparser.ParseExpr(expr)
+	if err != nil {
+		return err
+	}
+	// The strict caller-scope check type-checks the spelling against the real
+	// caller package: it knows the authored imports (and, via target.expr's
+	// position, any type parameters in scope) but NOT the yet-to-be-emitted
+	// _gsxtyN generated-import aliases. It is therefore valid ONLY when the
+	// spelling references no generated import. `len(txn.work.order) ==
+	// txn.baseLen` is not that condition: a spelling that REUSES a generated
+	// import already committed at an earlier call site (same cross-package type
+	// inferred twice) allocates no new order entry, yet still names _gsxtyN — it
+	// must go through the synthetic probe, which declares those aliases.
+	if !spellingReferencesGeneratedImport(parsed, txn) && target.expr != nil && target.expr.Pos().IsValid() {
 		info := &types.Info{Types: make(map[goast.Expr]types.TypeAndValue)}
 		if err := types.CheckExpr(fset, pkg, target.expr.Pos(), parsed, info); err != nil {
 			return err
@@ -805,6 +814,34 @@ func validateTypeArgumentSpelling(expr string, want types.Type, target component
 		return nil
 	}
 	return validateSyntheticTypeExpression(expr, want, pkg, txn)
+}
+
+// spellingReferencesGeneratedImport reports whether expr uses any selector
+// qualifier that names a generated (_gsxtyN) import alias. txn.work.order holds
+// every alias visible at this call site, including ones committed by prior
+// sites, so reused aliases are detected as well as freshly allocated ones.
+func spellingReferencesGeneratedImport(expr goast.Expr, txn *generatedImportTxn) bool {
+	if txn == nil {
+		return false
+	}
+	generated := make(map[string]bool, len(txn.work.order))
+	for _, spec := range txn.work.order {
+		generated[spec.name] = true
+	}
+	found := false
+	goast.Inspect(expr, func(node goast.Node) bool {
+		if found {
+			return false
+		}
+		if sel, ok := node.(*goast.SelectorExpr); ok {
+			if id, ok := sel.X.(*goast.Ident); ok && generated[id.Name] {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }
 
 func validateSyntheticTypeExpression(expr string, want types.Type, pkg *types.Package, txn *generatedImportTxn) error {

--- a/internal/corpus/testdata/cases/components/child_class_cond_loopvar.txtar
+++ b/internal/corpus/testdata/cases/components/child_class_cond_loopvar.txtar
@@ -1,0 +1,24 @@
+# A loop variable referenced ONLY inside a component-tag class-part condition
+# (class={ "first": i == 0 }) must count as used. Regression guard for the
+# component-tag branch, which — unlike the leaf-element branch — previously
+# omitted the class-part cond-guard liveness, so a var live only in the guard
+# was a synthetic `declared and not used: i`.
+-- input.gsx --
+package views
+
+import "github.com/gsxhq/gsx"
+
+component Item(label string, attrs gsx.Attrs) {
+	<span { attrs... }>{ label }</span>
+}
+
+component List(xs []string) {
+	{ for i, x := range xs {
+		<Item label={x} class={ "first": i == 0 } />
+	} }
+}
+-- invoke --
+List([]string{"a", "b"})
+-- diagnostics.golden --
+-- render.golden --
+<span class="first">a</span><span>b</span>

--- a/internal/corpus/testdata/cases/xpkg/generic_inferred_reused_import.txtar
+++ b/internal/corpus/testdata/cases/xpkg/generic_inferred_reused_import.txtar
@@ -1,0 +1,50 @@
+# Two component call sites in one file infer the SAME cross-package type
+# argument (val.Flag). The first site allocates a generated import alias
+# (_gsxty1) for val and commits it; the second REUSES that alias, so its
+# transaction records no new import. Regression guard: the reused alias must
+# still route through the synthetic type-spelling probe (which declares
+# _gsxtyN) rather than the strict caller-scope check — otherwise the second
+# site fails with `inferred type argument … cannot be emitted: undefined:
+# _gsxty1`.
+-- go.mod --
+module example.com/app
+
+go 1.26.1
+-- val/val.gsx --
+package val
+
+type Flag struct{ On bool }
+-- model/model.gsx --
+package model
+
+import "example.com/app/val"
+
+type Data struct{ F val.Flag }
+-- comp/box.gsx --
+package comp
+
+import (
+	"github.com/gsxhq/gsx"
+	"example.com/app/val"
+)
+
+component Box[T bool | val.Flag](v T, attrs gsx.Attrs) {
+	<span { attrs... }>box</span>
+}
+-- views/page.gsx --
+package views
+
+import (
+	"example.com/app/comp"
+	"example.com/app/model"
+)
+
+component Page(d model.Data) {
+	<comp.Box v={d.F} />
+	<comp.Box v={d.F} />
+}
+-- invoke --
+views.Page(model.Data{})
+-- diagnostics.golden --
+-- render.golden --
+<span>box</span><span>box</span>

--- a/internal/corpus/testdata/cases/xpkg/generic_typearg_only_import.txtar
+++ b/internal/corpus/testdata/cases/xpkg/generic_typearg_only_import.txtar
@@ -1,0 +1,43 @@
+# A cross-package generic component is invoked in markup with an EXPLICIT type
+# argument (<comp.Check[cons.Foo] …/>) whose package `cons` is imported by the
+# caller ONLY for that type argument. Regression guard: the shipping skeleton
+# must reference the authored markup type argument so `cons` is counted as used
+# — the target-discovery pass already did, but the shipping pass dropped it,
+# yielding a synthetic `"cons" imported and not used`.
+-- go.mod --
+module example.com/app
+
+go 1.26.1
+-- cons/cons.gsx --
+package cons
+
+type Foo struct{ V bool }
+-- comp/check.gsx --
+package comp
+
+import (
+	"github.com/gsxhq/gsx"
+	"example.com/app/cons"
+)
+
+func Zero() cons.Foo { return cons.Foo{} }
+
+component Check[T bool | cons.Foo](checked T, attrs gsx.Attrs) {
+	<label { attrs... }>check</label>
+}
+-- views/page.gsx --
+package views
+
+import (
+	"example.com/app/comp"
+	"example.com/app/cons"
+)
+
+component Page() {
+	<comp.Check[cons.Foo] checked={comp.Zero()} />
+}
+-- invoke --
+views.Page()
+-- diagnostics.golden --
+-- render.golden --
+<label>check</label>

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -882,6 +882,7 @@ verbatim/zero_inference_xpkg	diag gen render
 xpkg/cross_file_and_component	diag render
 xpkg/cross_package	diag render
 xpkg/generic_inferred_import	diag render
+xpkg/generic_inferred_reused_import	diag render
 xpkg/generic_inferred_two_files	diag gen render
 xpkg/generic_sibling_file	diag gen render
 xpkg/generic_skipped_sink_values	diag gen render
@@ -896,4 +897,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 898 cases (render: 771, error: 89, gen-pinned: 518)
+TOTAL: 899 cases (render: 772, error: 89, gen-pinned: 518)

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -118,6 +118,7 @@ comments/parse_snapshot	ast diag
 components/attrs_literal_merge	diag gen render
 components/attrs_literal_merge_tuple	diag gen render
 components/attrs_literal_multiple	diag gen render
+components/child_class_cond_loopvar	diag render
 components/child_class_evaluation_order	diag gen render
 components/child_class_fallthrough	diag render
 components/child_class_part_tuple	diag gen render
@@ -897,4 +898,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 899 cases (render: 772, error: 89, gen-pinned: 518)
+TOTAL: 900 cases (render: 773, error: 89, gen-pinned: 518)

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -885,6 +885,7 @@ xpkg/generic_inferred_import	diag render
 xpkg/generic_inferred_two_files	diag gen render
 xpkg/generic_sibling_file	diag gen render
 xpkg/generic_skipped_sink_values	diag gen render
+xpkg/generic_typearg_only_import	diag render
 xpkg/generic_unexported_constraint	diag render
 xpkg/go_component_attrs_literal	diag gen render
 xpkg/go_component_attrs_literal_missing	diag render
@@ -895,4 +896,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 897 cases (render: 770, error: 89, gen-pinned: 518)
+TOTAL: 898 cases (render: 771, error: 89, gen-pinned: 518)


### PR DESCRIPTION
Three independent codegen/analysis fixes found while migrating a large real project (one-learning) to the merged verbatim-component-signatures ABI. Each is root-caused, fixed with a real implementation (no heuristics), and pinned with a txtar corpus case. `make check` passes.

### 1. Count a markup type-argument as an import use (`37971caa`)
A generic component invoked in markup with an explicit type-arg whose type comes from a package used *only* there — `<form.EditCheckbox[pgtype.Bool] …/>` — was falsely reported `"pkg" imported and not used`. The shipping skeleton (`emitProbes`) probed the tag's attribute values but never referenced `Element.TypeArgs`, so go/types never saw the import used. Fix emits `var _ func() (<TypeArgs>)` anchored at `TypeArgsPos` (a func-result type list needs no ad-hoc comma splitting for nested/multiple args).
Corpus: `xpkg/generic_typearg_only_import`.

### 2. Emit the reused generated import for a repeated cross-package inferred type arg (`949d7afb`)
Two call sites inferring the *same* cross-package type argument failed at the second site with `inferred type argument … cannot be emitted: undefined: _gsxty1`. `validateTypeArgumentSpelling` used `len(work.order) == baseLen` as a proxy for "spelling references no generated import", but a *reused* alias is returned without appending to `work.order`, so the guard stayed true while the spelling still named `_gsxty1` — routing to the strict `types.CheckExpr` against the caller package that doesn't know the alias. Fix gates the strict branch on whether the spelling actually references a generated alias, so reused aliases go through the path that declares them.
Corpus: `xpkg/generic_inferred_reused_import`.

### 3. Count a loop var used only in a component-tag class condition (`7da3d738`)
A range/loop variable referenced only inside `class={ "cls": i == 0 }` on a **component tag** was reported `declared and not used: i`. The component branch of `emitProbes` probed each class part's value but not its `Cond` guard (the leaf-element branch already did, via `walkLivenessAttrExprs`). Fix adds the same guard-liveness emission to the component branch.
Corpus: `components/child_class_cond_loopvar`.

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa