### PR TITLE
fix(fmt): keep imports used only in markup type-args or component-tag attr expressions

### DIFF
--- a/gen/fmt_test.go
+++ b/gen/fmt_test.go
@@ -367,6 +367,35 @@ func TestFmtTwoDirsOneModule(t *testing.T) {
 	}
 }
 
+// TestFmtKeepsTypeArgAndAttrExprImports pins the detector fix for imports
+// referenced ONLY in positions the syntactic unused-import scan used to miss: a
+// markup type-argument (<comp.Check[cons.Foo]> uses cons) and a component-tag
+// attribute-value Go expression (attrs={{ "@x": gsx.RawJS(...) }} uses gsx).
+// componentTargetQualifiers formerly harvested only the tag qualifier, so fmt
+// stripped both imports and broke the file's compilation. Detection is
+// syntactic, so the referenced comp/cons packages need not exist; a genuinely
+// unused import (bytes) in the same file must still be the only one reported, to
+// prove the fix keeps used imports without disabling removal.
+func TestFmtKeepsTypeArgAndAttrExprImports(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newModule(t, "fmtmod")
+	src := "package views\n\nimport (\n\t\"bytes\"\n\n\t\"github.com/gsxhq/gsx\"\n\n\t\"fmtmod/comp\"\n\t\"fmtmod/cons\"\n)\n\n" +
+		"component Page(d bool) {\n\t<comp.Check[cons.Foo] checked={d} attrs={{ \"@x\": gsx.RawJS(\"f()\") }} />\n}\n"
+	page := writeFile(t, filepath.Join(dir, "views"), "views.gsx", src)
+
+	refs, _ := analyzeUnusedImports(
+		[]string{page},
+		codegen.Options{Classifier: attrclass.Builtin()},
+	)
+	abs, _ := filepath.Abs(page)
+	if len(refs[abs]) != 1 || refs[abs][0].Path != "bytes" {
+		t.Fatalf("want only bytes unused (cons used in type-arg, gsx in attr expr, comp in tag), got %+v", refs[abs])
+	}
+}
+
 // TestFmtToleratesMalformedConfig proves that with a builtin-only
 // codegen.Options (the fallback gen/main.go's `fmt` case uses when
 // resolveConfig fails on a malformed gsx.toml), formatting still succeeds.

--- a/internal/codegen/component_target.go
+++ b/internal/codegen/component_target.go
@@ -967,8 +967,116 @@ func componentTargetQualifiers(registry *callSiteRegistry, facts map[callSiteID]
 		if ok && token.IsIdentifier(qualifier) {
 			qualifiers[qualifier] = true
 		}
+		// The tag qualifier alone misses two authored uses of an import that never
+		// reach the operand skeleton: a markup type-argument (<comp.Check[cons.Foo]>
+		// references cons) and a component-tag attribute-value Go expression
+		// (attrs={{ "@x": gsx.RawJS(…) }} references gsx). Component-tag attributes
+		// are not emitted into the fmt skeleton, so skeletonUsedNames cannot see
+		// them; harvest their package-qualifier roots here so unused-import removal
+		// keeps them.
+		harvestElementQualifierRoots(record.element, qualifiers)
 	}
 	return qualifiers
+}
+
+// harvestElementQualifierRoots records, in qualifiers, every package-qualifier
+// root (the X in an X.Sel selector) authored in element's own type-argument list
+// and attribute-value Go expressions. It is a deliberately conservative
+// token-scan: any IDENT immediately followed by a PERIOD is a qualifier
+// reference, hence a use of that import. Over-keeping an import is safe;
+// dropping a used one is the bug this closes. It walks the element's attrs (not
+// its child elements — each nested component tag is its own registry record) via
+// gsxast.Inspect so every Go-expression carrier (ExprAttr, OrderedAttrsAttr
+// pairs, SpreadAttr, EmbeddedAttr holes, CondAttr branches, ClassAttr parts,
+// value-form control flow, pipeline stage args) is covered uniformly.
+func harvestElementQualifierRoots(element *gsxast.Element, qualifiers map[string]bool) {
+	if element == nil {
+		return
+	}
+	scanQualifierRoots(element.TypeArgs, qualifiers)
+	for _, attr := range element.Attrs {
+		gsxast.Inspect(attr, func(n gsxast.Node) bool {
+			switch n := n.(type) {
+			case *gsxast.ExprAttr:
+				scanQualifierRoots(n.Expr, qualifiers)
+				scanStageQualifierRoots(n.Stages, qualifiers)
+			case *gsxast.SpreadAttr:
+				scanQualifierRoots(n.Expr, qualifiers)
+				scanStageQualifierRoots(n.Stages, qualifiers)
+			case *gsxast.OrderedPair:
+				scanQualifierRoots(n.Value, qualifiers)
+			case *gsxast.Interp:
+				scanQualifierRoots(n.Expr, qualifiers)
+				scanStageQualifierRoots(n.Stages, qualifiers)
+			case *gsxast.EmbeddedAttr:
+				scanStageQualifierRoots(n.Stages, qualifiers)
+			case *gsxast.EmbeddedInterp:
+				scanStageQualifierRoots(n.Stages, qualifiers)
+			case *gsxast.CondAttr:
+				scanQualifierRoots(n.Cond, qualifiers)
+			case *gsxast.ClassPart:
+				scanQualifierRoots(n.Expr, qualifiers)
+				scanQualifierRoots(n.Cond, qualifiers)
+				scanStageQualifierRoots(n.Stages, qualifiers)
+			case *gsxast.ValueArm:
+				scanQualifierRoots(n.Expr, qualifiers)
+				scanStageQualifierRoots(n.Stages, qualifiers)
+			case *gsxast.ValueIf:
+				scanQualifierRoots(n.Cond, qualifiers)
+			case *gsxast.ValueSwitch:
+				scanQualifierRoots(n.Tag, qualifiers)
+			case *gsxast.ValueSwitchCase:
+				scanQualifierRoots(n.List, qualifiers)
+			case *gsxast.Element:
+				// A component tag nested inside a markup attribute value is its own
+				// registry record, so its attrs are harvested there; keep only its
+				// type arguments conservatively here.
+				scanQualifierRoots(n.TypeArgs, qualifiers)
+			}
+			return true
+		})
+	}
+}
+
+// scanStageQualifierRoots harvests qualifier roots from the argument source of
+// each pipeline stage (`|> name(args)`); the stage name is a registered filter
+// identifier, never a package qualifier.
+func scanStageQualifierRoots(stages []gsxast.PipeStage, qualifiers map[string]bool) {
+	for _, st := range stages {
+		if st.HasArgs {
+			scanQualifierRoots(st.Args, qualifiers)
+		}
+	}
+}
+
+// scanQualifierRoots tokenizes src with go/scanner and records, in qualifiers,
+// every identifier immediately followed by a `.` — the qualifier X in a selector
+// X.Sel, which is exactly how an imported package name is referenced. Lexical
+// errors are ignored: a partial scan can only under-report, and any qualifier it
+// does find is a genuine use.
+func scanQualifierRoots(src string, qualifiers map[string]bool) {
+	if strings.TrimSpace(src) == "" {
+		return
+	}
+	var s scanner.Scanner
+	fset := token.NewFileSet()
+	file := fset.AddFile("", fset.Base(), len(src))
+	s.Init(file, []byte(src), func(token.Position, string) {}, 0)
+	prevIdent := ""
+	for {
+		_, tok, lit := s.Scan()
+		if tok == token.EOF {
+			break
+		}
+		if tok == token.PERIOD && prevIdent != "" {
+			qualifiers[prevIdent] = true
+		}
+		if tok == token.IDENT {
+			prevIdent = lit
+		} else {
+			prevIdent = ""
+		}
+	}
 }
 
 func (r *callSiteRegistry) hasCandidates() bool {

--- a/internal/gsxfmt/testdata/cases/imports_keeps_typearg_and_attr_expr.txtar
+++ b/internal/gsxfmt/testdata/cases/imports_keeps_typearg_and_attr_expr.txtar
@@ -1,0 +1,36 @@
+A component tag carrying a markup type-argument (<comp.Check[cons.Foo]>) and an
+attrs={{ … }} bag whose value is a Go expression (gsx.RawJS(…)) round-trips
+through the formatter unchanged. The unused-import DETECTION for these positions
+is exercised in gen/fmt_test.go (TestFmtKeepsTypeArgAndAttrExprImports); this
+corpus layer takes the unused list as input, so with none supplied it pins that
+the formatter neither reorders nor drops these imports and keeps the tag's
+type-arg + attrs layout intact.
+
+-- imports --
+goimports
+-- input.gsx --
+package views
+
+import (
+	"github.com/gsxhq/gsx"
+
+	"views/comp"
+	"views/cons"
+)
+
+component Page(d bool) {
+	<comp.Check[cons.Foo] checked={d} attrs={{ "@x": gsx.RawJS("f()") }} />
+}
+-- fmt.golden --
+package views
+
+import (
+	"github.com/gsxhq/gsx"
+
+	"views/comp"
+	"views/cons"
+)
+
+component Page(d bool) {
+	<comp.Check[cons.Foo] checked={d} attrs={{ "@x": gsx.RawJS("f()") }}/>
+}


### PR DESCRIPTION
`gsx fmt` was stripping imports that **are** used, when their only use is a position its syntactic unused-import detector never scanned:
- a markup **type-argument** — `<comp.Check[cons.Foo] …>` uses `cons`, and
- a component-tag **attribute-value Go expression** — `attrs={{ "@x": gsx.RawJS("f()") }}` uses `gsx`.

After `fmt` removed them the file no longer compiled (`undefined: cons` / `undefined: gsx`) — so a `make fmt` in a real project silently broke the next build.

### Root cause
The detector's used-package set is `skeletonUsedNames(skel)` ∪ `targetQualifiers`. `componentTargetQualifiers` (`internal/codegen/component_target.go`) harvested only the tag-name qualifier (`strings.Cut(element.Tag, ".")`); it never looked at `element.TypeArgs` or the tag's attribute-value expressions, and component-tag attrs aren't emitted into the fmt skeleton, so `skeletonUsedNames` missed them too. (Companion to #124's defect #1, which fixed the *codegen* skeleton; this is the separate *formatter* import scan.)

### Fix
`componentTargetQualifiers` now also harvests qualifier roots from each in-scope component tag's `TypeArgs` and attribute-value Go expressions (`harvestElementQualifierRoots` walks `Attrs` via `gsxast.Inspect`, pulling Go source from every carrier — ExprAttr, OrderedAttrsAttr pairs, SpreadAttr, EmbeddedAttr/EmbeddedInterp holes+stages, CondAttr, ClassAttr parts, value-form control flow, Interp). Extraction is a conservative `go/scanner` token scan: any IDENT immediately followed by PERIOD is a used qualifier root. Over-keeping is safe; dropping a used import was the bug. Genuinely-unused removal is unchanged.

### Tests
- `gen/fmt_test.go` → `TestFmtKeepsTypeArgAndAttrExprImports`: runs the real `analyzeUnusedImports` detector and asserts that in a file using imports only via a type-arg and an `attrs={{…}}` expr, a genuinely-unused `bytes` is the **only** import removed — proving used imports survive without disabling removal (sits beside `TestFmtRemovesUnused*`).
- fmt-corpus case `imports_keeps_typearg_and_attr_expr.txtar`.

Verified end-to-end against a real project: `gsx fmt` now keeps the imports, and `gsx generate` + `go build ./...` stay green through a `fmt`. `make check` passes.

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa