### PR TITLE
feat(jsx): a whole-value js attribute hole JSON-encodes

### DIFF
--- a/docs/guide/syntax/javascript.md
+++ b/docs/guide/syntax/javascript.md
@@ -105,6 +105,13 @@ encoded as JSON values. The rendered attribute is then HTML-escaped; the browser
 restores the JSON text before the consumer reads it. Name keys in the literal
 and place dynamic holes in value positions.
 
+When the **entire** attribute value is a single hole — `data-labels=js`@{labels}``
+— gsx JSON-encodes the whole Go value, so chart `data-*` attributes and a
+whole-value `hx-vals` need no hand-built JSON. A hole that is *not* the whole
+value and sits before a token (`js`@{x} = 1``, `js`@{x} + 2``) is a
+binding/operand position and accepts only `gsx.RawJS`. This applies to `js`
+attributes; a plain `{ … }` attribute still takes only a string/number/bool.
+
 ## `<script>` interpolation
 
 Inside `<script>`, `@{ expr }` inserts a Go value in the surrounding JavaScript

--- a/internal/corpus/testdata/cases/jsattr/root_value_hole.txtar
+++ b/internal/corpus/testdata/cases/jsattr/root_value_hole.txtar
@@ -1,0 +1,23 @@
+# A js`…` ATTRIBUTE whose entire value is a single @{ } hole JSON-encodes the Go
+# value (slice/map/struct/string/number), the same way a hole INSIDE a JSON
+# literal does. The value is HTML-attr-escaped after JSON encoding, so a hostile
+# string can't break out. This is the idiom for chart data-* attributes and a
+# whole-value hx-vals. (A hole followed by tokens — `@{x} = 5`, `@{x} + 1` — is
+# still a binding/operand position and only accepts gsx.RawJS; see
+# goexpr-js-literal/binding_non_rawjs_rejected. A <script> body or Go-expression
+# js`…` literal keeps the strict binding rule too.)
+-- input.gsx --
+package views
+
+component Chart(labels []string, counts []int, opts map[string]string) {
+	<div
+		data-labels=js`@{labels}`
+		data-counts=js`@{counts}`
+		data-opts=js`@{opts}`
+	></div>
+}
+-- invoke --
+Chart([]string{"A", `B"x`}, []int{1, 2}, map[string]string{"page": "1"})
+-- diagnostics.golden --
+-- render.golden --
+<div data-labels="[&#34;A&#34;,&#34;B\&#34;x&#34;]" data-counts="[1,2]" data-opts="{&#34;page&#34;:&#34;1&#34;}"></div>

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -457,6 +457,7 @@ jsattr/manual_overridable	diag gen render
 jsattr/nested_f_in_js_hole	diag gen render
 jsattr/quoted_attr_literal_no_interp	diag render
 jsattr/regexp_hostile	diag gen render
+jsattr/root_value_hole	diag render
 jsattr/string_hostile	diag gen render
 jsattr/tmpl_hostile	diag gen render
 jsattr/value_pipeline	diag gen render
@@ -906,4 +907,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 908 cases (render: 782, error: 88, gen-pinned: 525)
+TOTAL: 909 cases (render: 783, error: 88, gen-pinned: 525)

--- a/internal/jsx/jsx.go
+++ b/internal/jsx/jsx.go
@@ -344,7 +344,7 @@ func resolveScript(el *ast.Element, bag *diag.Bag) bool {
 		}
 	}
 
-	if !classify(sb.String(), holes, bag) {
+	if !classify(sb.String(), holes, false, bag) {
 		return false
 	}
 
@@ -398,7 +398,7 @@ func ResolveJSAttr(name string, segments []ast.Markup) error {
 // binding / unclassifiable positions fail closed exactly as in <script>.
 // Returns true if clean, false if any diagnostic was added to bag.
 func resolveJSAttr(name string, segments []ast.Markup, bag *diag.Bag) bool {
-	return resolveEmbeddedJS(fmt.Sprintf("attribute %q", name), segments, bag)
+	return resolveEmbeddedJS(fmt.Sprintf("attribute %q", name), segments, true, bag)
 }
 
 // ResolveEmbedded classifies every @{ … } hole in a bare segment list for a
@@ -413,7 +413,7 @@ func resolveJSAttr(name string, segments []ast.Markup, bag *diag.Bag) bool {
 // already-classified segment list (re-classification just overwrites the same
 // values). Returns true if clean, false if any diagnostic was added to bag.
 func ResolveEmbedded(segments []ast.Markup, bag *diag.Bag) bool {
-	return resolveEmbeddedJS("js literal", segments, bag)
+	return resolveEmbeddedJS("js literal", segments, false, bag)
 }
 
 // resolveEmbeddedJS is the shared segment-walking core behind resolveJSAttr and
@@ -423,7 +423,7 @@ func ResolveEmbedded(segments []ast.Markup, bag *diag.Bag) bool {
 // diagnostic wording only (e.g. `attribute "x-data"` or the neutral
 // "js literal") and never affects classification logic.
 // Returns true if clean, false if any diagnostic was added to bag.
-func resolveEmbeddedJS(descriptor string, segments []ast.Markup, bag *diag.Bag) bool {
+func resolveEmbeddedJS(descriptor string, segments []ast.Markup, allowRootValue bool, bag *diag.Bag) bool {
 	// Bail early if there are no holes (a hole-free JS attr stays StaticAttr and
 	// never reaches here, but be defensive).
 	hasInterp := false
@@ -491,7 +491,7 @@ func resolveEmbeddedJS(descriptor string, segments []ast.Markup, bag *diag.Bag) 
 		}
 	}
 
-	if !classify(sb.String(), holes, bag) {
+	if !classify(sb.String(), holes, allowRootValue, bag) {
 		return false
 	}
 
@@ -517,11 +517,28 @@ func resolveEmbeddedJS(descriptor string, segments []ast.Markup, bag *diag.Bag) 
 // classify lexes the skeleton and assigns each hole a context (setting h.ctx /
 // h.comment / h.resolved), recording positioned fail-closed diagnostics in bag
 // for any hole in an unsafe code position. Returns true if clean.
-func classify(skeleton string, holes []*hole, bag *diag.Bag) bool {
+// allowRootValue enables the lone-hole-is-a-value rule below. It is true only for
+// JS ATTRIBUTES (`data-labels=js`@{labels}“, `hx-vals=js`@{obj}“), where a whole
+// attribute value that is one hole is intentionally the JSON of a Go value. In a
+// <script> body or a Go-expression js`…` literal a bare ordinary-value hole is
+// almost certainly a mistake (executable JS was meant), so those keep the
+// conservative binding rule and reject it — matching the strict plain-`{ }` attr.
+func classify(skeleton string, holes []*hole, allowRootValue bool, bag *diag.Bag) bool {
 	l := js.NewLexer(parse.NewInputString(skeleton))
 	pos := 0                 // running byte offset = start of the token about to be processed
 	prevSig := js.ErrorToken // previous SIGNIFICANT token (start-of-input)
 	ok := true
+
+	// A hole at expression start (`@{x}` with no preceding significant token) is
+	// classified JSCtxBinding by classifyHole (start-of-input is not a value
+	// position). But an expression that STARTS with a hole is a value unless a
+	// following significant token makes the hole an assignment target or operand
+	// (`@{x} = 5`, `@{x} + 1`). We can only know that on the NEXT significant
+	// token, so treat such a hole as a value tentatively and revert it if one
+	// follows. The surviving case — a LONE hole that is the whole js literal
+	// (`data-labels=js`@{labels}``) — cannot be an lvalue, so it stays a value and
+	// JSON-encodes, matching a hole INSIDE a JSON literal.
+	var pendingStartHole *hole
 
 	for {
 		tt, data := l.Next()
@@ -542,6 +559,13 @@ func classify(skeleton string, holes []*hole, bag *diag.Bag) bool {
 		start, end := pos, pos+len(data)
 		pos = end
 
+		// A significant token following a tentative start hole means the hole is
+		// not the whole expression — revert to the conservative binding rule.
+		if pendingStartHole != nil && isSignificant(tt) {
+			pendingStartHole.ctx = ast.JSCtxBinding
+			pendingStartHole = nil
+		}
+
 		for _, h := range holes {
 			if h.resolved {
 				continue
@@ -549,8 +573,12 @@ func classify(skeleton string, holes []*hole, bag *diag.Bag) bool {
 			if h.start < start || h.end > end {
 				continue // hole not (fully) within this token
 			}
+			atStart := prevSig == js.ErrorToken
 			if !classifyHole(h, tt, start, end, prevSig, bag) {
 				ok = false
+			} else if allowRootValue && atStart && h.ctx == ast.JSCtxBinding {
+				h.ctx = ast.JSCtxValue
+				pendingStartHole = h
 			}
 		}
 


### PR DESCRIPTION
## Problem

`data-labels=js`@{labels}`` — a `js` attribute whose **entire** value is one hole — failed:

```
@{ } here is a JavaScript binding/lvalue position … only a gsx.RawJS value may be spliced here
```

The classifier sees a hole at start-of-input, has no forward lookahead, and conservatively defers it to `JSCtxBinding` (it can't tell `@{x}` from `@{x} = 5`). Emit then rejects any non-`RawJS` value. But a **lone** hole can't be an assignment target — it's a value, and should JSON-encode the Go value exactly as a hole *inside* a JSON literal already does (`hx-vals=js`{"k": @{v}}``).

This forced hand-built `json.Marshal` helpers for every chart `data-*` attribute.

## Fix

`classify()` now treats a start-of-expression hole as `JSCtxValue` tentatively and reverts it to `JSCtxBinding` only if a significant token follows (`@{x} = 5`, `@{x} + 1`). A lone hole — nothing follows — stays a value. `JSCtxValue` and `JSCtxBinding` emit the *same* `_gsxgw.JSVal`, differing only in the type gate (Value accepts anything and JSON-encodes; `RawJS` passes through verbatim in both) — so **no regression**, and ordinary slices/maps/structs now JSON-encode.

Scoped with `allowRootValue`, true **only for JS attributes**. A `<script>` body and a Go-expression `js`…`` literal keep the strict binding rule — a bare ordinary value there is almost certainly a mistake (meant executable JS → use `RawJS`), the same "catch accidental use" logic as the strict plain-`{ }` attribute.

## Result

```gsx
<div data-labels=js`@{labels}` data-opts=js`@{opts}`></div>
// Chart([]string{"A", `B"x`}, map[string]string{"page":"1"})
// → data-labels="[&#34;A&#34;,&#34;B\&#34;x&#34;]" data-opts="{&#34;page&#34;:&#34;1&#34;}"
```

Hostile quote escaped; injection-safe. Lets consumers delete hand-built chart-JSON helpers.

## Tests / docs

- Corpus: `jsattr/root_value_hole` (slice / int-slice / map, hostile chars).
- The `jsx` module-script unit test is **unchanged** and still asserts `JSCtxBinding` — proving scripts are unaffected.
- Docs: `javascript.md` whole-value hole note.
- Full corpus + `internal/codegen` / `internal/jsx` / `gen` green.

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa
