### PR TITLE
perf: LSP round 2 - parse cache, lean diagnostics emit, non-blocking completion

### DIFF
--- a/ast/clone.go
+++ b/ast/clone.go
@@ -1,0 +1,313 @@
+package ast
+
+import "fmt"
+
+// CloneFile returns a deep copy of f in which every mutable node is a freshly
+// allocated pointer, while immutable leaves (strings, token.Pos, bools, the
+// embedded span) are copied by value and interned strings are shared. The clone
+// shares no slice backing array and no node pointer with f, so a caller may run
+// the codegen mutation passes (which populate Interp.Embedded / GoBlock.Embedded,
+// minify js/css into Segment/Text values, rebase RawJS, and stamp
+// Element.IsComponent) over the clone without contaminating f.
+//
+// This exists so a pristine parsed tree can be cached and re-served many times:
+// each analysis gets its own independent tree, preserving codegen's invariant
+// that every analyze() call walks a fresh AST (see Module.parsePackageWithFset).
+//
+// The switches are exhaustive over the sealed node families (Decl / Markup /
+// Attr / GoPart) plus the standalone Node types they contain (CaseClause,
+// ClassPart, OrderedPair, and the value-form control-flow nodes). An unhandled
+// concrete type panics rather than silently sharing a mutable node — the corpus
+// goldens, which exercise every node kind through Package/Generate, turn that
+// panic into a loud test failure if a new node type is added without a clone
+// case.
+func CloneFile(f *File) *File {
+	if f == nil {
+		return nil
+	}
+	nf := *f
+	nf.Decls = cloneDecls(f.Decls)
+	return &nf
+}
+
+func cloneDecls(in []Decl) []Decl {
+	if in == nil {
+		return nil
+	}
+	out := make([]Decl, len(in))
+	for i, d := range in {
+		out[i] = cloneDecl(d)
+	}
+	return out
+}
+
+func cloneDecl(d Decl) Decl {
+	switch v := d.(type) {
+	case *GoChunk:
+		n := *v
+		return &n
+	case *GoWithElements:
+		n := *v
+		n.Parts = cloneGoParts(v.Parts)
+		return &n
+	case *Component:
+		n := *v
+		n.Body = cloneMarkups(v.Body)
+		return &n
+	default:
+		panic(fmt.Sprintf("ast.cloneDecl: unhandled Decl type %T", d))
+	}
+}
+
+func cloneMarkups(in []Markup) []Markup {
+	if in == nil {
+		return nil
+	}
+	out := make([]Markup, len(in))
+	for i, m := range in {
+		out[i] = cloneMarkup(m)
+	}
+	return out
+}
+
+func cloneMarkup(m Markup) Markup {
+	switch v := m.(type) {
+	case *Element:
+		n := *v
+		n.Attrs = cloneAttrs(v.Attrs)
+		n.Children = cloneMarkups(v.Children)
+		return &n
+	case *Fragment:
+		n := *v
+		n.Children = cloneMarkups(v.Children)
+		return &n
+	case *Text:
+		n := *v
+		return &n
+	case *Doctype:
+		n := *v
+		return &n
+	case *HTMLComment:
+		n := *v
+		return &n
+	case *Comment:
+		n := *v
+		return &n
+	case *Interp:
+		n := *v
+		n.Stages = clonePipeStages(v.Stages)
+		n.Embedded = cloneGoParts(v.Embedded)
+		return &n
+	case *EmbeddedInterp:
+		n := *v
+		n.Segments = cloneMarkups(v.Segments)
+		n.Stages = clonePipeStages(v.Stages)
+		return &n
+	case *GoBlock:
+		n := *v
+		n.Embedded = cloneGoParts(v.Embedded)
+		if v.UnsupportedMarkup != nil {
+			n.UnsupportedMarkup = cloneGoPart(v.UnsupportedMarkup)
+		}
+		return &n
+	case *IfMarkup:
+		n := *v
+		n.Then = cloneMarkups(v.Then)
+		n.Else = cloneMarkups(v.Else)
+		return &n
+	case *ForMarkup:
+		n := *v
+		n.Body = cloneMarkups(v.Body)
+		return &n
+	case *SwitchMarkup:
+		n := *v
+		n.Cases = cloneCaseClauses(v.Cases)
+		return &n
+	default:
+		panic(fmt.Sprintf("ast.cloneMarkup: unhandled Markup type %T", m))
+	}
+}
+
+func cloneCaseClauses(in []*CaseClause) []*CaseClause {
+	if in == nil {
+		return nil
+	}
+	out := make([]*CaseClause, len(in))
+	for i, c := range in {
+		n := *c
+		n.Body = cloneMarkups(c.Body)
+		out[i] = &n
+	}
+	return out
+}
+
+func cloneAttrs(in []Attr) []Attr {
+	if in == nil {
+		return nil
+	}
+	out := make([]Attr, len(in))
+	for i, a := range in {
+		out[i] = cloneAttr(a)
+	}
+	return out
+}
+
+func cloneAttr(a Attr) Attr {
+	switch v := a.(type) {
+	case *StaticAttr:
+		n := *v
+		return &n
+	case *ExprAttr:
+		n := *v
+		n.Stages = clonePipeStages(v.Stages)
+		return &n
+	case *BoolAttr:
+		n := *v
+		return &n
+	case *SpreadAttr:
+		n := *v
+		n.Stages = clonePipeStages(v.Stages)
+		return &n
+	case *MarkupAttr:
+		n := *v
+		n.Value = cloneMarkups(v.Value)
+		return &n
+	case *EmbeddedAttr:
+		n := *v
+		n.Segments = cloneMarkups(v.Segments)
+		n.Stages = clonePipeStages(v.Stages)
+		return &n
+	case *CondAttr:
+		n := *v
+		n.Then = cloneAttrs(v.Then)
+		n.Else = cloneAttrs(v.Else)
+		return &n
+	case *ClassAttr:
+		n := *v
+		n.Parts = cloneClassParts(v.Parts)
+		return &n
+	case *OrderedAttrsAttr:
+		n := *v
+		n.Pairs = cloneOrderedPairs(v.Pairs)
+		return &n
+	case *CommentAttr:
+		n := *v
+		return &n
+	default:
+		panic(fmt.Sprintf("ast.cloneAttr: unhandled Attr type %T", a))
+	}
+}
+
+func cloneGoParts(in []GoPart) []GoPart {
+	if in == nil {
+		return nil
+	}
+	out := make([]GoPart, len(in))
+	for i, p := range in {
+		out[i] = cloneGoPart(p)
+	}
+	return out
+}
+
+func cloneGoPart(p GoPart) GoPart {
+	switch v := p.(type) {
+	case GoText:
+		// GoText is stored by value and carries only immutable leaves.
+		return v
+	case *Element:
+		return cloneMarkup(v).(*Element)
+	case *Fragment:
+		return cloneMarkup(v).(*Fragment)
+	case *EmbeddedInterp:
+		return cloneMarkup(v).(*EmbeddedInterp)
+	default:
+		panic(fmt.Sprintf("ast.cloneGoPart: unhandled GoPart type %T", p))
+	}
+}
+
+func cloneClassParts(in []ClassPart) []ClassPart {
+	if in == nil {
+		return nil
+	}
+	out := make([]ClassPart, len(in))
+	for i := range in {
+		out[i] = cloneClassPart(in[i])
+	}
+	return out
+}
+
+func cloneClassPart(p ClassPart) ClassPart {
+	// p is already a value copy; deep-copy its mutable slices/pointers.
+	p.Stages = clonePipeStages(p.Stages)
+	p.CSSSegments = cloneMarkups(p.CSSSegments)
+	if p.CF != nil {
+		p.CF = cloneValueCF(p.CF)
+	}
+	return p
+}
+
+func cloneValueCF(cf *ValueCF) *ValueCF {
+	n := *cf
+	if cf.If != nil {
+		n.If = cloneValueIf(cf.If)
+	}
+	if cf.Switch != nil {
+		n.Switch = cloneValueSwitch(cf.Switch)
+	}
+	return &n
+}
+
+func cloneValueIf(vi *ValueIf) *ValueIf {
+	n := *vi
+	if vi.Then != nil {
+		n.Then = cloneValueArm(vi.Then)
+	}
+	if vi.ElseIf != nil {
+		n.ElseIf = cloneValueIf(vi.ElseIf)
+	}
+	if vi.Else != nil {
+		n.Else = cloneValueArm(vi.Else)
+	}
+	return &n
+}
+
+func cloneValueSwitch(vs *ValueSwitch) *ValueSwitch {
+	n := *vs
+	if vs.Cases != nil {
+		n.Cases = make([]*ValueSwitchCase, len(vs.Cases))
+		for i, c := range vs.Cases {
+			cn := *c
+			if c.Value != nil {
+				cn.Value = cloneValueArm(c.Value)
+			}
+			n.Cases[i] = &cn
+		}
+	}
+	return &n
+}
+
+func cloneValueArm(va *ValueArm) *ValueArm {
+	n := *va
+	n.Stages = clonePipeStages(va.Stages)
+	return &n
+}
+
+func cloneOrderedPairs(in []OrderedPair) []OrderedPair {
+	if in == nil {
+		return nil
+	}
+	// OrderedPair carries only immutable leaves; a fresh backing array is all
+	// that is needed so &out[i] differs from the pristine tree's pointers.
+	out := make([]OrderedPair, len(in))
+	copy(out, in)
+	return out
+}
+
+func clonePipeStages(in []PipeStage) []PipeStage {
+	if in == nil {
+		return nil
+	}
+	out := make([]PipeStage, len(in))
+	copy(out, in)
+	return out
+}

--- a/ast/clone_test.go
+++ b/ast/clone_test.go
@@ -1,0 +1,108 @@
+package ast_test
+
+import (
+	"bytes"
+	"go/token"
+	"reflect"
+	"testing"
+
+	"github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/parser"
+)
+
+// cloneTestSrc exercises a broad spread of node families: a top-level
+// var-with-element (GoWithElements + GoText), a component body with an element
+// carrying static/expr/bool/class/spread attributes and an in-tag conditional,
+// interpolation with a pipe stage, control-flow markup (if/for/switch), a
+// fragment, an ordered-attrs bag, a {{ }} block, and an embedded css literal.
+const cloneTestSrc = "package views\n" +
+	"\n" +
+	"var help = <a href={u}>{ label }</a>\n" +
+	"\n" +
+	"component Page(title string, items []string, on bool) {\n" +
+	"\t<div id=\"x\" hidden>\n" +
+	"\t\t{ title |> upper }\n" +
+	"\t\t{ if on { <b>hi</b> } else { <i>bye</i> } }\n" +
+	"\t\t{ for _, it := range items { <li>{ it }</li> } }\n" +
+	"\t\t<Card attrs={{ \"data-x\": 1 }}>text</Card>\n" +
+	"\t\t<>frag</>\n" +
+	"\t\t<!-- keep -->\n" +
+	"\t</div>\n" +
+	"}\n"
+
+// collectPtrNodes returns the set of pointer-backed nodes reachable from n
+// (interface values whose dynamic kind is Ptr). Value nodes (GoText) are
+// excluded — they are immutable and legitimately shared by value.
+func collectPtrNodes(n ast.Node) map[ast.Node]bool {
+	set := map[ast.Node]bool{}
+	ast.Inspect(n, func(x ast.Node) bool {
+		if x == nil {
+			return false
+		}
+		if reflect.ValueOf(x).Kind() == reflect.Ptr {
+			set[x] = true
+		}
+		return true
+	})
+	return set
+}
+
+func TestCloneFileIndependentAndEqual(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "t.gsx", cloneTestSrc, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	clone := ast.CloneFile(f)
+
+	// Structural + value equality: the clone prints identically to the original.
+	var a, b bytes.Buffer
+	if err := ast.Fprint(&a, f); err != nil {
+		t.Fatalf("Fprint original: %v", err)
+	}
+	if err := ast.Fprint(&b, clone); err != nil {
+		t.Fatalf("Fprint clone: %v", err)
+	}
+	if a.String() != b.String() {
+		t.Fatalf("clone AST prints differently:\n--- original ---\n%s\n--- clone ---\n%s", a.String(), b.String())
+	}
+
+	// Deep independence: no pointer-backed node is shared between the two trees.
+	orig := collectPtrNodes(f)
+	cl := collectPtrNodes(clone)
+	if len(orig) == 0 {
+		t.Fatal("no pointer nodes collected; test is not exercising the tree")
+	}
+	if len(orig) != len(cl) {
+		t.Fatalf("node count differs: original=%d clone=%d (structure not preserved)", len(orig), len(cl))
+	}
+	for n := range cl {
+		if orig[n] {
+			t.Fatalf("clone shares node pointer %T with the original tree", n)
+		}
+	}
+
+	// Mutating the clone must not touch the original: stamp IsComponent on the
+	// first element found in the clone and confirm the original's counterpart
+	// stays false.
+	var cloneEl, origEl *ast.Element
+	ast.Inspect(clone, func(x ast.Node) bool {
+		if e, ok := x.(*ast.Element); ok && cloneEl == nil {
+			cloneEl = e
+		}
+		return true
+	})
+	ast.Inspect(f, func(x ast.Node) bool {
+		if e, ok := x.(*ast.Element); ok && origEl == nil {
+			origEl = e
+		}
+		return true
+	})
+	if cloneEl == nil || origEl == nil {
+		t.Fatal("no element found in tree")
+	}
+	cloneEl.IsComponent = true
+	if origEl.IsComponent {
+		t.Fatal("mutating the clone's Element.IsComponent leaked into the original tree")
+	}
+}

--- a/gen/lsp.go
+++ b/gen/lsp.go
@@ -626,6 +626,47 @@ func (a lspAnalyzer) AnalyzeEphemeral(dir, path string, content []byte) (*lsp.Pa
 	return adaptPackageResult(pr), nil
 }
 
+// AnalyzeEphemeralNonBlocking is the non-blocking variant of AnalyzeEphemeral
+// (see codegen.Module.TryAnalyzeEphemeral). It returns acquired=false without
+// analyzing when the warm Module's analysis lock is already held by an
+// in-flight background Package/Generate — the LSP dispatch loop uses it so a
+// completion or nav request never stalls behind that background work. On
+// acquired=true the (*lsp.Package, error) pair is identical to
+// AnalyzeEphemeral's; on acquired=false the package is nil and the handler
+// serves a retained-snapshot fallback (or replies empty/null) instead. A
+// module-resolution error (root/config/warm-Module setup) is returned with
+// acquired=false since no analysis was attempted.
+func (a lspAnalyzer) AnalyzeEphemeralNonBlocking(dir, path string, content []byte) (*lsp.Package, bool, error) {
+	root, modPath, err := moduleRoot(dir)
+	if err != nil {
+		return nil, false, err
+	}
+	merged := resolveConfigBestEffort(dir, a.optCfg, a.warnw)
+	m, _, err := a.module(root, modPath, merged)
+	if err != nil {
+		return nil, false, err
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, false, err
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, false, err
+	}
+	pr, acquired, err := m.TryAnalyzeEphemeral(abs, filepath.Clean(absPath), content)
+	if !acquired {
+		return nil, false, err
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	if pr == nil {
+		return &lsp.Package{}, true, nil
+	}
+	return adaptPackageResult(pr), true, nil
+}
+
 // AnalyzeModule analyzes every gsx package in the module containing dir and
 // returns a flat cross-reference list. It reuses the warm per-root Module
 // (same instance Analyze uses), so the warm type-cache is shared across

--- a/internal/codegen/element_value_test.go
+++ b/internal/codegen/element_value_test.go
@@ -122,7 +122,7 @@ func TestElementValueInterpCapturesOuterScope(t *testing.T) {
 		interp: types.Typ[types.String],
 	}
 	bag := diag.NewBag(fset)
-	out, ok := generateFile(file, nil, resolved, funcTables{}, fset, nil, bag, nil, nil, nil, false, false, nil, componentTargetPlan{}, componentPositionalPackagePlan{})
+	out, ok := generateFile(file, nil, resolved, funcTables{}, fset, nil, bag, nil, nil, nil, false, false, nil, componentTargetPlan{}, componentPositionalPackagePlan{}, false)
 	if !ok {
 		t.Fatalf("generateFile failed: %v", bag.Sorted())
 	}

--- a/internal/codegen/emit.go
+++ b/internal/codegen/emit.go
@@ -30,7 +30,16 @@ import (
 // interpolation types. It returns (nil, false) if any component failed; all
 // component errors are recorded in bag (component-boundary recovery continues
 // to the next component on failure, so multiple errors are always reported).
-func generateFile(file *ast.File, currentPkg *types.Package, resolved map[ast.Node]types.Type, table funcTables, fset *token.FileSet, cls *attrclass.Classifier, bag *diag.Bag, cssMin, jsMin, jsonMin func(string) (string, error), cssMinify, jsMinify bool, merger *ClassMergerRef, componentPlan componentTargetPlan, positionalPlan componentPositionalPackagePlan) ([]byte, bool) {
+//
+// diagnosticsOnly is set by Package's LSP diagnostics pass (module.go), which
+// runs this function purely to harvest bag side-effects (unknown filter,
+// attr-error, etc.) from the component/body walk and always discards the
+// returned bytes. When true, generateFile returns as soon as that walk
+// completes ok, skipping every remaining stage below — import-region
+// assembly, coalesceStaticWrites, and format.Source — because they exist
+// solely to shape output nobody reads. See the diagnosticsOnly branch below
+// for the one diagnostic class this intentionally forgoes.
+func generateFile(file *ast.File, currentPkg *types.Package, resolved map[ast.Node]types.Type, table funcTables, fset *token.FileSet, cls *attrclass.Classifier, bag *diag.Bag, cssMin, jsMin, jsonMin func(string) (string, error), cssMinify, jsMinify bool, merger *ClassMergerRef, componentPlan componentTargetPlan, positionalPlan componentPositionalPackagePlan, diagnosticsOnly bool) ([]byte, bool) {
 	if cls == nil {
 		cls = attrclass.Builtin()
 	}
@@ -286,6 +295,36 @@ func generateFile(file *ast.File, currentPkg *types.Package, resolved map[ast.No
 
 	if !ok {
 		return nil, false
+	}
+
+	if diagnosticsOnly {
+		// Every diagnostic this pass exists to harvest (component/attr errors,
+		// unknown filters, etc.) was already added to bag during the walk above —
+		// bag.Add/bag.Errorf fire inline as each component/GoWithElements decl is
+		// visited, not deferred to the assembly below. Everything past this point
+		// (the class-merger/filter-alias bookkeeping, writeImports, and the
+		// coalesceStaticWrites + format.Source tail) exists only to shape the
+		// FINAL BYTES — which the caller (Package's diagnostics-only emit,
+		// module.go) always discards. Skipping it is the P2 perf fix: that tail
+		// measured 33% of Package's warm background re-analysis wall time and
+		// coalesceStaticWrites was the #2 allocator (~425 MB/run), all for bytes
+		// nobody reads.
+		//
+		// TRADE-OFF (deliberate, not silently dropped): format.Source's own
+		// failure path below adds a "format generated source" diagnostic — the
+		// ONE diagnostic this skip forgoes. That diag class only fires when
+		// codegen's own component/body walk produced Go the formatter can't
+		// parse despite a clean bag and a clean type-check (see module.go's
+		// Package/Generate gates, both `len(a.typeErrs) == 0 &&
+		// !a.bag.HasErrors()`) — i.e. it signals an internal codegen bug, never
+		// a user-source error. It still surfaces from `gsx generate`'s real
+		// emit (Module.Generate's generateFile call, diagnosticsOnly=false,
+		// which always runs this tail). No corpus or unit test pins this
+		// diagnostic on the Package/LSP path — the corpus drives GenerateDirs
+		// (the real-emit path) exclusively — so accepting that it's
+		// generate-only is option (a), not a regression against any pinned
+		// behavior.
+		return nil, true
 	}
 
 	// The class merger package (if configured) is registered here under its

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -219,6 +219,7 @@ type Module struct {
 	targetDeclProvenance      componentTargetProvenanceCache      // abs dir -> logical component key -> exact authored declarations
 	configuredDeclTypes       map[string]*types.Package           // abs dir -> configured declaration-universe package cache
 	pkgResults                map[string]*PackageResult           // abs dir -> cached full analysis result (Package path only)
+	parseCache                map[string]parseCacheEntry          // abs .gsx path -> pristine per-file parse; served via ast.CloneFile so unchanged files skip re-parse. Flushed by rebuildFset (its token.Pos values live in m.fset).
 	imports                   map[string][]string                 // dir -> authoritative module-local shipping dependencies (forward edges)
 	importedBy                map[string]map[string]bool          // dep dir -> set of importer dirs (reverse edges)
 	targetImports             map[string][]string                 // exact-target declaration graph forward edges
@@ -332,6 +333,7 @@ func Open(opts Options) (*Module, error) {
 		externalImportPaths:       map[string]bool{},
 		externalBackedges:         map[string][]string{},
 		pkgResults:                map[string]*PackageResult{},
+		parseCache:                map[string]parseCacheEntry{},
 		imports:                   map[string][]string{},
 		importedBy:                map[string]map[string]bool{},
 		targetImports:             map[string][]string{},
@@ -1241,6 +1243,10 @@ func (m *Module) rebuildFset() {
 	m.targetDeclProvenance = componentTargetProvenanceCache{}
 	m.configuredDeclTypes = map[string]*types.Package{}
 	m.pkgResults = map[string]*PackageResult{}
+	// The parse cache's token.Pos values reference token.File entries in the old
+	// fset; a fresh fset orphans them, so it must be flushed in the same critical
+	// section that replaces the fset.
+	m.parseCache = map[string]parseCacheEntry{}
 	m.fsetBaseline = 0
 	m.rebuildCount++
 }

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -1324,7 +1324,7 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 	// by a concurrent or repeated generateFile pass on the same nodes.
 	if len(a.typeErrs) == 0 && !a.bag.HasErrors() {
 		for _, f := range a.gsxFiles {
-			generateFile(f, a.pkg, a.resolved, a.table, a.gsxFset, a.classifier, a.bag, nil, nil, nil, true, true, a.merger, a.componentPlan, a.positionalPlan)
+			generateFile(f, a.pkg, a.resolved, a.table, a.gsxFset, a.classifier, a.bag, nil, nil, nil, true, true, a.merger, a.componentPlan, a.positionalPlan, true)
 		}
 	}
 	res.Diags = a.bag.Sorted()
@@ -1504,7 +1504,7 @@ func (m *Module) Generate(dir string) (map[string][]byte, []diag.Diagnostic, err
 	// matching gate/comment in Package above.
 	if len(a.typeErrs) == 0 && !bag.HasErrors() {
 		for path, f := range a.gsxFiles {
-			gen, ok := generateFile(f, a.pkg, a.resolved, a.table, a.gsxFset, a.classifier, bag, m.opts.CSSMin, m.opts.JSMin, m.opts.JSONMin, m.opts.CSSMinify, m.opts.JSMinify, a.merger, a.componentPlan, a.positionalPlan)
+			gen, ok := generateFile(f, a.pkg, a.resolved, a.table, a.gsxFset, a.classifier, bag, m.opts.CSSMin, m.opts.JSMin, m.opts.JSONMin, m.opts.CSSMinify, m.opts.JSMinify, a.merger, a.componentPlan, a.positionalPlan, false)
 			if !ok {
 				continue
 			}

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -1289,6 +1289,27 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 		}
 		return nil, err
 	}
+	// Retention policy (P3, perf-hunt #2): this result is about to be cached in
+	// m.pkgResults and held for the life of the LSP session. checkSkeletonPackage
+	// populates Info.Scopes with one *types.Scope per func/block/if/for/switch,
+	// but the only retained-package consumer (importQualifierCandidates, via
+	// componentDeclPackage's ephemeral-then-retained fallback) reads only the
+	// *ast.File-keyed entries — prune to that subset before caching.
+	//
+	// MEASURED: this frees only the Info.Scopes index entries themselves (~1 MB
+	// on one-learning ui/), not the *types.Scope objects they point to — those
+	// remain fully reachable regardless, via res.Types.Scope()'s parent/children
+	// tree (go/types.NewScope unconditionally links every scope into that tree,
+	// independent of whether a Checker's Info records it — see scope.go). Types
+	// is retained for unrelated reasons (hover's qualifier, import resolution),
+	// so the ~96 MB the perf-hunt report attributed to "Info.Scopes" was actually
+	// pinned by Types all along; this policy narrows the supported/observable
+	// surface (and the small index overhead) without claiming a heap win it
+	// cannot deliver. See perf-hunt-2-report.md "P3 pass" for the measurement.
+	//
+	// AnalyzeEphemeral does NOT call this: its result is never cached, and the
+	// Go-completion scope walk (innermostScopeAt et al.) needs the full index.
+	retainFileScopesOnly(a.info)
 	res := &PackageResult{
 		Files:       map[string][]byte{},
 		GSXFset:     a.gsxFset,

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -134,6 +134,11 @@ type Options struct {
 // NOT acquire analysisMu — those functions run within a held analysisMu and
 // re-acquiring would deadlock. True fine-grained concurrent analysis (multiple
 // roots in parallel or partial invalidation) is deferred to Phase 2.
+// TryAnalyzeEphemeral is a non-blocking variant of the AnalyzeEphemeral entry
+// point: it acquires analysisMu via TryLock and returns acquired=false rather
+// than waiting when another entry point holds it. It composes with this
+// contract — the lock still serializes every entry point and stays
+// non-reentrant; TryLock only changes wait-vs-decline, never the invariant.
 //
 // Cache invalidation: SetOverride and ClearOverride compare against the frozen
 // saved-source state beneath the buffer and return the exact sorted affected
@@ -1418,6 +1423,39 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 func (m *Module) AnalyzeEphemeral(dir, absPath string, src []byte) (*PackageResult, error) {
 	m.analysisMu.Lock()
 	defer m.analysisMu.Unlock()
+	return m.analyzeEphemeralLocked(dir, absPath, src)
+}
+
+// TryAnalyzeEphemeral is the non-blocking sibling of AnalyzeEphemeral. It
+// attempts analysisMu.TryLock; if the lock is already held by an in-flight
+// top-level entry point (a background Package/Generate, or another ephemeral
+// run) it returns (nil, false, nil) immediately instead of blocking. On
+// acquisition (acquired == true) it runs the identical body as
+// AnalyzeEphemeral and returns the same (result, err) pair — when the Module
+// is uncontended TryLock succeeds at once, so the caller sees no difference.
+//
+// This is the insurance the LSP completion/nav handlers use unconditionally:
+// they run inline on the single dispatch goroutine, so blocking on analysisMu
+// behind a ~1 s background Package would stall the whole server. TryLock lets
+// them fall back to a retained-snapshot answer (or reply empty/null) instead.
+// TryLock composes cleanly with the concurrency contract above: analysisMu
+// still serializes every top-level entry point and is still non-reentrant —
+// TryAnalyzeEphemeral simply declines to enter rather than waiting, and the
+// not-acquired path touches no analysisMu-guarded state at all.
+func (m *Module) TryAnalyzeEphemeral(dir, absPath string, src []byte) (*PackageResult, bool, error) {
+	if !m.analysisMu.TryLock() {
+		return nil, false, nil
+	}
+	defer m.analysisMu.Unlock()
+	res, err := m.analyzeEphemeralLocked(dir, absPath, src)
+	return res, true, err
+}
+
+// analyzeEphemeralLocked is the shared body of AnalyzeEphemeral and
+// TryAnalyzeEphemeral. It assumes analysisMu is already held by the caller
+// (non-reentrant, per the concurrency contract) and does not acquire or
+// release it.
+func (m *Module) analyzeEphemeralLocked(dir, absPath string, src []byte) (*PackageResult, error) {
 	m.maybeRebuildFset()
 	m.applyDirty()
 	if err := m.validateConfiguredMergers(); err != nil {

--- a/internal/codegen/module_ephemeral_test.go
+++ b/internal/codegen/module_ephemeral_test.go
@@ -211,3 +211,48 @@ func TestAnalyzeEphemeralDoesNotDirty(t *testing.T) {
 		t.Fatalf("ephemeral analysis dirtied %v; must leave dirty tracking untouched", got)
 	}
 }
+
+// TestPackageRetainsFileScopesOnly pins the P3 retention policy (perf-hunt
+// #2): a cached Package() result's Info.Scopes must contain ONLY *ast.File
+// keys (retainFileScopesOnly, called before m.pkgResults[dir] is populated) —
+// exactly the subset internal/lsp/completion_gsx.go's importQualifierCandidates
+// needs via fileScopeSet, and the only retained-package reader of Scopes. An
+// AnalyzeEphemeral result, never cached and consumed by the Go-completion
+// scope walk (innermostScopeAt/innermostScopeAtAuthored), must keep every
+// scope go/types recorded (func/block scopes included).
+func TestPackageRetainsFileScopesOnly(t *testing.T) {
+	m, dir, pagePath := newEphemeralTestModule(t)
+	src := []byte("package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name }</div>\n}\n")
+	m.SetOverride(pagePath, src)
+
+	res, err := m.Package(dir)
+	if err != nil {
+		t.Fatalf("Package: %v", err)
+	}
+	if res.Info == nil || len(res.Info.Scopes) == 0 {
+		t.Fatalf("Package result Info.Scopes empty; want file scopes retained (Info=%v)", res.Info)
+	}
+	for node := range res.Info.Scopes {
+		if _, ok := node.(*goast.File); !ok {
+			t.Fatalf("Package result Info.Scopes has a non-file entry %T; want only *ast.File keys after retainFileScopesOnly", node)
+		}
+	}
+
+	eph, err := m.AnalyzeEphemeral(dir, pagePath, src)
+	if err != nil {
+		t.Fatalf("AnalyzeEphemeral: %v", err)
+	}
+	if eph.Info == nil {
+		t.Fatal("AnalyzeEphemeral result Info is nil")
+	}
+	var sawNonFileScope bool
+	for node := range eph.Info.Scopes {
+		if _, ok := node.(*goast.File); !ok {
+			sawNonFileScope = true
+			break
+		}
+	}
+	if !sawNonFileScope {
+		t.Fatal("AnalyzeEphemeral result Info.Scopes has no func/block scopes; the Go-completion scope walk needs the full chain")
+	}
+}

--- a/internal/codegen/module_ephemeral_test.go
+++ b/internal/codegen/module_ephemeral_test.go
@@ -4,6 +4,7 @@ import (
 	goast "go/ast"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // newEphemeralTestModule creates a temporary module with a single "page"
@@ -120,6 +121,84 @@ func TestAnalyzeEphemeralBasics(t *testing.T) {
 	}
 	if after != base {
 		t.Fatal("AnalyzeEphemeral evicted the cached PackageResult; must not touch pkgResults")
+	}
+}
+
+// TestTryAnalyzeEphemeralUncontended proves the fast path: on a free Module,
+// TryAnalyzeEphemeral acquires (acquired=true) and returns a result with the
+// same facts AnalyzeEphemeral produces over the identical buffer. This is the
+// justification for the LSP handlers switching to the non-blocking variant
+// unconditionally — when uncontended it is indistinguishable from the blocking
+// call.
+func TestTryAnalyzeEphemeralUncontended(t *testing.T) {
+	m, dir, pagePath := newEphemeralTestModule(t)
+	live := []byte("package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name }</div>\n}\n")
+	m.SetOverride(pagePath, live)
+	if _, err := m.Package(dir); err != nil {
+		t.Fatalf("baseline Package: %v", err)
+	}
+	patched := []byte("package page\n\ncomponent Home(user User) {\n\t<div>{ user._ }</div>\n}\n")
+
+	blocking, err := m.AnalyzeEphemeral(dir, pagePath, patched)
+	if err != nil {
+		t.Fatalf("AnalyzeEphemeral: %v", err)
+	}
+	tryRes, acquired, err := m.TryAnalyzeEphemeral(dir, pagePath, patched)
+	if err != nil {
+		t.Fatalf("TryAnalyzeEphemeral: %v", err)
+	}
+	if !acquired {
+		t.Fatal("uncontended TryAnalyzeEphemeral did not acquire the lock")
+	}
+	if tryRes == nil || tryRes.Info == nil || tryRes.Types == nil {
+		t.Fatalf("TryAnalyzeEphemeral result missing Info/Types: %+v", tryRes)
+	}
+	if len(tryRes.ExprMap) == 0 {
+		t.Fatal("TryAnalyzeEphemeral result ExprMap empty; want the user._ interp bridged")
+	}
+	// Same facts as the blocking variant over the identical buffer.
+	if len(tryRes.Filters) != len(blocking.Filters) {
+		t.Fatalf("Filters len = %d, want %d (identical to AnalyzeEphemeral)", len(tryRes.Filters), len(blocking.Filters))
+	}
+	if len(tryRes.ComponentDecls) != len(blocking.ComponentDecls) {
+		t.Fatalf("ComponentDecls len = %d, want %d (identical to AnalyzeEphemeral)", len(tryRes.ComponentDecls), len(blocking.ComponentDecls))
+	}
+	if len(tryRes.ExprMap) != len(blocking.ExprMap) {
+		t.Fatalf("ExprMap len = %d, want %d (identical to AnalyzeEphemeral)", len(tryRes.ExprMap), len(blocking.ExprMap))
+	}
+}
+
+// TestTryAnalyzeEphemeralContended proves the insurance: while analysisMu is
+// held (modeling an in-flight background Package/Generate), TryAnalyzeEphemeral
+// declines rather than blocks — acquired=false, nil result, no error, and it
+// returns promptly. The test holds the real analysisMu directly (same-package
+// access, no export needed and no sleep-based synchronization).
+func TestTryAnalyzeEphemeralContended(t *testing.T) {
+	m, dir, pagePath := newEphemeralTestModule(t)
+	src := []byte("package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name }</div>\n}\n")
+	m.SetOverride(pagePath, src)
+	if _, err := m.Package(dir); err != nil {
+		t.Fatalf("baseline Package: %v", err)
+	}
+
+	// Hold the same lock every top-level entry point takes.
+	m.analysisMu.Lock()
+	start := time.Now()
+	res, acquired, err := m.TryAnalyzeEphemeral(dir, pagePath, src)
+	elapsed := time.Since(start)
+	m.analysisMu.Unlock()
+
+	if acquired {
+		t.Fatal("TryAnalyzeEphemeral acquired the lock while it was held; want acquired=false")
+	}
+	if res != nil {
+		t.Fatalf("not-acquired result must be nil, got %+v", res)
+	}
+	if err != nil {
+		t.Fatalf("not-acquired must not error, got %v", err)
+	}
+	if elapsed > 10*time.Millisecond {
+		t.Fatalf("TryAnalyzeEphemeral blocked %v under contention; must return promptly", elapsed)
 	}
 }
 

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	goast "go/ast"
@@ -1761,6 +1762,64 @@ func harvestProbeSpans(f *goast.File) []posSpan {
 	return spans
 }
 
+// parseCacheEntry is a pristine, per-file gsx parse kept so unchanged files skip
+// re-parsing on every analysis. file is the parsed + wsnorm-normalized tree; it
+// is NEVER handed out — parsedGSXFile serves ast.CloneFile(file) so the codegen
+// mutation passes (which populate Interp/GoBlock.Embedded, minify js/css into
+// node values, rebase RawJS, and stamp Element.IsComponent) never contaminate
+// the cached tree. hash pins the source bytes, classifier pins the per-dir
+// attrclass.Classifier identity the parse used. The cached token.Pos values
+// reference the token.File m.fset minted at parse time; re-serving them keeps
+// fset growth at zero for unchanged files (the entry stays alive until
+// rebuildFset, which flushes the whole cache in the same critical section).
+type parseCacheEntry struct {
+	hash       [sha256.Size]byte
+	classifier *attrclass.Classifier
+	file       *gsxast.File
+}
+
+// parsedGSXFile returns a fresh, safe-to-mutate gsx AST for path. It serves a
+// clone of a cached pristine tree when the source bytes and classifier are
+// unchanged, and otherwise parses (into fset), normalizes, and caches a new
+// pristine tree before returning its clone. A parse error is returned as a
+// sourceDiagnosticsError and is never cached.
+func (m *Module) parsedGSXFile(path string, src []byte, classifier *attrclass.Classifier, fset *token.FileSet) (*gsxast.File, error) {
+	hash := sha256.Sum256(src)
+	m.mu.Lock()
+	entry, ok := m.parseCache[path]
+	m.mu.Unlock()
+	if ok && entry.hash == hash && entry.classifier == classifier {
+		return gsxast.CloneFile(entry.file), nil
+	}
+	f, perrs := gsxparser.ParseFileWithClassifier(fset, path, src, 0, classifier)
+	if len(perrs) > 0 {
+		diags := make([]diag.Diagnostic, 0, len(perrs))
+		for _, perr := range perrs {
+			pos := fset.Position(perr.Pos)
+			end := pos
+			if perr.End.IsValid() {
+				end = fset.Position(perr.End)
+			}
+			diags = append(diags, diag.Diagnostic{
+				Start:    pos,
+				End:      end,
+				Severity: diag.Error,
+				Code:     "parse-error",
+				Message:  perr.Msg,
+				Source:   "parser",
+			})
+		}
+		return nil, sourceDiagnosticsError{diags: diags}
+	}
+	// Normalize the pristine tree ONCE (wsnorm is idempotent and deterministic);
+	// clones inherit the normalized structure.
+	wsnorm.Normalize(f)
+	m.mu.Lock()
+	m.parseCache[path] = parseCacheEntry{hash: hash, classifier: classifier, file: f}
+	m.mu.Unlock()
+	return gsxast.CloneFile(f), nil
+}
+
 // parsePackageWithFset parses every .gsx in dir into the provided fset and
 // returns the private package owner for the one preprocessing transition. The
 // shared FileSet remains required for valid skeleton //line directives.
@@ -1803,27 +1862,10 @@ func (m *Module) parsePackageWithFset(dir string, fset *token.FileSet) (*parsedG
 		if !ok {
 			continue
 		}
-		f, perrs := gsxparser.ParseFileWithClassifier(fset, p, src, 0, classifier)
-		if len(perrs) > 0 {
-			diags := make([]diag.Diagnostic, 0, len(perrs))
-			for _, perr := range perrs {
-				pos := fset.Position(perr.Pos)
-				end := pos
-				if perr.End.IsValid() {
-					end = fset.Position(perr.End)
-				}
-				diags = append(diags, diag.Diagnostic{
-					Start:    pos,
-					End:      end,
-					Severity: diag.Error,
-					Code:     "parse-error",
-					Message:  perr.Msg,
-					Source:   "parser",
-				})
-			}
-			return nil, sourceDiagnosticsError{diags: diags}
+		f, err := m.parsedGSXFile(p, src, classifier, fset)
+		if err != nil {
+			return nil, err
 		}
-		wsnorm.Normalize(f)
 		if pkgName != "" && f.Package != pkgName {
 			return nil, fmt.Errorf(
 				"codegen: GSX package %s contains different package clauses: %s declares %q; %s declares %q",

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -72,6 +72,40 @@ func checkSkeletonPackage(dir, pkgName string, files []*goast.File, fset *token.
 	return pkg, info, errs
 }
 
+// retainFileScopesOnly prunes info.Scopes down to its *ast.File-keyed entries,
+// discarding every func/block/if/for/switch scope go/types recorded during
+// the check. Call this ONLY on a PackageResult.Info that is about to be
+// cached in Module.pkgResults (Package's retained result) — never on an
+// AnalyzeEphemeral result, which the LSP's Go-completion scope walk
+// (internal/lsp/completion_go.go innermostScopeAt/innermostScopeAtAuthored)
+// needs in full.
+//
+// The only retained-package consumer of Info.Scopes is
+// internal/lsp/completion_gsx.go's importQualifierCandidates, reached through
+// componentDeclPackage's ephemeral-then-retained fallback (a shell ephemeral
+// analysis + a `<qualifier.` cursor + an aliased import — narrow but real).
+// It reads exactly the file scopes via fileScopeSet (filters Info.Scopes for
+// *ast.File keys), so pruning to that subset changes nothing observable while
+// dropping the vast majority of the map's ENTRIES: a package has one scope
+// per func/block/if/for/switch (thousands, in a large package) but only one
+// scope per FILE (a handful).
+//
+// This does NOT free the pruned *types.Scope objects themselves — they stay
+// alive via the retained *types.Package's own scope tree regardless (see the
+// MEASURED note at this function's one call site, module.go's Package). Only
+// the map's own entries (~1 MB on one-learning ui/) are reclaimed. See
+// .superpowers/sdd/perf-hunt-2-report.md "P3 pass" for the measurement.
+func retainFileScopesOnly(info *types.Info) {
+	if info == nil {
+		return
+	}
+	for node := range info.Scopes {
+		if _, ok := node.(*goast.File); !ok {
+			delete(info.Scopes, node)
+		}
+	}
+}
+
 // moduleImporter owns one coherent shipping declaration universe for every
 // authoritative module-local package. GSX directories are rebuilt from shipping
 // skeletons; Go-only directories are rebuilt from the retained compiled syntax

--- a/internal/codegen/parse_cache_test.go
+++ b/internal/codegen/parse_cache_test.go
@@ -1,0 +1,81 @@
+package codegen
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+// TestParseCacheServesIndependentASTs pins the per-file parse cache's core
+// invariant: unchanged files are served as independent clones of a pristine
+// cached tree, never the shared pristine itself. Two full analyses of the same
+// source must (a) produce byte-identical generated output despite the emit
+// passes mutating the AST in place (js/css minify, IsComponent stamping,
+// Embedded population) and (b) hand out distinct *ast.File pointers. A cache
+// that re-served the same mutated tree would fail one or both.
+func TestParseCacheServesIndependentASTs(t *testing.T) {
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	writeFile(t, root, "page/other.gsx", "package page\n\ncomponent Other() {\n\t<div>ok</div>\n}\n")
+	// page.gsx exercises every in-place mutating pass at once: <style> (CSS
+	// minify), <script> (JS minify), and a component tag (IsComponent stamping +
+	// positional component call).
+	src := "package page\n\ncomponent Home() {\n" +
+		"\t<style>.a {\n\t\tcolor: red;\n\t}</style>\n" +
+		"\t<script>const answer = 1 + 2;</script>\n" +
+		"\t<div>\n\t\t<Other/>\n\t</div>\n" +
+		"}\n"
+	writeFile(t, root, "page/page.gsx", src)
+
+	m, err := Open(Options{ModuleRoot: root, ModulePath: "example.com/app", JSMinify: true, CSSMinify: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	dir := filepath.Join(root, "page")
+	pagePath := filepath.Join(dir, "page.gsx")
+
+	// Two full generations over identical source. The second serves cloned
+	// pristine trees from the parse cache; the emit passes mutate the clone.
+	out1, diags1, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate 1: %v", err)
+	}
+	out2, diags2, err := m.Generate(dir)
+	if err != nil {
+		t.Fatalf("Generate 2: %v", err)
+	}
+	if len(out1[pagePath]) == 0 {
+		t.Fatalf("empty generated output for page.gsx; test never reached emit (diags=%v)", diags1)
+	}
+	if !bytes.Equal(out1[pagePath], out2[pagePath]) {
+		t.Fatalf("generated output diverged across two analyses (parse-cache contamination):\n--- run 1 ---\n%s\n--- run 2 ---\n%s", out1[pagePath], out2[pagePath])
+	}
+	if len(diags1) != len(diags2) {
+		t.Fatalf("diagnostics count diverged across analyses: %d vs %d", len(diags1), len(diags2))
+	}
+
+	// Independent ASTs: two retained analyses (forced apart by Invalidate, same
+	// bytes → parse-cache HIT) must carry distinct *ast.File pointers. A shared
+	// pristine tree would make these equal.
+	res1, err := m.Package(dir)
+	if err != nil {
+		t.Fatalf("Package 1: %v", err)
+	}
+	m.Invalidate(dir)
+	res2, err := m.Package(dir)
+	if err != nil {
+		t.Fatalf("Package 2: %v", err)
+	}
+	f1 := res1.GSXFiles[pagePath]
+	f2 := res2.GSXFiles[pagePath]
+	if f1 == nil || f2 == nil {
+		t.Fatalf("GSXFiles missing page.gsx: run1=%v run2=%v", f1, f2)
+	}
+	if f1 == f2 {
+		t.Fatal("two independent analyses shared the same *ast.File pointer; parse-cache clone-on-use is not isolating trees")
+	}
+}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -79,8 +79,13 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 		patched = append(patched, src[off:]...)
 		src = patched
 	}
-	eph, err := s.analyzer.AnalyzeEphemeral(filepath.Dir(path), path, src)
-	if err != nil || eph == nil || eph.Info == nil {
+	// Non-blocking: this runs inline on the dispatch goroutine, so it must never
+	// stall behind an in-flight background analysis. On not-acquired (contention)
+	// a Go identifier cursor has no retained fallback worth serving — a stale
+	// scope-chain would list objects the current buffer may no longer have — so
+	// fail soft to an empty list, exactly as a shell/error result already does.
+	eph, acquired, err := s.analyzer.AnalyzeEphemeralNonBlocking(filepath.Dir(path), path, src)
+	if !acquired || err != nil || eph == nil || eph.Info == nil {
 		return emptyCompletion()
 	}
 	// The classifier's fragment start in buffer-byte coordinates; the cursor's

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -64,8 +64,12 @@ func (s *Server) pipeStageCompletion(cc completionContext, path, text string, of
 // is safe. Both empty (or absent) yields nil, and pipeStageCompletion turns
 // that into an empty list — fail soft, never an error.
 func (s *Server) pipeFilters(dir, path string, src []byte) []FilterCandidate {
-	eph, err := s.analyzer.AnalyzeEphemeral(dir, path, src)
-	if err == nil && eph != nil && (eph.Info != nil || len(eph.Filters) > 0) {
+	// Non-blocking (see goContextCompletion): under contention acquired=false
+	// (eph nil) falls through to the retained snapshot below — filter NAMES are
+	// position-independent, so a stale list is a safe, instant answer rather than
+	// a whole-server stall.
+	eph, acquired, err := s.analyzer.AnalyzeEphemeralNonBlocking(dir, path, src)
+	if acquired && err == nil && eph != nil && (eph.Info != nil || len(eph.Filters) > 0) {
 		return eph.Filters
 	}
 	if pkg := s.pkgs[dir]; pkg != nil {
@@ -118,8 +122,12 @@ func (s *Server) tagCompletion(cc completionContext, path, text string, off int,
 // safe fallback. Both absent/empty yields nil, and tagCompletion turns that
 // into an empty list — fail soft, never an error.
 func (s *Server) componentDeclPackage(dir, path string, src []byte) *Package {
-	eph, err := s.analyzer.AnalyzeEphemeral(dir, path, src)
-	if err == nil && eph != nil && (eph.Info != nil || len(eph.ComponentDecls) > 0) {
+	// Non-blocking (see goContextCompletion): under contention acquired=false
+	// (eph nil) falls through to the retained snapshot below — component
+	// identities are position-independent, so a stale package answers instantly
+	// rather than stalling the dispatch loop.
+	eph, acquired, err := s.analyzer.AnalyzeEphemeralNonBlocking(dir, path, src)
+	if acquired && err == nil && eph != nil && (eph.Info != nil || len(eph.ComponentDecls) > 0) {
 		return eph
 	}
 	if pkg := s.pkgs[dir]; pkg != nil {
@@ -534,8 +542,12 @@ func (s *Server) attrNameCompletion(cc completionContext, path, text string, off
 	// on codegen's own parse, never on the classification parse cc.element belongs
 	// to — and (b) reading the dir's url-presets. A shell result (analyzer error,
 	// or no matching element) simply routes to the HTML path, which needs neither.
-	eph, err := s.analyzer.AnalyzeEphemeral(dir, path, r.src)
-	if err != nil {
+	// Non-blocking (see goContextCompletion): a not-acquired (contention) or error
+	// result leaves eph nil, routing to the HTML attribute path below, which needs
+	// no analysis — and dirURLPresets falls back to the retained snapshot. So a
+	// contended request still answers HTML attrs instantly instead of stalling.
+	eph, acquired, err := s.analyzer.AnalyzeEphemeralNonBlocking(dir, path, r.src)
+	if !acquired || err != nil {
 		eph = nil
 	}
 	var ephEl *gsxast.Element

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -434,6 +434,14 @@ func importQualifierItems(pkg *Package, text string, start, end int, enc encodin
 // blind to aliases — `import myui "example.com/ui"` would resolve as "ui",
 // never "myui".
 //
+// A RETAINED package (s.pkgs[dir], codegen's Package result) carries only the
+// *ast.File-keyed entries of Info.Scopes — codegen's retainFileScopesOnly
+// prunes every func/block/if/for/switch scope before caching it, since this
+// is the only retained-package reader of Info.Scopes. That is exactly the
+// subset fileScopeSet needs, so this walk is unaffected; an EPHEMERAL package
+// (AnalyzeEphemeral, the common case reaching this function) keeps every
+// scope, used in full by the Go-completion scope walk elsewhere.
+//
 // When pkg.Info is nil (a shell / type-error package with no scope info to
 // walk) this falls back to pkg.Types.Imports(), which cannot see aliases —
 // a documented best-effort degradation; the alternative is offering nothing

--- a/internal/lsp/completion_gsx_test.go
+++ b/internal/lsp/completion_gsx_test.go
@@ -79,13 +79,25 @@ func TestFilterItemsEmpty(t *testing.T) {
 // tests can drive both the ephemeral path and the s.pkgs[dir] fallback path.
 type pipeFilterAnalyzer struct {
 	nilAnalyzer
-	ephPkg   *Package
-	ephErr   error
-	analyzed *Package // returned by Analyze, populates s.pkgs[dir] via didOpen
+	ephPkg         *Package
+	ephErr         error
+	ephNotAcquired bool     // when true, the non-blocking variant reports acquired=false (contention)
+	analyzed       *Package // returned by Analyze, populates s.pkgs[dir] via didOpen
 }
 
 func (a pipeFilterAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return a.ephPkg, a.ephErr
+}
+
+// AnalyzeEphemeralNonBlocking scripts contention: when ephNotAcquired it
+// reports acquired=false (nil Package) so the handler must serve the retained
+// snapshot; otherwise it acquires and delegates to AnalyzeEphemeral.
+func (a pipeFilterAnalyzer) AnalyzeEphemeralNonBlocking(dir, path string, content []byte) (*Package, bool, error) {
+	if a.ephNotAcquired {
+		return nil, false, nil
+	}
+	pkg, err := a.AnalyzeEphemeral(dir, path, content)
+	return pkg, true, err
 }
 
 func (a pipeFilterAnalyzer) Analyze(string, map[string][]byte) (*Package, error) {
@@ -162,6 +174,50 @@ func TestPipeStageCompletionBothEmpty(t *testing.T) {
 	items := decodeCompletionItems(t, out, 2)
 	if len(items) != 0 {
 		t.Fatalf("pipe-stage items = %v, want empty", items)
+	}
+}
+
+// TestPipeStageCompletionServesRetainedWhenContended pins the P4 insurance
+// policy: when the non-blocking ephemeral analysis reports acquired=false (a
+// background analysis holds the lock), pipe-stage completion serves the
+// retained s.pkgs[dir] snapshot's Filters instead of stalling — and never
+// consults the ephemeral package (ephPkg here carries a bogus filter that must
+// NOT appear, proving the contended path skipped it).
+func TestPipeStageCompletionServesRetainedWhenContended(t *testing.T) {
+	uri := "file:///m/a.gsx"
+	text := "package p\n\ncomponent C(x string) {\n\t<div>{ x |> up }</div>\n}\n"
+	off := strings.Index(text, "|> up") + len("|> up")
+	pos := positionForByteOffset(text, off, encUTF16)
+
+	a := pipeFilterAnalyzer{
+		ephNotAcquired: true,
+		ephPkg:         &Package{Filters: []FilterCandidate{{Name: "shouldNotAppear", Pkg: "x", Func: "X"}}},
+		analyzed:       &Package{Filters: []FilterCandidate{{Name: "lower", Pkg: "github.com/gsxhq/gsx/std", Func: "Lower"}}},
+	}
+
+	out := drive(t, a, initFrame()+didOpenFrame(uri, text)+
+		completionFrame(2, uri, pos)+exitFrame())
+	items := decodeCompletionItems(t, out, 2)
+	if len(items) != 1 || items[0].Label != "lower" {
+		t.Fatalf("contended pipe-stage items = %v, want exactly [lower] from the retained snapshot", items)
+	}
+}
+
+// TestGoContextCompletionEmptyWhenContended pins the P4 policy for Go-identifier
+// cursors: under contention (acquired=false) there is no safe retained fallback
+// — a stale scope chain would list objects the live buffer may no longer have —
+// so the handler answers an empty (non-nil) list, never an error and never a
+// stall. Exercised directly since the empty answer is returned at the
+// not-acquired guard, before any type-info bridging a fake could not supply.
+func TestGoContextCompletionEmptyWhenContended(t *testing.T) {
+	s := &Server{analyzer: pipeFilterAnalyzer{ephNotAcquired: true}, enc: encUTF16}
+	text := "{ x }"
+	got := s.goContextCompletion(completionContext{kind: ctxGoExpr}, "/m/a.gsx", text, 3, repairResult{src: []byte(text)})
+	if got.Items == nil {
+		t.Fatal("Go-context contended completion returned nil Items; want an empty non-nil list")
+	}
+	if len(got.Items) != 0 {
+		t.Fatalf("Go-context contended completion returned %d items; want 0 (fail soft, not stale)", len(got.Items))
 	}
 }
 
@@ -487,6 +543,11 @@ type tagCompletionAnalyzer struct {
 
 func (a tagCompletionAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return a.ephPkg, a.ephErr
+}
+
+func (a tagCompletionAnalyzer) AnalyzeEphemeralNonBlocking(dir, path string, content []byte) (*Package, bool, error) {
+	pkg, err := a.AnalyzeEphemeral(dir, path, content)
+	return pkg, true, err
 }
 
 func (a tagCompletionAnalyzer) Analyze(string, map[string][]byte) (*Package, error) {

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -671,8 +671,12 @@ func (s *Server) definitionFallback(path, text string, off int, sources *request
 	if !ok {
 		return nil, false
 	}
-	eph, err := s.analyzer.AnalyzeEphemeral(filepath.Dir(path), path, r.src)
-	if err != nil || eph == nil || (eph.Info == nil && eph.Files == nil) {
+	// Non-blocking: this fallback runs inline on the dispatch goroutine after the
+	// retained-snapshot primary missed. Under contention (acquired=false) just
+	// skip the ephemeral pass and reply null (answered=false), the pre-mid-edit-nav
+	// behavior — never block the whole server behind a background analysis.
+	eph, acquired, err := s.analyzer.AnalyzeEphemeralNonBlocking(filepath.Dir(path), path, r.src)
+	if !acquired || err != nil || eph == nil || (eph.Info == nil && eph.Files == nil) {
 		return nil, false
 	}
 	sources.setRepair(path, insertOff, len(r.patch))

--- a/internal/lsp/documentsymbol_test.go
+++ b/internal/lsp/documentsymbol_test.go
@@ -41,6 +41,9 @@ func (symbolFileAnalyzer) Analyze(_ string, override map[string][]byte) (*Packag
 func (symbolFileAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return nil, errors.New("not implemented")
 }
+func (symbolFileAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
+}
 func (symbolFileAnalyzer) AnalyzeModule(string, map[string][]byte) ([]CrossRef, error) {
 	return nil, nil
 }

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -246,8 +246,11 @@ func (s *Server) hoverFallback(path, text string, off int, sources *requestSourc
 	if !ok {
 		return nil, false
 	}
-	eph, err := s.analyzer.AnalyzeEphemeral(filepath.Dir(path), path, r.src)
-	if err != nil || eph == nil || (eph.Info == nil && eph.Files == nil) {
+	// Non-blocking (see definitionFallback): under contention skip the ephemeral
+	// pass and reply null rather than stall the dispatch loop behind a background
+	// analysis.
+	eph, acquired, err := s.analyzer.AnalyzeEphemeralNonBlocking(filepath.Dir(path), path, r.src)
+	if !acquired || err != nil || eph == nil || (eph.Info == nil && eph.Files == nil) {
 		return nil, false
 	}
 	sources.setRepair(path, insertOff, len(r.patch))

--- a/internal/lsp/midedit_nav_test.go
+++ b/internal/lsp/midedit_nav_test.go
@@ -98,6 +98,14 @@ func (a ephemeralCountingAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Pa
 	return nil, nil
 }
 
+// AnalyzeEphemeralNonBlocking is the variant the nav handlers now call. It
+// always acquires (uncontended) and delegates to AnalyzeEphemeral, so the
+// ephCount assertions in the fallback-gate tests are unchanged.
+func (a ephemeralCountingAnalyzer) AnalyzeEphemeralNonBlocking(dir, path string, content []byte) (*Package, bool, error) {
+	pkg, err := a.AnalyzeEphemeral(dir, path, content)
+	return pkg, true, err
+}
+
 // tagAnsweringPackage hand-builds a Package whose retained facts answer
 // go-to-definition on a same-package component tag (`<Row/>`) via CrossIndex —
 // no ephemeral analysis required.
@@ -147,6 +155,66 @@ func TestDefinitionFallbackNotConsultedWhenPrimaryAnswers(t *testing.T) {
 	result := responseByID(t, out, 2)["result"]
 	if strings.TrimSpace(string(result)) == "null" {
 		t.Fatalf("primary go-to-definition returned null; want the Row declaration Location")
+	}
+}
+
+// contendedNavAnalyzer models the P4 contention case: the retained package
+// answers primary nav, but the non-blocking ephemeral reports acquired=false.
+// ephBlocking is what a *successful* ephemeral would return (must never be
+// consulted); nbCalls/blkCalls count the two entry points so a test can prove
+// the blocking body was skipped.
+type contendedNavAnalyzer struct {
+	nilAnalyzer
+	analyzed    *Package
+	ephBlocking *Package
+	nbCalls     *int
+	blkCalls    *int
+}
+
+func (a contendedNavAnalyzer) Analyze(string, map[string][]byte) (*Package, error) {
+	return a.analyzed, nil
+}
+
+func (a contendedNavAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
+	*a.blkCalls++
+	return a.ephBlocking, nil
+}
+
+func (a contendedNavAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	*a.nbCalls++
+	return nil, false, nil
+}
+
+// TestNavFallbackSkippedWhenContended pins the P4 nav policy: on a primary miss
+// the fallback IS consulted (nbCalls >= 1), but under contention it skips the
+// ephemeral pass entirely (blkCalls == 0 — the resolving ephBlocking package is
+// never used) and replies null, exactly the pre-mid-edit-nav behavior. This is
+// what turns the worst-case ~1.5 s dispatch-loop stall into an instant null.
+func TestNavFallbackSkippedWhenContended(t *testing.T) {
+	uri := "file:///m/a.gsx"
+	path := "/m/a.gsx"
+	nb, blk := 0, 0
+	a := contendedNavAnalyzer{
+		analyzed:    tagAnsweringPackage(t, path, midEditNavPage),
+		ephBlocking: tagAnsweringPackage(t, path, midEditNavPage), // would resolve if consulted
+		nbCalls:     &nb,
+		blkCalls:    &blk,
+	}
+
+	// Cursor on the "hi" plain text (line 7) — primary misses, fallback runs.
+	textOff := strings.Index(midEditNavPage, ">hi<") + 1
+	pos := positionForByteOffset(midEditNavPage, textOff, encUTF16)
+	out := drive(t, a, initFrame()+didOpenFrame(uri, midEditNavPage)+
+		definitionFrame(2, uri, pos)+exitFrame())
+
+	if nb == 0 {
+		t.Fatal("non-blocking ephemeral never called; the fallback was not consulted")
+	}
+	if blk != 0 {
+		t.Fatalf("blocking AnalyzeEphemeral called %d times under contention; the ephemeral body must be skipped", blk)
+	}
+	if r := strings.TrimSpace(string(responseByID(t, out, 2)["result"])); r != "null" {
+		t.Fatalf("contended nav fallback result = %s, want null", r)
 	}
 }
 

--- a/internal/lsp/references_cache_test.go
+++ b/internal/lsp/references_cache_test.go
@@ -41,6 +41,9 @@ func (a *moduleRefsAnalyzer) Analyze(string, map[string][]byte) (*Package, error
 func (a *moduleRefsAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return nil, errFake
 }
+func (a *moduleRefsAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errFake
+}
 func (a *moduleRefsAnalyzer) AnalyzeModule(_ string, overrides map[string][]byte) ([]CrossRef, error) {
 	a.moduleCalls++
 	captured := make(map[string][]byte, len(overrides))

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -41,9 +41,20 @@ type Analyzer interface {
 	Analyze(dir string, override map[string][]byte) (*Package, error)
 	// AnalyzeEphemeral runs one synchronous warm analysis of dir with path's
 	// source replaced by content, WITHOUT touching override lifetime, caches, or
-	// dirty tracking. Used by completion on the (possibly repaired) live buffer.
-	// Fails soft: source-level breakage returns a diagnostics-only Package.
+	// dirty tracking. Fails soft: source-level breakage returns a
+	// diagnostics-only Package. Kept for e2e/tooling callers that want the
+	// blocking guarantee; the completion/nav handlers use the non-blocking
+	// variant below.
 	AnalyzeEphemeral(dir, path string, content []byte) (*Package, error)
+	// AnalyzeEphemeralNonBlocking is AnalyzeEphemeral that never blocks on the
+	// warm Module's analysis lock: acquired=false (with a nil Package) means an
+	// in-flight background analysis held the lock and this request declined to
+	// wait. The completion/nav handlers run inline on the single dispatch
+	// goroutine, so they call this unconditionally — when uncontended it acquires
+	// at once and is identical to AnalyzeEphemeral; when contended they serve a
+	// retained-snapshot fallback (or reply empty/null) rather than stall the whole
+	// server behind a ~1 s background Package. Fails soft like AnalyzeEphemeral.
+	AnalyzeEphemeralNonBlocking(dir, path string, content []byte) (*Package, bool, error)
 	// ClearOverride ends the authoritative lifetime of one editor buffer. The
 	// analyzer must restore the path to saved-disk or absent-source semantics;
 	// omitting a path from a later Analyze override map is not that transition,

--- a/internal/lsp/server_async_test.go
+++ b/internal/lsp/server_async_test.go
@@ -66,6 +66,10 @@ func (a *overrideLifetimeAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Pa
 	return nil, errors.New("not implemented")
 }
 
+func (a *overrideLifetimeAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
+}
+
 func (a *overrideLifetimeAnalyzer) AnalyzeModule(string, map[string][]byte) ([]CrossRef, error) {
 	return nil, nil
 }
@@ -98,6 +102,10 @@ func (a *blockingAnalyzer) ClearOverride(string) ([]string, error)       { retur
 func (a *blockingAnalyzer) SetOverride(string, []byte) ([]string, error) { return nil, nil }
 func (a *blockingAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (a *blockingAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
 }
 
 func (a *blockingAnalyzer) AnalyzeModule(string, map[string][]byte) ([]CrossRef, error) {

--- a/internal/lsp/server_debounce_test.go
+++ b/internal/lsp/server_debounce_test.go
@@ -30,6 +30,10 @@ func (a *countingAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, e
 	return nil, errors.New("not implemented")
 }
 
+func (a *countingAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
+}
+
 // SetOverride returns the edited directory as invalidated, per the Analyzer
 // contract: a content-bearing change invalidates that package view, so the
 // server schedules a fresh analysis instead of republishing the retained

--- a/internal/lsp/server_lifecycle_test.go
+++ b/internal/lsp/server_lifecycle_test.go
@@ -25,6 +25,9 @@ func (nilAnalyzer) Analyze(string, map[string][]byte) (*Package, error) { return
 func (nilAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return nil, errors.New("not implemented")
 }
+func (nilAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
+}
 func (nilAnalyzer) ClearOverride(string) ([]string, error) { return nil, nil }
 func (nilAnalyzer) AnalyzeModule(string, map[string][]byte) ([]CrossRef, error) {
 	return nil, nil

--- a/internal/lsp/server_sync_test.go
+++ b/internal/lsp/server_sync_test.go
@@ -47,6 +47,10 @@ func (a fakeAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error)
 	return nil, errors.New("not implemented")
 }
 
+func (a fakeAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
+}
+
 func (a fakeAnalyzer) FormatSettings(string) gsxfmt.FormatSettings {
 	return gsxfmt.FormatSettings{Width: 80, TabWidth: pretty.DefaultTabWidth}
 }

--- a/internal/lsp/source_text_test.go
+++ b/internal/lsp/source_text_test.go
@@ -422,6 +422,9 @@ func (a *authoritativeLocationAnalyzer) ClearOverride(string) ([]string, error) 
 func (a *authoritativeLocationAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return nil, errors.New("not implemented")
 }
+func (a *authoritativeLocationAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
+}
 func (a *authoritativeLocationAnalyzer) Analyze(string, map[string][]byte) (*Package, error) {
 	if a.pkg != nil {
 		return a.pkg, nil

--- a/internal/lsp/workspacesymbol_test.go
+++ b/internal/lsp/workspacesymbol_test.go
@@ -35,6 +35,9 @@ func (a *wsSymAnalyzer) SetOverride(string, []byte) ([]string, error) { return n
 func (a *wsSymAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
 	return nil, errors.New("not implemented")
 }
+func (a *wsSymAnalyzer) AnalyzeEphemeralNonBlocking(string, string, []byte) (*Package, bool, error) {
+	return nil, true, errors.New("not implemented")
+}
 
 func (a *wsSymAnalyzer) Analyze(string, map[string][]byte) (*Package, error) { return &Package{}, nil }
 func (a *wsSymAnalyzer) AnalyzeModule(string, map[string][]byte) ([]CrossRef, error) {


### PR DESCRIPTION
## Summary

Second measured performance round on the LSP, driven by a fresh post-#137 profile of the real one-learning project (105-file package). Headline: **CPU was 57% GC — latency is allocation-bound** — so this round attacks allocation and redundant work.

**Commits (each independently reviewed):**

1. **`940e2491` — skip output-only emit stages in the diagnostics pass.** `Package()`'s diag-harvest emit ran `coalesceStaticWrites` (#2 allocator, ~425MB/run) + `format.Source` on bytes it then discarded — 33% of the warm background analysis. A `diagnosticsOnly` mode skips them; every diagnostic class preserved except the internal-bug "format generated source" diag (deliberately accepted, documented inline, still surfaces via `gsx generate`). **Warm background: 1021 → 769ms.**
2. **`f46c2888` — Info.Scopes retention policy (honest negative).** Intended as a ~96MB win; the pprof attribution turned out to be an allocation-site artifact — the scope tree stays reachable via retained `Types` regardless. Kept as a contract-tightening (cached results retain file scopes only, pinned by test; ephemeral results keep the full chain). Real saving ~1MB. The true memory target — `Types` fidelity of cached results — is flagged for its own design pass.
3. **`8d83e6b3` — per-file pristine parse cache with clone-on-use.** Every analysis re-parsed all 105 files (`scanGoExpr` = 30% of all allocation). Pristine ASTs cached by content hash, `ast.CloneFile` (exhaustive reflection-free deep clone; review audited every sealed-family field — zero uncovered) served per analysis so the in-place mutation passes never touch the pristine. Doubly safe: pristine is cached pre-preprocessing, and mutation passes assign fresh values. **Clone is 16× cheaper than parse; zero fset growth from unchanged files; ephemeral 540 → ~475ms; the ~2.5s fset-rebuild cliff moves from every ~53 to every ~74 completions** (residual growth is skeleton-side — follow-up noted).
4. **`b8782a6b` — non-blocking ephemeral analysis.** Completion/nav's ephemeral pass now uses `TryLock`; on contention with a background analysis they answer instantly from retained facts (pipes/tags/HTML) or fail soft (Go contexts empty, nav null) instead of **stalling the entire dispatch loop up to ~1.5s**. Uncontended behavior byte-identical (shared locked body; pinned by tests).

**Cumulative since the user's report (baseline pre-#137):** background re-analysis 1.28s → ~650ms; completion analysis 720 → ~475ms; RSS 4.86GiB → ~1.3GiB; worst-case server stall ~2s → none.

**Follow-ups recorded:** skeleton-parse caching (residual fset growth); cached-result `Types` fidelity + the double-typecheck unification (both need a design pass — scheduled).

## Testing

- `make ci` green at head (corpus goldens = differential proof for the emit-skip and parse-cache commits)
- New tests: diagnosticsOnly parity, retained-scopes pin, clone independence (zero shared pointers + mutation-leak probe), parse-cache AST independence (double-Generate byte-identity), TryLock contended/uncontended, contended-completion fallback/empty/null policies
- All measurements on the real one-learning project, medians of 5-9 runs, before/after in each commit's evidence

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa