### PR TITLE
Completion + nav field fixes: bare tags, component values, bracket-safe kinds

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -574,7 +574,16 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   **Follow-ups:** auto-import completion (own design); expected-type ranking;
   snippet placeholders; typed pipe-filter compatibility filtering;
   `completionItem/resolve` for lazy docs; method-component (`<recv.Name>`)
-  tags.
+  tags; extend the repair + ephemeral-analysis machinery to
+  definition/hover on mid-edit buffers (an unclosed tag currently drops the
+  package to a shell and nav reads the stale retained snapshot).
+- [ ] **emit.go `//line` for top-level Go body chunks** - shipped `.x.go`
+  emits no `//line` for plain GoChunk text or GoWithElements GoText, so a
+  cross-module dep loaded from its published `.x.go` resolves value positions
+  (gd on component values, compiler errors in top-level var blocks) up to a
+  few lines off within the correct `.gsx`. Same-module is exact (in-memory
+  skeleton anchors correctly since the `part.Pos()+start` fix). Emit `//line`
+  for these chunks like components/elements already get.
 - **Deferred:** external/non-project references; references cover project
   components discovered during module analysis.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -570,13 +570,18 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   docs + MDN links); `hx-*` attributes when the module's htmx preset is
   enabled. Plain text edits, no snippets. Warm per-request analysis measured
   at ~140µs (`BenchmarkAnalyzeEphemeralWarm`, Apple M3 Ultra). Spec
-  `2026-07-21-lsp-completion-design.md`.
+  `2026-07-21-lsp-completion-design.md`. The same repair + ephemeral-analysis
+  machinery now also backs go-to-definition and hover on mid-edit buffers: when
+  the primary cascade answers nothing (an unclosed tag drops the package to a
+  shell), nav repairs the token under the cursor, runs one ephemeral analysis,
+  and re-runs the cascade — so gd/hover on a half-typed `<icon.Bell` resolve.
+  Fallback-only (zero change to answerable cases); returned current-file spans
+  map repaired→live coordinates. Cursor-local, so it heals breakage at the
+  cursor, not on an unrelated line.
   **Follow-ups:** auto-import completion (own design); expected-type ranking;
   snippet placeholders; typed pipe-filter compatibility filtering;
   `completionItem/resolve` for lazy docs; method-component (`<recv.Name>`)
-  tags; extend the repair + ephemeral-analysis machinery to
-  definition/hover on mid-edit buffers (an unclosed tag currently drops the
-  package to a shell and nav reads the stale retained snapshot).
+  tags.
 - [ ] **emit.go `//line` for top-level Go body chunks** - shipped `.x.go`
   emits no `//line` for plain GoChunk text or GoWithElements GoText, so a
   cross-module dep loaded from its published `.x.go` resolves value positions

--- a/gen/definition_crosspkg_value_e2e_test.go
+++ b/gen/definition_crosspkg_value_e2e_test.go
@@ -1,0 +1,331 @@
+package gen
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/lsp"
+)
+
+// crossPkgValueDep is a dependency package whose .gsx declares component VALUES
+// (`X = icon("x")` in a top-level var block) alongside a helper whose body is a
+// gsx element. `icon` returns a `func(...gsx.Attr) gsx.Node`, so each var is a
+// component value usable as `<widget.X/>`. The var block is a plain Go chunk;
+// its declarations resolve back to this .gsx via a //line directive, NOT via the
+// importing package's SourceIndex (that only holds the importer's own spans).
+const crossPkgValueDep = `package widget
+
+import "github.com/gsxhq/gsx"
+
+func icon(name string) func(attrs ...gsx.Attr) gsx.Node {
+	return func(attrs ...gsx.Attr) gsx.Node {
+		return (
+			<svg
+				width="24"
+				{ attrs... }
+			>
+				<title>{ name }</title>
+			</svg>
+		)
+	}
+}
+
+var (
+	Check = icon("check")
+	X     = icon("x")
+	Menu  = icon("menu")
+)
+`
+
+func writeCrossPkgValueModule(t *testing.T, dir, page string) {
+	t.Helper()
+	repoRoot, _ := filepath.Abs("..")
+	mk := func(p, c string) {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("go.mod", "module example.com/x\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	mk("widget/named.gsx", crossPkgValueDep)
+	mk("page/page.gsx", page)
+
+	// Generate the dependency so the importer type-checks against it (matching the
+	// real-world setup where ds/icon has a generated .x.go on disk). The X decl
+	// position still comes from widget/named.gsx via //line, never its .x.go.
+	if _, err := Generate([]string{filepath.Join(dir, "widget")}); err != nil {
+		t.Fatalf("generate dep: %v", err)
+	}
+}
+
+// runCrossPkgValueDefinition opens page.gsx and requests definition + hover at
+// the cursor (0-based line/character), returning both results.
+func runCrossPkgValueDefinition(t *testing.T, dir, page string, line, character int) (*lsp.Location, *lsp.Hover) {
+	t.Helper()
+	uri := "file://" + filepath.Join(dir, "page", "page.gsx")
+	frame := func(v any) string {
+		b, _ := json.Marshal(v)
+		return "Content-Length: " + strconv.Itoa(len(b)) + "\r\n\r\n" + string(b)
+	}
+	in := frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "version": 1, "text": page}}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/definition",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri},
+			"position": map[string]any{"line": line, "character": character}}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "id": 3, "method": "textDocument/hover",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri},
+			"position": map[string]any{"line": line, "character": character}}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "method": "exit"})
+
+	var out, errBuf bytes.Buffer
+	if code := runLSP(strings.NewReader(in), &out, &errBuf, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, errBuf.String())
+	}
+	loc := definitionResult(t, out.String(), 2)
+	hov := authoredHoverResult(t, out.String(), 3)
+	return loc, hov
+}
+
+// wantXLocation is the expected declaration site of `X` in widget/named.gsx: the
+// var line's 0-based line index and the 0-based column of the `X` identifier.
+func wantXLocation(t *testing.T) (line, character int) {
+	t.Helper()
+	lines := strings.Split(crossPkgValueDep, "\n")
+	for i, l := range lines {
+		if c := strings.Index(l, "X     = icon"); c >= 0 {
+			return i, c
+		}
+	}
+	t.Fatal("could not locate X declaration in dep source")
+	return 0, 0
+}
+
+// gd on the cross-package tag `<widget.X/>` (X is a component VALUE declared in
+// a Go var block of widget/named.gsx) resolves to X's declaration in that .gsx,
+// NOT to null and NOT into a generated .x.go. Regression guard for the value-
+// target definition gap: fact.TargetDecls is empty for value targets, so
+// resolution falls through to the raw go/types object position, which //line-
+// maps to an authored .gsx of a sibling package.
+func TestDefinitionCrossPkgValueTag(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	page := "package page\n\nimport \"example.com/x/widget\"\n\ncomponent Page() {\n\t<widget.X/>\n}\n"
+	writeCrossPkgValueModule(t, dir, page)
+
+	var line, character int
+	for i, l := range strings.Split(page, "\n") {
+		if c := strings.Index(l, "widget.X"); c >= 0 {
+			line, character = i, c+len("widget.") // a column on "X"
+			break
+		}
+	}
+
+	loc, hov := runCrossPkgValueDefinition(t, dir, page, line, character)
+	if loc == nil {
+		t.Fatal("tag definition returned null; want widget/named.gsx X declaration")
+	}
+	if !strings.HasSuffix(loc.URI, filepath.Join("widget", "named.gsx")) {
+		t.Fatalf("resolved to %q, want widget/named.gsx", loc.URI)
+	}
+	if strings.HasSuffix(loc.URI, ".x.go") {
+		t.Fatalf("resolved into a generated .x.go (%q); must never jump into generated code", loc.URI)
+	}
+	wantLine, wantCol := wantXLocation(t)
+	if loc.Range.Start.Line != wantLine || loc.Range.Start.Character != wantCol {
+		t.Fatalf("tag gd landed at L%d:C%d, want L%d:C%d (the X value decl)",
+			loc.Range.Start.Line, loc.Range.Start.Character, wantLine, wantCol)
+	}
+	if hov == nil {
+		t.Fatalf("hover on tag was null; want non-null signature")
+	}
+}
+
+// gd on the cross-package reference `widget.X` inside an interpolation
+// `{ widget.X }` resolves to the same X declaration as the tag case — the
+// source-index / expression path (exprNodeAtOffset → Info.Uses → Fset.Position),
+// which shares the same authored-.gsx target policy.
+func TestDefinitionCrossPkgValueInterp(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	page := "package page\n\nimport \"example.com/x/widget\"\n\ncomponent Page() {\n\t<div>{ widget.X }</div>\n}\n"
+	writeCrossPkgValueModule(t, dir, page)
+
+	var line, character int
+	for i, l := range strings.Split(page, "\n") {
+		if c := strings.Index(l, "widget.X"); c >= 0 {
+			line, character = i, c+len("widget.") // a column on "X"
+			break
+		}
+	}
+
+	loc, hov := runCrossPkgValueDefinition(t, dir, page, line, character)
+	if loc == nil {
+		t.Fatal("interp definition returned null; want widget/named.gsx X declaration")
+	}
+	if !strings.HasSuffix(loc.URI, filepath.Join("widget", "named.gsx")) {
+		t.Fatalf("resolved to %q, want widget/named.gsx", loc.URI)
+	}
+	if strings.HasSuffix(loc.URI, ".x.go") {
+		t.Fatalf("resolved into a generated .x.go (%q); must never jump into generated code", loc.URI)
+	}
+	wantLine, wantCol := wantXLocation(t)
+	if loc.Range.Start.Line != wantLine || loc.Range.Start.Character != wantCol {
+		t.Fatalf("interp gd landed at L%d:C%d, want L%d:C%d (the X value decl)",
+			loc.Range.Start.Line, loc.Range.Start.Character, wantLine, wantCol)
+	}
+	if hov == nil {
+		t.Fatalf("hover on interp reference was null; want non-null signature")
+	}
+}
+
+// writeCrossModuleValueModules wires two SEPARATE modules: `app` (the page) and
+// `dep` (the widget library, joined by a `replace` directive, mirroring the
+// hello-gsx→libgsx setup). It returns the app dir and the page.gsx path. The dep
+// is generated so it type-checks; the caller decides whether to keep the dep's
+// .gsx (sources-present) or delete it (only-.x.go).
+func writeCrossModuleValueModules(t *testing.T, page string, keepDepSource bool) (appDir, pagePath, depGSX, depXGo string) {
+	t.Helper()
+	root := t.TempDir()
+	repoRoot, _ := filepath.Abs("..")
+	mk := func(p, c string) {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("app/go.mod", "module app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\nrequire dep v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\nreplace dep => ../dep\n")
+	mk("dep/go.mod", "module dep\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	mk("dep/widget/named.gsx", crossPkgValueDep)
+	mk("app/page.gsx", page)
+
+	if _, err := Generate([]string{filepath.Join(root, "dep", "widget")}); err != nil {
+		t.Fatalf("generate dep: %v", err)
+	}
+	depGSX = filepath.Join(root, "dep", "widget", "named.gsx")
+	depXGo = filepath.Join(root, "dep", "widget", "named.x.go")
+	if !keepDepSource {
+		// Only the generated .x.go remains on disk (an external dependency that
+		// ships its generated output but not its .gsx sources).
+		if err := os.Remove(depGSX); err != nil {
+			t.Fatalf("remove dep .gsx: %v", err)
+		}
+	}
+	return filepath.Join(root, "app"), filepath.Join(root, "app", "page.gsx"), depGSX, depXGo
+}
+
+func runDefinitionAt(t *testing.T, appDir, pagePath, page string, line, character int) (*lsp.Location, *lsp.Hover) {
+	t.Helper()
+	uri := "file://" + pagePath
+	frame := func(v any) string {
+		b, _ := json.Marshal(v)
+		return "Content-Length: " + strconv.Itoa(len(b)) + "\r\n\r\n" + string(b)
+	}
+	in := frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{"rootUri": "file://" + appDir}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "version": 1, "text": page}}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/definition",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri},
+			"position": map[string]any{"line": line, "character": character}}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "id": 3, "method": "textDocument/hover",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri},
+			"position": map[string]any{"line": line, "character": character}}})
+	in += frame(map[string]any{"jsonrpc": "2.0", "method": "exit"})
+	var out, errBuf bytes.Buffer
+	if code := runLSP(strings.NewReader(in), &out, &errBuf, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, errBuf.String())
+	}
+	return definitionResult(t, out.String(), 2), authoredHoverResult(t, out.String(), 3)
+}
+
+func tagCursor(t *testing.T, page string) (line, character int) {
+	t.Helper()
+	for i, l := range strings.Split(page, "\n") {
+		if c := strings.Index(l, "widget.X"); c >= 0 {
+			return i, c + len("widget.")
+		}
+	}
+	t.Fatal("could not find widget.X in page")
+	return 0, 0
+}
+
+// Case (a): a cross-MODULE dependency whose .gsx sources are present (joined via
+// a `replace` directive, like hello-gsx→libgsx). gd on `<widget.X/>` resolves to
+// X's declaration IN THE .gsx, never the generated .x.go.
+func TestDefinitionCrossModuleValueSourcesPresent(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	page := "package main\n\nimport \"dep/widget\"\n\ncomponent Page() {\n\t<widget.X/>\n}\n\nfunc main() {}\n"
+	appDir, pagePath, _, _ := writeCrossModuleValueModules(t, page, true)
+	line, character := tagCursor(t, page)
+	loc, hov := runDefinitionAt(t, appDir, pagePath, page, line, character)
+	if loc == nil {
+		t.Fatal("cross-module tag definition returned null; want dep .gsx X declaration")
+	}
+	if !strings.HasSuffix(loc.URI, filepath.Join("dep", "widget", "named.gsx")) {
+		t.Fatalf("resolved to %q, want dep/widget/named.gsx", loc.URI)
+	}
+	if strings.HasSuffix(loc.URI, ".x.go") {
+		t.Fatalf("resolved into a generated .x.go (%q); the .gsx exists, so navigation must land there", loc.URI)
+	}
+	// The line is resolved from the dependency's published .x.go //line directives
+	// (a separate module is loaded from its generated Go, not re-analyzed in
+	// memory). emit.go does not //line-stamp top-level Go var chunks, so the line
+	// can drift within the .gsx — the exact-line guarantee holds for SAME-module
+	// deps (analyzed via the in-memory skeleton), pinned by the value tests above.
+	// This case pins the refined policy's contract: authored .gsx present → the
+	// Location lands in that .gsx (never the .x.go), non-null.
+	if hov == nil {
+		t.Fatal("hover was null; want non-null signature")
+	}
+}
+
+// Case (b): a cross-MODULE dependency that ships ONLY its generated .x.go (its
+// .gsx sources absent). gd on `<widget.X/>` must still be non-null: it falls back
+// to the .x.go func definition — a generated-file location beats no location when
+// it is all that exists on disk.
+func TestDefinitionCrossModuleValueOnlyXGo(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	page := "package main\n\nimport \"dep/widget\"\n\ncomponent Page() {\n\t<widget.X/>\n}\n\nfunc main() {}\n"
+	appDir, pagePath, depGSX, depXGo := writeCrossModuleValueModules(t, page, false)
+	if _, err := os.Stat(depGSX); !os.IsNotExist(err) {
+		t.Fatalf("dep .gsx should be absent for this case, stat err=%v", err)
+	}
+	if _, err := os.Stat(depXGo); err != nil {
+		t.Fatalf("dep .x.go should exist for this case: %v", err)
+	}
+	line, character := tagCursor(t, page)
+	loc, hov := runDefinitionAt(t, appDir, pagePath, page, line, character)
+	if loc == nil {
+		t.Fatal("only-.x.go tag definition returned null; want the generated .x.go location as fallback")
+	}
+	if !strings.HasSuffix(loc.URI, filepath.Join("dep", "widget", "named.x.go")) {
+		t.Fatalf("resolved to %q, want dep/widget/named.x.go (the .gsx is absent, so the generated file is the only target)", loc.URI)
+	}
+	if hov == nil {
+		t.Fatal("hover was null; want non-null signature even for a generated-only dependency")
+	}
+}

--- a/gen/definition_midedit_e2e_test.go
+++ b/gen/definition_midedit_e2e_test.go
@@ -1,0 +1,109 @@
+package gen
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cursorOnNeedle returns the 0-based line/character of a cursor placed ON the
+// last character of needle inside page (the natural "I just typed this" spot).
+func cursorOnNeedle(t *testing.T, page, needle string) (line, character int) {
+	t.Helper()
+	i := strings.Index(page, needle)
+	if i < 0 {
+		t.Fatalf("needle %q not found in page", needle)
+	}
+	off := i + len(needle) - 1
+	line = strings.Count(page[:off], "\n")
+	character = off - (strings.LastIndexByte(page[:off], '\n') + 1)
+	return line, character
+}
+
+// TestDefinitionMidEditUnclosedTag is the core regression: go-to-definition on a
+// cross-package component-value tag that has NOT been closed yet (`<widget.X`,
+// no `/>`). The unclosed tag makes the buffer unparseable, so analysis falls back
+// to a diagnostics-only shell and the primary resolver cascade answers nothing;
+// the completion-repair + ephemeral-analysis fallback heals `<widget.X/>` and
+// resolves X to its declaration in widget/named.gsx.
+func TestDefinitionMidEditUnclosedTag(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	// `<widget.X` with no closing `/>` — a mid-edit half-typed tag.
+	page := "package page\n\nimport \"example.com/x/widget\"\n\ncomponent Page() {\n\t<widget.X\n}\n"
+	writeCrossPkgValueModule(t, dir, page)
+	line, character := cursorOnNeedle(t, page, "widget.X")
+
+	loc, hov := runCrossPkgValueDefinition(t, dir, page, line, character)
+	if loc == nil {
+		t.Fatal("mid-edit tag definition returned null; want widget/named.gsx X declaration")
+	}
+	if !strings.HasSuffix(loc.URI, filepath.Join("widget", "named.gsx")) {
+		t.Fatalf("resolved to %q, want widget/named.gsx", loc.URI)
+	}
+	if strings.HasSuffix(loc.URI, ".x.go") {
+		t.Fatalf("resolved into a generated .x.go (%q); must never jump into generated code", loc.URI)
+	}
+	wantLine, wantCol := wantXLocation(t)
+	if loc.Range.Start.Line != wantLine || loc.Range.Start.Character != wantCol {
+		t.Fatalf("mid-edit gd landed at L%d:C%d, want L%d:C%d (the X value decl)",
+			loc.Range.Start.Line, loc.Range.Start.Character, wantLine, wantCol)
+	}
+	if hov == nil {
+		t.Fatal("mid-edit hover on the unclosed tag was null; want the value signature")
+	}
+	if !strings.Contains(hov.Contents.Value, "gsx.Node") {
+		t.Fatalf("mid-edit hover = %q, want the func(...gsx.Attr) gsx.Node signature", hov.Contents.Value)
+	}
+}
+
+// TestDefinitionMidEditInterpInUnclosedAttr covers a NON-tag cursor: an
+// identifier inside an attribute expression whose interpolation and enclosing
+// component tag are both still open (`foo={ widget.Menu`, no `}` and no `/>`).
+// The completion patch set closes both (`}/>`), and the fallback resolves the
+// cross-package reference under the cursor. This proves the fallback heals
+// expression positions, not just tag names.
+func TestDefinitionMidEditInterpInUnclosedAttr(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	page := "package page\n\nimport \"example.com/x/widget\"\n\ncomponent Page() {\n\t<widget.X foo={ widget.Menu\n}\n"
+	writeCrossPkgValueModule(t, dir, page)
+	line, character := cursorOnNeedle(t, page, "widget.Menu")
+
+	loc, hov := runCrossPkgValueDefinition(t, dir, page, line, character)
+	if loc == nil {
+		t.Fatal("mid-edit interp definition returned null; want widget/named.gsx Menu declaration")
+	}
+	if !strings.HasSuffix(loc.URI, filepath.Join("widget", "named.gsx")) {
+		t.Fatalf("resolved to %q, want widget/named.gsx", loc.URI)
+	}
+	if hov == nil {
+		t.Fatal("mid-edit hover on the interp reference was null")
+	}
+}
+
+// TestDefinitionMidEditUnhealableGarbage confirms the fallback fails soft: a
+// buffer no single repair patch can heal yields a null result and no error (the
+// server keeps serving).
+func TestDefinitionMidEditUnhealableGarbage(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := t.TempDir()
+	// Structurally broken markup no self-close / interp-close patch can repair.
+	page := "package page\n\ncomponent Page() {\n\t<div><span></div> foo }} { <<\n}\n"
+	writeCrossPkgValueModule(t, dir, page)
+	line, character := cursorOnNeedle(t, page, "foo")
+
+	loc, _ := runCrossPkgValueDefinition(t, dir, page, line, character)
+	if loc != nil {
+		t.Fatalf("unhealable buffer resolved to %+v; want null", loc)
+	}
+}

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -764,6 +764,71 @@ func TestTagCompletionE2E(t *testing.T) {
 			t.Errorf("qualifier item TextEdit = %+v, want NewText %q", qualItem.TextEdit, "myui.")
 		}
 	})
+
+	// bare cursor mid-edit: a completely untyped `<` with nothing after it —
+	// not even a self-close — fails to parse on its own; repairAtCursor's
+	// last-tried "_/>" phantom patch heals it (a placeholder tag name plus a
+	// self-close). The merged tag list must still surface all three
+	// candidate families at once: the local sibling component, a vendored
+	// HTML tag, and the imported package's qualifier item. The local
+	// component's Kind is asserted ciKindClass (not Function): these items
+	// are offered in TAG position, and editors (blink.cmp observed)
+	// auto-append "()" on accepting a Function/Method-kind item, which is
+	// wrong for a tag.
+	t.Run("bare cursor mid-edit", func(t *testing.T) {
+		uiSource := "package ui\n\ncomponent Button(label string) {\n\t<button>{label}</button>\n}\n"
+		source := "package page\n\nimport \"example.com/app/ui\"\n\ncomponent Other() {\n\t<div/>\n}\n\ncomponent Home() {\n\t<ui.Button label=\"hi\"/>\n\t<\n}\n"
+		cursor := strings.LastIndex(source, "<") + len("<")
+		files := map[string]string{
+			"page/page.gsx": source,
+			"ui/ui.gsx":     uiSource,
+		}
+		items := completionItems(t, runRaw(t, files, "page/page.gsx", source, cursor), 2)
+		const lspCompletionItemKindClass = 7 // ciKindClass in internal/lsp (unexported)
+		var other, div, qual *lsp.CompletionItem
+		for i := range items {
+			switch items[i].Label {
+			case "Other":
+				other = &items[i]
+			case "div":
+				div = &items[i]
+			case "ui":
+				qual = &items[i]
+			}
+		}
+		if other == nil {
+			t.Fatalf("bare-cursor tag completion missing local component `Other`; items=%+v", items)
+		}
+		if other.Kind != lspCompletionItemKindClass {
+			t.Errorf("`Other` Kind = %d, want ciKindClass (%d) — tag position must not trigger editor auto-brackets", other.Kind, lspCompletionItemKindClass)
+		}
+		if div == nil {
+			t.Fatalf("bare-cursor tag completion missing HTML tag `div`; items=%+v", items)
+		}
+		if qual == nil {
+			t.Fatalf("bare-cursor tag completion missing import qualifier item `ui`; items=%+v", items)
+		}
+	})
+
+	// qualified trailing dot mid-edit: `<ui.` with nothing typed after the dot
+	// and no self-close. Unlike a bare `<`, the parser accepts a qualified tag
+	// with a trailing dot and no member token (`<ui./>` parses clean — see
+	// TestRepairAtCursor/qualified_tag_trailing_dot in internal/lsp), so the
+	// plain `/>` patch heals it before the phantom `_/>` patch is ever tried.
+	// The qualifier "ui" extracted from the healed Tag ("ui.") still resolves
+	// the import and lists every one of its components.
+	t.Run("qualified trailing dot mid-edit", func(t *testing.T) {
+		uiSource := "package ui\n\ncomponent Button(label string) {\n\t<button>{label}</button>\n}\n"
+		source := "package page\n\nimport \"example.com/app/ui\"\n\ncomponent Home() {\n\t<ui.Button label=\"hi\"/>\n\t<ui.\n}\n"
+		cursor := strings.LastIndex(source, "<ui.") + len("<ui.")
+		got := run(t, map[string]string{
+			"page/page.gsx": source,
+			"ui/ui.gsx":     uiSource,
+		}, "page/page.gsx", source, cursor)
+		if !got["Button"] {
+			t.Errorf("qualified trailing-dot tag completion missing imported component `Button`; labels=%v", got)
+		}
+	})
 }
 
 // TestComponentAttrCompletionE2E drives textDocument/completion for a

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -968,6 +968,76 @@ func TestComponentAttrCompletionE2E(t *testing.T) {
 	})
 }
 
+// TestComponentAttrForwardedGlobalsE2E drives the new forwarded-attrs-globals
+// rule end to end: a component whose signature declares the reserved "attrs"
+// catch-all forwards arbitrary attributes to whatever element it renders, so
+// an attr-name cursor on its call site now also offers the HTML GLOBAL
+// attribute set (in addition to any named params) — icon.Bell's real shape,
+// `func(attrs ...gsx.Attr) gsx.Node`, is a component VALUE (a plain package-
+// scope Go func, no `component`-keyword decl) in a sibling package, so this
+// also exercises the componentValueNameItems/tag-callable-value resolution
+// path, not just a `component`-keyword decl. A sibling component with no
+// attrs catch-all must NOT offer the HTML globals — an unknown attribute
+// there would be rejected by the planner.
+func TestComponentAttrForwardedGlobalsE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	labelsOf := func(items []lsp.CompletionItem) map[string]bool {
+		m := map[string]bool{}
+		for _, it := range items {
+			m[it.Label] = true
+		}
+		return m
+	}
+	itemOf := func(items []lsp.CompletionItem, label string) *lsp.CompletionItem {
+		for i := range items {
+			if items[i].Label == label {
+				return &items[i]
+			}
+		}
+		return nil
+	}
+	iconFile := "package icon\n\nimport \"github.com/gsxhq/gsx\"\n\nfunc Bell(attrs ...gsx.Attr) gsx.Node {\n\treturn nil\n}\n"
+
+	t.Run("value-component with attrs catch-all offers HTML globals", func(t *testing.T) {
+		source := "package page\n\nimport \"example.com/app/icon\"\n\ncomponent Home() {\n\t<icon.Bell />\n}\n"
+		cursor := strings.Index(source, "<icon.Bell ") + len("<icon.Bell ")
+		items := runHTMLCompletionE2E(t, map[string]string{"icon/icon.go": iconFile}, source, cursor)
+		labels := labelsOf(items)
+		if !labels["hidden"] {
+			t.Fatalf("forwarded-globals completion missing boolean global `hidden`; labels=%v", labels)
+		}
+		if !labels["class"] {
+			t.Fatalf("forwarded-globals completion missing value global `class`; labels=%v", labels)
+		}
+		if hidden := itemOf(items, "hidden"); hidden == nil || hidden.TextEdit == nil || hidden.TextEdit.NewText != "hidden" {
+			t.Errorf("`hidden` must insert the bare name; got %+v", hidden)
+		}
+		if class := itemOf(items, "class"); class == nil || class.TextEdit == nil || class.TextEdit.NewText != `class=""` {
+			t.Errorf("`class` must insert class=\"\"; got %+v", class)
+		}
+		if labels["attrs"] {
+			t.Errorf("forwarded-globals completion must not offer the reserved `attrs` name itself; labels=%v", labels)
+		}
+	})
+
+	t.Run("component-keyword decl without attrs catch-all offers no HTML globals", func(t *testing.T) {
+		source := "package page\n\ncomponent Plain(title string) {\n\t<div>{ title }</div>\n}\n\ncomponent Home() {\n\t<Plain />\n}\n"
+		cursor := strings.Index(source, "<Plain ") + len("<Plain ")
+		items := runHTMLCompletionE2E(t, nil, source, cursor)
+		labels := labelsOf(items)
+		if !labels["title"] {
+			t.Fatalf("component-attr completion missing named param `title`; labels=%v", labels)
+		}
+		for _, global := range []string{"class", "hidden", "id", "style"} {
+			if labels[global] {
+				t.Errorf("component without attrs catch-all must NOT offer HTML global %q; labels=%v", global, labels)
+			}
+		}
+	})
+}
+
 // runHTMLCompletionE2E writes a temp module (with the given extra files, e.g. a
 // gsx.toml), opens gsxPath's source as a buffer, sends one completion at cursor,
 // and returns the response items. Mirrors the other e2e runners but parameterizes

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -474,15 +474,15 @@ func buildSkeletonWithRecorder(file *gsxast.File, table funcTables, fset *token.
 		for i, part := range we.Parts {
 			switch p := part.(type) {
 			case gsxast.GoText:
-				// Block-form directive (no newline) so an element mid-expression
-				// (`Wrap(<Foo/>)`) keeps its trailing `)` attached to the IIFE's
-				// `}()` — a `//line` newline there would trip ASI.
-				emitSkeletonBlockLine(goWithElementsBuf, fset, p.Pos())
 				emitted := targetGoWithElementsText(we, shapes, i, p)
-				if mode == skeletonDeclarations {
-					writeSkeletonGenerated(goWithElementsBuf, emitted)
-					continue
-				}
+				// A decorative leading paren stripped off this GoText (the `)` of a
+				// fmt `( <el/> )` wrap) advances `start` past one or more source lines.
+				// The emitted bytes therefore begin at p.Pos()+start, not p.Pos() —
+				// so the //line directive MUST anchor there too. Anchoring at p.Pos()
+				// maps every following line one line too early, and because
+				// consecutive top-level Go (a trailing `var (…)`/`func …` chunk) shares
+				// this same GoWithElements region as trailing GoText, that drift lands
+				// cross-package go-to-definition on the wrong declaration line.
 				start := 0
 				end := len(p.Src)
 				if i > 0 && parenWrappable(we.Parts[i-1], shapes, i-1) {
@@ -492,6 +492,14 @@ func buildSkeletonWithRecorder(file *gsxast.File, table funcTables, fset *token.
 				if i < len(we.Parts)-1 && parenWrappable(we.Parts[i+1], shapes, i+1) {
 					stripped := goexprshape.StripTrailingParen(p.Src[start:end])
 					end = start + len(stripped)
+				}
+				// Block-form directive (no newline) so an element mid-expression
+				// (`Wrap(<Foo/>)`) keeps its trailing `)` attached to the IIFE's
+				// `}()` — a `//line` newline there would trip ASI.
+				emitSkeletonBlockLine(goWithElementsBuf, fset, p.Pos()+token.Pos(start))
+				if mode == skeletonDeclarations {
+					writeSkeletonGenerated(goWithElementsBuf, emitted)
+					continue
 				}
 				if p.Src[start:end] != emitted {
 					return "", nil, nil, nil, nil, fmt.Errorf("codegen: Go-with-elements text transform did not preserve an exact authored subspan")

--- a/internal/codegen/component_identity.go
+++ b/internal/codegen/component_identity.go
@@ -3,6 +3,8 @@ package codegen
 import (
 	"fmt"
 	"go/types"
+
+	"github.com/gsxhq/gsx/internal/tagcallable"
 )
 
 func componentResultType(sig *types.Signature, runtime runtimeContract) (types.Type, error) {
@@ -18,7 +20,11 @@ func componentResultType(sig *types.Signature, runtime runtimeContract) (types.T
 		return nil, fmt.Errorf("component-result-count: callable has %d results; want exactly one", results.Len())
 	}
 	result := results.At(0).Type()
-	if invalidSemanticTypeSeen(result, checked) || !types.AssignableTo(result, runtime.node) {
+	// The assignability half of this check is single-sourced through
+	// tagcallable.IsResult (shared with internal/lsp's mirrored tag-value
+	// scan); the result count above stays a separate, earlier check so its
+	// diagnostic can distinguish "wrong count" from "wrong type".
+	if invalidSemanticTypeSeen(result, checked) || !tagcallable.IsResult(sig, runtime.node) {
 		return nil, fmt.Errorf("component-result-type: result %s is not assignable to %s", result, runtime.node)
 	}
 	return result, nil

--- a/internal/codegen/component_target.go
+++ b/internal/codegen/component_target.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gsxhq/gsx/internal/attrclass"
 	"github.com/gsxhq/gsx/internal/diag"
 	"github.com/gsxhq/gsx/internal/jsx"
+	"github.com/gsxhq/gsx/internal/tagcallable"
 )
 
 type componentTargetProvenance uint8
@@ -459,16 +460,11 @@ func componentTargetShapeOf(expr goast.Expr) (componentTargetShape, bool) {
 	return shape, true
 }
 
+// targetCallableSignature delegates to tagcallable.Signature, the
+// single-sourced signature-unwrap rule shared with internal/lsp's mirrored
+// tag-value scan (see tagcallable's package doc).
 func targetCallableSignature(typ types.Type) *types.Signature {
-	if typ == nil {
-		return nil
-	}
-	unaliased := types.Unalias(typ)
-	if signature, ok := unaliased.(*types.Signature); ok {
-		return signature
-	}
-	signature, _ := unaliased.Underlying().(*types.Signature)
-	return signature
+	return tagcallable.Signature(typ)
 }
 
 func targetDeclaredReceiverIsInterface(fn *types.Func) bool {

--- a/internal/codegen/component_target_skeleton.go
+++ b/internal/codegen/component_target_skeleton.go
@@ -221,7 +221,17 @@ func emitTargetGoWithElements(
 	for index, part := range decl.Parts {
 		switch part := part.(type) {
 		case gsxast.GoText:
-			emitSkeletonBlockLine(builder, fset, part.Pos())
+			// A stripped leading decorative paren advances the emitted text past one
+			// or more source lines, so the //line directive must anchor at the
+			// post-strip position, not part.Pos(): otherwise every following line —
+			// including a trailing top-level var/func chunk sharing this region —
+			// maps one line too early, landing cross-package go-to-definition on the
+			// wrong declaration line. Mirrors buildSkeletonWithRecorder's GoText case.
+			start := 0
+			if index > 0 && parenWrappable(decl.Parts[index-1], shapes, index-1) {
+				start = len(part.Src) - len(goexprshape.StripLeadingParen(part.Src))
+			}
+			emitSkeletonBlockLine(builder, fset, part.Pos()+token.Pos(start))
 			builder.WriteString(targetGoWithElementsText(decl, shapes, index, part))
 		case *gsxast.Element:
 			builder.WriteString("func() _gsxrt.Node {\n")

--- a/internal/lsp/completion_context.go
+++ b/internal/lsp/completion_context.go
@@ -30,7 +30,7 @@ type completionContext struct {
 	element   *gsxast.Element // tag/attr-name/attr-value contexts: the enclosing element
 	attr      gsxast.Attr     // attr-value context: the StaticAttr under the cursor
 	qualifier string          // tag context: "pkg" when completing <pkg.▮; "" otherwise
-	phantom   bool            // a repair phantom sits at the cursor (`_` pipe stage, or the injected `""` attr value)
+	phantom   bool            // a repair phantom sits at the cursor (`_` pipe stage, the injected `""` attr value, or the injected `_` tag/member name)
 }
 
 // spanContainsForCompletion reports whether off lies within [start, start+length]
@@ -62,9 +62,13 @@ func classifyCompletionContext(r repairResult, path string, off int) completionC
 
 	// phantomStage: the `_` patch healed an empty `|> ` stage — the `_` at the
 	// cursor is a repair token, not authored. phantomValue: the `""/>` patch
-	// healed a dangling `attr=` — the empty string value is injected, not typed.
+	// healed a dangling `attr=` — the empty string value is injected, not
+	// typed. phantomTag: the `_/>` patch healed a bare `<▮` or a qualified
+	// `<pkg.▮` with nothing after the dot — the `_` standing in for the
+	// tag/member name is injected, not typed.
 	phantomStage := r.patch == "_"
 	phantomValue := r.patch == "\"\"/>"
+	phantomTag := r.patch == "_/>"
 
 	var pipeCtx, goCtx, tagCtx, nameCtx, valueCtx, sigCtx *completionContext
 
@@ -121,7 +125,7 @@ func classifyCompletionContext(r repairResult, path string, off int) completionC
 		// Rule 3 (tag) + Rule 4 (BoolAttr name): element-level.
 		if el, ok := n.(*gsxast.Element); ok {
 			if el.TagPos.IsValid() && spanContainsForCompletion(posOff(el.TagPos), len(el.Tag), off) {
-				tagCtx = &completionContext{kind: ctxTag, node: el, element: el}
+				tagCtx = &completionContext{kind: ctxTag, node: el, element: el, phantom: phantomTag}
 				if i := strings.Index(el.Tag, "."); i >= 0 && off > posOff(el.TagPos)+i {
 					tagCtx.qualifier = el.Tag[:i]
 				}

--- a/internal/lsp/completion_context.go
+++ b/internal/lsp/completion_context.go
@@ -125,6 +125,10 @@ func classifyCompletionContext(r repairResult, path string, off int) completionC
 		// Rule 3 (tag) + Rule 4 (BoolAttr name): element-level.
 		if el, ok := n.(*gsxast.Element); ok {
 			if el.TagPos.IsValid() && spanContainsForCompletion(posOff(el.TagPos), len(el.Tag), off) {
+				// phantom is recorded here for classification symmetry with the
+				// other ctx*/phantom* pairs above (pipe stage, attr value); it is
+				// currently unread by tagCompletion, which serves the same
+				// candidate list whether or not the tag token is repair-injected.
 				tagCtx = &completionContext{kind: ctxTag, node: el, element: el, phantom: phantomTag}
 				if i := strings.Index(el.Tag, "."); i >= 0 && off > posOff(el.TagPos)+i {
 					tagCtx.qualifier = el.Tag[:i]

--- a/internal/lsp/completion_context_test.go
+++ b/internal/lsp/completion_context_test.go
@@ -139,6 +139,45 @@ func TestClassifyCompletionContextFields(t *testing.T) {
 		}
 	})
 
+	t.Run("bare tag phantom flag set", func(t *testing.T) {
+		// A completely untyped `<` heals via the last-tried "_/>" patch
+		// (completion_repair.go); the injected "_" standing in for the
+		// tag name is not authored, so phantom must be true.
+		got, _ := classify("package p\n\ncomponent C() {\n\t<§\n}\n")
+		if got.kind != ctxTag {
+			t.Fatalf("kind = %v, want ctxTag", got.kind)
+		}
+		if !got.phantom {
+			t.Fatal("phantom = false, want true (injected _ tag name)")
+		}
+		if got.qualifier != "" {
+			t.Fatalf("qualifier = %q, want empty", got.qualifier)
+		}
+	})
+
+	t.Run("qualified tag trailing dot via repair", func(t *testing.T) {
+		// `<icon.` with nothing typed after the dot has no self-close either,
+		// so it needs repair too — but unlike a bare `<`, the parser accepts a
+		// qualified tag with a trailing dot and no member token, so the plain
+		// "/>" patch heals it (see TestRepairAtCursor/qualified_tag_trailing_dot)
+		// and the healed Tag stays "icon." verbatim — not phantom. The empty
+		// member token after the dot must still classify as ctxTag with
+		// qualifier "icon".
+		got, _ := classify("package p\n\ncomponent C() {\n\t<icon.§\n}\n")
+		if got.kind != ctxTag {
+			t.Fatalf("kind = %v, want ctxTag", got.kind)
+		}
+		if got.qualifier != "icon" {
+			t.Fatalf("qualifier = %q, want %q", got.qualifier, "icon")
+		}
+		if got.phantom {
+			t.Fatal("phantom = true, want false (\"/>\" heals it — no injected tag/member name)")
+		}
+		if got.element == nil || got.element.Tag != "icon." {
+			t.Fatalf("element = %+v, want tag \"icon.\"", got.element)
+		}
+	})
+
 	t.Run("unrepairable is ctxNone", func(t *testing.T) {
 		text := "package p\n\ncomponent C() {\n\t<<<%%\n}\n"
 		r := repairAtCursor(token.NewFileSet(), "/tmp/x.gsx", text, len("package p\n\ncomponent C() {\n\t<"))

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -16,6 +16,12 @@ import (
 // matches against label/filterText as the user types). Detail renders as
 // "Pkg.Func", with a " (ctx)" suffix when the filter's leading argument is a
 // context.Context (WantsCtx).
+//
+// kind is ciKindOperator, not ciKindFunction: editors (blink.cmp observed)
+// auto-append "()" on accepting a Function/Method-kind item, but a bare pipe
+// stage (`f`) and a parameterized one (`f()`) are different stages with
+// different semantics — auto-inserting "()" the user did not ask for silently
+// changes which stage gets authored.
 func filterItems(filters []FilterCandidate, text string, start, end int, enc encoding) []CompletionItem {
 	items := make([]CompletionItem, 0, len(filters))
 	for _, f := range filters {
@@ -23,7 +29,7 @@ func filterItems(filters []FilterCandidate, text string, start, end int, enc enc
 		if f.WantsCtx {
 			detail += " (ctx)"
 		}
-		items = append(items, newCompletionItem(text, start, end, enc, f.Name, f.Name, ciKindFunction, tierContext, detail, nil))
+		items = append(items, newCompletionItem(text, start, end, enc, f.Name, f.Name, ciKindOperator, tierContext, detail, nil))
 	}
 	return items
 }
@@ -139,6 +145,20 @@ func (s *Server) componentDeclPackage(dir, path string, src []byte) *Package {
 // receiver expression before the tag can resolve and are excluded from v1
 // (spec follow-up).
 //
+// Both branches additionally scan for component VALUES — package-scope
+// vars/funcs (like `var X = named("x")` in a plain Go sibling package) that
+// are never a `component`-keyword decl and so never appear in ComponentDecls,
+// but are still a legal tag target: codegen's "callable universe" rule
+// (internal/codegen/component_target.go, harvestComponentTargetFacts) accepts
+// ANY package-scope types.Func or function-valued types.Var whose signature
+// has one result implementing gsx.Node and every parameter named — that is
+// the SAME predicate componentValueNameItems applies here, reimplemented as a
+// package-scope scan (there is no enumerable table for it; codegen only
+// probes a specific already-authored call site). Without this, a pure-Go
+// design-system package (icons, wrapped factories, ...) with zero
+// `component`-keyword declarations completes to nothing at its tag/qualifier
+// cursor even though its values compile fine as tags.
+//
 // capitalizedPrefix does not affect the tier of component items — every
 // candidate here is tierContext regardless. Per the tag-merge rule (see
 // tagCompletion), components always lead at tierContext; only the merged-in HTML
@@ -151,19 +171,185 @@ func componentTagItems(pkg *Package, qualifier string, capitalizedPrefix bool, t
 		return nil
 	}
 	if qualifier != "" {
-		if path, ok := importQualifierCandidates(pkg)[qualifier]; ok {
-			return componentNameItems(pkg, path, text, start, end, enc)
+		path, ok := importQualifierCandidates(pkg)[qualifier]
+		if !ok {
+			return nil
 		}
-		return nil
+		items := componentNameItems(pkg, path, text, start, end, enc)
+		if target := importedPackageAt(pkg, path); target != nil {
+			items = append(items, componentValueNameItems(target, offeredNames(items), true, text, start, end, enc)...)
+		}
+		return items
 	}
 	items := componentNameItems(pkg, pkg.Types.Path(), text, start, end, enc)
+	items = append(items, componentValueNameItems(pkg.Types, offeredNames(items), false, text, start, end, enc)...)
 	items = append(items, importQualifierItems(pkg, text, start, end, enc)...)
 	return items
+}
+
+// offeredNames extracts the label set already produced by componentNameItems,
+// so componentValueNameItems can skip a name it would otherwise duplicate — a
+// `component`-keyword decl's underlying Go func trivially also satisfies the
+// callable-universe signature shape, so without this every such component
+// would be offered twice.
+func offeredNames(items []CompletionItem) map[string]bool {
+	names := make(map[string]bool, len(items))
+	for _, it := range items {
+		names[it.Label] = true
+	}
+	return names
+}
+
+// importedPackageAt resolves the *types.Package object for one of pkg.Types'
+// direct imports whose Path() == path. pkg.Types.Imports() only ever needs a
+// linear scan (a file's import list is small), and — unlike
+// importQualifierCandidates, which resolves local-name -> path — this needs
+// the resolved package OBJECT to scan its Scope() below.
+func importedPackageAt(pkg *Package, path string) *types.Package {
+	if pkg.Types == nil {
+		return nil
+	}
+	for _, imp := range pkg.Types.Imports() {
+		if imp.Path() == path {
+			return imp
+		}
+	}
+	return nil
+}
+
+// componentValueNameItems enumerates target's package-scope identifiers that
+// satisfy codegen's callable-universe tag shape (see componentTagItems' doc
+// comment) and are not already in skip, as completion items.
+func componentValueNameItems(target *types.Package, skip map[string]bool, exportedOnly bool, text string, start, end int, enc encoding) []CompletionItem {
+	names := tagCallableValueNames(target, skip, exportedOnly)
+	items := make([]CompletionItem, 0, len(names))
+	for _, name := range names {
+		items = append(items, newCompletionItem(text, start, end, enc, name, name, ciKindClass, tierContext, "", nil))
+	}
+	return items
+}
+
+// tagCallableValueNames returns target's package-scope identifiers — sorted,
+// minus skip — that satisfy codegen's callable-universe tag shape: a
+// types.Func or function-valued types.Var whose signature has one result
+// implementing gsx.Node and every parameter named (see
+// internal/codegen/component_target.go's harvestComponentTargetFacts, the
+// authoritative acceptance rule this mirrors). exportedOnly gates on
+// obj.Exported() — required when target is a DIFFERENT package than the one
+// completion is running in (Go visibility), and false for target's own
+// package (every package-scope identifier, exported or not, is a legal
+// same-package tag).
+//
+// gsxNodeInterface resolving to nil (target does not import gsx.Node at all,
+// directly or — for the tests' synthetic packages — because it has no
+// imports set up) is a silent, fail-soft "no value candidates", not an error:
+// most packages never define a component-shaped value.
+func tagCallableValueNames(target *types.Package, skip map[string]bool, exportedOnly bool) []string {
+	iface := gsxNodeInterface(target)
+	if iface == nil {
+		return nil
+	}
+	scope := target.Scope()
+	var names []string
+	for _, name := range scope.Names() {
+		if skip[name] {
+			continue
+		}
+		obj := scope.Lookup(name)
+		if exportedOnly && !obj.Exported() {
+			continue
+		}
+		var sig *types.Signature
+		switch o := obj.(type) {
+		case *types.Func:
+			sig, _ = o.Type().(*types.Signature)
+		case *types.Var:
+			sig = callableSignature(o.Type())
+		default:
+			continue
+		}
+		if sig == nil || !isTagCallableSignature(sig, iface) {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// callableSignature returns typ's *types.Signature — unwrapping a defined
+// (named) function type's underlying type, mirroring
+// internal/codegen/component_target.go's targetCallableSignature exactly (the
+// same unwrap is needed for a `type Factory func(...) gsx.Node`-shaped
+// package var, not just a bare `func(...) gsx.Node` one) — or nil when typ is
+// not callable at all.
+func callableSignature(typ types.Type) *types.Signature {
+	if typ == nil {
+		return nil
+	}
+	unaliased := types.Unalias(typ)
+	if sig, ok := unaliased.(*types.Signature); ok {
+		return sig
+	}
+	sig, _ := unaliased.Underlying().(*types.Signature)
+	return sig
+}
+
+// isTagCallableSignature reports whether sig matches codegen's
+// callable-universe shape: exactly one result implementing the gsx.Node
+// interface, and every parameter named (an unnamed parameter can never be
+// bound to a markup attribute, so codegen never treats such a signature as
+// tag-callable either).
+func isTagCallableSignature(sig *types.Signature, node *types.Interface) bool {
+	if sig.Results().Len() != 1 || !types.Implements(sig.Results().At(0).Type(), node) {
+		return false
+	}
+	for param := range sig.Params().Variables() {
+		if param.Name() == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// gsxNodeInterface locates the gsx.Node interface type within target's OWN
+// direct imports. target must import "github.com/gsxhq/gsx" itself for any
+// of its declarations to type-check against gsx.Node in the first place, so
+// this never needs to search transitively or reach into a different
+// package's import graph (in particular, the LSP's own analyzed root
+// package's imports are irrelevant — target is scanned as an independent
+// package, per the go/types identity rule that every *types.Package in one
+// checked build shares one canonical object per imported package). Returns
+// nil (fail-soft) when target does not import gsx at all.
+func gsxNodeInterface(target *types.Package) *types.Interface {
+	if target == nil {
+		return nil
+	}
+	for _, imp := range target.Imports() {
+		if imp.Path() != "github.com/gsxhq/gsx" {
+			continue
+		}
+		tn, ok := imp.Scope().Lookup("Node").(*types.TypeName)
+		if !ok {
+			return nil
+		}
+		iface, ok := types.Unalias(tn.Type()).Underlying().(*types.Interface)
+		if !ok {
+			return nil
+		}
+		return iface
+	}
+	return nil
 }
 
 // componentNameItems returns one item per plain (non-receiver) component
 // declared in pkgPath, sorted by name for a deterministic list (ComponentDecls
 // is a map; iteration order is not).
+//
+// kind is ciKindClass, not ciKindFunction: these items are offered in TAG
+// position (`<▮`), read by the author as a tag/type name, not a call — and
+// editors (blink.cmp observed) auto-append "()" on accepting a Function-kind
+// item, which is wrong for a tag (`<Card()` is not valid markup).
 func componentNameItems(pkg *Package, pkgPath string, text string, start, end int, enc encoding) []CompletionItem {
 	var names []string
 	for key := range pkg.ComponentDecls {
@@ -177,7 +363,7 @@ func componentNameItems(pkg *Package, pkgPath string, text string, start, end in
 	sort.Strings(names)
 	items := make([]CompletionItem, 0, len(names))
 	for _, name := range names {
-		items = append(items, newCompletionItem(text, start, end, enc, name, name, ciKindFunction, tierContext, "", nil))
+		items = append(items, newCompletionItem(text, start, end, enc, name, name, ciKindClass, tierContext, "", nil))
 	}
 	return items
 }
@@ -195,13 +381,16 @@ func plainComponentName(key string) (string, bool) {
 }
 
 // importQualifierItems returns one item per imported package that declares at
-// least one component (any ComponentDeclKey.PackagePath == the import's
-// path), sorted by the import's local name for a deterministic list.
+// least one component (any ComponentDeclKey.PackagePath == the import's path)
+// OR at least one tag-callable component VALUE (tagCallableValueNames — a
+// pure-Go sibling package like an icon set, with zero `component`-keyword
+// decls, still deserves a qualifier item), sorted by the import's local name
+// for a deterministic list.
 func importQualifierItems(pkg *Package, text string, start, end int, enc encoding) []CompletionItem {
 	type qualifier struct{ name, path string }
 	var quals []qualifier
 	for name, path := range importQualifierCandidates(pkg) {
-		if !packageHasComponentDecls(pkg, path) {
+		if !packageHasComponentDecls(pkg, path) && !packageHasTagCallableValue(pkg, path) {
 			continue
 		}
 		quals = append(quals, qualifier{name, path})
@@ -271,6 +460,19 @@ func packageHasComponentDecls(pkg *Package, pkgPath string) bool {
 		}
 	}
 	return false
+}
+
+// packageHasTagCallableValue reports whether the import at pkgPath exports at
+// least one package-scope identifier matching codegen's callable-universe tag
+// shape (tagCallableValueNames) — the value-component counterpart of
+// packageHasComponentDecls, for a pure-Go sibling package with zero
+// `component`-keyword decls.
+func packageHasTagCallableValue(pkg *Package, pkgPath string) bool {
+	target := importedPackageAt(pkg, pkgPath)
+	if target == nil {
+		return false
+	}
+	return len(tagCallableValueNames(target, nil, true)) > 0
 }
 
 // attrNameCompletion answers a ctxAttrName cursor (inside an open tag, on an

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -542,8 +542,13 @@ func (s *Server) attrNameCompletion(cc completionContext, path, text string, off
 	// dash, so this is a no-op for the component path.
 	start, end := completionTokenSpan(text, off, true)
 
+	// Computed up front: both branches below need it — the component branch
+	// to gate the forwarded-attrs-catch-all's hx-* candidates the same way
+	// the plain HTML branch gates its own.
+	htmxEnabled := slices.Contains(s.dirURLPresets(dir, eph), "htmx")
+
 	if ephEl != nil && ephEl.IsComponent {
-		items := componentAttrItems(eph, ephEl, text, start, end, s.enc)
+		items := componentAttrItems(eph, ephEl, htmxEnabled, text, start, end, s.enc)
 		if len(items) == 0 {
 			return emptyCompletion()
 		}
@@ -553,8 +558,7 @@ func (s *Server) attrNameCompletion(cc completionContext, path, text string, off
 	// HTML element (confirmed non-component, or analysis is a shell): offer HTML
 	// attribute names computed purely from the classification element — no codegen
 	// facts needed, so this works even when the ephemeral analysis failed.
-	htmxEnabled := slices.Contains(s.dirURLPresets(dir, eph), "htmx")
-	items := htmlAttrItems(cc.element, cc.element.Tag, htmxEnabled, text, start, end, s.enc)
+	items := htmlAttrItems(cc.element, cc.element.Tag, htmxEnabled, tierContext, text, start, end, s.enc)
 	if len(items) == 0 {
 		return emptyCompletion()
 	}
@@ -668,9 +672,29 @@ func reservedComponentAttrName(name string) bool {
 // qualifierFor, tier = tierContext. newText is the plain name — no `={}`
 // snippet in v1, per the task-13 spec.
 //
+// When the signature also declares an "attrs" catch-all parameter
+// (signatureHasAttrsCatchAll — component_signature.go's roleAttrs, e.g.
+// `func(attrs ...gsx.Attr) gsx.Node`), the component forwards arbitrary
+// attributes to whatever element it ultimately renders, so the candidate set
+// is extended with the HTML GLOBAL attribute set (htmldata.GlobalAttributes,
+// plus hx-* when htmxEnabled) via htmlAttrItems — the SAME boolean/insert/
+// present-attr/own-token logic the plain-HTML attrTagName path uses, single-
+// sourced rather than reimplemented here. There is no per-tag contribution:
+// which concrete element receives the forwarded bag is unknowable from the
+// call site (tagName ""), so only globals are offered — see htmlAttrItems'
+// doc for how an unmatched tagName collapses to globals-only. Forwarded items
+// sort at tierSecondary so the component's own named params (tierContext)
+// lead; a name collision with an already-offered named param (e.g. a
+// component that happens to declare a "class" prop) is skipped so the same
+// label never appears twice with two different insert behaviors.
+//
+// No signature-with-attrs → unchanged: named params only. An unknown attr
+// would be rejected by the planner at build time, so offering HTML attrs
+// there would suggest invalid input.
+//
 // No fact for el (the call was never planned — a broken tag, an unresolved
 // target, ...) returns nil: fail-soft, never a guess.
-func componentAttrItems(pkg *Package, el *gsxast.Element, text string, start, end int, enc encoding) []CompletionItem {
+func componentAttrItems(pkg *Package, el *gsxast.Element, htmxEnabled bool, text string, start, end int, enc encoding) []CompletionItem {
 	if pkg == nil || el == nil {
 		return nil
 	}
@@ -714,7 +738,36 @@ func componentAttrItems(pkg *Package, el *gsxast.Element, text string, start, en
 		detail := types.TypeString(p.Type(), qf)
 		items = append(items, newCompletionItem(text, start, end, enc, name, name, ciKindField, tierContext, detail, nil))
 	}
+
+	if signatureHasAttrsCatchAll(sig) {
+		named := offeredNames(items)
+		for _, g := range htmlAttrItems(el, "", htmxEnabled, tierSecondary, text, start, end, enc) {
+			if named[g.Label] {
+				continue
+			}
+			items = append(items, g)
+		}
+	}
 	return items
+}
+
+// signatureHasAttrsCatchAll reports whether sig declares a parameter named
+// "attrs" — codegen's reserved forwarded-attrs-bag role
+// (component_signature.go's roleAttrs). ComponentCalls only ever holds
+// successfully PLANNED calls, so any signature reaching componentAttrItems
+// already passed classifyAttrsParam's shape check (variadic `...gsx.Attr`,
+// or a non-variadic `[]gsx.Attr`/defined-slice-of-Attr parameter — codegen's
+// "underlying []gsx.Attr" structural rule); completion does not need to
+// re-verify the type, only detect the reserved name, exactly as
+// reservedComponentAttrName already treats "attrs" as reserved without
+// inspecting its type.
+func signatureHasAttrsCatchAll(sig *types.Signature) bool {
+	for param := range sig.Params().Variables() {
+		if param.Name() == "attrs" {
+			return true
+		}
+	}
+	return false
 }
 
 // attrNameSpanContains reports whether attr's own name span — [pos,

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/tagcallable"
 )
 
 // filterItems builds one CompletionItem per resolved filter candidate for a
@@ -148,14 +149,16 @@ func (s *Server) componentDeclPackage(dir, path string, src []byte) *Package {
 // Both branches additionally scan for component VALUES — package-scope
 // vars/funcs (like `var X = named("x")` in a plain Go sibling package) that
 // are never a `component`-keyword decl and so never appear in ComponentDecls,
-// but are still a legal tag target: codegen's "callable universe" rule
-// (internal/codegen/component_target.go, harvestComponentTargetFacts) accepts
-// ANY package-scope types.Func or function-valued types.Var whose signature
-// has one result implementing gsx.Node and every parameter named — that is
-// the SAME predicate componentValueNameItems applies here, reimplemented as a
-// package-scope scan (there is no enumerable table for it; codegen only
-// probes a specific already-authored call site). Without this, a pure-Go
-// design-system package (icons, wrapped factories, ...) with zero
+// but are still a legal tag target: codegen's callable-universe shape — any
+// package-scope types.Func or function-valued types.Var whose signature has
+// one result assignable to gsx.Node, see internal/tagcallable's package doc —
+// is the SAME predicate componentValueNameItems applies here, reimplemented
+// as a package-scope scan (there is no enumerable table for it; codegen only
+// probes a specific already-authored call site, via
+// component_identity.go's componentResultType). componentValueNameItems
+// additionally requires every parameter named, a completion-only exclusion
+// layered on top — see tagCallableValueNames' doc for why. Without this scan,
+// a pure-Go design-system package (icons, wrapped factories, ...) with zero
 // `component`-keyword declarations completes to nothing at its tag/qualifier
 // cursor even though its values compile fine as tags.
 //
@@ -232,13 +235,29 @@ func componentValueNameItems(target *types.Package, skip map[string]bool, export
 // tagCallableValueNames returns target's package-scope identifiers — sorted,
 // minus skip — that satisfy codegen's callable-universe tag shape: a
 // types.Func or function-valued types.Var whose signature has one result
-// implementing gsx.Node and every parameter named (see
-// internal/codegen/component_target.go's harvestComponentTargetFacts, the
-// authoritative acceptance rule this mirrors). exportedOnly gates on
-// obj.Exported() — required when target is a DIFFERENT package than the one
-// completion is running in (Go visibility), and false for target's own
-// package (every package-scope identifier, exported or not, is a legal
-// same-package tag).
+// assignable to gsx.Node (single-sourced from internal/tagcallable — see its
+// package doc) AND every parameter named.
+//
+// The named-parameter half is NOT part of the shared tagcallable predicate:
+// it is a deliberate, conservative choice specific to offering completion
+// candidates, not a copy of some single codegen acceptance function. codegen
+// itself only requires named parameters at the point it plans how markup
+// attributes bind to a resolved call target — component_signature.go's
+// analyzeComponentSignature (the "component-parameter-name" check), reached
+// from component_positional_plan.go's operand planning
+// (planComponentPositionalCalls) — which runs on one already-authored,
+// already-resolved call site, never on a package-scope scan like this one.
+// An unnamed parameter could never receive a markup attribute that way, so
+// completion excludes it up front rather than offering a candidate codegen
+// would reject at the call site; but nothing stops a future codegen change
+// from accepting unnamed parameters through some other binding path this
+// scan does not know about, without this file needing to track it — hence
+// "deliberate choice", not "mirrored rule".
+//
+// exportedOnly gates on obj.Exported() — required when target is a DIFFERENT
+// package than the one completion is running in (Go visibility), and false
+// for target's own package (every package-scope identifier, exported or
+// not, is a legal same-package tag).
 //
 // gsxNodeInterface resolving to nil (target does not import gsx.Node at all,
 // directly or — for the tests' synthetic packages — because it has no
@@ -264,7 +283,7 @@ func tagCallableValueNames(target *types.Package, skip map[string]bool, exported
 		case *types.Func:
 			sig, _ = o.Type().(*types.Signature)
 		case *types.Var:
-			sig = callableSignature(o.Type())
+			sig = tagcallable.Signature(o.Type())
 		default:
 			continue
 		}
@@ -277,31 +296,14 @@ func tagCallableValueNames(target *types.Package, skip map[string]bool, exported
 	return names
 }
 
-// callableSignature returns typ's *types.Signature — unwrapping a defined
-// (named) function type's underlying type, mirroring
-// internal/codegen/component_target.go's targetCallableSignature exactly (the
-// same unwrap is needed for a `type Factory func(...) gsx.Node`-shaped
-// package var, not just a bare `func(...) gsx.Node` one) — or nil when typ is
-// not callable at all.
-func callableSignature(typ types.Type) *types.Signature {
-	if typ == nil {
-		return nil
-	}
-	unaliased := types.Unalias(typ)
-	if sig, ok := unaliased.(*types.Signature); ok {
-		return sig
-	}
-	sig, _ := unaliased.Underlying().(*types.Signature)
-	return sig
-}
-
 // isTagCallableSignature reports whether sig matches codegen's
-// callable-universe shape: exactly one result implementing the gsx.Node
-// interface, and every parameter named (an unnamed parameter can never be
-// bound to a markup attribute, so codegen never treats such a signature as
-// tag-callable either).
+// callable-universe shape — tagcallable.IsResult, single-sourced with
+// codegen's component_identity.go — AND every parameter is named. See
+// tagCallableValueNames' doc for why the named-parameter half stays a
+// completion-local, deliberately conservative addition rather than part of
+// the shared predicate.
 func isTagCallableSignature(sig *types.Signature, node *types.Interface) bool {
-	if sig.Results().Len() != 1 || !types.Implements(sig.Results().At(0).Type(), node) {
+	if !tagcallable.IsResult(sig, node) {
 		return false
 	}
 	for param := range sig.Params().Variables() {
@@ -321,6 +323,21 @@ func isTagCallableSignature(sig *types.Signature, node *types.Interface) bool {
 // package, per the go/types identity rule that every *types.Package in one
 // checked build shares one canonical object per imported package). Returns
 // nil (fail-soft) when target does not import gsx at all.
+//
+// This duplicates a lookup codegen also performs — component_signature.go's
+// runtimeContractFromAnalysisPackage is the authority there, and its
+// runtimeContract.node is exactly this same gsx.Node identity — but that
+// helper is not reachable from here without either a layering violation
+// (internal/lsp importing internal/codegen) or pulling in invariants this
+// scan does not need: runtimeContractFromAnalysisPackage resolves Node,
+// Attr, AND Attrs together for one fixed "the analysis package" and errors
+// if any is missing or inconsistent, whereas this needs only Node, resolved
+// against an arbitrary imported target package that is never itself "the
+// analysis package". Folding the two would mean either exporting a
+// narrower, Node-only codegen entry point (not part of this pass; a
+// follow-up if the duplication proves troublesome) or accepting the
+// unrelated Attr/Attrs requirement here. Kept local for now, with codegen's
+// runtimeContract as the documented authority for the identity this mirrors.
 func gsxNodeInterface(target *types.Package) *types.Interface {
 	if target == nil {
 		return nil

--- a/internal/lsp/completion_gsx_test.go
+++ b/internal/lsp/completion_gsx_test.go
@@ -646,7 +646,7 @@ func TestComponentAttrItems(t *testing.T) {
 	// Cursor position unrelated to the "title" attr's own span (e.g. right
 	// after the tag name, in the whitespace before "title").
 	cursor := strings.Index(src, "<Card") + len("<Card")
-	items := componentAttrItems(pkg, el, src, cursor, cursor, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
 
 	if len(items) != 1 {
 		t.Fatalf("items = %+v, want exactly 1 (count)", items)
@@ -722,7 +722,7 @@ func TestComponentAttrItemsExcludesGoOnlyVariadic(t *testing.T) {
 	}
 
 	cursor := strings.Index(src, "<Card") + len("<Card")
-	items := componentAttrItems(pkg, el, src, cursor, cursor, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
 
 	if len(items) != 1 {
 		t.Fatalf("items = %+v, want exactly 1 (count)", items)
@@ -744,7 +744,7 @@ func TestComponentAttrItemsCursorOnBoundAttrStaysOffered(t *testing.T) {
 
 	nameStart := strings.Index(src, "title")
 	nameEnd := nameStart + len("title")
-	items := componentAttrItems(pkg, el, src, nameStart, nameEnd, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, nameStart, nameEnd, encUTF8)
 
 	labels := map[string]bool{}
 	for _, it := range items {
@@ -779,18 +779,215 @@ func TestComponentAttrItemsNoFact(t *testing.T) {
 		return true
 	})
 	pkg := &Package{GSXFset: fset, Files: map[string]*gsxast.File{"page.gsx": f}, ComponentCalls: map[*gsxast.Element]ComponentCallFact{}}
-	if items := componentAttrItems(pkg, el, src, 0, 0, encUTF8); items != nil {
+	if items := componentAttrItems(pkg, el, false, src, 0, 0, encUTF8); items != nil {
 		t.Fatalf("items = %+v, want nil (no planned call fact)", items)
 	}
 }
 
 // TestComponentAttrItemsNilGuards checks that a nil pkg or nil el fails soft.
 func TestComponentAttrItemsNilGuards(t *testing.T) {
-	if items := componentAttrItems(nil, &gsxast.Element{}, "", 0, 0, encUTF8); items != nil {
+	if items := componentAttrItems(nil, &gsxast.Element{}, false, "", 0, 0, encUTF8); items != nil {
 		t.Fatalf("items = %+v, want nil for nil pkg", items)
 	}
-	if items := componentAttrItems(&Package{}, nil, "", 0, 0, encUTF8); items != nil {
+	if items := componentAttrItems(&Package{}, nil, false, "", 0, 0, encUTF8); items != nil {
 		t.Fatalf("items = %+v, want nil for nil el", items)
+	}
+}
+
+// componentAttrsCatchAllFixture parses src (which must contain exactly one
+// element whose Tag == tag) and wires a *Package/element pair for
+// componentAttrItems whose ComponentCalls[el].Signature is caller-supplied —
+// unlike componentAttrFixture's fixed (ctx, title, count, children) shape,
+// these tests need to vary whether an "attrs" catch-all parameter is present.
+// Every attr already present on el is bound in fact.Params keyed by its own
+// position, from a caller-supplied attr->param-name map (mirrors
+// componentAttrFixture).
+func componentAttrsCatchAllFixture(t *testing.T, src, tag string, sig *types.Signature, bound map[string]string) (pkg *Package, el *gsxast.Element) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := gsxparser.ParseFile(fset, "page.gsx", []byte(src), 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	gsxast.Inspect(f, func(n gsxast.Node) bool {
+		if e, ok := n.(*gsxast.Element); ok && e.Tag == tag {
+			el = e
+		}
+		return true
+	})
+	if el == nil {
+		t.Fatalf("no <%s> element found in source", tag)
+	}
+
+	boundParams := map[gsxast.Attr]ComponentParamFact{}
+	for _, attr := range el.Attrs {
+		name, ok := attrName(attr)
+		if !ok {
+			continue
+		}
+		if paramName, ok := bound[name]; ok {
+			boundParams[attr] = ComponentParamFact{Name: paramName}
+		}
+	}
+
+	pkg = &Package{
+		GSXFset: fset,
+		Files:   map[string]*gsxast.File{"page.gsx": f},
+		ComponentCalls: map[*gsxast.Element]ComponentCallFact{
+			el: {Signature: sig, Params: boundParams},
+		},
+	}
+	return pkg, el
+}
+
+// TestComponentAttrItemsAttrsCatchAllOffersHTMLGlobals checks the core new
+// rule: a component signature declaring a variadic "attrs" catch-all
+// (`func(attrs ...gsx.Attr) gsx.Node` — icon.Bell's real shape) offers the
+// HTML GLOBAL attribute set in addition to (here, absent) named params —
+// boolean globals inserting the bare name (hidden), value globals inserting
+// `name=""` (class), all sorted at tierSecondary (20) so real component
+// params would lead.
+func TestComponentAttrItemsAttrsCatchAllOffersHTMLGlobals(t *testing.T) {
+	src := "package page\n\ncomponent Home() {\n\t<icon.Bell/>\n}\n"
+	params := types.NewTuple(
+		types.NewVar(token.NoPos, nil, "attrs", types.NewSlice(types.Typ[types.Int])),
+	)
+	sig := types.NewSignatureType(nil, nil, nil, params, nil, true)
+	pkg, el := componentAttrsCatchAllFixture(t, src, "icon.Bell", sig, nil)
+
+	cursor := strings.Index(src, "<icon.Bell") + len("<icon.Bell")
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+
+	byLabel := map[string]CompletionItem{}
+	for _, it := range items {
+		byLabel[it.Label] = it
+	}
+
+	hidden, ok := byLabel["hidden"]
+	if !ok {
+		t.Fatalf("labels = %v, want boolean global %q offered", byLabel, "hidden")
+	}
+	if hidden.TextEdit == nil || hidden.TextEdit.NewText != "hidden" {
+		t.Errorf("hidden.TextEdit = %+v, want bare-name insert %q", hidden.TextEdit, "hidden")
+	}
+	if !strings.HasPrefix(hidden.SortText, "20") {
+		t.Errorf("hidden.SortText = %q, want tierSecondary (20) prefix", hidden.SortText)
+	}
+
+	class, ok := byLabel["class"]
+	if !ok {
+		t.Fatalf("labels = %v, want value global %q offered", byLabel, "class")
+	}
+	if class.TextEdit == nil || class.TextEdit.NewText != `class=""` {
+		t.Errorf("class.TextEdit = %+v, want %q insert", class.TextEdit, `class=""`)
+	}
+	if !strings.HasPrefix(class.SortText, "20") {
+		t.Errorf("class.SortText = %q, want tierSecondary (20) prefix", class.SortText)
+	}
+
+	// The reserved "attrs" name itself is never offered as an attribute.
+	if byLabel["attrs"].Label != "" {
+		t.Errorf("labels = %v, must not offer reserved %q", byLabel, "attrs")
+	}
+}
+
+// TestComponentAttrItemsNoAttrsCatchAllNoHTMLGlobals checks the negative
+// case: a plain-props signature with no "attrs" catch-all offers only the
+// named params — no HTML globals leak in (an unknown attribute would be
+// rejected by the planner, so suggesting one would invite invalid input).
+func TestComponentAttrItemsNoAttrsCatchAllNoHTMLGlobals(t *testing.T) {
+	src := "package page\n\ncomponent Home() {\n\t<Card/>\n}\n"
+	params := types.NewTuple(
+		types.NewVar(token.NoPos, nil, "title", types.Typ[types.String]),
+		types.NewVar(token.NoPos, nil, "count", types.Typ[types.Int]),
+	)
+	sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
+	pkg, el := componentAttrsCatchAllFixture(t, src, "Card", sig, nil)
+
+	cursor := strings.Index(src, "<Card") + len("<Card")
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	if len(labels) != 2 || !labels["title"] || !labels["count"] {
+		t.Fatalf("labels = %v, want exactly {title, count}", labels)
+	}
+	for _, global := range []string{"class", "hidden", "id", "style"} {
+		if labels[global] {
+			t.Errorf("labels = %v, must NOT offer HTML global %q (no attrs catch-all)", labels, global)
+		}
+	}
+}
+
+// TestComponentAttrItemsAttrsCatchAllPresentAttrExcluded checks that the
+// forwarded-globals list applies the same present-attr exclusion and
+// cursor-on-own-token carve-out as the plain HTML path (htmlAttrItems),
+// reused rather than reimplemented: an already-authored "class" attribute
+// elsewhere on the tag is excluded, but stays offered when the cursor sits
+// on that very attribute's own token.
+func TestComponentAttrItemsAttrsCatchAllPresentAttrExcluded(t *testing.T) {
+	src := "package page\n\ncomponent Home() {\n\t<icon.Bell class=\"x\"/>\n}\n"
+	params := types.NewTuple(
+		types.NewVar(token.NoPos, nil, "attrs", types.NewSlice(types.Typ[types.Int])),
+	)
+	sig := types.NewSignatureType(nil, nil, nil, params, nil, true)
+	pkg, el := componentAttrsCatchAllFixture(t, src, "icon.Bell", sig, nil)
+
+	// Cursor elsewhere (right after the tag name): "class" already present,
+	// must be excluded.
+	elsewhere := strings.Index(src, "<icon.Bell") + len("<icon.Bell")
+	items := componentAttrItems(pkg, el, false, src, elsewhere, elsewhere, encUTF8)
+	for _, it := range items {
+		if it.Label == "class" {
+			t.Fatalf("items = %+v, must exclude already-present %q", items, "class")
+		}
+	}
+
+	// Cursor ON the "class" token itself: carve-out keeps it offered.
+	nameStart := strings.Index(src, "class")
+	nameEnd := nameStart + len("class")
+	onToken := componentAttrItems(pkg, el, false, src, nameStart, nameEnd, encUTF8)
+	found := false
+	for _, it := range onToken {
+		if it.Label == "class" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("items = %+v, want %q offered (cursor is on its own token)", onToken, "class")
+	}
+}
+
+// TestComponentAttrItemsAttrsCatchAllHTMXGated checks that hx-* forwarded
+// candidates only appear when htmxEnabled — the same gate htmlAttrItems
+// applies on the plain HTML path.
+func TestComponentAttrItemsAttrsCatchAllHTMXGated(t *testing.T) {
+	src := "package page\n\ncomponent Home() {\n\t<icon.Bell/>\n}\n"
+	params := types.NewTuple(
+		types.NewVar(token.NoPos, nil, "attrs", types.NewSlice(types.Typ[types.Int])),
+	)
+	sig := types.NewSignatureType(nil, nil, nil, params, nil, true)
+	pkg, el := componentAttrsCatchAllFixture(t, src, "icon.Bell", sig, nil)
+	cursor := strings.Index(src, "<icon.Bell") + len("<icon.Bell")
+
+	off := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+	for _, it := range off {
+		if strings.HasPrefix(it.Label, "hx-") {
+			t.Fatalf("items = %+v, must NOT offer hx-* when htmxEnabled=false", off)
+		}
+	}
+
+	on := componentAttrItems(pkg, el, true, src, cursor, cursor, encUTF8)
+	foundHx := false
+	for _, it := range on {
+		if strings.HasPrefix(it.Label, "hx-") {
+			foundHx = true
+		}
+	}
+	if !foundHx {
+		t.Fatalf("items = %+v, want at least one hx-* candidate when htmxEnabled=true", on)
 	}
 }
 

--- a/internal/lsp/completion_gsx_test.go
+++ b/internal/lsp/completion_gsx_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 // TestFilterItems checks filterItems' shape: label = Name, detail =
-// "Pkg.Func" (with a " (ctx)" suffix when WantsCtx), kind = ciKindFunction,
-// tier = tierContext, and every item's TextEdit replaces the given [start,end)
-// span. Order is preserved verbatim (filters arrives pre-sorted from
+// "Pkg.Func" (with a " (ctx)" suffix when WantsCtx), kind = ciKindOperator
+// (not Function — accepting a bare filter must not auto-append "()"), tier =
+// tierContext, and every item's TextEdit replaces the given [start,end) span.
+// Order is preserved verbatim (filters arrives pre-sorted from
 // Package.Filters).
 func TestFilterItems(t *testing.T) {
 	fs := []FilterCandidate{
@@ -48,8 +49,8 @@ func TestFilterItems(t *testing.T) {
 	}
 
 	for i, it := range items {
-		if it.Kind != ciKindFunction {
-			t.Errorf("items[%d].Kind = %d, want ciKindFunction", i, it.Kind)
+		if it.Kind != ciKindOperator {
+			t.Errorf("items[%d].Kind = %d, want ciKindOperator", i, it.Kind)
 		}
 		if !strings.HasPrefix(it.SortText, "05") {
 			t.Errorf("items[%d].SortText = %q, want tierContext (05) prefix", i, it.SortText)
@@ -217,8 +218,8 @@ func TestComponentTagItemsBareCursor(t *testing.T) {
 	if len(items) != 2 {
 		t.Fatalf("len(items) = %d, want 2: %+v", len(items), items)
 	}
-	if items[0].Label != "Card" || items[0].Kind != ciKindFunction {
-		t.Errorf("items[0] = %+v, want label Card kind ciKindFunction", items[0])
+	if items[0].Label != "Card" || items[0].Kind != ciKindClass {
+		t.Errorf("items[0] = %+v, want label Card kind ciKindClass", items[0])
 	}
 	if items[0].TextEdit == nil || items[0].TextEdit.NewText != "Card" {
 		t.Errorf("items[0].TextEdit = %+v, want NewText %q", items[0].TextEdit, "Card")
@@ -244,8 +245,8 @@ func TestComponentTagItemsQualified(t *testing.T) {
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d, want 1: %+v", len(items), items)
 	}
-	if items[0].Label != "Button" || items[0].Kind != ciKindFunction {
-		t.Errorf("items[0] = %+v, want label Button kind ciKindFunction", items[0])
+	if items[0].Label != "Button" || items[0].Kind != ciKindClass {
+		t.Errorf("items[0] = %+v, want label Button kind ciKindClass", items[0])
 	}
 	if items[0].TextEdit == nil || items[0].TextEdit.NewText != "Button" {
 		t.Errorf("items[0].TextEdit = %+v, want NewText %q", items[0].TextEdit, "Button")
@@ -320,6 +321,156 @@ var _ = myui.ToUpper
 	}
 	if qualItem.TextEdit == nil || qualItem.TextEdit.NewText != "myui." {
 		t.Errorf("qualifier item TextEdit = %+v, want NewText %q", qualItem.TextEdit, "myui.")
+	}
+}
+
+// buildIconValueComponentFixture constructs, entirely via the go/types object
+// API (types.NewPackage/NewVar/NewFunc/NewSignatureType — no source parsed, no
+// real import resolution needed, mirroring componentTagFixturePackage's
+// approach), a three-package graph that reproduces the real-world gap this
+// fixture is named after: a "github.com/gsxhq/gsx" package declaring the Node
+// interface, a pure-Go "icon" sibling package (no `component`-keyword decls
+// at all — see internal/lsp/completion_gsx.go's componentTagItems doc
+// comment) with candidates spanning every shape tagCallableValueNames must
+// discriminate, and a "page" package importing "icon" plus declaring one
+// local value-component of its own.
+//
+// icon's package-scope names:
+//   - X: exported var, func(name string) Node — the common shape (`var X =
+//     named("x")`); must be offered.
+//   - DirectFunc: exported FUNC (not var) of the same shape; must be offered.
+//   - BadParam: exported var, func(string) Node with an UNNAMED parameter;
+//     never offered (an unnamed parameter can never bind to a markup
+//     attribute).
+//   - WrongResult: exported var, func(name string) int — result does not
+//     implement Node; never offered.
+//   - unexp: unexported var of the X shape; never offered when scanned as an
+//     IMPORTED package (Go visibility — only reachable via qualifier!="").
+//
+// page's package-scope names:
+//   - LocalIcon: unexported var of the X shape, declared directly in page —
+//     must be offered at a BARE (qualifier=="") cursor, proving the
+//     exportedOnly=false same-package rule (contrast icon's "unexp").
+func buildIconValueComponentFixture() *Package {
+	gsxPkg := types.NewPackage("github.com/gsxhq/gsx", "gsx")
+	nodeMethod := types.NewFunc(token.NoPos, gsxPkg, "isNode", types.NewSignatureType(nil, nil, nil, nil, nil, false))
+	nodeIface := types.NewInterfaceType([]*types.Func{nodeMethod}, nil)
+	nodeIface.Complete()
+	nodeName := types.NewTypeName(token.NoPos, gsxPkg, "Node", nil)
+	nodeNamed := types.NewNamed(nodeName, nodeIface, nil)
+	gsxPkg.Scope().Insert(nodeName)
+	gsxPkg.MarkComplete()
+
+	nodeResult := func() *types.Tuple {
+		return types.NewTuple(types.NewVar(token.NoPos, nil, "", nodeNamed))
+	}
+	namedParams := func() *types.Tuple {
+		return types.NewTuple(types.NewVar(token.NoPos, nil, "name", types.Typ[types.String]))
+	}
+
+	iconPkg := types.NewPackage("github.com/tespkg/one-learning/ds/icon", "icon")
+	iconPkg.SetImports([]*types.Package{gsxPkg})
+
+	xSig := types.NewSignatureType(nil, nil, nil, namedParams(), nodeResult(), false)
+	iconPkg.Scope().Insert(types.NewVar(token.NoPos, iconPkg, "X", xSig))
+	iconPkg.Scope().Insert(types.NewFunc(token.NoPos, iconPkg, "DirectFunc", types.NewSignatureType(nil, nil, nil, namedParams(), nodeResult(), false)))
+
+	unnamedParams := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.String]))
+	badSig := types.NewSignatureType(nil, nil, nil, unnamedParams, nodeResult(), false)
+	iconPkg.Scope().Insert(types.NewVar(token.NoPos, iconPkg, "BadParam", badSig))
+
+	intResult := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int]))
+	wrongSig := types.NewSignatureType(nil, nil, nil, namedParams(), intResult, false)
+	iconPkg.Scope().Insert(types.NewVar(token.NoPos, iconPkg, "WrongResult", wrongSig))
+
+	iconPkg.Scope().Insert(types.NewVar(token.NoPos, iconPkg, "unexp", xSig))
+	iconPkg.MarkComplete()
+
+	pagePkg := types.NewPackage("example.com/app/page", "page")
+	pagePkg.SetImports([]*types.Package{gsxPkg, iconPkg})
+	localSig := types.NewSignatureType(nil, nil, nil, namedParams(), nodeResult(), false)
+	pagePkg.Scope().Insert(types.NewVar(token.NoPos, pagePkg, "LocalIcon", localSig))
+	pagePkg.MarkComplete()
+
+	return &Package{Types: pagePkg}
+}
+
+// TestComponentValueNameItemsQualified checks the qualifier!="" scan against
+// the imported "icon" package: X and DirectFunc are offered (kind
+// ciKindClass), BadParam/WrongResult/unexp are not.
+func TestComponentValueNameItemsQualified(t *testing.T) {
+	pkg := buildIconValueComponentFixture()
+	items := componentTagItems(pkg, "icon", false, "", 0, 0, encUTF8)
+	got := map[string]CompletionItem{}
+	for _, it := range items {
+		got[it.Label] = it
+	}
+	for _, name := range []string{"X", "DirectFunc"} {
+		it, ok := got[name]
+		if !ok {
+			t.Fatalf("items = %+v, want %q offered", items, name)
+		}
+		if it.Kind != ciKindClass {
+			t.Errorf("%s.Kind = %d, want ciKindClass", name, it.Kind)
+		}
+	}
+	for _, name := range []string{"BadParam", "WrongResult", "unexp"} {
+		if _, ok := got[name]; ok {
+			t.Errorf("items = %+v, must NOT offer %q", items, name)
+		}
+	}
+}
+
+// TestComponentValueNameItemsBareCursorLocal checks the qualifier=="" scan
+// against page's OWN scope: the unexported LocalIcon value-component is
+// offered (same-package visibility has no exported-only gate), and the
+// bare-cursor candidate list also carries the "icon" import qualifier item —
+// packageHasTagCallableValue must recognize icon as qualifier-worthy even
+// though it has zero ComponentDecls entries.
+func TestComponentValueNameItemsBareCursorLocal(t *testing.T) {
+	pkg := buildIconValueComponentFixture()
+	items := componentTagItems(pkg, "", false, "", 0, 0, encUTF8)
+	var local, qual *CompletionItem
+	for i := range items {
+		switch items[i].Label {
+		case "LocalIcon":
+			local = &items[i]
+		case "icon":
+			qual = &items[i]
+		}
+	}
+	if local == nil {
+		t.Fatalf("items = %+v, want local value-component LocalIcon offered", items)
+	}
+	if local.Kind != ciKindClass {
+		t.Errorf("LocalIcon.Kind = %d, want ciKindClass", local.Kind)
+	}
+	if qual == nil {
+		t.Fatalf("items = %+v, want qualifier item \"icon\" (zero ComponentDecls, but has tag-callable values)", items)
+	}
+	if qual.TextEdit == nil || qual.TextEdit.NewText != "icon." {
+		t.Errorf("icon qualifier TextEdit = %+v, want NewText %q", qual.TextEdit, "icon.")
+	}
+}
+
+// TestComponentValueNameItemsDedup checks that a name present in BOTH
+// pkg.ComponentDecls (a `component`-keyword decl) and the value-component
+// scan (its own underlying Go func trivially satisfies the same signature
+// shape) is offered exactly once.
+func TestComponentValueNameItemsDedup(t *testing.T) {
+	pkg := buildIconValueComponentFixture()
+	pkg.ComponentDecls = map[ComponentDeclKey][]sourceintel.VersionedSpan{
+		{PackagePath: "github.com/tespkg/one-learning/ds/icon", ComponentKey: ".X"}: nil,
+	}
+	items := componentTagItems(pkg, "icon", false, "", 0, 0, encUTF8)
+	count := 0
+	for _, it := range items {
+		if it.Label == "X" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("label \"X\" appeared %d times, want exactly 1: %+v", count, items)
 	}
 }
 

--- a/internal/lsp/completion_html.go
+++ b/internal/lsp/completion_html.go
@@ -52,7 +52,16 @@ func htmlTagItems(prefixCapitalized bool, text string, start, end int, enc encod
 // bridge: presence exclusion reads only el.Attrs' names, which are a pure parse
 // fact of the same bytes — no codegen semantics required — so this path works
 // even when analysis is a shell.
-func htmlAttrItems(el *gsxast.Element, tagName string, htmxEnabled bool, text string, start, end int, enc encoding) []CompletionItem {
+//
+// tagName == "" (no dataset tag matches) yields tag-specific attributes as an
+// empty contribution, so the candidate set collapses to GlobalAttributes (plus
+// hx-* when htmxEnabled) — the "globals only" shape componentAttrItems reuses
+// for a component's forwarded-attrs catch-all, where no concrete receiving
+// element is known. tier is threaded into every item's SortText so callers can
+// rank this list against sibling candidates: tierContext for the direct HTML
+// path, tierSecondary for the forwarded-globals path so real component params
+// sort first.
+func htmlAttrItems(el *gsxast.Element, tagName string, htmxEnabled bool, tier int, text string, start, end int, enc encoding) []CompletionItem {
 	// typed is the attribute-name token the cursor sits on. When a present
 	// attribute's lowercase name exact-matches it, that attribute must stay
 	// offered rather than be excluded as "already present" — the cursor is
@@ -93,12 +102,12 @@ func htmlAttrItems(el *gsxast.Element, tagName string, htmxEnabled bool, text st
 		seen[lower] = true
 		if attr.Boolean() || gsx.IsBooleanAttr(attr.Name) {
 			// Presence-only: insert the bare name.
-			items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, attr.Name, ciKindField, markdownDoc(attr.Doc)))
+			items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, attr.Name, ciKindField, tier, markdownDoc(attr.Doc)))
 			continue
 		}
 		// Value attribute: insert `name=""`, but keep FilterText = name so the
 		// client matches against the typed name, not the `=""` suffix.
-		items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, attr.Name+`=""`, ciKindField, markdownDoc(attr.Doc)))
+		items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, attr.Name+`=""`, ciKindField, tier, markdownDoc(attr.Doc)))
 	}
 	return items
 }
@@ -163,12 +172,12 @@ func valueSetFor(tagName, attrName string) string {
 // user's typed prefix against the name, not the `=""` insertion. newText == the
 // name for a boolean attribute, in which case FilterText is left unset (the
 // client falls back to the label).
-func htmlAttrItem(text string, start, end int, enc encoding, name, newText string, kind int, doc *MarkupContent) CompletionItem {
+func htmlAttrItem(text string, start, end int, enc encoding, name, newText string, kind int, tier int, doc *MarkupContent) CompletionItem {
 	item := CompletionItem{
 		Label:         name,
 		Kind:          kind,
 		Documentation: doc,
-		SortText:      fmt.Sprintf("%02d%s", tierContext, name),
+		SortText:      fmt.Sprintf("%02d%s", tier, name),
 		TextEdit: &TextEdit{
 			Range:   rangeForSpan(text, start, end, enc),
 			NewText: newText,

--- a/internal/lsp/completion_html_test.go
+++ b/internal/lsp/completion_html_test.go
@@ -88,7 +88,7 @@ func TestHTMLTagItems(t *testing.T) {
 // attributes remain offered.
 func TestHTMLAttrItemsExcludesPresent(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div class=\"x\"/>\n}\n", "div")
-	items := htmlAttrItems(el, "div", false, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
 	labels := labelSet(items)
 	if labels["class"] {
 		t.Errorf("attr list still offers already-present `class`: %v", labels)
@@ -111,7 +111,7 @@ func TestHTMLAttrItemsCursorOnPresentAttrStaysOffered(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div class=\"x\" id=\"y\"/>\n}\n", "div")
 
 	text := "class"
-	items := htmlAttrItems(el, "div", false, text, 0, len(text), encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, text, 0, len(text), encUTF8)
 	labels := labelSet(items)
 	if !labels["class"] {
 		t.Errorf("labels = %v, want `class` offered (cursor is on its own token)", labels)
@@ -125,7 +125,7 @@ func TestHTMLAttrItemsCursorOnPresentAttrStaysOffered(t *testing.T) {
 	}
 
 	for _, typed := range []string{"cl", ""} {
-		items := htmlAttrItems(el, "div", false, typed, 0, len(typed), encUTF8)
+		items := htmlAttrItems(el, "div", false, tierContext, typed, 0, len(typed), encUTF8)
 		labels := labelSet(items)
 		if labels["class"] {
 			t.Errorf("typed %q: labels = %v, want `class` excluded (not an exact match)", typed, labels)
@@ -140,7 +140,7 @@ func TestHTMLAttrItemsCursorOnPresentAttrStaysOffered(t *testing.T) {
 // dataset valueSet "v") inserts the bare name with no `=""` and no FilterText.
 func TestHTMLAttrItemsBooleanBareName(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div/>\n}\n", "div")
-	items := htmlAttrItems(el, "div", false, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
 	hidden := itemByLabel(items, "hidden")
 	if hidden == nil {
 		t.Fatal("attr list missing boolean `hidden`")
@@ -158,7 +158,7 @@ func TestHTMLAttrItemsBooleanBareName(t *testing.T) {
 // the client keeps matching against the typed name, not the `=""` suffix.
 func TestHTMLAttrItemsValueInsertsEquals(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div/>\n}\n", "div")
-	items := htmlAttrItems(el, "div", false, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
 	class := itemByLabel(items, "class")
 	if class == nil {
 		t.Fatal("attr list missing value attr `class`")
@@ -175,7 +175,7 @@ func TestHTMLAttrItemsValueInsertsEquals(t *testing.T) {
 // <input> is an enumerated (non-boolean) attribute, so it inserts `type=""`.
 func TestHTMLAttrItemsInputType(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<input/>\n}\n", "input")
-	items := htmlAttrItems(el, "input", false, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "input", false, tierContext, "", 0, 0, encUTF8)
 	typ := itemByLabel(items, "type")
 	if typ == nil {
 		t.Fatal("input attr list missing `type`")
@@ -190,12 +190,12 @@ func TestHTMLAttrItemsInputType(t *testing.T) {
 func TestHTMLAttrItemsHTMXGated(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div/>\n}\n", "div")
 
-	off := htmlAttrItems(el, "div", false, "", 0, 0, encUTF8)
+	off := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
 	if labelSet(off)["hx-get"] {
 		t.Errorf("hx-get offered with htmx disabled")
 	}
 
-	on := htmlAttrItems(el, "div", true, "", 0, 0, encUTF8)
+	on := htmlAttrItems(el, "div", true, tierContext, "", 0, 0, encUTF8)
 	hxGet := itemByLabel(on, "hx-get")
 	if hxGet == nil {
 		t.Fatalf("hx-get NOT offered with htmx enabled")

--- a/internal/lsp/completion_repair.go
+++ b/internal/lsp/completion_repair.go
@@ -2,6 +2,8 @@ package lsp
 
 import (
 	"go/token"
+	"unicode"
+	"unicode/utf8"
 
 	gsxast "github.com/gsxhq/gsx/ast"
 	gsxparser "github.com/gsxhq/gsx/parser"
@@ -63,4 +65,46 @@ func repairAtCursor(fset *token.FileSet, path string, text string, off int) repa
 		}
 	}
 	return repairResult{src: []byte(text), patch: ""}
+}
+
+// navRepair repairs a mid-edit buffer for the go-to-definition / hover fallback.
+// Completion's cursor is the edit point, so it repairs AT the cursor; a nav
+// cursor, by contrast, may sit inside — or just after — the identifier or tag
+// name it is resolving, and a patch inserted at the cursor would split that token
+// (`<icon.Be▮ll` + `/>` → `<icon.Be/>ll`, the wrong tag). navRepair instead
+// finds the identifier/tag token under the cursor and inserts the repair patch at
+// its END, keeping the token whole, and returns a query offset strictly inside
+// the token for the resolver cascade (the shared half-open [start,start+len)
+// span check never matches a cursor exactly at a token's end). insertOff is also
+// the pivot for repaired→live coordinate mapping. ok=false when the buffer is
+// unrepairable even after moving the insertion to the token boundary.
+func navRepair(path, text string, off int) (r repairResult, insertOff, queryOff int, ok bool) {
+	if off < 0 {
+		off = 0
+	}
+	if off > len(text) {
+		off = len(text)
+	}
+	tokStart, _ := completionTokenSpan(text, off, true)
+	tokEnd := off
+	for tokEnd < len(text) {
+		rn, size := utf8.DecodeRuneInString(text[tokEnd:])
+		if rn == '_' || rn == '-' || unicode.IsLetter(rn) || unicode.IsDigit(rn) {
+			tokEnd += size
+			continue
+		}
+		break
+	}
+	insertOff, queryOff = off, off
+	if tokEnd > tokStart { // the cursor is on, or immediately after, a token
+		insertOff = tokEnd
+		if queryOff >= tokEnd {
+			queryOff = tokEnd - 1 // step inside so the span check can match
+		}
+	}
+	r = repairAtCursor(token.NewFileSet(), path, text, insertOff)
+	if r.parsed == nil {
+		return repairResult{}, 0, 0, false
+	}
+	return r, insertOff, queryOff, true
 }

--- a/internal/lsp/completion_repair.go
+++ b/internal/lsp/completion_repair.go
@@ -10,7 +10,7 @@ import (
 // repairResult is the buffer completion analyzes, plus what was done to it.
 type repairResult struct {
 	src    []byte         // patched bytes (== live buffer when patch == "")
-	patch  string         // inserted at off (see completionPatches): "", "_", "/>", "\"/>", "\"\"/>", "}/>"
+	patch  string         // inserted at off (see completionPatches): "", "_", "/>", "\"/>", "\"\"/>", "}/>", "_/>"
 	parsed *gsxast.File   // parse of src (nil only when unrepairable)
 	fset   *token.FileSet // resolves parsed's positions
 }
@@ -18,7 +18,21 @@ type repairResult struct {
 // completionPatches is the closed, ordered repair set. Each is tried by
 // inserting at the cursor and reparsing; the first parse wins. Bytes before
 // the cursor are never modified, so every client-visible offset survives.
-var completionPatches = []string{"", "_", "/>", "\"/>", "\"\"/>", "}/>"}
+//
+// "_/>" is last: a phantom tag-name closer for a bare `<▮` or a qualified
+// `<pkg.▮` with nothing typed after the dot — neither has any typed text a
+// simple `/>` self-close can attach to (`</>`  and `<pkg./>` both still fail
+// to parse), so a placeholder identifier is required to stand in for the
+// not-yet-typed tag/member name. `_` was chosen (over e.g. `x`) because gsx
+// tag names carry no Go identifier semantics — an element's Tag is an opaque
+// string, never resolved as a Go expression — so there is no risk of it
+// colliding with blank-identifier handling elsewhere; it is also visually
+// inert if it were ever (it never is) surfaced. It sorts after "/>" so a
+// prefixed half-typed tag/attr (`<Ca`, `<div cl`) keeps healing via the
+// simpler `/>` patch alone — `<div cl` + "_/>" would parse too (as attribute
+// `cl_`), but that muddies the present-attr-name reasoning downstream, so the
+// plain `/>` heal (attribute `cl`) must keep winning.
+var completionPatches = []string{"", "_", "/>", "\"/>", "\"\"/>", "}/>", "_/>"}
 
 // repairAtCursor parses text; on failure tries a closed, ordered patch list
 // inserted at off, first parse wins. Deterministic; never touches bytes before

--- a/internal/lsp/completion_repair_test.go
+++ b/internal/lsp/completion_repair_test.go
@@ -17,6 +17,13 @@ func TestRepairAtCursor(t *testing.T) {
 		{"empty pipe stage", "package p\n\ncomponent C() {\n\t<div>{ x |> § }</div>\n}\n", "_", true},
 		{"half-typed component tag", "package p\n\ncomponent C() {\n\t<div><Ca§</div>\n}\n", "/>", true},
 		{"half-typed attr name", "package p\n\ncomponent C() {\n\t<div cl§\n}\n", "/>", true},
+		{"bare tag trigger", "package p\n\ncomponent C() {\n\t<§\n}\n", "_/>", true},
+		// Observed: unlike a bare `<`, the parser accepts a qualified tag with
+		// a trailing dot and no member token (`<icon./>` parses clean, same as
+		// the standalone "trailing dot parses as gsx" Go-expr case above), so
+		// the plain `/>` patch already heals it and wins before `_/>` is ever
+		// tried — the healed Tag stays "icon." (no injected "_").
+		{"qualified tag trailing dot", "package p\n\ncomponent C() {\n\t<icon.§\n}\n", "/>", true},
 		{"unclosed attr string", "package p\n\ncomponent C() {\n\t<div class=\"x§\n}\n", "\"/>", true},
 		// Observed: `class=` demands a value; only `""/>` (an empty quoted
 		// value + self-close) heals it with zero parser errors. The brief's

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -43,7 +43,7 @@ func semanticDefinitionFromSnapshot(pkg *Package, path string, source []byte, of
 		return semanticDefinitionTarget{}, false
 	}
 	goPosition := pkg.Fset.Position(object.Pos())
-	if goPosition.Filename == "" || !strings.HasSuffix(goPosition.Filename, ".go") {
+	if goPosition.Filename == "" || !isNavigableTargetFile(goPosition.Filename) {
 		return semanticDefinitionTarget{}, false
 	}
 	if sources == nil || sources.isPairedGeneratedOutput(goPosition.Filename) {
@@ -255,21 +255,22 @@ func objectDefinitionResult(sources *requestSourceSnapshot, pkg *Package, obj ty
 	}
 	if object.Pkg() != nil {
 		key := ComponentDeclKey{PackagePath: object.Pkg().Path(), ComponentKey: componentObjectKey(object)}
-		if result, ok := versionedDefinitionResult(sources, pkg.ComponentDecls[key]); ok {
-			return result, true
+		if decls := pkg.ComponentDecls[key]; len(decls) > 0 {
+			// This object is a component with tracked declaration spans; those
+			// versioned spans are the authoritative, stale-validated answer. Return
+			// them (failing closed when they no longer match the current buffer)
+			// rather than falling through to resolve the raw object position against
+			// possibly-stale source.
+			return versionedDefinitionResult(sources, decls)
 		}
 	}
-	if !object.Pos().IsValid() {
-		return nil, false
+	// A plain package-level value/symbol (a component VALUE like `icon.X`, or a Go
+	// helper) has no tracked component spans: resolve its declaring position —
+	// authored .gsx when present, else the physical generated file.
+	if location, ok := objectSourceLocation(sources, pkg, object); ok {
+		return location, true
 	}
-	if pkg.Fset == nil {
-		return nil, false
-	}
-	dp := pkg.Fset.Position(object.Pos())
-	if dp.Filename == "" {
-		return nil, false
-	}
-	return sources.locationForGoPosition(dp, len(object.Name()))
+	return nil, false
 }
 
 func componentObjectKey(object types.Object) string {
@@ -474,15 +475,35 @@ func versionedDefinitionResult(sources *requestSourceSnapshot, spans []sourceint
 	return locations, true
 }
 
-func genuineGoObjectLocation(sources *requestSourceSnapshot, pkg *Package, object types.Object) (Location, bool) {
+// objectSourceLocation resolves a go/types object's declaring position to a
+// navigation target under the authored-first policy:
+//
+//   - The //line-adjusted position (pkg.Fset.Position) points at an authored .gsx
+//     when the object is a component VALUE (or any top-level Go symbol) declared
+//     in a Go chunk of a .gsx analyzed from sources — its own package, or a
+//     dependency whose .gsx ships beside its generated .x.go (same module, a
+//     nested module, or a module cache with sources). When that .gsx exists, jump
+//     there.
+//   - Otherwise fall back to the PHYSICAL position (Fset.PositionFor without
+//     //line adjustment): the real .go / .x.go the object was type-checked from.
+//     This covers an external dependency shipping only its generated .x.go (the
+//     authored .gsx absent), where a generated-file location beats null.
+//
+// locationForExistingFile still rejects a paired generated .x.go while its
+// authored .gsx exists, so navigation never lands in generated code when the
+// source is available. Same-package authored objects are resolved by callers via
+// SourceIndex before reaching here.
+func objectSourceLocation(sources *requestSourceSnapshot, pkg *Package, object types.Object) (Location, bool) {
 	if pkg == nil || pkg.Fset == nil || object == nil || !object.Pos().IsValid() {
 		return Location{}, false
 	}
-	position := pkg.Fset.Position(object.Pos())
-	if !strings.HasSuffix(position.Filename, ".go") {
-		return Location{}, false
+	if adjusted := pkg.Fset.Position(object.Pos()); strings.HasSuffix(adjusted.Filename, ".gsx") {
+		if location, ok := sources.locationForExistingFile(adjusted, len(object.Name())); ok {
+			return location, true
+		}
 	}
-	return sources.locationForGoPosition(position, len(object.Name()))
+	physical := pkg.Fset.PositionFor(object.Pos(), false)
+	return sources.locationForExistingFile(physical, len(object.Name()))
 }
 
 // handleDefinition answers textDocument/definition for D1: a Go symbol under the
@@ -519,7 +540,7 @@ func (s *Server) handleDefinition(f frame) error {
 		if result, valid := versionedDefinitionResult(sources, cursor.fact.TargetDecls); valid {
 			return s.reply(f.ID, result)
 		}
-		location, ok := genuineGoObjectLocation(sources, pkg, componentTargetObject(cursor.fact))
+		location, ok := objectSourceLocation(sources, pkg, componentTargetObject(cursor.fact))
 		if !ok {
 			return s.reply(f.ID, nil)
 		}
@@ -564,7 +585,7 @@ func (s *Server) handleDefinition(f frame) error {
 		if param == nil {
 			param = cursor.param.Var
 		}
-		location, ok := genuineGoObjectLocation(sources, pkg, param)
+		location, ok := objectSourceLocation(sources, pkg, param)
 		if !ok {
 			return s.reply(f.ID, nil)
 		}
@@ -604,7 +625,7 @@ func (s *Server) handleDefinition(f frame) error {
 			}
 			return s.reply(f.ID, nil)
 		}
-		location, ok := sources.locationForGoPosition(target.Go, 0)
+		location, ok := sources.locationForExistingFile(target.Go, 0)
 		if !ok {
 			return s.reply(f.ID, nil)
 		}

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -507,7 +507,11 @@ func objectSourceLocation(sources *requestSourceSnapshot, pkg *Package, object t
 }
 
 // handleDefinition answers textDocument/definition for D1: a Go symbol under the
-// cursor that resolves to a definition in a real .go file.
+// cursor that resolves to a definition in a real .go file. When the retained
+// package answers nothing — most often because the live buffer is mid-edit and
+// unparseable, so analysis fell back to a diagnostics-only shell — it retries the
+// same resolver cascade against one ephemeral analysis of the completion-repaired
+// buffer (definitionFallback), healing go-to-definition on a half-typed tag.
 func (s *Server) handleDefinition(f frame) error {
 	var p textDocumentPositionParams
 	if err := json.Unmarshal(f.Params, &p); err != nil {
@@ -526,25 +530,44 @@ func (s *Server) handleDefinition(f frame) error {
 	if !ok {
 		return s.reply(f.ID, nil)
 	}
-	pkg := s.pkgs[filepath.Dir(path)]
-	if pkg == nil || pkg.Info == nil {
-		return s.reply(f.ID, nil)
-	}
-
 	off := byteOffsetForPosition(text, p.Position.Line, p.Position.Character, s.enc)
+
+	pkg := s.pkgs[filepath.Dir(path)]
+	if result, answered := s.definitionAnswerFromPkg(pkg, path, []byte(text), off, sources); answered {
+		return s.reply(f.ID, result)
+	}
+	if result, answered := s.definitionFallback(path, text, off, sources); answered {
+		return s.reply(f.ID, result)
+	}
+	return s.reply(f.ID, nil)
+}
+
+// definitionAnswerFromPkg runs the go-to-definition resolver cascade against one
+// package. It is the shared body called first with the retained package (exactly
+// the prior handler behavior, including every fail-closed guard) and again with
+// an ephemeral package on a total miss. answered=true means a cursor branch
+// matched and result is the reply to send (possibly nil when the branch matched
+// but resolved nothing); answered=false means no branch matched, so the caller
+// may try the fallback. source is the exact bytes pkg was analyzed from — live
+// buffer for the retained pass, the repaired buffer for the ephemeral pass — so
+// the SourceIndex staleness guards compare against the right text.
+func (s *Server) definitionAnswerFromPkg(pkg *Package, path string, source []byte, off int, sources *requestSourceSnapshot) (any, bool) {
+	if pkg == nil || pkg.Info == nil {
+		return nil, false
+	}
 
 	// D2: exact call-target identity from codegen. For a GSX build-variant
 	// family, retain the existing multi-location picker after the exact target
 	// establishes that this authored element is a component call.
 	if cursor, ok := componentTargetAtOffset(pkg, path, off); ok {
 		if result, valid := versionedDefinitionResult(sources, cursor.fact.TargetDecls); valid {
-			return s.reply(f.ID, result)
+			return result, true
 		}
 		location, ok := objectSourceLocation(sources, pkg, componentTargetObject(cursor.fact))
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
-		return s.reply(f.ID, location)
+		return location, true
 	}
 
 	// D2: cursor on a component tag name in a .gsx file → jump to the component
@@ -559,9 +582,9 @@ func (s *Server) handleDefinition(f frame) error {
 		if len(decls) == 1 {
 			location, ok := sources.locationForAuthoredPosition(decls[0], nameLength)
 			if !ok {
-				return s.reply(f.ID, nil)
+				return nil, true
 			}
-			return s.reply(f.ID, location)
+			return location, true
 		}
 		locs := make([]Location, 0, len(decls))
 		for _, d := range decls {
@@ -570,16 +593,16 @@ func (s *Server) handleDefinition(f frame) error {
 			}
 		}
 		if len(locs) == 0 {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
-		return s.reply(f.ID, locs)
+		return locs, true
 	}
 
 	// A/C: cursor on a component-invocation attribute name → the matching component
 	// parameter (same-package function components and cross-package dotted tags).
 	if cursor, ok := componentAttrAtOffset(pkg, path, off); ok {
 		if result, valid := versionedDefinitionResult(sources, cursor.fact.ParamDecls[cursor.param.Ordinal]); valid {
-			return s.reply(f.ID, result)
+			return result, true
 		}
 		param := cursor.param.Origin
 		if param == nil {
@@ -587,9 +610,9 @@ func (s *Server) handleDefinition(f frame) error {
 		}
 		location, ok := objectSourceLocation(sources, pkg, param)
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
-		return s.reply(f.ID, location)
+		return location, true
 	}
 
 	// E: cursor on an identifier inside a component-signature parameter TYPE
@@ -599,13 +622,13 @@ func (s *Server) handleDefinition(f frame) error {
 	// gopls-style). A cursor on a signature type that does not resolve replies
 	// null rather than falling through to expression resolution.
 	if obj, _, _, ok := signatureTypeIdentAt(pkg, path, off); ok {
-		return s.reply(f.ID, signatureTypeDefinition(sources, pkg, obj))
+		return signatureTypeDefinition(sources, pkg, obj), true
 	}
 
 	// F: cursor on an import statement in the .gsx → into the imported package
 	// (its files' `package` clauses), the same picker as a type qualifier.
 	if res, ok := importDefAt(sources, pkg, path, off); ok {
-		return s.reply(f.ID, res)
+		return res, true
 	}
 
 	if target, ok := exprDefinitionTargetAt(pkg, path, off); ok {
@@ -614,24 +637,47 @@ func (s *Server) handleDefinition(f frame) error {
 			result, ok = sources.locationForResolvedPosition(target.position, 0)
 		}
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
-		return s.reply(f.ID, result)
+		return result, true
 	}
-	if target, ok := semanticDefinitionFromSnapshot(pkg, path, []byte(text), off, sources); ok {
+	if target, ok := semanticDefinitionFromSnapshot(pkg, path, source, off, sources); ok {
 		if target.Authored.Path != "" {
 			if location, ok := sources.locationForSpan(target.Authored); ok {
-				return s.reply(f.ID, location)
+				return location, true
 			}
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
 		location, ok := sources.locationForExistingFile(target.Go, 0)
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
-		return s.reply(f.ID, location)
+		return location, true
 	}
-	return s.reply(f.ID, nil)
+	return nil, false
+}
+
+// definitionFallback answers go-to-definition from a completion-repaired,
+// ephemerally analyzed buffer when the retained package matched nothing. It
+// repairs the (mid-edit) buffer at the cursor with the same closed patch set
+// completion uses, runs one warm uncached analysis, and re-runs the resolver
+// cascade against it. Current-file byte spans the cascade returns are in repaired
+// coordinates, so the snapshot is armed to map them back to the live buffer
+// (setRepair). answered=false — reply null as before — whenever the buffer is
+// unrepairable, analysis errors, or the result is a shell with neither type info
+// nor a parse.
+func (s *Server) definitionFallback(path, text string, off int, sources *requestSourceSnapshot) (any, bool) {
+	r, insertOff, queryOff, ok := navRepair(path, text, off)
+	if !ok {
+		return nil, false
+	}
+	eph, err := s.analyzer.AnalyzeEphemeral(filepath.Dir(path), path, r.src)
+	if err != nil || eph == nil || (eph.Info == nil && eph.Files == nil) {
+		return nil, false
+	}
+	sources.setRepair(path, insertOff, len(r.patch))
+	defer sources.clearRepair()
+	return s.definitionAnswerFromPkg(eph, path, r.src, queryOff, sources)
 }
 
 type resolvedDefinitionTarget struct {

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -39,7 +39,7 @@ func semanticHoverOccurrenceFromSources(pkg *Package, path string, source []byte
 					return Hover{}, sourceintel.Span{}, false
 				}
 				position := pkg.Fset.Position(object.Pos())
-				if position.Filename == "" || !strings.HasSuffix(position.Filename, ".go") || sources.isPairedGeneratedOutput(position.Filename) {
+				if position.Filename == "" || !isNavigableTargetFile(position.Filename) || sources.isPairedGeneratedOutput(position.Filename) {
 					return Hover{}, sourceintel.Span{}, false
 				}
 			}

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -54,7 +54,10 @@ func semanticHoverOccurrenceFromSources(pkg *Package, path string, source []byte
 
 // handleHover answers textDocument/hover for a .gsx file: it shows the Go
 // type/signature of the symbol or expression under the cursor. .go files are
-// gopls's to hover (null).
+// gopls's to hover (null). When the retained package answers nothing — most
+// often a mid-edit unparseable buffer analyzed down to a diagnostics-only shell —
+// it retries the same cascade against one ephemeral analysis of the
+// completion-repaired buffer (hoverFallback).
 func (s *Server) handleHover(f frame) error {
 	var p textDocumentPositionParams
 	if err := json.Unmarshal(f.Params, &p); err != nil {
@@ -72,11 +75,28 @@ func (s *Server) handleHover(f frame) error {
 	if !ok {
 		return s.reply(f.ID, nil)
 	}
-	pkg := s.pkgs[filepath.Dir(path)]
-	if pkg == nil {
-		return s.reply(f.ID, nil)
-	}
 	off := byteOffsetForPosition(text, p.Position.Line, p.Position.Character, s.enc)
+
+	pkg := s.pkgs[filepath.Dir(path)]
+	if result, answered := s.hoverAnswerFromPkg(pkg, path, []byte(text), off, sources); answered {
+		return s.reply(f.ID, result)
+	}
+	if result, answered := s.hoverFallback(path, text, off, sources); answered {
+		return s.reply(f.ID, result)
+	}
+	return s.reply(f.ID, nil)
+}
+
+// hoverAnswerFromPkg runs the hover resolver cascade against one package. Like
+// definitionAnswerFromPkg it is the shared body invoked first with the retained
+// package (prior handler behavior, guards intact) and again with an ephemeral
+// package on a total miss. answered=true means a branch matched and result is the
+// reply (possibly nil); answered=false means the caller may try the fallback.
+// source is the exact bytes pkg was analyzed from, for the SourceIndex guards.
+func (s *Server) hoverAnswerFromPkg(pkg *Package, path string, source []byte, off int, sources *requestSourceSnapshot) (any, bool) {
+	if pkg == nil {
+		return nil, false
+	}
 	rangeAt := func(start, end int) (Range, bool) {
 		return sources.rangeForSpan(sourceintel.Span{Path: path, Start: start, End: end})
 	}
@@ -87,16 +107,16 @@ func (s *Server) handleHover(f frame) error {
 	if cursor, ok := componentTargetAtOffset(pkg, path, off); ok {
 		rng, ok := rangeAt(cursor.start, cursor.start+cursor.length)
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
 		if len(cursor.fact.TargetDecls) != 0 {
 			if _, valid := versionedDefinitionResult(sources, cursor.fact.TargetDecls); !valid || cursor.fact.TargetPresentation == "" {
-				return s.reply(f.ID, nil)
+				return nil, true
 			}
-			return s.reply(f.ID, Hover{Contents: markdownGo(cursor.fact.TargetPresentation), Range: &rng})
+			return Hover{Contents: markdownGo(cursor.fact.TargetPresentation), Range: &rng}, true
 		}
 		if obj := componentTargetObject(cursor.fact); obj != nil {
-			return s.reply(f.ID, Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng})
+			return Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng}, true
 		}
 	}
 
@@ -106,16 +126,16 @@ func (s *Server) handleHover(f frame) error {
 	if c, nameStart, nameLen, ok := componentAtTag(pkg, path, off); ok {
 		rng, ok := rangeAt(nameStart, nameStart+nameLen)
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
-		return s.reply(f.ID, Hover{Contents: markdownGo(renderComponentSig(c)), Range: &rng})
+		return Hover{Contents: markdownGo(renderComponentSig(c)), Range: &rng}, true
 	}
 	if c, nameStart, ok := componentDeclarationAtOffset(pkg, path, off); ok {
 		rng, ok := rangeAt(nameStart, nameStart+len(c.Name))
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
-		return s.reply(f.ID, Hover{Contents: markdownGo(renderComponentSig(c)), Range: &rng})
+		return Hover{Contents: markdownGo(renderComponentSig(c)), Range: &rng}, true
 	}
 
 	// H1: a component-invocation attribute name → codegen's exact bound
@@ -130,9 +150,9 @@ func (s *Server) handleHover(f frame) error {
 			decl := cursor.param.Name + " " + types.TypeString(param.Type(), qualifierFor(pkg))
 			rng, ok := rangeAt(cursor.start, cursor.start+len(cursor.name))
 			if !ok {
-				return s.reply(f.ID, nil)
+				return nil, true
 			}
-			return s.reply(f.ID, Hover{Contents: markdownGo(decl), Range: &rng})
+			return Hover{Contents: markdownGo(decl), Range: &rng}, true
 		}
 	}
 
@@ -143,9 +163,9 @@ func (s *Server) handleHover(f frame) error {
 		if obj, idStart, idLen, ok := signatureTypeIdentAt(pkg, path, off); ok {
 			rng, ok := rangeAt(idStart, idStart+idLen)
 			if !ok {
-				return s.reply(f.ID, nil)
+				return nil, true
 			}
-			return s.reply(f.ID, Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng})
+			return Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng}, true
 		}
 
 		node, exprPos := exprNodeAtOffset(pkg, path, off)
@@ -159,20 +179,20 @@ func (s *Server) handleHover(f frame) error {
 				if obj, idStart, idLen, ok := ctrlObjectAt(pkg, node, exprPos, off); ok {
 					rng, ok := rangeAt(idStart, idStart+idLen)
 					if !ok {
-						return s.reply(f.ID, nil)
+						return nil, true
 					}
-					return s.reply(f.ID, Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng})
+					return Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng}, true
 				}
-				return s.reply(f.ID, nil)
+				return nil, true
 			} else if hasPipeStages(node) {
 				if obj, span, ok := pipedTarget(pkg, node, exprPos, off); ok {
 					rng, ok := rangeAt(span[0], span[1])
 					if !ok {
-						return s.reply(f.ID, nil)
+						return nil, true
 					}
-					return s.reply(f.ID, Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng})
+					return Hover{Contents: markdownGo(types.ObjectString(obj, qualifierFor(pkg))), Range: &rng}, true
 				}
-				return s.reply(f.ID, nil)
+				return nil, true
 			} else if skel := pkg.ExprMap[node]; skel != nil {
 				exprStart := pkg.GSXFset.Position(exprPos).Offset
 				skelPos := skel.Pos() + token.Pos(off-exprStart)
@@ -188,31 +208,51 @@ func (s *Server) handleHover(f frame) error {
 						identStart := exprStart + int(id.Pos()-skel.Pos())
 						rng, ok := rangeAt(identStart, identStart+len(id.Name))
 						if !ok {
-							return s.reply(f.ID, nil)
+							return nil, true
 						}
-						return s.reply(f.ID, Hover{Contents: markdownGo(types.ObjectString(obj, qf)), Range: &rng})
+						return Hover{Contents: markdownGo(types.ObjectString(obj, qf)), Range: &rng}, true
 					}
 				}
 				// Otherwise → the whole expression's type.
 				if tv, ok := pkg.Info.Types[skel]; ok && tv.Type != nil {
 					rng, ok := rangeAt(exprStart, exprStart+len(exprText(node)))
 					if !ok {
-						return s.reply(f.ID, nil)
+						return nil, true
 					}
-					return s.reply(f.ID, Hover{Contents: markdownGo(types.TypeString(tv.Type, qf)), Range: &rng})
+					return Hover{Contents: markdownGo(types.TypeString(tv.Type, qf)), Range: &rng}, true
 				}
 			}
 		}
 	}
-	if hover, span, ok := semanticHoverOccurrenceFromSources(pkg, path, []byte(text), off, sources); ok {
+	if hover, span, ok := semanticHoverOccurrenceFromSources(pkg, path, source, off, sources); ok {
 		rng, ok := sources.rangeForSpan(span)
 		if !ok {
-			return s.reply(f.ID, nil)
+			return nil, true
 		}
 		hover.Range = &rng
-		return s.reply(f.ID, hover)
+		return hover, true
 	}
-	return s.reply(f.ID, nil)
+	return nil, false
+}
+
+// hoverFallback answers hover from a completion-repaired, ephemerally analyzed
+// buffer when the retained package matched nothing — the hover mirror of
+// definitionFallback. A shell with neither type info nor a parse yields
+// answered=false (reply null as before); note the shell gate keeps a
+// parse-but-no-typecheck result, since the component-tag hover path answers from
+// the AST alone.
+func (s *Server) hoverFallback(path, text string, off int, sources *requestSourceSnapshot) (any, bool) {
+	r, insertOff, queryOff, ok := navRepair(path, text, off)
+	if !ok {
+		return nil, false
+	}
+	eph, err := s.analyzer.AnalyzeEphemeral(filepath.Dir(path), path, r.src)
+	if err != nil || eph == nil || (eph.Info == nil && eph.Files == nil) {
+		return nil, false
+	}
+	sources.setRepair(path, insertOff, len(r.patch))
+	defer sources.clearRepair()
+	return s.hoverAnswerFromPkg(eph, path, r.src, queryOff, sources)
 }
 
 // qualifierFor renders the analyzed package's own types unqualified and imported

--- a/internal/lsp/midedit_nav_test.go
+++ b/internal/lsp/midedit_nav_test.go
@@ -1,0 +1,174 @@
+package lsp
+
+import (
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/sourceintel"
+	gsxparser "github.com/gsxhq/gsx/parser"
+)
+
+// TestAdjustRepairedSpan pins the repaired→live byte-span mapping used by the
+// mid-edit go-to-definition / hover fallback. The repair inserted patchLen bytes
+// at off; a returned span in repaired coordinates must map back to the live
+// buffer before it is converted to an LSP range.
+func TestAdjustRepairedSpan(t *testing.T) {
+	const off, patchLen = 10, 3 // patch "_/>" inserted at offset 10
+	cases := []struct {
+		name               string
+		start, end         int
+		wantStart, wantEnd int
+	}{
+		// A span entirely before the insertion is untouched (identifier ending at
+		// the cursor — the common tag-name hover range).
+		{"before off", 4, 10, 4, 10},
+		// A span entirely at/after the inserted patch shifts left by patchLen (a
+		// control-clause identifier after the cursor).
+		{"after patch", 13, 18, 10, 15},
+		// A span starting before off but ending past the patch keeps its start and
+		// pulls its end back (the identifier the patch landed inside).
+		{"straddling the patch", 6, 15, 6, 12},
+		// A degenerate span wholly inside the inserted patch clamps to the
+		// insertion point (names no live byte).
+		{"inside the patch", 11, 12, 10, 10},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotStart, gotEnd := adjustRepairedSpan(c.start, c.end, off, patchLen)
+			if gotStart != c.wantStart || gotEnd != c.wantEnd {
+				t.Fatalf("adjustRepairedSpan(%d,%d,%d,%d) = (%d,%d), want (%d,%d)",
+					c.start, c.end, off, patchLen, gotStart, gotEnd, c.wantStart, c.wantEnd)
+			}
+		})
+	}
+}
+
+// TestAdjustRepairedSpanOtherFileUntouched documents that the mapping is gated
+// on the current (repaired) file at the snapshot boundary: a span belonging to
+// another file is never passed to adjustRepairedSpan, so a target Location in a
+// dependency .gsx keeps its coordinates. rangeForSpan applies the mapping only
+// when span.Path == repairPath.
+func TestAdjustRepairedSpanOtherFileUntouched(t *testing.T) {
+	snap := &requestSourceSnapshot{
+		enc:     encUTF16,
+		sources: map[string]*capturedSource{},
+	}
+	// Two files with distinct content; the repair is armed for /m/a.gsx only.
+	snap.sources["/m/a.gsx"] = &capturedSource{stringValue: "0123456789ABCDEF", hasString: true, ok: true}
+	snap.sources["/m/dep.gsx"] = &capturedSource{stringValue: "0123456789ABCDEF", hasString: true, ok: true}
+	snap.setRepair("/m/a.gsx", 4, 3)
+
+	// A span in the OTHER file must not be shifted.
+	depRange, ok := snap.rangeForSpan(sourceintel.Span{Path: "/m/dep.gsx", Start: 10, End: 12})
+	if !ok {
+		t.Fatal("dep range not ok")
+	}
+	want := rangeForSpan("0123456789ABCDEF", 10, 12, encUTF16)
+	if depRange != want {
+		t.Fatalf("dep-file span was adjusted: got %+v want %+v", depRange, want)
+	}
+	// A current-file span at/after the patch IS shifted (10 -> 7, 12 -> 9).
+	curRange, ok := snap.rangeForSpan(sourceintel.Span{Path: "/m/a.gsx", Start: 10, End: 12})
+	if !ok {
+		t.Fatal("cur range not ok")
+	}
+	wantCur := rangeForSpan("0123456789ABCDEF", 7, 9, encUTF16)
+	if curRange != wantCur {
+		t.Fatalf("current-file span not adjusted: got %+v want %+v", curRange, wantCur)
+	}
+}
+
+// ephemeralCountingAnalyzer records how many times AnalyzeEphemeral is invoked
+// and returns a scripted Analyze result to populate s.pkgs via didOpen.
+type ephemeralCountingAnalyzer struct {
+	nilAnalyzer
+	analyzed *Package
+	ephCount *int
+}
+
+func (a ephemeralCountingAnalyzer) Analyze(string, map[string][]byte) (*Package, error) {
+	return a.analyzed, nil
+}
+
+func (a ephemeralCountingAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
+	*a.ephCount++
+	return nil, nil
+}
+
+// tagAnsweringPackage hand-builds a Package whose retained facts answer
+// go-to-definition on a same-package component tag (`<Row/>`) via CrossIndex —
+// no ephemeral analysis required.
+func tagAnsweringPackage(t *testing.T, path, text string) *Package {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := gsxparser.ParseFile(fset, path, []byte(text), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stampSyntacticComponents(f)
+	rowNameOff := strings.Index(text, "component Row") + len("component ")
+	decl := token.Position{Filename: path, Offset: rowNameOff}
+	return &Package{
+		GSXFset: fset,
+		Fset:    fset,
+		Info:    &types.Info{},
+		Files:   map[string]*gsxast.File{path: f},
+		CrossIndex: map[string]CrossRef{
+			".Row": {Name: "Row", Decl: decl, Decls: []token.Position{decl}},
+		},
+	}
+}
+
+const midEditNavPage = "package x\n\ncomponent Page() {\n\t<Row/>\n}\n\ncomponent Row() {\n\t<div>hi</div>\n}\n"
+
+// TestDefinitionFallbackNotConsultedWhenPrimaryAnswers is the scope guard: when
+// the retained package answers go-to-definition (here, a component tag), the
+// completion-repair + ephemeral-analysis fallback must never run — proven by a
+// zero AnalyzeEphemeral count. It also confirms the primary answer is unchanged
+// (a real Location).
+func TestDefinitionFallbackNotConsultedWhenPrimaryAnswers(t *testing.T) {
+	uri := "file:///m/a.gsx"
+	path := "/m/a.gsx"
+	count := 0
+	a := ephemeralCountingAnalyzer{analyzed: tagAnsweringPackage(t, path, midEditNavPage), ephCount: &count}
+
+	// Cursor on the "Row" of "<Row/>" (line 3).
+	rowTagOff := strings.Index(midEditNavPage, "<Row/>") + 2 // on 'o'
+	pos := positionForByteOffset(midEditNavPage, rowTagOff, encUTF16)
+	out := drive(t, a, initFrame()+didOpenFrame(uri, midEditNavPage)+
+		definitionFrame(2, uri, pos)+exitFrame())
+
+	if count != 0 {
+		t.Fatalf("AnalyzeEphemeral called %d times on an answered request; want 0", count)
+	}
+	result := responseByID(t, out, 2)["result"]
+	if strings.TrimSpace(string(result)) == "null" {
+		t.Fatalf("primary go-to-definition returned null; want the Row declaration Location")
+	}
+}
+
+// TestDefinitionFallbackConsultedOnPrimaryMiss is the complement: when the
+// retained package matches nothing (cursor on plain text), the fallback IS
+// consulted (AnalyzeEphemeral count >= 1), so the gate is not merely always-off.
+func TestDefinitionFallbackConsultedOnPrimaryMiss(t *testing.T) {
+	uri := "file:///m/a.gsx"
+	path := "/m/a.gsx"
+	count := 0
+	a := ephemeralCountingAnalyzer{analyzed: tagAnsweringPackage(t, path, midEditNavPage), ephCount: &count}
+
+	// Cursor on the "hi" plain text inside Row's <div> (line 7) — nothing to resolve.
+	textOff := strings.Index(midEditNavPage, ">hi<") + 1 // on 'h'
+	pos := positionForByteOffset(midEditNavPage, textOff, encUTF16)
+	out := drive(t, a, initFrame()+didOpenFrame(uri, midEditNavPage)+
+		definitionFrame(2, uri, pos)+exitFrame())
+
+	if count == 0 {
+		t.Fatalf("AnalyzeEphemeral never called on a primary miss; the fallback was not consulted")
+	}
+	if r := strings.TrimSpace(string(responseByID(t, out, 2)["result"])); r != "null" {
+		t.Fatalf("expected null result on an unresolved cursor, got %s", r)
+	}
+}

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -348,20 +348,25 @@ type CompletionItem struct {
 
 // LSP CompletionItemKind constants used across completion tasks.
 const (
-	ciKindText          = 1  // Text
-	ciKindMethod        = 2  // Method
-	ciKindFunction      = 3  // Function
-	ciKindConstructor   = 4  // Constructor
-	ciKindField         = 5  // Field
-	ciKindVariable      = 6  // Variable
-	ciKindClass         = 7  // Class
-	ciKindInterface     = 8  // Interface
-	ciKindModule        = 9  // Module
-	ciKindProperty      = 10 // Property
-	ciKindEnum          = 13 // Enum
-	ciKindKeyword       = 14 // Keyword
-	ciKindEnumMember    = 20 // EnumMember
-	ciKindConstant      = 21 // Constant
-	ciKindStruct        = 22 // Struct
+	ciKindText        = 1  // Text
+	ciKindMethod      = 2  // Method
+	ciKindFunction    = 3  // Function
+	ciKindConstructor = 4  // Constructor
+	ciKindField       = 5  // Field
+	ciKindVariable    = 6  // Variable
+	ciKindClass       = 7  // Class
+	ciKindInterface   = 8  // Interface
+	ciKindModule      = 9  // Module
+	ciKindProperty    = 10 // Property
+	ciKindEnum        = 13 // Enum
+	ciKindKeyword     = 14 // Keyword
+	ciKindEnumMember  = 20 // EnumMember
+	ciKindConstant    = 21 // Constant
+	ciKindStruct      = 22 // Struct
+	// ciKindOperator marks pipe filter items: a bare filter name (`f`) and a
+	// parameterized call (`f()`) are distinct, semantically different pipe
+	// stages, so accepting the item must never auto-append `()` the way
+	// editors do for Function/Method kinds.
+	ciKindOperator      = 24 // Operator
 	ciKindTypeParameter = 25 // TypeParameter
 )

--- a/internal/lsp/source_text.go
+++ b/internal/lsp/source_text.go
@@ -280,6 +280,48 @@ func authoredSpanForPosition(pos token.Position, length int) (sourceintel.Span, 
 	return sourceintel.Span{Path: sourcePath(pos.Filename), Start: pos.Offset, End: pos.Offset + length}, true
 }
 
+// isNavigableTargetFile reports whether a Go-fileset position naming filename
+// may be published as a navigation target: a real .go source file, or an
+// authored .gsx (a Go-chunk position that go/types //line-mapped back to its
+// .gsx — e.g. a component VALUE declared in another package's .gsx var block).
+// Generated paired .x.go outputs end in .go and pass this suffix test, so
+// callers still gate them out with isPairedGeneratedOutput.
+func isNavigableTargetFile(filename string) bool {
+	return strings.HasSuffix(filename, ".go") || strings.HasSuffix(filename, ".gsx")
+}
+
+// locationForExistingFile resolves a Go-fileset token.Position — a real .go file
+// or an authored .gsx that go/types //line-mapped to — to a Location by
+// Line/Column against the target's on-disk or open-buffer content (its Offset is
+// the generated skeleton's, not the target file's). Unlike locationForGoPosition
+// it REQUIRES the target file to be readable: a //line-reconstructed .gsx path
+// that no longer exists (an external dependency shipping only its generated
+// .x.go) yields false so callers can fall back to the physical generated file. A
+// paired generated .x.go whose authored .gsx exists is rejected, so navigation
+// never lands in generated code while the source is available.
+func (snapshot *requestSourceSnapshot) locationForExistingFile(pos token.Position, length int) (Location, bool) {
+	if pos.Filename == "" || length < 0 || !isNavigableTargetFile(pos.Filename) || snapshot.isPairedGeneratedOutput(pos.Filename) {
+		return Location{}, false
+	}
+	text, ok := snapshot.sourceText(pos.Filename)
+	if !ok {
+		return Location{}, false
+	}
+	start, ok := offsetForTokenPosition(text, pos)
+	if !ok || start+length > len(text) {
+		return Location{}, false
+	}
+	return snapshot.locationForSpan(sourceintel.Span{
+		Path: sourcePath(pos.Filename), Start: start, End: start + length,
+	})
+}
+
+// locationForGoPosition resolves a Go-fileset token.Position naming a real .go
+// file to a navigation target, by Line/Column against its content (falling back
+// to the raw line/column when the file is unavailable). Generated paired .x.go
+// outputs are rejected. Authored-.gsx and physical-generated targets go through
+// objectSourceLocation → locationForExistingFile instead, which is existence-
+// aware; this stays .go-only for its package-clause and same-package Go callers.
 func (snapshot *requestSourceSnapshot) locationForGoPosition(pos token.Position, length int) (Location, bool) {
 	if pos.Filename == "" || length < 0 || !strings.HasSuffix(pos.Filename, ".go") || snapshot.isPairedGeneratedOutput(pos.Filename) {
 		return Location{}, false

--- a/internal/lsp/source_text.go
+++ b/internal/lsp/source_text.go
@@ -35,6 +35,59 @@ type requestSourceSnapshot struct {
 	ownershipMu sync.Mutex
 	openGSX     map[string]struct{}
 	ownership   map[string]pairedGeneratedOwnership
+
+	// Repair-coordinate mapping, set only for the ephemeral go-to-definition /
+	// hover fallback pass (see setRepair). The ephemeral package was analyzed from
+	// a repaired buffer that inserted repairPatchLen bytes at repairOff into the
+	// file at repairPath; any current-file byte span it yields is therefore in
+	// repaired coordinates and must be mapped back to the live buffer before
+	// conversion. Zero-valued (repairPath == "") for every ordinary request, so
+	// all other handlers are unaffected.
+	repairPath     string
+	repairOff      int
+	repairPatchLen int
+}
+
+// setRepair arms repaired→live coordinate mapping for current-file (path) byte
+// spans, for the duration of one ephemeral fallback cascade. patchLen bytes were
+// inserted at off; clearRepair disarms it. Single-goroutine per request, so the
+// set/clear pair needs no synchronization.
+func (snapshot *requestSourceSnapshot) setRepair(path string, off, patchLen int) {
+	snapshot.repairPath = sourcePath(path)
+	snapshot.repairOff = off
+	snapshot.repairPatchLen = patchLen
+}
+
+func (snapshot *requestSourceSnapshot) clearRepair() {
+	snapshot.repairPath = ""
+	snapshot.repairOff = 0
+	snapshot.repairPatchLen = 0
+}
+
+// adjustRepairedOffset maps one byte offset from repaired-buffer coordinates back
+// to live-buffer coordinates. The repair inserted patchLen bytes at off, so an
+// offset at or before off names the same live byte, an offset at or beyond the
+// end of the inserted patch shifts left by patchLen, and an offset strictly
+// inside the patch names no live byte and clamps to the insertion point.
+func adjustRepairedOffset(o, off, patchLen int) int {
+	switch {
+	case o <= off:
+		return o
+	case o >= off+patchLen:
+		return o - patchLen
+	default:
+		return off
+	}
+}
+
+// adjustRepairedSpan maps a [start,end) byte span from repaired-buffer
+// coordinates to live-buffer coordinates. A span entirely before off is
+// unchanged; a span entirely at or beyond the patch shifts left by patchLen; a
+// span that starts before off but ends past the inserted patch keeps its start
+// and pulls its end back by patchLen (the "identifier the patch landed inside"
+// case).
+func adjustRepairedSpan(start, end, off, patchLen int) (int, int) {
+	return adjustRepairedOffset(start, off, patchLen), adjustRepairedOffset(end, off, patchLen)
 }
 
 type pairedGeneratedOwnership uint8
@@ -197,6 +250,20 @@ func (s *Server) position(path string, offset int) (Position, bool) {
 }
 
 func (snapshot *requestSourceSnapshot) rangeForSpan(span sourceintel.Span) (Range, bool) {
+	// A current-file span produced by the ephemeral fallback pass is in repaired
+	// coordinates; map it back to the live buffer before conversion. Spans for
+	// other files, and every span when the mapping is disarmed, pass through.
+	if snapshot.repairPath != "" && sourcePath(span.Path) == snapshot.repairPath {
+		span.Start, span.End = adjustRepairedSpan(span.Start, span.End, snapshot.repairOff, snapshot.repairPatchLen)
+	}
+	return snapshot.rangeForSpanRaw(span)
+}
+
+// rangeForSpanRaw converts a byte span to a Range with NO repaired→live mapping.
+// Callers that already hold live-buffer offsets (e.g. locationForExistingFile,
+// which derives them from the target file's own Line/Column) use this to avoid a
+// spurious second adjustment when the repair mapping is armed.
+func (snapshot *requestSourceSnapshot) rangeForSpanRaw(span sourceintel.Span) (Range, bool) {
 	text, ok := snapshot.sourceString(span.Path)
 	if !ok || span.Start < 0 || span.End < span.Start || span.End > len(text) {
 		return Range{}, false
@@ -311,9 +378,15 @@ func (snapshot *requestSourceSnapshot) locationForExistingFile(pos token.Positio
 	if !ok || start+length > len(text) {
 		return Location{}, false
 	}
-	return snapshot.locationForSpan(sourceintel.Span{
+	// start is already a live-buffer offset (derived from the target file's own
+	// Line/Column), so bypass the repaired→live mapping to avoid double-adjusting.
+	rng, ok := snapshot.rangeForSpanRaw(sourceintel.Span{
 		Path: sourcePath(pos.Filename), Start: start, End: start + length,
 	})
+	if !ok {
+		return Location{}, false
+	}
+	return Location{URI: pathToURI(sourcePath(pos.Filename)), Range: rng}, true
 }
 
 // locationForGoPosition resolves a Go-fileset token.Position naming a real .go

--- a/internal/tagcallable/tagcallable.go
+++ b/internal/tagcallable/tagcallable.go
@@ -1,0 +1,54 @@
+// Package tagcallable classifies whether a Go value — a func, or a
+// function-typed var — has the shape a gsx tag can call: a signature with
+// exactly one result assignable to gsx.Node.
+//
+// It is the single source for that shape check, shared by internal/codegen
+// (which enforces it, via component_identity.go's componentResultType, at a
+// real syntactic component call site — one already-authored target the
+// analyzer resolved) and internal/lsp (which mirrors it in
+// completion_gsx.go's tagCallableValueNames to scan an entire imported
+// package's scope for candidate tag VALUES completion can offer — there is
+// no call site to probe there, only a package to enumerate). Both consumers
+// import this package directly (the same arrangement internal/goexprshape
+// uses between internal/printer and internal/codegen); internal/lsp must not
+// import internal/codegen, so this leaf package is the only legal place for
+// the shared rule to live.
+//
+// This package intentionally does NOT decide the "every parameter must be
+// named" restriction some callers additionally apply — that is not part of
+// the callable-universe shape itself (see each consumer's own doc for where
+// and why it layers that on).
+package tagcallable
+
+import "go/types"
+
+// Signature returns typ's callable *types.Signature — unwrapping a defined
+// (named) function type's underlying type — or nil when typ is not callable
+// at all. This unwrap is needed for a `type Factory func(...) gsx.Node`-shaped
+// package var, not just a bare `func(...) gsx.Node` one.
+func Signature(typ types.Type) *types.Signature {
+	if typ == nil {
+		return nil
+	}
+	unaliased := types.Unalias(typ)
+	if sig, ok := unaliased.(*types.Signature); ok {
+		return sig
+	}
+	sig, _ := unaliased.Underlying().(*types.Signature)
+	return sig
+}
+
+// IsResult reports whether sig has exactly one result assignable to node —
+// the result half of the callable-universe tag shape. types.AssignableTo,
+// not types.Implements: node is gsx.Node's own defined type identity in the
+// relevant build, and assignability (not just interface satisfaction) is the
+// exact rule a real component call site is checked against, so completion
+// candidates must be held to the identical standard or the two would accept
+// different value sets.
+func IsResult(sig *types.Signature, node types.Type) bool {
+	if sig == nil || node == nil {
+		return false
+	}
+	results := sig.Results()
+	return results.Len() == 1 && types.AssignableTo(results.At(0).Type(), node)
+}

--- a/internal/tagcallable/tagcallable_test.go
+++ b/internal/tagcallable/tagcallable_test.go
@@ -1,0 +1,122 @@
+package tagcallable
+
+import (
+	"go/types"
+	"testing"
+)
+
+// nodeInterface builds a minimal `interface{ Render() }`-shaped interface
+// type standing in for gsx.Node, and a defined type implementing it — enough
+// to exercise types.AssignableTo without importing the real gsx package.
+func nodeInterface() (*types.Interface, *types.Named) {
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	method := types.NewFunc(0, nil, "Render", sig)
+	iface := types.NewInterfaceType([]*types.Func{method}, nil).Complete()
+
+	pkg := types.NewPackage("example.com/node", "node")
+	named := types.NewNamed(types.NewTypeName(0, pkg, "Element", nil), types.NewStruct(nil, nil), nil)
+	// Element implements Render via a pointer receiver method set below.
+	recv := types.NewVar(0, pkg, "e", types.NewPointer(named))
+	rendersig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	rendermethod := types.NewFunc(0, pkg, "Render", rendersig)
+	named.AddMethod(rendermethod)
+	return iface, named
+}
+
+func namedParam(pkg *types.Package, name string, typ types.Type) *types.Var {
+	return types.NewParam(0, pkg, name, typ)
+}
+
+func TestSignature(t *testing.T) {
+	iface, node := nodeInterface()
+	nodePtr := types.NewPointer(node)
+	pkg := types.NewPackage("example.com/p", "p")
+
+	funcSig := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(namedParam(pkg, "name", types.Typ[types.String])),
+		types.NewTuple(types.NewVar(0, pkg, "", nodePtr)), false)
+
+	t.Run("bare signature type", func(t *testing.T) {
+		got := Signature(funcSig)
+		if got != funcSig {
+			t.Fatalf("Signature(bare sig) = %v, want the same signature back", got)
+		}
+	})
+
+	t.Run("named function type unwraps to its underlying signature", func(t *testing.T) {
+		defined := types.NewNamed(types.NewTypeName(0, pkg, "Factory", nil), funcSig, nil)
+		got := Signature(defined)
+		if got == nil || !types.Identical(got, funcSig) {
+			t.Fatalf("Signature(named func type) = %v, want a signature identical to %v", got, funcSig)
+		}
+	})
+
+	t.Run("non-callable type yields nil", func(t *testing.T) {
+		if got := Signature(types.Typ[types.String]); got != nil {
+			t.Fatalf("Signature(string) = %v, want nil", got)
+		}
+	})
+
+	t.Run("nil type yields nil", func(t *testing.T) {
+		if got := Signature(nil); got != nil {
+			t.Fatalf("Signature(nil) = %v, want nil", got)
+		}
+	})
+
+	_ = iface
+}
+
+func TestIsResult(t *testing.T) {
+	iface, node := nodeInterface()
+	nodeType := types.Type(iface)
+	nodePtr := types.NewPointer(node)
+	pkg := types.NewPackage("example.com/p", "p")
+
+	t.Run("one result assignable to node is accepted", func(t *testing.T) {
+		sig := types.NewSignatureType(nil, nil, nil, nil,
+			types.NewTuple(types.NewVar(0, pkg, "", nodePtr)), false)
+		if !IsResult(sig, nodeType) {
+			t.Fatalf("IsResult(one Node-assignable result) = false, want true")
+		}
+	})
+
+	t.Run("(Node, error) two results is rejected", func(t *testing.T) {
+		sig := types.NewSignatureType(nil, nil, nil, nil,
+			types.NewTuple(
+				types.NewVar(0, pkg, "", nodePtr),
+				types.NewVar(0, pkg, "", types.Universe.Lookup("error").Type()),
+			), false)
+		if IsResult(sig, nodeType) {
+			t.Fatalf("IsResult((Node, error)) = true, want false (exactly one result required)")
+		}
+	})
+
+	t.Run("zero results is rejected", func(t *testing.T) {
+		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+		if IsResult(sig, nodeType) {
+			t.Fatalf("IsResult(zero results) = true, want false")
+		}
+	})
+
+	t.Run("result not assignable to node is rejected", func(t *testing.T) {
+		sig := types.NewSignatureType(nil, nil, nil, nil,
+			types.NewTuple(types.NewVar(0, pkg, "", types.Typ[types.Int])), false)
+		if IsResult(sig, nodeType) {
+			t.Fatalf("IsResult(int result) = true, want false")
+		}
+	})
+
+	t.Run("nil signature is rejected", func(t *testing.T) {
+		if IsResult(nil, nodeType) {
+			t.Fatalf("IsResult(nil sig) = true, want false")
+		}
+	})
+
+	t.Run("nil node is rejected", func(t *testing.T) {
+		sig := types.NewSignatureType(nil, nil, nil, nil,
+			types.NewTuple(types.NewVar(0, pkg, "", nodePtr)), false)
+		if IsResult(sig, nil) {
+			t.Fatalf("IsResult(sig, nil node) = true, want false")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Field fixes from real-editor testing of the just-merged completion feature (#134), plus navigation gaps it exposed.

**Completion fixes:**
- **Bare `<` returned 0 items** — the repair patch set couldn't heal a lone `<` (`/>` yields `</>`, which doesn't parse). New `_/>` phantom tag-name-closer patch, ordered last so prefixed heals (`<Ca`, `<div cl`) keep their simpler `/>` patch. Real-project probe: 0 → 633 items.
- **`<icon.` returned 0 items** — two stacked causes: the parser accepts trailing-dot tags (`<icon./>` parses; documented as observed behavior), and the qualifier/candidate chain mishandled a tag spelled `"icon."`. Also: **pure-Go component-value packages** (e.g. an icon library with `var X = named("x")` — no `component` decls) were invisible to tag completion; candidates now include package-scope values accepted by the tag-callable rule. Probe: 0 → 82 items.
- **Accepting a component inserted `()`** (blink.cmp auto-brackets on Function-kind items). Kinds are now bracket-safe: tag components → `Class`, pipe filters → new `Operator` kind (a bare filter `f` and parameterized `f()` are semantically different stages — auto-`()` was corrupting). Go-expression items keep Function/Method, where brackets are right.
- The tag-callable predicate is **single-sourced** in `internal/tagcallable` (consumed by codegen + LSP; drift found in review: `AssignableTo` vs `Implements`, misattributed param rule).
- **Components with an `attrs` catch-all offer HTML global attributes** in attr-name position (`<icon.Bell ▮` → `hidden`, `class=""`, …, at a lower sort tier than named params; hx-* when the htmx preset is on). Components without the catch-all reject unknown attrs and keep offering named params only.

**Navigation fixes:**
- **gd on `<icon.X/>` returned null** (hover worked). Policy: a raw object position resolving to an **authored `.gsx`** is a jump target (same module, nested modules, module cache with sources); a dep shipping **only generated `.x.go`** falls back to the `.x.go` func def instead of null; a paired `.x.go` stays rejected while its `.gsx` exists. Fixes tag, attr, interp (`{ icon.X }`), source-index, and hover fallback routes consistently.
- **Mid-edit gd/hover**: an unclosed `<icon.Bell` now resolves — on a total miss of the retained-snapshot cascade, the handlers re-run it against completion's repair + ephemeral analysis (~140µs, user-initiated), with repaired→live range mapping. Fallback-only: answerable requests are byte-identical to before (pinned by a zero-ephemeral-calls test).
- Fixes a skeleton `//line` off-by-one (decorative-paren stripping advanced emitted bytes past the anchor) in both skeleton builders — same-module gd on component values is now exact-line; verified load-bearing by revert-and-fail.

**Surfaced, out of scope (now in ROADMAP):** shipped `.x.go` emits no `//line` for top-level Go body chunks, so cross-module value positions can drift a few lines within the correct file.

## Testing

- New unit + e2e coverage across all fixes: repair table, classification, component-value candidates, kind assertions, attrs-catch-all globals (offered/absent), gd e2e (same-module exact-line, cross-module with sources, `.x.go`-only fallback, interp route, `.x.go` negative), mid-edit nav e2e (unclosed tag, interp-in-unclosed-attr, unhealable → null, fallback-not-consulted)
- Full suites green: `internal/lsp`, `internal/codegen`, `gen`, golangci-lint
- Real-project probes (one-learning, read-only): bare `<` → 633 items; `<icon.` → 82; `<icon.Bell ▮` → 149 globals; gd `<icon.X` → `named.gsx` exact line; **unclosed** `<icon.Bell` gd/hover → resolves; cross-module `hello-gsx → libgsx` gd → `hello.gsx`
- Each commit independently reviewed with live re-probes

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa