### PR TITLE
perf: eliminate O(calls×facts) map cloning; raise diagnostics debounce to 1s

### DIFF
--- a/internal/codegen/component_call_plan.go
+++ b/internal/codegen/component_call_plan.go
@@ -386,7 +386,7 @@ func planComponentInputs(site callSiteID, el *gsxast.Element, target componentSi
 // tuple-returning value must be (T, error) so it can be consumed as one value
 // before positional assembly. The plan is returned unchanged on success; the
 // diagnostics are positioned at the offending authored node.
-func validateComponentOperands(plan componentCallPlan, facts map[gsxast.Node]expressionFact, runtime runtimeContract) (componentCallPlan, []diag.Diagnostic) {
+func validateComponentOperands(plan componentCallPlan, facts expressionFactSet, runtime runtimeContract) (componentCallPlan, []diag.Diagnostic) {
 	var diagnostics []diag.Diagnostic
 	report := func(node gsxast.Node, code, message string) {
 		d := diag.Diagnostic{Severity: diag.Error, Code: code, Message: message, Source: "codegen"}
@@ -400,7 +400,7 @@ func validateComponentOperands(plan componentCallPlan, facts map[gsxast.Node]exp
 	}
 
 	for _, value := range plan.values {
-		fact, ok := facts[value.node]
+		fact, ok := facts.get(value.node)
 		if !ok {
 			continue
 		}

--- a/internal/codegen/component_call_plan_test.go
+++ b/internal/codegen/component_call_plan_test.go
@@ -628,7 +628,7 @@ func TestValidateComponentOperands(t *testing.T) {
 			attrsNode: &componentAttrsStreamNode{kind: componentAttrsStreamSpread},
 		})
 		facts := map[gsxast.Node]expressionFact{spread: {tv: types.TypeAndValue{Type: fx.runtime.attrs}}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 0 {
 			t.Fatalf("gsx.Attrs spread must validate, got %+v", diags)
 		}
@@ -642,7 +642,7 @@ func TestValidateComponentOperands(t *testing.T) {
 			attrsNode: &componentAttrsStreamNode{kind: componentAttrsStreamSpread},
 		})
 		facts := map[gsxast.Node]expressionFact{spread: {tv: types.TypeAndValue{Type: types.NewSlice(fx.runtime.attr)}}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 0 {
 			t.Fatalf("[]gsx.Attr spread must validate, got %+v", diags)
 		}
@@ -658,7 +658,7 @@ func TestValidateComponentOperands(t *testing.T) {
 			attrsNode: &componentAttrsStreamNode{kind: componentAttrsStreamSpread},
 		})
 		facts := map[gsxast.Node]expressionFact{spread: {tv: types.TypeAndValue{Type: props}}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 1 || diags[0].Code != "component-attrs-spread-type" {
 			t.Fatalf("struct splat must be rejected, got %+v", diags)
 		}
@@ -672,7 +672,7 @@ func TestValidateComponentOperands(t *testing.T) {
 			attrsNode: &componentAttrsStreamNode{kind: componentAttrsStreamContributor},
 		})
 		facts := map[gsxast.Node]expressionFact{contributor: {tv: types.TypeAndValue{Type: types.Typ[types.String]}}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 1 || diags[0].Code != "component-attrs-spread-type" {
 			t.Fatalf("non-bag attrs contributor must be rejected, got %+v", diags)
 		}
@@ -690,7 +690,7 @@ func TestValidateComponentOperands(t *testing.T) {
 			attrsNode: &componentAttrsStreamNode{kind: componentAttrsStreamContributor},
 		})
 		facts := map[gsxast.Node]expressionFact{contributor: {tv: types.TypeAndValue{Type: tuple}, tuple: tuple}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 1 || diags[0].Code != "component-attrs-spread-type" {
 			t.Fatalf("(int, error) attrs contributor must be rejected as a non-bag, got %+v", diags)
 		}
@@ -708,7 +708,7 @@ func TestValidateComponentOperands(t *testing.T) {
 			attrsNode: &componentAttrsStreamNode{kind: componentAttrsStreamContributor},
 		})
 		facts := map[gsxast.Node]expressionFact{contributor: {tv: types.TypeAndValue{Type: tuple}, tuple: tuple}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 0 {
 			t.Fatalf("(gsx.Attrs, error) attrs contributor must validate, got %+v", diags)
 		}
@@ -722,7 +722,7 @@ func TestValidateComponentOperands(t *testing.T) {
 		)
 		plan := newPlan(componentInputValue{kind: componentInputProp, node: prop})
 		facts := map[gsxast.Node]expressionFact{prop: {tv: types.TypeAndValue{Type: tuple}, tuple: tuple}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 0 {
 			t.Fatalf("(T, error) prop must validate, got %+v", diags)
 		}
@@ -736,7 +736,7 @@ func TestValidateComponentOperands(t *testing.T) {
 		)
 		plan := newPlan(componentInputValue{kind: componentInputProp, node: prop})
 		facts := map[gsxast.Node]expressionFact{prop: {tv: types.TypeAndValue{Type: tuple}, tuple: tuple}}
-		_, diags := validateComponentOperands(plan, facts, fx.runtime)
+		_, diags := validateComponentOperands(plan, newExpressionFactSet(facts), fx.runtime)
 		if len(diags) != 1 || diags[0].Code != "invalid-tuple" {
 			t.Fatalf("non-(T,error) tuple must be rejected, got %+v", diags)
 		}

--- a/internal/codegen/component_positional_emit.go
+++ b/internal/codegen/component_positional_emit.go
@@ -134,9 +134,9 @@ func emitPositionalComponentCall(
 			continue
 		}
 		value := plan.call.values[valueIndex]
-		fact := materializationFacts[value.node]
+		fact, _ := materializationFacts.get(value.node)
 		fact.emitsStatements = true
-		materializationFacts[value.node] = fact
+		materializationFacts.set(value.node, fact)
 	}
 	materialization := planComponentMaterialization(plan.call, materializationFacts)
 	materialized := make(map[int]materializedValue, len(materialization.values))
@@ -249,7 +249,7 @@ func normalizePositionalAttrsContributor(expr string, value componentInputValue,
 	if value.attrsNode == nil || (value.attrsNode.kind != componentAttrsStreamSpread && value.attrsNode.kind != componentAttrsStreamContributor) {
 		return expr
 	}
-	fact, ok := plan.expressionFacts[value.node]
+	fact, ok := plan.expressionFacts.get(value.node)
 	if !ok || fact.tv.Type == nil {
 		return expr // planning already owns the missing-fact diagnostic
 	}
@@ -524,7 +524,7 @@ func positionalOrderedAttrsExpr(b *bytes.Buffer, attr *gsxast.OrderedAttrsAttr, 
 	for i := range attr.Pairs {
 		pair := &attr.Pairs[i]
 		expr := strings.TrimSpace(pair.Value)
-		fact, hasFact := plan.expressionFacts[pair]
+		fact, hasFact := plan.expressionFacts.get(pair)
 		// The pair value's semantic type drives renderer application below. A
 		// (T, error) authored value is unwrapped first (matching every other
 		// emit site), leaving the renderer to act on the unwrapped T.

--- a/internal/codegen/component_positional_emit_test.go
+++ b/internal/codegen/component_positional_emit_test.go
@@ -27,7 +27,7 @@ func TestNormalizePositionalAttrsContributor(t *testing.T) {
 	t.Run("canonical bag stays direct", func(t *testing.T) {
 		plan := componentPositionalSitePlan{
 			runtime:         fx.runtime,
-			expressionFacts: map[gsxast.Node]expressionFact{attr: {tv: types.TypeAndValue{Type: fx.runtime.attrs}}},
+			expressionFacts: newExpressionFactSet(map[gsxast.Node]expressionFact{attr: {tv: types.TypeAndValue{Type: fx.runtime.attrs}}}),
 		}
 		got := normalizePositionalAttrsContributor("bag", value, plan, positionalEmitContext{rt: rtImports{}})
 		if got != "bag" {
@@ -44,7 +44,7 @@ func TestNormalizePositionalAttrsContributor(t *testing.T) {
 		)
 		plan := componentPositionalSitePlan{
 			runtime:         fx.runtime,
-			expressionFacts: map[gsxast.Node]expressionFact{attr: {tv: types.TypeAndValue{Type: defined}}},
+			expressionFacts: newExpressionFactSet(map[gsxast.Node]expressionFact{attr: {tv: types.TypeAndValue{Type: defined}}}),
 		}
 		got := normalizePositionalAttrsContributor("bag", value, plan, positionalEmitContext{rt: rtImports{}})
 		if got != "_gsxrt.Attrs(bag)" {
@@ -217,7 +217,7 @@ func TestPositionalValueLoweringOwnsFailureOutcome(t *testing.T) {
 			types.NewVar(token.NoPos, nil, "", types.Typ[types.String]),
 		)
 		got := positionalValueExpr(&bytes.Buffer{}, componentInputValue{node: attr}, componentPositionalSitePlan{
-			expressionFacts: map[gsxast.Node]expressionFact{&attr.Pairs[0]: {tv: types.TypeAndValue{Type: tuple}, tuple: tuple}},
+			expressionFacts: newExpressionFactSet(map[gsxast.Node]expressionFact{&attr.Pairs[0]: {tv: types.TypeAndValue{Type: tuple}, tuple: tuple}}),
 		}, positionalEmitContext{bag: bag, interpTemp: &counter})
 		if got.outcome != positionalLoweringDiagnosed {
 			t.Fatalf("outcome = %d, want diagnosed", got.outcome)

--- a/internal/codegen/component_positional_plan.go
+++ b/internal/codegen/component_positional_plan.go
@@ -432,9 +432,12 @@ func positionalSignatureDiagnostic(node gsxast.Node, fset *token.FileSet, err er
 // 2026-07-22). The base map is the whole-package `expressionFacts` harvested
 // once per package (harvestComponentTargetExpressionFacts) and is NEVER mutated
 // after construction — every per-call addition or override lands in the overlay.
+// expressionFactSet layers a per-call overlay over a shared base of expression facts.
+// The zero value is invalid; always construct via newExpressionFactSet or derive.
+// The overlay must not be nil when set or derive are called.
 type expressionFactSet struct {
 	base    map[gsxast.Node]expressionFact // shared, immutable
-	overlay map[gsxast.Node]expressionFact // per-call additions/overrides
+	overlay map[gsxast.Node]expressionFact // per-call additions/overrides; must not be nil
 }
 
 // newExpressionFactSet layers an eagerly-allocated per-call overlay over the

--- a/internal/codegen/component_positional_plan.go
+++ b/internal/codegen/component_positional_plan.go
@@ -42,7 +42,7 @@ type componentPositionalSitePlan struct {
 	typeArgs        []types.Type
 	typeArgExprs    []string
 	operands        []suppliedOperand
-	expressionFacts map[gsxast.Node]expressionFact
+	expressionFacts expressionFactSet
 	zeros           []componentZeroArgument
 	assembly        componentPositionalAssembly
 	directTarget    *directComponentFamily
@@ -424,11 +424,52 @@ func positionalSignatureDiagnostic(node gsxast.Node, fset *token.FileSet, err er
 	return positionalDiagnostic(node, fset, code, message)
 }
 
-func completeComponentOperandFacts(plan componentCallPlan, discovered map[gsxast.Node]expressionFact, runtime runtimeContract, fset *token.FileSet) (map[gsxast.Node]expressionFact, []diag.Diagnostic) {
-	facts := maps.Clone(discovered)
-	if facts == nil {
-		facts = make(map[gsxast.Node]expressionFact)
+// expressionFactSet is a two-layer view of expression facts: a shared,
+// immutable package-wide base map plus a small per-call overlay consulted
+// first. It replaces per-call maps.Clone of the whole-package facts map, which
+// was O(component-calls × package-facts) transient allocation (measured as 67%
+// of all allocation churn on a 105-file package; see the perf investigation
+// 2026-07-22). The base map is the whole-package `expressionFacts` harvested
+// once per package (harvestComponentTargetExpressionFacts) and is NEVER mutated
+// after construction — every per-call addition or override lands in the overlay.
+type expressionFactSet struct {
+	base    map[gsxast.Node]expressionFact // shared, immutable
+	overlay map[gsxast.Node]expressionFact // per-call additions/overrides
+}
+
+// newExpressionFactSet layers an eagerly-allocated per-call overlay over the
+// shared base. The overlay is allocated up front so the struct may be passed by
+// value while still sharing one overlay map (set writes are visible to every
+// copy). The base is shared, not cloned.
+func newExpressionFactSet(base map[gsxast.Node]expressionFact) expressionFactSet {
+	return expressionFactSet{base: base, overlay: make(map[gsxast.Node]expressionFact)}
+}
+
+// get consults the overlay first (so a per-call override wins) then the base.
+func (s expressionFactSet) get(node gsxast.Node) (expressionFact, bool) {
+	if fact, ok := s.overlay[node]; ok {
+		return fact, true
 	}
+	fact, ok := s.base[node]
+	return fact, ok
+}
+
+// set records a per-call addition or override in the overlay, never touching
+// the shared base.
+func (s expressionFactSet) set(node gsxast.Node, fact expressionFact) {
+	s.overlay[node] = fact
+}
+
+// derive returns an independent set sharing the same base but with a fresh
+// overlay seeded from this set's overlay. Mutations to the result never leak
+// back to the parent. The clone is O(per-call overlay entries) — a handful —
+// not O(package facts), which is the whole point.
+func (s expressionFactSet) derive() expressionFactSet {
+	return expressionFactSet{base: s.base, overlay: maps.Clone(s.overlay)}
+}
+
+func completeComponentOperandFacts(plan componentCallPlan, discovered map[gsxast.Node]expressionFact, runtime runtimeContract, fset *token.FileSet) (expressionFactSet, []diag.Diagnostic) {
+	facts := newExpressionFactSet(discovered)
 	var diagnostics []diag.Diagnostic
 
 	var completeNode func(gsxast.Node) bool
@@ -436,14 +477,14 @@ func completeComponentOperandFacts(plan componentCallPlan, discovered map[gsxast
 		if node == nil {
 			return false
 		}
-		if _, ok := facts[node]; ok {
+		if _, ok := facts.get(node); ok {
 			return true
 		}
 		fact, ok := syntaxDefinedComponentFact(node, facts, runtime)
 		if !ok {
 			return false
 		}
-		facts[node] = fact
+		facts.set(node, fact)
 		return true
 	}
 	var completeAttrsTree func(componentAttrsStreamNode)
@@ -455,8 +496,8 @@ func completeComponentOperandFacts(plan componentCallPlan, discovered map[gsxast
 			for _, child := range node.otherwise {
 				completeAttrsTree(child)
 			}
-			if _, exists := facts[node.attr]; !exists {
-				facts[node.attr] = expressionFact{tv: types.TypeAndValue{Type: runtime.attrs}, hasOrderedOperation: true}
+			if _, exists := facts.get(node.attr); !exists {
+				facts.set(node.attr, expressionFact{tv: types.TypeAndValue{Type: runtime.attrs}, hasOrderedOperation: true})
 			}
 			return
 		}
@@ -468,7 +509,7 @@ func completeComponentOperandFacts(plan componentCallPlan, discovered map[gsxast
 			completeAttrsTree(*value.attrsNode)
 		}
 		if value.kind == componentInputBody {
-			facts[value.node] = expressionFact{tv: types.TypeAndValue{Type: runtime.node}}
+			facts.set(value.node, expressionFact{tv: types.TypeAndValue{Type: runtime.node}})
 		}
 		if !completeNode(value.node) {
 			diagnostics = append(diagnostics, positionalDiagnostic(value.node, fset, "component-operand-fact", fmt.Sprintf("component input %T has no exact syntax-derived or go/types operand fact", value.node)))
@@ -478,7 +519,7 @@ func completeComponentOperandFacts(plan componentCallPlan, discovered map[gsxast
 	return facts, diagnostics
 }
 
-func syntaxDefinedComponentFact(node gsxast.Node, nested map[gsxast.Node]expressionFact, runtime runtimeContract) (expressionFact, bool) {
+func syntaxDefinedComponentFact(node gsxast.Node, nested expressionFactSet, runtime runtimeContract) (expressionFact, bool) {
 	switch node := node.(type) {
 	case *gsxast.StaticAttr:
 		return expressionFact{tv: types.TypeAndValue{Type: types.Typ[types.UntypedString], Value: constant.MakeString(node.Value)}}, true
@@ -521,7 +562,7 @@ func syntaxDefinedComponentFact(node gsxast.Node, nested map[gsxast.Node]express
 	return expressionFact{}, false
 }
 
-func aggregateNestedComponentFacts(root gsxast.Node, facts map[gsxast.Node]expressionFact) (ordered, complete bool) {
+func aggregateNestedComponentFacts(root gsxast.Node, facts expressionFactSet) (ordered, complete bool) {
 	complete = true
 	seenValue := false
 	gsxast.Inspect(root, func(node gsxast.Node) bool {
@@ -530,7 +571,7 @@ func aggregateNestedComponentFacts(root gsxast.Node, facts map[gsxast.Node]expre
 		}
 		if nestedComponentFactBearingNode(node) {
 			seenValue = true
-			fact, ok := facts[node]
+			fact, ok := facts.get(node)
 			if !ok || fact.tv.Type == nil {
 				complete = false
 				return true
@@ -589,13 +630,13 @@ func runtimePackageType(runtime runtimeContract, name string) types.Type {
 // own nested (T, error) operations while assembling that final expression.
 // The outer positional materializer must still treat that work as ordered, but
 // must not try to unwrap the already-consumed tuple a second time.
-func positionalMaterializationFacts(plan componentCallPlan, facts map[gsxast.Node]expressionFact, runtime runtimeContract) map[gsxast.Node]expressionFact {
-	result := maps.Clone(facts)
+func positionalMaterializationFacts(plan componentCallPlan, facts expressionFactSet, runtime runtimeContract) expressionFactSet {
+	result := facts.derive()
 	for _, value := range plan.values {
 		if !positionalLoweringOwnsTuple(value) {
 			continue
 		}
-		fact, ok := result[value.node]
+		fact, ok := result.get(value.node)
 		if !ok || fact.tuple == nil {
 			continue
 		}
@@ -608,7 +649,7 @@ func positionalMaterializationFacts(plan componentCallPlan, facts map[gsxast.Nod
 		} else if lowered, ok := syntaxDefinedComponentFact(value.node, facts, runtime); ok {
 			fact.tv.Type = lowered.tv.Type
 		}
-		result[value.node] = fact
+		result.set(value.node, fact)
 	}
 	return result
 }
@@ -634,7 +675,7 @@ func positionalLoweringOwnsTuple(value componentInputValue) bool {
 	}
 }
 
-func validateRecursiveAttrsOperands(plan componentCallPlan, facts map[gsxast.Node]expressionFact, runtime runtimeContract) []diag.Diagnostic {
+func validateRecursiveAttrsOperands(plan componentCallPlan, facts expressionFactSet, runtime runtimeContract) []diag.Diagnostic {
 	var diagnostics []diag.Diagnostic
 	var visit func(componentAttrsStreamNode)
 	visit = func(node componentAttrsStreamNode) {
@@ -669,7 +710,7 @@ func validateRecursiveAttrsOperands(plan componentCallPlan, facts map[gsxast.Nod
 	return diagnostics
 }
 
-func validateRequiredAttrsFacts(plan componentCallPlan, facts map[gsxast.Node]expressionFact, fset *token.FileSet) []diag.Diagnostic {
+func validateRequiredAttrsFacts(plan componentCallPlan, facts expressionFactSet, fset *token.FileSet) []diag.Diagnostic {
 	var diagnostics []diag.Diagnostic
 	var visit func(componentAttrsStreamNode)
 	visit = func(node componentAttrsStreamNode) {
@@ -685,7 +726,7 @@ func validateRequiredAttrsFacts(plan componentCallPlan, facts map[gsxast.Node]ex
 		if node.kind != componentAttrsStreamSpread && node.kind != componentAttrsStreamContributor {
 			return
 		}
-		fact, ok := facts[node.attr]
+		fact, ok := facts.get(node.attr)
 		if !ok || fact.tv.Type == nil {
 			diagnostics = append(diagnostics, positionalDiagnostic(node.attr, fset, "component-operand-fact", "attrs contributor has no authoritative go/types operand fact"))
 		}
@@ -698,14 +739,14 @@ func validateRequiredAttrsFacts(plan componentCallPlan, facts map[gsxast.Node]ex
 	return diagnostics
 }
 
-func positionalSuppliedOperands(plan componentCallPlan, facts map[gsxast.Node]expressionFact, runtime runtimeContract, fset *token.FileSet) ([]suppliedOperand, []diag.Diagnostic) {
+func positionalSuppliedOperands(plan componentCallPlan, facts expressionFactSet, runtime runtimeContract, fset *token.FileSet) ([]suppliedOperand, []diag.Diagnostic) {
 	var operands []suppliedOperand
 	var diagnostics []diag.Diagnostic
 	for valueIndex, value := range plan.values {
 		if value.kind != componentInputProp {
 			continue
 		}
-		fact, ok := facts[value.node]
+		fact, ok := facts.get(value.node)
 		if !ok || fact.tv.Type == nil {
 			diagnostics = append(diagnostics, positionalDiagnostic(value.node, fset, "component-operand-fact", "component prop has no authoritative go/types operand fact"))
 			continue

--- a/internal/codegen/component_positional_plan_test.go
+++ b/internal/codegen/component_positional_plan_test.go
@@ -383,7 +383,8 @@ func TestPlanComponentPositionalCallsDerivesSyntaxDefinedOrdinaryPropFacts(t *te
 	}
 	wantTypes := []types.Type{types.Typ[types.UntypedString], types.Typ[types.UntypedBool], fx.runtime.node, fx.runtime.attrs, types.Typ[types.String]}
 	for i, want := range wantTypes {
-		if gotType := site.expressionFacts[site.call.values[i].node].tv.Type; !types.Identical(gotType, want) {
+		fact, _ := site.expressionFacts.get(site.call.values[i].node)
+		if gotType := fact.tv.Type; !types.Identical(gotType, want) {
 			t.Errorf("value %d fact type = %v, want %v", i, gotType, want)
 		}
 	}
@@ -456,7 +457,7 @@ func TestPlanComponentPositionalCallsDerivesNestedClassAndStyleFactsForSiblings(
 			t.Errorf("site %d missing", id)
 			continue
 		}
-		fact, ok := site.expressionFacts[attr]
+		fact, ok := site.expressionFacts.get(attr)
 		if !ok || !types.Identical(fact.tv.Type, types.Typ[types.String]) || !fact.hasOrderedOperation {
 			t.Errorf("site %d class fact = %+v, want ordered string", id, fact)
 		}
@@ -468,15 +469,15 @@ func TestAggregateNestedComponentFactsUsesOnlyProbedValueNodes(t *testing.T) {
 		part := &gsxast.ClassPart{Expr: "label"}
 		root := &gsxast.ClassAttr{Parts: []gsxast.ClassPart{*part}}
 		part = &root.Parts[0]
-		if _, complete := aggregateNestedComponentFacts(root, nil); complete {
+		if _, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(nil)); complete {
 			t.Fatal("plain part without its authoritative fact reported complete")
 		}
-		if _, complete := aggregateNestedComponentFacts(root, map[gsxast.Node]expressionFact{part: {}}); complete {
+		if _, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(map[gsxast.Node]expressionFact{part: {}})); complete {
 			t.Fatal("plain part with an incomplete authoritative fact reported complete")
 		}
-		ordered, complete := aggregateNestedComponentFacts(root, map[gsxast.Node]expressionFact{
+		ordered, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(map[gsxast.Node]expressionFact{
 			part: {tv: types.TypeAndValue{Type: types.Typ[types.String]}, hasOrderedOperation: true},
-		})
+		}))
 		if !complete || !ordered {
 			t.Fatalf("plain part aggregate = ordered %v complete %v", ordered, complete)
 		}
@@ -490,12 +491,12 @@ func TestAggregateNestedComponentFactsUsesOnlyProbedValueNodes(t *testing.T) {
 			thenArm: {tv: types.TypeAndValue{Type: types.Typ[types.String]}},
 			elseArm: {tv: types.TypeAndValue{Type: types.Typ[types.UntypedString]}},
 		}
-		ordered, complete := aggregateNestedComponentFacts(root, facts)
+		ordered, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(facts))
 		if !complete || !ordered {
 			t.Fatalf("control-flow aggregate = ordered %v complete %v", ordered, complete)
 		}
 		delete(facts, elseArm)
-		if _, complete := aggregateNestedComponentFacts(root, facts); complete {
+		if _, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(facts)); complete {
 			t.Fatal("control flow with a missing arm fact reported complete")
 		}
 	})
@@ -503,16 +504,16 @@ func TestAggregateNestedComponentFactsUsesOnlyProbedValueNodes(t *testing.T) {
 	t.Run("CSS literal delegates to embedded values", func(t *testing.T) {
 		value := &gsxast.Interp{Expr: "tone()"}
 		root := &gsxast.ClassAttr{Parts: []gsxast.ClassPart{{CSSSegments: []gsxast.Markup{&gsxast.Text{Value: "color:"}, value}}}}
-		ordered, complete := aggregateNestedComponentFacts(root, map[gsxast.Node]expressionFact{
+		ordered, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(map[gsxast.Node]expressionFact{
 			value: {tv: types.TypeAndValue{Type: types.Typ[types.String]}, tuple: types.NewTuple(
 				types.NewVar(token.NoPos, nil, "", types.Typ[types.String]),
 				types.NewVar(token.NoPos, nil, "", types.Universe.Lookup("error").Type()),
 			)},
-		})
+		}))
 		if !complete || !ordered {
 			t.Fatalf("CSS aggregate = ordered %v complete %v", ordered, complete)
 		}
-		if _, complete := aggregateNestedComponentFacts(root, nil); complete {
+		if _, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(nil)); complete {
 			t.Fatal("CSS literal with a missing embedded-value fact reported complete")
 		}
 	})
@@ -688,8 +689,8 @@ func TestPlanComponentPositionalCallsPinsConditionalAttrsAtAuthoredOrder(t *test
 	if len(materialization.values) != 2 || materialization.values[0].temp == "" || materialization.values[1].temp == "" {
 		t.Fatalf("crossing ordered values must both be pinned: %+v", materialization.values)
 	}
-	if !site.expressionFacts[el.Attrs[1]].hasOrderedOperation {
-		t.Fatalf("conditional attrs fact = %+v", site.expressionFacts[el.Attrs[1]])
+	if fact, _ := site.expressionFacts.get(el.Attrs[1]); !fact.hasOrderedOperation {
+		t.Fatalf("conditional attrs fact = %+v", fact)
 	}
 }
 
@@ -716,14 +717,14 @@ func TestPositionalMaterializationFactsLeaveTupleOwnershipWithCompoundLowering(t
 		pair:     {tv: types.TypeAndValue{Type: tuple}, tuple: tuple},
 	}
 
-	materializationFacts := positionalMaterializationFacts(plan, facts, fx.runtime)
-	if got := materializationFacts[embedded]; got.tuple != nil || !types.Identical(got.tv.Type, types.Typ[types.String]) || !got.hasOrderedOperation {
+	materializationFacts := positionalMaterializationFacts(plan, newExpressionFactSet(facts), fx.runtime)
+	if got, _ := materializationFacts.get(embedded); got.tuple != nil || !types.Identical(got.tv.Type, types.Typ[types.String]) || !got.hasOrderedOperation {
 		t.Fatalf("embedded lowering fact = %+v, want ordered string without outer tuple", got)
 	}
-	if got := materializationFacts[pair]; got.tuple != nil || !types.Identical(got.tv.Type, fx.runtime.attrs) || !got.hasOrderedOperation {
+	if got, _ := materializationFacts.get(pair); got.tuple != nil || !types.Identical(got.tv.Type, fx.runtime.attrs) || !got.hasOrderedOperation {
 		t.Fatalf("attrs-pair lowering fact = %+v, want ordered attrs without outer tuple", got)
 	}
-	if got := materializationFacts[plain]; got.tuple == nil {
+	if got, _ := materializationFacts.get(plain); got.tuple == nil {
 		t.Fatalf("plain expression tuple ownership moved away from outer materializer: %+v", got)
 	}
 }

--- a/internal/codegen/component_zero.go
+++ b/internal/codegen/component_zero.go
@@ -764,7 +764,7 @@ type materializationPlan struct {
 // (unwrap + error check) and is always a temp. Two side-effect-free reads that
 // merely swap relative to each other cross no ordered work and stay inline —
 // reordering them is unobservable.
-func planComponentMaterialization(plan componentCallPlan, facts map[gsxast.Node]expressionFact) materializationPlan {
+func planComponentMaterialization(plan componentCallPlan, facts expressionFactSet) materializationPlan {
 	type entry struct {
 		valueIndex int
 		value      componentInputValue
@@ -780,7 +780,7 @@ func planComponentMaterialization(plan componentCallPlan, facts map[gsxast.Node]
 		if v.kind == componentInputBody {
 			continue
 		}
-		fact, ok := facts[v.node]
+		fact, ok := facts.get(v.node)
 		entries = append(entries, entry{
 			valueIndex: i,
 			value:      v,

--- a/internal/codegen/component_zero_test.go
+++ b/internal/codegen/component_zero_test.go
@@ -394,7 +394,7 @@ func TestPlanComponentMaterialization(t *testing.T) {
 			first:  {tv: types.TypeAndValue{Type: types.Typ[types.String]}, hasOrderedOperation: true},
 			second: {tv: types.TypeAndValue{Type: types.Typ[types.String]}, hasOrderedOperation: true},
 		}
-		got := planComponentMaterialization(plan, facts)
+		got := planComponentMaterialization(plan, newExpressionFactSet(facts))
 		if len(got.values) != 2 || got.values[0].temp == "" || got.values[1].temp == "" {
 			t.Fatalf("both reordered calls must materialize, got %+v", got.values)
 		}
@@ -411,7 +411,7 @@ func TestPlanComponentMaterialization(t *testing.T) {
 		facts := map[gsxast.Node]expressionFact{
 			n: {tv: types.TypeAndValue{Type: types.Typ[types.UntypedInt], Value: constant.MakeInt64(1)}},
 		}
-		got := planComponentMaterialization(plan, facts)
+		got := planComponentMaterialization(plan, newExpressionFactSet(facts))
 		if len(got.values) != 1 || !got.values[0].inline || got.values[0].temp != "" {
 			t.Fatalf("constant must stay inline, got %+v", got.values)
 		}
@@ -429,7 +429,7 @@ func TestPlanComponentMaterialization(t *testing.T) {
 		facts := map[gsxast.Node]expressionFact{
 			n: {tv: types.TypeAndValue{Type: tuple}, tuple: tuple, hasOrderedOperation: true},
 		}
-		got := planComponentMaterialization(plan, facts)
+		got := planComponentMaterialization(plan, newExpressionFactSet(facts))
 		if len(got.values) != 1 || !got.values[0].unwrapTuple || got.values[0].temp == "" {
 			t.Fatalf("tuple value must unwrap to a temp, got %+v", got.values)
 		}
@@ -450,7 +450,7 @@ func TestPlanComponentMaterialization(t *testing.T) {
 			x:    {tv: types.TypeAndValue{Type: types.Typ[types.String]}},
 			sink: {tv: types.TypeAndValue{Type: types.Typ[types.String]}, hasOrderedOperation: true},
 		}
-		got := planComponentMaterialization(plan, facts)
+		got := planComponentMaterialization(plan, newExpressionFactSet(facts))
 		// out.values are in authored order: x first, sink second.
 		if got.values[0].inline || got.values[0].temp == "" {
 			t.Fatalf("x crosses a side effect and must be materialized, got %+v", got.values[0])
@@ -468,7 +468,7 @@ func TestPlanComponentMaterialization(t *testing.T) {
 		facts := map[gsxast.Node]expressionFact{
 			n: {tv: types.TypeAndValue{Type: types.Typ[types.String]}, hasOrderedOperation: true},
 		}
-		got := planComponentMaterialization(plan, facts)
+		got := planComponentMaterialization(plan, newExpressionFactSet(facts))
 		if !got.values[0].inline || got.values[0].temp != "" {
 			t.Fatalf("a lone ordered value needs no temp, got %+v", got.values)
 		}
@@ -488,7 +488,7 @@ func TestPlanComponentMaterialization(t *testing.T) {
 			middle: {tv: types.TypeAndValue{Type: types.Typ[types.String]}, hasOrderedOperation: true},
 			last:   {tv: types.TypeAndValue{Type: types.Typ[types.String]}, hasOrderedOperation: true},
 		}
-		got := planComponentMaterialization(plan, facts)
+		got := planComponentMaterialization(plan, newExpressionFactSet(facts))
 		if len(got.values) != 3 || got.values[0].temp == "" || got.values[1].temp == "" || got.values[2].temp == "" {
 			t.Fatalf("a later eager temp must not overtake an earlier call: %+v", got.values)
 		}

--- a/internal/codegen/module_perf_test.go
+++ b/internal/codegen/module_perf_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -92,6 +93,99 @@ func setupComponentBenchmarkFixture(b *testing.B, kind string) componentBenchmar
 	}
 	write(overrideRel, string(fixture.variants[0]))
 	return fixture
+}
+
+// setupManyComponentCallsFixture builds one flat package with many component
+// definitions and a page that calls them hundreds of times. Every call site
+// drives planComponentPositionalCalls, whose per-call cost historically included
+// a maps.Clone of the WHOLE-PACKAGE expression-fact map — O(calls × facts). With
+// many calls contributing facts, the package fact map is large and cloned once
+// per call, so this fixture makes that quadratic allocation dominate. Warm
+// regeneration isolates the analyze/plan cost from packages.Load.
+func setupManyComponentCallsFixture(b *testing.B, components, calls int) componentBenchmarkFixture {
+	b.Helper()
+	root := b.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		b.Fatal(err)
+	}
+	write := func(path, contents string) {
+		b.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(contents), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	write("go.mod", "module example.com/componentbench\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+
+	var defs strings.Builder
+	defs.WriteString("package app\n\n")
+	for i := range components {
+		fmt.Fprintf(&defs, "component Comp%d(title string, subtitle string, count int) {\n\t<article><h1>{ title }</h1><p>{ subtitle }</p><span>{ count }</span></article>\n}\n\n", i)
+	}
+	write("app/components.gsx", defs.String())
+
+	page := func(marker string) []byte {
+		var b strings.Builder
+		fmt.Fprintf(&b, "package app\n\n// warm variant %s\ncomponent Page(label string, n int) {\n\t<main>\n", marker)
+		for i := range calls {
+			fmt.Fprintf(&b, "\t\t<Comp%d title={ label } subtitle={ label } count={ n + %d }/>\n", i%components, i)
+		}
+		b.WriteString("\t</main>\n}\n")
+		return []byte(b.String())
+	}
+
+	fixture := componentBenchmarkFixture{
+		opts: Options{
+			ModuleRoot: root,
+			ModulePath: "example.com/componentbench",
+			FilterPkgs: []string{StdImportPath},
+		},
+		targetDir:    filepath.Join(root, "app"),
+		overridePath: filepath.Join(root, "app", "page.gsx"),
+		variants:     [2][]byte{page("a"), page("b")},
+	}
+	write("app/page.gsx", string(fixture.variants[0]))
+	return fixture
+}
+
+func BenchmarkModuleGenerateManyComponentCalls(b *testing.B) {
+	fixture := setupManyComponentCallsFixture(b, 50, 200)
+	m, err := Open(fixture.opts)
+	if err != nil {
+		b.Fatal(err)
+	}
+	out, diags, err := m.Generate(fixture.targetDir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if len(diags) != 0 {
+		b.Fatalf("prime Generate diagnostics: %v", diags)
+	}
+	if len(out) == 0 {
+		b.Fatal("prime Generate produced no component output")
+	}
+	componentBenchmarkOutput = out
+	b.ReportAllocs()
+	for i := range b.N {
+		m.SetOverride(fixture.overridePath, fixture.variants[(i+1)%len(fixture.variants)])
+		b.StartTimer()
+		out, diags, err := m.Generate(fixture.targetDir)
+		b.StopTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(diags) != 0 {
+			b.Fatalf("Generate diagnostics: %v", diags)
+		}
+		if len(out) == 0 {
+			b.Fatal("Generate produced no component output")
+		}
+		componentBenchmarkOutput = out
+	}
 }
 
 func BenchmarkModuleGenerateComponentCold(b *testing.B) {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -16,8 +16,13 @@ import (
 )
 
 // defaultDebounce is how long the server waits for typing to settle before
-// re-analyzing a changed package. Matches gopls's diagnosticsDelay default.
-const defaultDebounce = 250 * time.Millisecond
+// re-analyzing a changed package. Matches modern gopls's diagnosticsDelay
+// default (1s; raised from 250ms years ago). It also reduces analysisMu
+// collisions between a background re-analysis worker and completion's ephemeral
+// analysis: a whole-package warm re-analyze is ~1.3s and blocks completion on
+// analysisMu until it finishes, so re-analyzing less eagerly keeps completion at
+// its floor during active typing (see perf investigation 2026-07-22).
+const defaultDebounce = time.Second
 
 // Analyzer computes diagnostics for the package in dir. Analysis override maps
 // are immutable invocation snapshots for stateless implementations; they must


### PR DESCRIPTION
## Summary

Measured performance investigation of the LSP on a real ~74k-line project (105-file package), after user reports of slow completion and ~4.6GiB RSS (vs gopls ~2GB on the same project).

**Findings (all numbers from the real project):**
- 67% of ALL allocation (142GB cumulative churn) was `maps.Clone` of the whole-package expression-facts map, executed **once per component call site** — O(calls × facts). RSS was GC churn, not retention (live heap ~300MB).
- Completion latency = ~692ms of warm ephemeral analysis **plus up to ~1.3s blocked on `analysisMu`** behind the debounced background re-analysis — and since completion runs on the dispatch goroutine, the whole server stalls for that window.
- The 250ms debounce comment claimed gopls parity; modern gopls defaults `diagnosticsDelay` to 1s.

**Changes:**
1. `expressionFactSet{base, overlay}` replaces the per-call clone: shared immutable package map + small per-call overlay (`get` = overlay→base, `set` = overlay-only, `derive` clones only the overlay so emit's mutations stay isolated). Reviewed adversarially: base is written exactly once at harvest (no post-harvest write path exists), `expressionFact` is a pure value type (no deref-mutated reference fields), nothing iterates the map, and node keys are position-unique so cross-call collision is structurally impossible. Corpus goldens (the differential harness) prove byte-identical output.
2. Debounce 250ms → 1s (modern gopls parity; also reduces `analysisMu` collisions with completion).

**Measured results (one-learning ui/, before → after):**
| Metric | Before | After |
|---|---|---|
| RSS plateau | 4863 MiB | **1303 MiB (−73%)** |
| Warm background re-analysis | 1.28s | 1.04s |
| Warm completion analysis | 720ms | 574ms |
| Bench bytes/op (200 calls × 50 components) | 98.3MB | 60.4MB |

**Not done yet (candidates if still needed after this lands):** taking completion off the dispatch-goroutine `analysisMu` block (TryLock + stale fast path); scratch fset for ephemeral runs (removes a ~3s rebuild cliff every ~50 completions); `Info.Scopes` retention policy; cold `pkgResults` eviction.

## Testing

- `make ci` green (corpus goldens = no-miscompile proof for the planning-code change)
- New `BenchmarkModuleGenerateManyComponentCalls` pins the allocation win
- Debounce tests use injected schedulers — unaffected (verified)
- Adversarial review traced every write path to the facts structure, the derive/snapshot semantics, and golden coverage of the divergence-prone shapes (multi-call tuple/conditional cases named in review)

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa