### PR TITLE
Completion follow-ups: snippets, typed pipes, method tags, expected-type ranking, //line chunks

### DIFF
--- a/ast/clone_exhaustive_test.go
+++ b/ast/clone_exhaustive_test.go
@@ -1,0 +1,253 @@
+package ast_test
+
+import (
+	goast "go/ast"
+	goparser "go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/gsxhq/gsx/ast"
+)
+
+// This file is CloneFile's exhaustiveness check (P1 review suggestion): every
+// concrete type ast.go stamps into one of the four sealed families
+// (Decl/Markup/Attr/GoPart — see ast.go's interface docs) must have a working
+// clone.go case, or CloneFile silently shares a mutable node across trees
+// instead of copying it (clone.go's own doc: an unhandled type panics rather
+// than sharing).
+//
+// The family MEMBERSHIP side is fully automatic and cannot silently drift: it
+// is discovered by parsing ast.go's own source for the marker methods
+// (markupNode/declNode/attrNode/goPartNode) that make a type a sealed-family
+// member in the first place — the exact mechanism ast.go itself uses. A type
+// added to ast.go with a new marker method is picked up here with no list to
+// update.
+//
+// The one place this test DOES require upkeep is astZeroValueTypes below: a
+// reflect.Type has no runtime "look up by name string" operation, so mapping
+// a discovered type name to a constructible reflect.Type needs one explicit
+// entry per type (this is the "maintained explicit list, tied to ast.go"
+// fallback the P1 review sanctioned). Forgetting an entry fails loudly, naming
+// the type — it can drift out of sync with "missing", never silently pass.
+
+// markerFamilies maps each sealed-family marker method (see ast.go's Markup/
+// Decl/Attr/GoPart interface definitions) to the family label used in this
+// file's failure messages and in astZeroValueTypes lookups.
+var markerFamilies = map[string]string{
+	"declNode":   "Decl",
+	"markupNode": "Markup",
+	"attrNode":   "Attr",
+	"goPartNode": "GoPart",
+}
+
+// familyMember records one concrete type ast.go declares as belonging to a
+// sealed family, discovered by scanning for its marker-method receiver.
+type familyMember struct {
+	typeName string
+	pointer  bool // marker method has a pointer receiver (false only for GoText)
+}
+
+// discoverFamilyMembers parses ast.go's source and returns, per family label,
+// every concrete type ast.go stamps into that family — the live,
+// self-updating half of this exhaustiveness check. It intentionally does NOT
+// use go/types: a type belongs to a sealed family, in this codebase, exactly
+// when it declares the corresponding zero-method marker (see ast.go's
+// comment above the interfaces), so a syntactic scan for that marker is both
+// sufficient and precise, and needs no `go build`/packages.Load.
+func discoverFamilyMembers(t *testing.T) map[string][]familyMember {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate ast.go relative to this test file")
+	}
+	astGoPath := filepath.Join(filepath.Dir(thisFile), "ast.go")
+	fset := token.NewFileSet()
+	f, err := goparser.ParseFile(fset, astGoPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", astGoPath, err)
+	}
+	out := map[string][]familyMember{}
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*goast.FuncDecl)
+		if !ok || fd.Recv == nil || len(fd.Recv.List) != 1 {
+			continue
+		}
+		family, isMarker := markerFamilies[fd.Name.Name]
+		if !isMarker {
+			continue
+		}
+		recvType := fd.Recv.List[0].Type
+		pointer := false
+		if star, ok := recvType.(*goast.StarExpr); ok {
+			pointer = true
+			recvType = star.X
+		}
+		ident, ok := recvType.(*goast.Ident)
+		if !ok {
+			t.Fatalf("marker method %s has unexpected receiver type %T; discovery scan needs updating", fd.Name.Name, recvType)
+		}
+		out[family] = append(out[family], familyMember{typeName: ident.Name, pointer: pointer})
+	}
+	return out
+}
+
+// astZeroValueTypes maps every concrete sealed-family type name ast.go can
+// declare to its reflect.Type, so TestCloneHandlesEverySealedType can
+// construct a zero value generically instead of one hand-written CloneFile
+// call per type. See this file's top-of-file doc for why this map, unlike
+// family membership above, must be maintained by hand.
+var astZeroValueTypes = map[string]reflect.Type{
+	"GoChunk":          reflect.TypeFor[ast.GoChunk](),
+	"GoWithElements":   reflect.TypeFor[ast.GoWithElements](),
+	"Component":        reflect.TypeFor[ast.Component](),
+	"Element":          reflect.TypeFor[ast.Element](),
+	"Fragment":         reflect.TypeFor[ast.Fragment](),
+	"Text":             reflect.TypeFor[ast.Text](),
+	"Doctype":          reflect.TypeFor[ast.Doctype](),
+	"HTMLComment":      reflect.TypeFor[ast.HTMLComment](),
+	"Comment":          reflect.TypeFor[ast.Comment](),
+	"Interp":           reflect.TypeFor[ast.Interp](),
+	"EmbeddedInterp":   reflect.TypeFor[ast.EmbeddedInterp](),
+	"GoBlock":          reflect.TypeFor[ast.GoBlock](),
+	"IfMarkup":         reflect.TypeFor[ast.IfMarkup](),
+	"ForMarkup":        reflect.TypeFor[ast.ForMarkup](),
+	"SwitchMarkup":     reflect.TypeFor[ast.SwitchMarkup](),
+	"StaticAttr":       reflect.TypeFor[ast.StaticAttr](),
+	"ExprAttr":         reflect.TypeFor[ast.ExprAttr](),
+	"BoolAttr":         reflect.TypeFor[ast.BoolAttr](),
+	"SpreadAttr":       reflect.TypeFor[ast.SpreadAttr](),
+	"MarkupAttr":       reflect.TypeFor[ast.MarkupAttr](),
+	"EmbeddedAttr":     reflect.TypeFor[ast.EmbeddedAttr](),
+	"CondAttr":         reflect.TypeFor[ast.CondAttr](),
+	"ClassAttr":        reflect.TypeFor[ast.ClassAttr](),
+	"OrderedAttrsAttr": reflect.TypeFor[ast.OrderedAttrsAttr](),
+	"CommentAttr":      reflect.TypeFor[ast.CommentAttr](),
+	"GoText":           reflect.TypeFor[ast.GoText](),
+}
+
+// TestCloneHandlesEverySealedType discovers every concrete type ast.go stamps
+// into the Decl/Markup/Attr/GoPart sealed families, constructs a zero value of
+// each, and drives it through CloneFile in the syntactic position its family
+// occupies. clone.go's switches panic on an unhandled concrete type; a family
+// member missing a clone.go case therefore fails this test with a panic
+// naming the type, instead of surfacing only via a corpus golden or (worse) a
+// silent shared-mutable-node bug in production.
+func TestCloneHandlesEverySealedType(t *testing.T) {
+	families := discoverFamilyMembers(t)
+	for _, label := range []string{"Decl", "Markup", "Attr", "GoPart"} {
+		members := families[label]
+		if len(members) == 0 {
+			t.Fatalf("discovered no %s-family members in ast.go; the marker-method scan is broken", label)
+		}
+		for _, m := range members {
+			t.Run(label+"/"+m.typeName, func(t *testing.T) {
+				zt, ok := astZeroValueTypes[m.typeName]
+				if !ok {
+					t.Fatalf("ast.go declares %s as a %s-family member (via its marker method) with no entry in astZeroValueTypes in this file; add one", m.typeName, label)
+				}
+				var node any
+				if m.pointer {
+					node = reflect.New(zt).Interface()
+				} else {
+					node = reflect.New(zt).Elem().Interface()
+				}
+				file := wrapForFamily(t, label, node)
+				clone := mustCloneOK(t, file)
+				assertClonedDistinct(t, label, file, clone, m.pointer)
+			})
+		}
+	}
+}
+
+// wrapForFamily builds the minimal *ast.File that exercises node in the
+// syntactic position its family occupies: a Decl at the top level, a Markup
+// inside a Component's body, an Attr inside an Element's attribute list
+// (itself inside a Component's body), and a GoPart inside a GoWithElements'
+// part list.
+func wrapForFamily(t *testing.T, label string, node any) *ast.File {
+	t.Helper()
+	switch label {
+	case "Decl":
+		d, ok := node.(ast.Decl)
+		if !ok {
+			t.Fatalf("%T does not implement ast.Decl despite declaring declNode()", node)
+		}
+		return &ast.File{Decls: []ast.Decl{d}}
+	case "Markup":
+		m, ok := node.(ast.Markup)
+		if !ok {
+			t.Fatalf("%T does not implement ast.Markup despite declaring markupNode()", node)
+		}
+		return &ast.File{Decls: []ast.Decl{&ast.Component{Body: []ast.Markup{m}}}}
+	case "Attr":
+		a, ok := node.(ast.Attr)
+		if !ok {
+			t.Fatalf("%T does not implement ast.Attr despite declaring attrNode()", node)
+		}
+		return &ast.File{Decls: []ast.Decl{&ast.Component{Body: []ast.Markup{&ast.Element{Attrs: []ast.Attr{a}}}}}}
+	case "GoPart":
+		p, ok := node.(ast.GoPart)
+		if !ok {
+			t.Fatalf("%T does not implement ast.GoPart despite declaring goPartNode()", node)
+		}
+		return &ast.File{Decls: []ast.Decl{&ast.GoWithElements{Parts: []ast.GoPart{p}}}}
+	default:
+		t.Fatalf("unknown family label %q", label)
+		return nil
+	}
+}
+
+// mustCloneOK runs ast.CloneFile(f), converting a panic (an unhandled
+// concrete type in one of clone.go's switches) into a t.Fatalf naming it,
+// instead of aborting the whole test binary.
+func mustCloneOK(t *testing.T, f *ast.File) *ast.File {
+	t.Helper()
+	var clone *ast.File
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("CloneFile panicked (a sealed-family type in ast.go has no clone.go case): %v", r)
+			}
+		}()
+		clone = ast.CloneFile(f)
+	}()
+	return clone
+}
+
+// assertClonedDistinct extracts the cloned node back out of clone at the same
+// family position and, for pointer-kind nodes, confirms it is a different
+// pointer than the original — catching a clone.go case that returns v as-is
+// instead of a fresh copy (a shared-mutable-node bug, distinct from the
+// missing-case panic mustCloneOK catches). Value-kind nodes (GoText) are
+// legitimately shared by value; see clone.go's doc on that case.
+func assertClonedDistinct(t *testing.T, label string, orig, clone *ast.File, pointer bool) {
+	t.Helper()
+	if !pointer {
+		return
+	}
+	var origNode, cloneNode any
+	switch label {
+	case "Decl":
+		origNode, cloneNode = orig.Decls[0], clone.Decls[0]
+	case "Markup":
+		origNode = orig.Decls[0].(*ast.Component).Body[0]
+		cloneNode = clone.Decls[0].(*ast.Component).Body[0]
+	case "Attr":
+		origNode = orig.Decls[0].(*ast.Component).Body[0].(*ast.Element).Attrs[0]
+		cloneNode = clone.Decls[0].(*ast.Component).Body[0].(*ast.Element).Attrs[0]
+	case "GoPart":
+		origNode = orig.Decls[0].(*ast.GoWithElements).Parts[0]
+		cloneNode = clone.Decls[0].(*ast.GoWithElements).Parts[0]
+	}
+	ov := reflect.ValueOf(origNode)
+	cv := reflect.ValueOf(cloneNode)
+	if ov.Kind() != reflect.Ptr || cv.Kind() != reflect.Ptr {
+		t.Fatalf("expected pointer-kind original/clone for %s, got %s/%s", label, ov.Kind(), cv.Kind())
+	}
+	if ov.Pointer() == cv.Pointer() {
+		t.Fatalf("clone shares the original %s pointer; clone.go's case must allocate a fresh copy", label)
+	}
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -632,12 +632,62 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   Complex (call/index) receivers resolve opportunistically through their
   Expression occurrence when one is recorded; fails soft to an empty member
   list otherwise, never wrong.
-  **Follow-ups:** auto-import completion (own design);
-  snippet placeholders;
-  `completionItem/resolve` for lazy docs; body-local value bindings as method-
-  component qualifiers (declared in a `{{ }}` block, a v1 gap); Go doc comments
-  on candidates (requires comment retention through the
-  skeleton); stale-snapshot fast path — largely subsumed by the non-blocking
+  **Go doc comments on candidates (T9+T10)** — DONE. Documentation is
+  doc-comment text only (Detail already carries the rendered signature).
+  Uniform rule (`completionDocFor`, completion_docs.go): an object whose OWN
+  package is the analyzed package (`obj.Pkg() == pkg.Types`) is "authored" and
+  gets EAGER Documentation, extracted synchronously from the already-parsed
+  .gsx source (`authoredDoc` reuses documentSymbol's byte-exact recovery
+  reconstruction, `reconstructGoChunk`/`reconstructGoWithElements` — refactored
+  out of symbols.go — so a GoWithElements decl, e.g. a package-level var
+  initialized to an embedded element, resolves correctly too); every other
+  candidate with a resolvable position — an imported dependency's
+  func/type/var/const/member, or a pipeline filter's target func — gets a
+  LAZY `CompletionItem.Data{file,line}` payload instead, resolved on demand via
+  the new `completionItem/resolve` request (`CompletionOptions.ResolveProvider
+  = true`). Same-package MEMBER items (fields/methods on a same-package
+  receiver type) follow the eager rule automatically — authored-ness is a
+  property of the object itself, checked once in `completionDocFor`, not of
+  which completion path found it. `chunkDocCache` memoizes the eager path per
+  (path, declaration-start-line), keyed additionally by the reconstructed
+  chunk's own text (content-validated, so an edit simply misses and
+  overwrites); caching a SINGLE line's answer per chunk was tried first and
+  is UNSOUND — a chunk holding more than one declaration (a struct type
+  immediately followed by a method on it, both merged into the same GoChunk)
+  let one declaration's cached doc leak onto its sibling's lookup — fixed by
+  caching the whole chunk's line→doc map in one pass. `depDocCache` (in
+  `completion_resolve.go`) caches real dependency-file parses by absolute
+  path, no invalidation (module-cache/GOROOT files are immutable within a
+  session). SECURITY: `completionItem/resolve`'s Data round-trips through the
+  CLIENT — a hostile/buggy client could send an arbitrary `{file,line}`, so
+  `resolvablePath` gates every resolve to a `.go` file under GOMODCACHE,
+  GOROOT (`go/build.Default.GOROOT`, not the deprecated `runtime.GOROOT()`),
+  or a negotiated workspace module root, computed fresh per request (a
+  bare env/in-memory lookup, no filesystem/subprocess cost) rather than
+  memoized, so it stays testable via `t.Setenv`. Filters resolve through the
+  SAME `{file,line}` mechanism: codegen's filter harvest
+  (`harvestFromTypes`/`filterEntry.pos`) now resolves each candidate's
+  declaration position immediately at harvest time via whatever `*token.
+  FileSet` the caller's `packages.Load`/Module used — resolving IMMEDIATELY
+  (not carrying a raw `token.Pos` forward) is what keeps two independent
+  harvests of the same filter (the go-list path and the types-based path
+  compared byte-for-byte in `filtertable_equiv_test.go`) agreeing: a raw
+  `token.Pos` is meaningless across two different `*token.FileSet` instances,
+  while the resolved `token.Position` is content-derived and so identical
+  either way — the equivalence test caught this the first time as a real
+  regression. Tests: unit (eager scope/member/GoWithElements, no-doc case,
+  chunk-cache reuse, resolve no-Data/malformed-Data/outside-allowed-roots/
+  GOMODCACHE/workspace-root) in internal/lsp; e2e (eager doc on a fixture
+  symbol, stdlib `strings.HasPrefix` resolve round trip, filter `upper`→
+  std.Upper resolve round trip) in gen/lsp_completion_docs_e2e_test.go.
+  **Follow-ups:** auto-import completion (own design); snippet placeholders;
+  body-local value bindings as method-component qualifiers (declared in a
+  `{{ }}` block, a v1 gap); `Component.Doc` — component-tag completion/hover
+  still show only the rendered signature (`renderComponentSig`), never a doc
+  comment: the parser attaches no leading comment to a `component` decl at
+  all (`ast.Component` has no `Doc` field), unlike a Go func/type/var/const.
+  Adding one is a small, self-contained parser+AST change (S), out of scope
+  for T9/T10; stale-snapshot fast path — largely subsumed by the non-blocking
   `TryAnalyzeEphemeral` work above, only worth revisiting if a benchmark still
   demands it.
 - [x] **emit.go `//line` for top-level Go body chunks** - DONE. `generateFile`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -612,6 +612,26 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   only the hole's own skeleton expr, not its enclosing statement — as is the
   top-level render hole `{ ▮ }` ("renderable", too broad). No expected type = every
   SortText byte-identical to the tier-only form (the no-regression contract).
+  MEMBER COMPLETION IN STATEMENT POSITIONS: a member cursor inside a `{{ }}`
+  GoBlock or a bare GoChunk (`{{ x.▮ }}`, a top-level `u.▮`) now completes —
+  closing the v1 "KNOWN GAP" these two bridges left (they carry no skeleton
+  selector for the ExprMap member path to walk). `statementMemberItems`
+  (completion_go.go) resolves the receiver directly from AUTHORED text instead
+  of a skeleton selector: `pkg.SourceIndex.At(path, recEnd)` — the same
+  offset-keyed occurrence lookup hover/go-to-definition trust — at the byte
+  before the dot. A `*types.PkgName` object is a package receiver; otherwise
+  the object's type, or (no object — a call/index/selector-chain receiver) the
+  occurrence's recorded Expression `TypeAndValue`, drives the member list.
+  Package/value item construction is shared with the skeleton path via two
+  extracted builders, `packageMemberItems`/`valueMemberItems`. The lookup uses
+  the ephemeral package's SourceIndex directly, without the `MatchesSource`
+  staleness gate hover/definition apply to a RETAINED package: the ephemeral
+  index is built from this exact request's buffer, so no retained/live
+  divergence is possible. Expected-type ranking does not apply here (nil,
+  matching the skeleton member path's existing statement-context behavior).
+  Complex (call/index) receivers resolve opportunistically through their
+  Expression occurrence when one is recorded; fails soft to an empty member
+  list otherwise, never wrong.
   **Follow-ups:** auto-import completion (own design);
   snippet placeholders;
   `completionItem/resolve` for lazy docs; body-local value bindings as method-

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -583,8 +583,21 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   package-scope var — resolved via the enclosing component's generated-func scope
   seeded from `SigTypes`, not authored-offset alignment) offers that type's
   method components; a value binding shadows a same-named import per Go scoping.
+  Pipe-filter completion is TYPE-NARROWED: `{ x |> ▮ }` offers only filters whose
+  subject parameter accepts the stage's incoming type (the seed's type at stage 0,
+  the preceding filter's result type after — an `(R, error)` filter chains its R;
+  a ctx-taking filter's subject is parameter 1). Filter signatures are resolved in
+  the ephemeral skeleton's own type universe (the same universe the incoming type
+  comes from, so `types.AssignableTo` is sound); a generic (type-parameter) subject
+  and an `any`/interface subject always match. Narrowing is a refinement, never a
+  gate: it fails OPEN — offering the full list — whenever the incoming type can't be
+  determined (broken seed, or a preceding filter whose package is not imported into
+  the skeleton because no successfully-lowered pipe referenced it), and per-candidate
+  when a candidate's own package is likewise absent. Known limitation: a preceding
+  stage that carries ARGS followed by an unknown/empty stage currently yields an
+  empty analysis (a codegen edge), which routes to the full-list fail-open.
   **Follow-ups:** auto-import completion (own design); expected-type ranking;
-  snippet placeholders; typed pipe-filter compatibility filtering;
+  snippet placeholders;
   `completionItem/resolve` for lazy docs; body-local value bindings as method-
   component qualifiers (declared in a `{{ }}` block, a v1 gap); Go doc comments
   on candidates (requires comment retention through the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -578,10 +578,16 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   Fallback-only (zero change to answerable cases); returned current-file spans
   map repaired→live coordinates. Cursor-local, so it heals breakage at the
   cursor, not on an unrelated line.
+  Method-component (`<recv.Name>`) tags complete: a qualified `<recv.▮` cursor
+  whose qualifier resolves to an in-scope value binding (receiver, parameter, or
+  package-scope var — resolved via the enclosing component's generated-func scope
+  seeded from `SigTypes`, not authored-offset alignment) offers that type's
+  method components; a value binding shadows a same-named import per Go scoping.
   **Follow-ups:** auto-import completion (own design); expected-type ranking;
   snippet placeholders; typed pipe-filter compatibility filtering;
-  `completionItem/resolve` for lazy docs; method-component (`<recv.Name>`)
-  tags; Go doc comments on candidates (requires comment retention through the
+  `completionItem/resolve` for lazy docs; body-local value bindings as method-
+  component qualifiers (declared in a `{{ }}` block, a v1 gap); Go doc comments
+  on candidates (requires comment retention through the
   skeleton); stale-snapshot fast path — largely subsumed by the non-blocking
   `TryAnalyzeEphemeral` work above, only worth revisiting if a benchmark still
   demands it.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -581,7 +581,10 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   **Follow-ups:** auto-import completion (own design); expected-type ranking;
   snippet placeholders; typed pipe-filter compatibility filtering;
   `completionItem/resolve` for lazy docs; method-component (`<recv.Name>`)
-  tags.
+  tags; Go doc comments on candidates (requires comment retention through the
+  skeleton); stale-snapshot fast path — largely subsumed by the non-blocking
+  `TryAnalyzeEphemeral` work above, only worth revisiting if a benchmark still
+  demands it.
 - [ ] **emit.go `//line` for top-level Go body chunks** - shipped `.x.go`
   emits no `//line` for plain GoChunk text or GoWithElements GoText, so a
   cross-module dep loaded from its published `.x.go` resolves value positions

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -585,13 +585,16 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   skeleton); stale-snapshot fast path — largely subsumed by the non-blocking
   `TryAnalyzeEphemeral` work above, only worth revisiting if a benchmark still
   demands it.
-- [ ] **emit.go `//line` for top-level Go body chunks** - shipped `.x.go`
-  emits no `//line` for plain GoChunk text or GoWithElements GoText, so a
-  cross-module dep loaded from its published `.x.go` resolves value positions
-  (gd on component values, compiler errors in top-level var blocks) up to a
-  few lines off within the correct `.gsx`. Same-module is exact (in-memory
-  skeleton anchors correctly since the `part.Pos()+start` fix). Emit `//line`
-  for these chunks like components/elements already get.
+- [x] **emit.go `//line` for top-level Go body chunks** - DONE. `generateFile`
+  now anchors plain `*ast.GoChunk` bodies with `emitLine` (newline form, at
+  `splitChunk`'s `bodyOff`) and each `*ast.GoWithElements` GoText part with a
+  new `emitBlockLine` (block form, at `p.Pos()+start` after decorative-paren
+  stripping — mirrors the skeleton builders' f0f590e8 anchoring recipe, but
+  base-names the filename like `emitLine` does, unlike the skeleton's
+  `emitSkeletonBlockLine`). Cross-module gd on a component value now lands on
+  the exact `.gsx` line (`gen.TestDefinitionCrossModuleValueSourcesPresent`
+  upgraded from file-only to exact-line); corpus goldens regenerated
+  (directive-only churn, spot-checked).
 - **Deferred:** external/non-project references; references cover project
   components discovered during module analysis.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -596,7 +596,23 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   when a candidate's own package is likewise absent. Known limitation: a preceding
   stage that carries ARGS followed by an unknown/empty stage currently yields an
   empty analysis (a codegen edge), which routes to the full-list fail-open.
-  **Follow-ups:** auto-import completion (own design); expected-type ranking;
+  EXPECTED-TYPE RANKING (never filtering): in a Go-context cursor a candidate
+  whose type matches the type expected at the position sorts ahead of the rest
+  WITHIN its locality tier — a single match digit inserted after the tier digits
+  and before the label (`05` → `050`/`051`), so locality still dominates (a
+  matched package-scope item never outranks an unmatched local) and matching only
+  refines ties. Match = `AssignableTo`, plus a func candidate whose single result
+  is assignable (calling it satisfies the position). Derivation subset (cheaply
+  sound, else no boost): the innermost enclosing call argument `{ f(▮) }` /
+  `title={ f(▮) }` (callee param type at the cursor's arg index, variadic tail
+  resolved; selector receivers excluded — before the `(`), and a component attr
+  value hole `title={ ▮ }` (the bound parameter's type, from the ComponentCalls
+  fact). Cross-statement positions (assignment RHS, return result, binary operand,
+  top-level arg where the hole IS the argument) are skipped — the bridge retains
+  only the hole's own skeleton expr, not its enclosing statement — as is the
+  top-level render hole `{ ▮ }` ("renderable", too broad). No expected type = every
+  SortText byte-identical to the tier-only form (the no-regression contract).
+  **Follow-ups:** auto-import completion (own design);
   snippet placeholders;
   `completionItem/resolve` for lazy docs; body-local value bindings as method-
   component qualifiers (declared in a `{{ }}` block, a v1 gap); Go doc comments

--- a/gen/definition_crosspkg_value_e2e_test.go
+++ b/gen/definition_crosspkg_value_e2e_test.go
@@ -290,11 +290,15 @@ func TestDefinitionCrossModuleValueSourcesPresent(t *testing.T) {
 	}
 	// The line is resolved from the dependency's published .x.go //line directives
 	// (a separate module is loaded from its generated Go, not re-analyzed in
-	// memory). emit.go does not //line-stamp top-level Go var chunks, so the line
-	// can drift within the .gsx — the exact-line guarantee holds for SAME-module
-	// deps (analyzed via the in-memory skeleton), pinned by the value tests above.
-	// This case pins the refined policy's contract: authored .gsx present → the
-	// Location lands in that .gsx (never the .x.go), non-null.
+	// memory): emit.go now //line-stamps the top-level Go var chunk that declares
+	// X, so this cross-MODULE resolution lands on the exact declaration line, the
+	// same guarantee the in-memory same-module skeleton already gave the value
+	// tests above.
+	wantLine, wantCol := wantXLocation(t)
+	if loc.Range.Start.Line != wantLine || loc.Range.Start.Character != wantCol {
+		t.Fatalf("cross-module tag gd landed at L%d:C%d, want L%d:C%d (the X value decl)",
+			loc.Range.Start.Line, loc.Range.Start.Character, wantLine, wantCol)
+	}
 	if hov == nil {
 		t.Fatal("hover was null; want non-null signature")
 	}

--- a/gen/lsp.go
+++ b/gen/lsp.go
@@ -343,7 +343,11 @@ func adaptPackageResult(pr *codegen.PackageResult) *lsp.Package {
 	}
 	filters := make([]lsp.FilterCandidate, len(pr.Filters))
 	for i, fc := range pr.Filters {
-		filters[i] = lsp.FilterCandidate{Name: fc.Name, Pkg: fc.Pkg, Func: fc.Func, WantsCtx: fc.WantsCtx}
+		// fc.Pos is already a resolved token.Position (see codegen's
+		// filterEntry.pos) — a straight copy becomes the exact same
+		// {file,line} shape completionItem/resolve already serves for every
+		// other lazy-doc candidate (T9/T10).
+		filters[i] = lsp.FilterCandidate{Name: fc.Name, Pkg: fc.Pkg, Func: fc.Func, WantsCtx: fc.WantsCtx, Pos: fc.Pos}
 	}
 	return &lsp.Package{
 		Diags:          pr.Diags,

--- a/gen/lsp_completion_docs_e2e_test.go
+++ b/gen/lsp_completion_docs_e2e_test.go
@@ -1,0 +1,377 @@
+package gen
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestCompletionEagerDocE2E drives textDocument/completion through the full
+// JSON-RPC server (T9): a documented package-scope func offered at a bare
+// scope cursor carries its doc comment inline, as `documentation.value` on
+// the SAME completion reply — no completionItem/resolve round trip needed.
+func TestCompletionEagerDocE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, content string) string {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	write("go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	source := "package page\n\n" +
+		"// Greeting renders a friendly hello to name.\n" +
+		"func Greeting(name string) string {\n\treturn \"Hello, \" + name\n}\n\n" +
+		"component Home() {\n\t<div>{ Greeting(\"world\") }</div>\n}\n"
+	pagePath := write("page/page.gsx", source)
+	uri := "file://" + pagePath
+
+	cursor := strings.Index(source, "{ Greeting(") + len("{ Gree") // mid-identifier, inside the interp
+
+	frame := func(value any) string {
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return "Content-Length: " + strconv.Itoa(len(data)) + "\r\n\r\n" + string(data)
+	}
+	var input strings.Builder
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}}))
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "version": 1, "text": source}},
+	}))
+	pos := lspUTF16PositionAt(source, cursor)
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": pos.Line, "character": pos.Character},
+		},
+	}))
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
+
+	var output, stderr bytes.Buffer
+	if code := runLSP(strings.NewReader(input.String()), &output, &stderr, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, stderr.String())
+	}
+
+	items := completionItems(t, output.String(), 2)
+	var docValue string
+	found := false
+	for _, it := range items {
+		if it.Label != "Greeting" {
+			continue
+		}
+		found = true
+		if it.Documentation != nil {
+			docValue = it.Documentation.Value
+		}
+	}
+	if !found {
+		t.Fatalf("completion missing package-scope func `Greeting`; items=%+v", items)
+	}
+	if docValue == "" {
+		t.Fatal("`Greeting` completion item carries no Documentation, want the eager doc comment")
+	}
+	if !strings.Contains(docValue, "Greeting renders a friendly hello") {
+		t.Errorf("`Greeting` Documentation = %q, want it to contain the doc comment text", docValue)
+	}
+
+	// Confirm via the RAW reply that an eager item carries NO "data" (eager
+	// and lazy are mutually exclusive per the design's uniform rule).
+	rawItem := rawCompletionItemByLabel(t, output.String(), 2, "Greeting")
+	if _, hasData := rawItem["data"]; hasData {
+		t.Errorf("eager `Greeting` item carries a \"data\" field, want none: %s", rawItem["data"])
+	}
+}
+
+// TestCompletionResolveStdlibE2E drives completionItem/resolve through the
+// full JSON-RPC server (T10): a member-completion item for a real stdlib
+// symbol (`strings.HasPrefix`) carries no Documentation in the initial
+// completion reply (lazy) but a non-empty one after the client round-trips
+// the item's untouched Data back via completionItem/resolve — the exact
+// client contract (send the item back verbatim, Data included).
+func TestCompletionResolveStdlibE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, content string) string {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	write("go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	source := "package page\n\nimport \"strings\"\n\ncomponent Home() {\n\t<div>{ strings. }</div>\n\t<span>{ strings.ToUpper(\"x\") }</span>\n}\n"
+	pagePath := write("page/page.gsx", source)
+	uri := "file://" + pagePath
+
+	cursor := strings.Index(source, "{ strings. }") + len("{ strings.")
+
+	frame := func(value any) string {
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return "Content-Length: " + strconv.Itoa(len(data)) + "\r\n\r\n" + string(data)
+	}
+	var input strings.Builder
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}}))
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "version": 1, "text": source}},
+	}))
+	pos := lspUTF16PositionAt(source, cursor)
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": pos.Line, "character": pos.Character},
+		},
+	}))
+
+	var output1, stderr bytes.Buffer
+	// Run just far enough to capture the completion response; the resolve
+	// request needs the RAW item echoed back, so it is built from this
+	// output before continuing the session.
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
+	if code := runLSP(strings.NewReader(input.String()), &output1, &stderr, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, stderr.String())
+	}
+
+	rawItem := rawCompletionItemByLabel(t, output1.String(), 2, "HasPrefix")
+	if _, hasDoc := rawItem["documentation"]; hasDoc {
+		t.Errorf("lazy `HasPrefix` item already carries \"documentation\" before resolve: %s", rawItem["documentation"])
+	}
+	dataField, hasData := rawItem["data"]
+	if !hasData || len(dataField) == 0 || string(dataField) == "null" {
+		t.Fatalf("lazy `HasPrefix` item carries no \"data\" to resolve: %+v", rawItem)
+	}
+
+	// Build the full item JSON to echo back verbatim, exactly as a real
+	// client does (it round-trips the WHOLE item, not just Data).
+	itemJSON, err := json.Marshal(rawItem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resolveInput strings.Builder
+	resolveInput.WriteString(frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}}))
+	resolveInput.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "completionItem/resolve",
+		"params": json.RawMessage(itemJSON),
+	}))
+	resolveInput.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
+
+	var output2 bytes.Buffer
+	if code := runLSP(strings.NewReader(resolveInput.String()), &output2, &stderr, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, stderr.String())
+	}
+
+	var resolved struct {
+		Documentation *struct {
+			Kind  string `json:"kind"`
+			Value string `json:"value"`
+		} `json:"documentation"`
+	}
+	found := false
+	for part := range strings.SplitSeq(output2.String(), "Content-Length:") {
+		_, body, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
+			continue
+		}
+		var response struct {
+			ID     int             `json:"id"`
+			Result json.RawMessage `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(body), &response); err != nil || response.ID != 2 {
+			continue
+		}
+		if err := json.Unmarshal(response.Result, &resolved); err != nil {
+			t.Fatalf("decode resolve result: %v (%s)", err, response.Result)
+		}
+		found = true
+	}
+	if !found {
+		t.Fatalf("no completionItem/resolve response (id 2) in:\n%s", output2.String())
+	}
+	if resolved.Documentation == nil || resolved.Documentation.Value == "" {
+		t.Fatal("completionItem/resolve for stdlib `strings.HasPrefix` returned empty Documentation")
+	}
+}
+
+// TestCompletionResolveFilterE2E drives completionItem/resolve for a pipe
+// filter candidate (T10's Filters class): `upper` resolves to std's
+// `Upper`, a documented func in a real .go file (github.com/gsxhq/gsx/std) —
+// the SAME lazy Data{file,line}+resolve round trip as an imported symbol,
+// this time sourced from codegen's filter harvest (FilterCandidate.Pos)
+// rather than an object's own go/types position. Confirms the filter-table
+// plumbing (filterEntry.pos -> FilterCandidate.Pos -> lsp.FilterCandidate.Pos
+// -> filterItems' Data) resolves to a REAL, readable position end to end.
+func TestCompletionResolveFilterE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, content string) string {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	write("go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	write("page/types.go", "package page\n\ntype User struct{ Name string }\n")
+	source := "package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name |> up }</div>\n}\n"
+	pagePath := write("page/page.gsx", source)
+	uri := "file://" + pagePath
+
+	cursor := strings.Index(source, "|> up") + len("|> up")
+
+	frame := func(value any) string {
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return "Content-Length: " + strconv.Itoa(len(data)) + "\r\n\r\n" + string(data)
+	}
+	var input strings.Builder
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}}))
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "version": 1, "text": source}},
+	}))
+	pos := lspUTF16PositionAt(source, cursor)
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": pos.Line, "character": pos.Character},
+		},
+	}))
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
+
+	var output1, stderr bytes.Buffer
+	if code := runLSP(strings.NewReader(input.String()), &output1, &stderr, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, stderr.String())
+	}
+
+	rawItem := rawCompletionItemByLabel(t, output1.String(), 2, "upper")
+	dataField, hasData := rawItem["data"]
+	if !hasData || len(dataField) == 0 || string(dataField) == "null" {
+		t.Fatalf("filter `upper` item carries no \"data\" to resolve: %+v", rawItem)
+	}
+
+	itemJSON, err := json.Marshal(rawItem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resolveInput strings.Builder
+	resolveInput.WriteString(frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}}))
+	resolveInput.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "completionItem/resolve",
+		"params": json.RawMessage(itemJSON),
+	}))
+	resolveInput.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
+
+	var output2 bytes.Buffer
+	if code := runLSP(strings.NewReader(resolveInput.String()), &output2, &stderr, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, stderr.String())
+	}
+
+	var resolved struct {
+		Documentation *struct {
+			Value string `json:"value"`
+		} `json:"documentation"`
+	}
+	found := false
+	for part := range strings.SplitSeq(output2.String(), "Content-Length:") {
+		_, body, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
+			continue
+		}
+		var response struct {
+			ID     int             `json:"id"`
+			Result json.RawMessage `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(body), &response); err != nil || response.ID != 2 {
+			continue
+		}
+		if err := json.Unmarshal(response.Result, &resolved); err != nil {
+			t.Fatalf("decode resolve result: %v (%s)", err, response.Result)
+		}
+		found = true
+	}
+	if !found {
+		t.Fatalf("no completionItem/resolve response (id 2) in:\n%s", output2.String())
+	}
+	if resolved.Documentation == nil || resolved.Documentation.Value == "" {
+		t.Fatal("completionItem/resolve for filter `upper` (std.Upper) returned empty Documentation")
+	}
+	if !strings.Contains(resolved.Documentation.Value, "Upper returns s with all Unicode letters mapped to their upper case") {
+		t.Errorf("resolved `upper` Documentation = %q, want std.Upper's doc comment", resolved.Documentation.Value)
+	}
+}
+
+// rawCompletionItemByLabel returns the raw JSON object (as a
+// map[string]json.RawMessage, preserving exactly what the server sent — no
+// typed re-encoding) of the completion item with the given label from the
+// completion response with id, or fails the test if not found.
+func rawCompletionItemByLabel(t *testing.T, output string, id int, label string) map[string]json.RawMessage {
+	t.Helper()
+	for part := range strings.SplitSeq(output, "Content-Length:") {
+		_, body, ok := strings.Cut(part, "\r\n\r\n")
+		if !ok {
+			continue
+		}
+		var response struct {
+			ID     int `json:"id"`
+			Result struct {
+				Items []map[string]json.RawMessage `json:"items"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(body), &response); err != nil || response.ID != id {
+			continue
+		}
+		for _, item := range response.Result.Items {
+			var l string
+			if err := json.Unmarshal(item["label"], &l); err == nil && l == label {
+				return item
+			}
+		}
+	}
+	t.Fatalf("no completion item labeled %q in response id %d:\n%s", label, id, output)
+	return nil
+}

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -1609,6 +1609,95 @@ func assertNoGsxInternalLeak(t *testing.T, output string) {
 	}
 }
 
+// TestExpectedTypeRankingE2E drives expected-type ranking end to end: in a
+// component attr value hole `<Card title={ s }/>` whose parameter is `title
+// string`, the string-typed local `s` sorts ahead of the int-typed local `n`
+// (both stay in tierLocal — ranking never filters, only refines within a tier).
+func TestExpectedTypeRankingE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	write := func(name, content string) string {
+		t.Helper()
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	write("go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+
+	source := "package page\n\n" +
+		"component Card(title string) {\n\t<div>{ title }</div>\n}\n\n" +
+		"component Home(s string, n int) {\n\t<Card title={ s }/>\n}\n"
+	pagePath := write("page/page.gsx", source)
+	uri := "file://" + pagePath
+
+	frame := func(value any) string {
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return "Content-Length: " + strconv.Itoa(len(data)) + "\r\n\r\n" + string(data)
+	}
+	// Cursor right after `s` inside the component attr value hole.
+	cursor := strings.Index(source, "title={ s") + len("title={ s")
+	pos := lspUTF16PositionAt(source, cursor)
+
+	var input strings.Builder
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{}}))
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "version": 1, "text": source}},
+	}))
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": pos.Line, "character": pos.Character},
+		},
+	}))
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
+
+	var output, stderr bytes.Buffer
+	if code := runLSP(strings.NewReader(input.String()), &output, &stderr, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, stderr.String())
+	}
+
+	var sItem, nItem *lsp.CompletionItem
+	items := completionItems(t, output.String(), 2)
+	for i := range items {
+		switch items[i].Label {
+		case "s":
+			sItem = &items[i]
+		case "n":
+			nItem = &items[i]
+		}
+	}
+	if sItem == nil || nItem == nil {
+		t.Fatalf("component-attr value hole missing locals (s=%v n=%v); items=%v", sItem, nItem, items)
+	}
+	// Ranking never filters: both stay in tierLocal ("05"). The string-typed `s`
+	// matches the `title string` parameter and sorts ahead of the int-typed `n`.
+	if !strings.HasPrefix(sItem.SortText, "05") {
+		t.Errorf("`s` SortText = %q, want tierLocal prefix \"05\"", sItem.SortText)
+	}
+	if !strings.HasPrefix(nItem.SortText, "05") {
+		t.Errorf("`n` SortText = %q, want tierLocal prefix \"05\" (mismatch is ranked, never filtered)", nItem.SortText)
+	}
+	if sItem.SortText >= nItem.SortText {
+		t.Errorf("type-matching `s` (SortText %q) must sort before mismatching `n` (SortText %q)", sItem.SortText, nItem.SortText)
+	}
+}
+
 // completionItems extracts the full CompletionItem slice from the completion
 // response with the given id.
 func completionItems(t *testing.T, output string, id int) []lsp.CompletionItem {

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -1099,6 +1099,74 @@ func runHTMLCompletionE2E(t *testing.T, extra map[string]string, source string, 
 	return completionItems(t, output.String(), 2)
 }
 
+// runHTMLCompletionE2ESnippet mirrors runHTMLCompletionE2E exactly, except the
+// initialize params advertise textDocument.completion.completionItem
+// .snippetSupport=true, so the response is expected to carry `$1`-tabstop
+// snippet inserts for value attributes instead of the plain `name=""` form.
+// Kept as a separate helper (rather than a parameter added to
+// runHTMLCompletionE2E) so every existing call site — and therefore every
+// existing e2e assertion pinning the no-capability behavior — stays untouched.
+func runHTMLCompletionE2ESnippet(t *testing.T, source string, cursor int) []lsp.CompletionItem {
+	t.Helper()
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	write := func(name, content string) string {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	write("go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	pagePath := write("page/page.gsx", source)
+	uri := "file://" + pagePath
+
+	frame := func(value any) string {
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return "Content-Length: " + strconv.Itoa(len(data)) + "\r\n\r\n" + string(data)
+	}
+	var input strings.Builder
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{"capabilities": map[string]any{
+			"textDocument": map[string]any{"completion": map[string]any{
+				"completionItem": map[string]any{"snippetSupport": true},
+			}},
+		}},
+	}))
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "method": "textDocument/didOpen",
+		"params": map[string]any{"textDocument": map[string]any{"uri": uri, "version": 1, "text": source}},
+	}))
+	pos := lspUTF16PositionAt(source, cursor)
+	input.WriteString(frame(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": pos.Line, "character": pos.Character},
+		},
+	}))
+	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
+
+	var output, stderr bytes.Buffer
+	if code := runLSP(strings.NewReader(input.String()), &output, &stderr, config{}, nil); code != 0 {
+		t.Fatalf("runLSP=%d stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(output.String(), ".x.go") {
+		t.Fatalf("completion response exposed virtual generated Go:\n%s", output.String())
+	}
+	return completionItems(t, output.String(), 2)
+}
+
 // TestHTMLCompletionE2E drives the HTML tag/attr/value completion paths through
 // the full JSON-RPC server against a real temp module: a `<di▮` tag cursor
 // offers `div` (kind Property, doc non-empty); a `<div ▮>` attr-name cursor
@@ -1176,6 +1244,32 @@ func TestHTMLCompletionE2E(t *testing.T) {
 		items := runHTMLCompletionE2E(t, nil, source, cursor)
 		if !labelsOf(items)["submit"] {
 			t.Fatalf("attr-value completion missing `submit`; labels=%v", labelsOf(items))
+		}
+	})
+
+	t.Run("html attr snippet capability", func(t *testing.T) {
+		// Same cursor as "html attr" above, but the client advertises
+		// snippetSupport this time: `class` must insert `class="$1"` with
+		// insertTextFormat=2 (Snippet) so the cursor lands INSIDE the quotes,
+		// while `hidden` — no quotes to place a tabstop inside — is unaffected.
+		source := "package page\n\ncomponent Home() {\n\t<div ></div>\n}\n"
+		cursor := strings.Index(source, "<div ") + len("<div ")
+		items := runHTMLCompletionE2ESnippet(t, source, cursor)
+
+		class := itemOf(items, "class")
+		if class == nil || class.TextEdit == nil || class.TextEdit.NewText != `class="$1"` {
+			t.Fatalf("`class` must insert `class=\"$1\"` under snippetSupport; got %+v", class)
+		}
+		if class.InsertTextFormat != 2 {
+			t.Errorf("class.InsertTextFormat = %d, want 2 (Snippet)", class.InsertTextFormat)
+		}
+
+		hidden := itemOf(items, "hidden")
+		if hidden == nil || hidden.TextEdit == nil || hidden.TextEdit.NewText != "hidden" {
+			t.Errorf("`hidden` must still insert the bare name under snippetSupport; got %+v", hidden)
+		}
+		if hidden.InsertTextFormat != 0 {
+			t.Errorf("hidden.InsertTextFormat = %d, want 0 (no quotes to tabstop into)", hidden.InsertTextFormat)
 		}
 	})
 }

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -859,6 +859,29 @@ func TestTagCompletionE2E(t *testing.T) {
 			t.Errorf("qualified trailing-dot tag completion missing imported component `Button`; labels=%v", got)
 		}
 	})
+
+	// method component: a `<recv.▮` cursor where `recv` is the enclosing method
+	// component's RECEIVER var (not an import) resolves the receiver type's method
+	// components. `Page` is a method on UsersPage; its body invokes a sibling
+	// method component `<p.Row/>` on the same receiver `p`. A trailing-dot cursor
+	// `<p.` heals through the same `/>` repair as the qualified-import case and
+	// classifies with qualifier "p"; receiverVarComponentItems resolves `p` to the
+	// UsersPage receiver var and offers its methods (Row, Page), never HTML tags
+	// (a qualified cursor is component-only) or the plain sibling component.
+	t.Run("method component receiver var", func(t *testing.T) {
+		source := "package page\n\ntype UsersPage struct {\n\tTitle string\n}\n\ncomponent (p UsersPage) Row(x string) {\n\t<span>{x}-{p.Title}</span>\n}\n\ncomponent (p UsersPage) Page() {\n\t<div><p.Row x=\"a\"/>\n\t<p.\n\t</div>\n}\n"
+		cursor := strings.LastIndex(source, "<p.") + len("<p.")
+		got := run(t, map[string]string{"page/page.gsx": source}, "page/page.gsx", source, cursor)
+		if !got["Row"] {
+			t.Errorf("method-component tag completion missing receiver method `Row`; labels=%v", got)
+		}
+		if !got["Page"] {
+			t.Errorf("method-component tag completion missing receiver method `Page`; labels=%v", got)
+		}
+		if got["div"] {
+			t.Errorf("qualified `<p.` cursor offered an HTML tag `div`; labels=%v", got)
+		}
+	})
 }
 
 // TestComponentAttrCompletionE2E drives textDocument/completion for a

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -164,10 +164,13 @@ func TestGoCompletionE2E(t *testing.T) {
 	pagePath := write("page/page.gsx", "package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name }</div>\n}\n")
 	uri := "file://" + pagePath
 
-	// Buffer under edit: a top-level GoChunk func body, an expression cursor after
+	// Buffer under edit: a top-level GoChunk with two adjacent funcs (a bare
+	// cursor sits in the blank line BETWEEN them), an expression cursor after
 	// `us`, and a statement-context `{{ }}` GoBlock inside a second component.
 	source := "package page\n\n" +
+		"import \"strings\"\n\n" +
 		"func helper() User {\n\treturn Us\n}\n\n" +
+		"func greet() string {\n\treturn strings.ToUpper(\"x\")\n}\n\n" +
 		"component Home(user User) {\n\t<div>{ us }</div>\n}\n\n" +
 		"component Block(item User) {\n\t{{  }}\n\t<span>{ item.Name }</span>\n}\n"
 
@@ -175,6 +178,10 @@ func TestGoCompletionE2E(t *testing.T) {
 	exprCursor := strings.Index(source, "{ us }") + len("{ us")           // right after `us`
 	blockCursor := strings.Index(source, "{{  }}") + len("{{ ")           // between the two spaces
 	sigCursor := strings.Index(source, "(user User)") + len("(user User") // on the signature type `User`
+	// A bare GoChunk cursor in the blank line between the two top-level funcs
+	// (helper's `}` and `func greet`): no enclosing func body, only the file
+	// scope — where imported package names live.
+	betweenCursor := strings.Index(source, "}\n\nfunc greet") + len("}\n")
 
 	frame := func(value any) string {
 		data, err := json.Marshal(value)
@@ -203,6 +210,7 @@ func TestGoCompletionE2E(t *testing.T) {
 	req(3, blockCursor)
 	req(4, chunkCursor)
 	req(5, sigCursor)
+	req(6, betweenCursor)
 	input.WriteString(frame(map[string]any{"jsonrpc": "2.0", "method": "exit"}))
 
 	var output, stderr bytes.Buffer
@@ -281,6 +289,28 @@ func TestGoCompletionE2E(t *testing.T) {
 	}
 	if sigItems["return"] {
 		t.Errorf("signature-type completion should not offer statement keywords; labels=%v", sigItems)
+	}
+
+	// Bare GoChunk position between two top-level funcs (T4): the enclosing file
+	// scope resolves, so the imported package name `strings` completes
+	// (tierImported), alongside package-scope decls and statement keywords.
+	betweenItems := completionLabels(t, output.String(), 6)
+	if !betweenItems["strings"] {
+		t.Errorf("bare GoChunk completion missing imported package `strings`; labels=%v", betweenItems)
+	}
+	for _, name := range []string{"helper", "greet", "Home"} {
+		if !betweenItems[name] {
+			t.Errorf("bare GoChunk completion missing package-scope %q; labels=%v", name, betweenItems)
+		}
+	}
+	if !betweenItems["func"] {
+		t.Errorf("bare GoChunk completion missing keyword `func`; labels=%v", betweenItems)
+	}
+	// The `strings` item carries the tierImported (40) sort prefix.
+	for _, it := range completionItems(t, output.String(), 6) {
+		if it.Label == "strings" && !strings.HasPrefix(it.SortText, "40") {
+			t.Errorf("imported `strings` SortText = %q, want tierImported prefix \"40\"", it.SortText)
+		}
 	}
 }
 

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -612,6 +612,35 @@ func TestPipeStageEmptyCompletionE2E(t *testing.T) {
 	}
 }
 
+// TestPipeStageTypedNarrowingE2E drives the typed pipe-filter compatibility
+// filtering end to end: at `{ user.Age |> ▮ }` the incoming type is int, so
+// string-subject filters (upper) are withheld while the any-subject printf and
+// generic default are offered. A companion `{ user.Name |> lower }` pipe imports
+// std into the skeleton universe so the candidate signatures resolve (a filter
+// whose package is not imported fails open — offered — per the design's
+// per-candidate fail-open rule).
+func TestPipeStageTypedNarrowingE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	extra := map[string]string{"page/types.go": "package page\n\ntype User struct{ Name string; Age int }\n"}
+	source := "package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name |> lower }{ user.Age |> u }</div>\n}\n"
+	cursor := strings.Index(source, "|> u") + len("|> u")
+	items := runHTMLCompletionE2E(t, extra, source, cursor)
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	for _, name := range []string{"printf", "default"} {
+		if !labels[name] {
+			t.Errorf("int-seed pipe completion missing any/generic filter %q; labels=%v", name, labels)
+		}
+	}
+	if labels["upper"] {
+		t.Errorf("int-seed pipe completion offered string-subject filter %q; labels=%v", "upper", labels)
+	}
+}
+
 // TestTagCompletionE2E drives textDocument/completion for a ctxTag cursor end
 // to end: a bare `<Ot▮` cursor offers the sibling local component ("Other"),
 // and a qualified `<ui.▮` cursor offers the imported gsx package's component

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -1582,6 +1582,77 @@ func TestGoBlockDeclaredAfterCursorE2E(t *testing.T) {
 	}
 }
 
+// TestGoMemberStatementCompletionE2E drives textDocument/completion end to end
+// at a member (`.`) cursor sitting in a GoBlock/GoChunk STATEMENT position —
+// the gap statementMemberItems closes (internal/lsp/completion_go.go). Unlike
+// the ExprMap-bridged member cursors TestGoMemberCompletionE2E covers, these
+// bridges (CtrlMap/GoBlock and the bare GoChunk) have no skeleton selector for
+// the original member path to walk; statementMemberItems resolves the receiver
+// directly from AUTHORED text via pkg.SourceIndex.At instead. Each subtest
+// hits the SAME phantom trailing-dot repair (goContextCompletion) that heals
+// `{ user. }`'s broken skeleton selector, since GoBlock/GoChunk both classify
+// as ctxGoExpr (completion_context.go) exactly like the ExprMap bridge does.
+func TestGoMemberStatementCompletionE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	labelsOf := func(items []lsp.CompletionItem) map[string]bool {
+		m := map[string]bool{}
+		for _, it := range items {
+			m[it.Label] = true
+		}
+		return m
+	}
+
+	// GoBlock member: `{{ user. }}` — a CtrlMap-bridged statement cursor with a
+	// value (struct) receiver.
+	t.Run("goblock value receiver", func(t *testing.T) {
+		extra := map[string]string{"page/types.go": "package page\n\ntype User struct {\n\tName string\n\tAge  int\n}\n"}
+		source := "package page\n\ncomponent Home(user User) {\n\t{{ user. }}\n}\n"
+		cursor := strings.Index(source, "user.") + len("user.")
+		got := labelsOf(runHTMLCompletionE2E(t, extra, source, cursor))
+		for _, name := range []string{"Name", "Age"} {
+			if !got[name] {
+				t.Errorf("GoBlock statement member %q missing; labels=%v", name, got)
+			}
+		}
+		if got["user"] {
+			t.Errorf("member position must not offer scope locals; got `user`: %v", got)
+		}
+	})
+
+	// GoChunk member: `return u.` inside a top-level func body — a bare verbatim
+	// Go span with no ExprMap/CtrlMap entry at all.
+	t.Run("gochunk value receiver", func(t *testing.T) {
+		source := "package page\n\ntype User struct {\n\tName string\n\tAge  int\n}\n\n" +
+			"func greet(u User) string {\n\treturn u.\n}\n\n" +
+			"component Home() {\n\t<div></div>\n}\n"
+		cursor := strings.Index(source, "return u.") + len("return u.")
+		got := labelsOf(runHTMLCompletionE2E(t, nil, source, cursor))
+		for _, name := range []string{"Name", "Age"} {
+			if !got[name] {
+				t.Errorf("GoChunk statement member %q missing; labels=%v", name, got)
+			}
+		}
+		if got["greet"] || got["u"] {
+			t.Errorf("member position must not offer scope names; labels=%v", got)
+		}
+	})
+
+	// GoBlock package receiver: `{{ strings. }}` — the *types.PkgName branch of
+	// statementMemberItems, exercised at a statement (not expression) cursor.
+	t.Run("goblock package receiver", func(t *testing.T) {
+		source := "package page\n\nimport \"strings\"\n\ncomponent Home() {\n\t{{ x := strings.\n\t_ = x }}\n\t<div></div>\n}\n"
+		cursor := strings.Index(source, "strings.") + len("strings.")
+		got := labelsOf(runHTMLCompletionE2E(t, nil, source, cursor))
+		for _, name := range []string{"ToUpper", "ToLower", "Contains"} {
+			if !got[name] {
+				t.Errorf("GoBlock package-receiver member %q missing; labels=%v", name, got)
+			}
+		}
+	})
+}
+
 // assertNoGsxInternalLeak fails if any completion item, in ANY completion
 // response carried by output, has a label with the reserved `_gsx` prefix — the
 // generated-code internals (_gsxuse/_gsxcompsig/_gsxrt/_gsxbody/...) the

--- a/internal/codegen/bundle.go
+++ b/internal/codegen/bundle.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"fmt"
+	"go/token"
 	"go/types"
 	goversion "go/version"
 )
@@ -25,7 +26,11 @@ import (
 // which path ran.
 //
 // aliases maps each package path to its reserved import alias (filterAliases).
-func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, explicitAliases []FilterAlias, aliases map[string]string) (map[string][]filterEntry, error) {
+// fset resolves each harvested func's declaration Position immediately (see
+// filterEntry.pos) — pass nil when no real Fset is available at this call
+// site (e.g. the WASM/typebundle path), which simply leaves every entry's pos
+// at its zero value.
+func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, explicitAliases []FilterAlias, aliases map[string]string, fset *token.FileSet) (map[string][]filterEntry, error) {
 	harvested := map[string][]filterEntry{}
 	for _, path := range pkgPaths {
 		pkg, ok := byPath[path]
@@ -58,6 +63,7 @@ func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, expli
 				hasErr:   sig.Results().Len() == 2,
 				alias:    alias,
 				pkgPath:  path,
+				pos:      funcPosition(fn, fset),
 			})
 		}
 	}
@@ -94,6 +100,7 @@ func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, expli
 			hasErr:   sig.Results().Len() == 2,
 			alias:    aliases[a.PkgPath],
 			pkgPath:  a.PkgPath,
+			pos:      funcPosition(fn, fset),
 		})
 	}
 	return harvested, nil
@@ -105,7 +112,7 @@ func harvestFromTypes(byPath map[string]*types.Package, pkgPaths []string, expli
 // shares its alias with a same-path filter package, and harvestRenderers runs
 // after harvestFromTypes to produce the rendererTable returned alongside the
 // filterTable.
-func loadFilterTableFromTypes(byPath map[string]*types.Package, pkgPaths []string, explicitAliases []FilterAlias, renderers []RendererAlias) (filterTable, rendererTable, error) {
+func loadFilterTableFromTypes(byPath map[string]*types.Package, pkgPaths []string, explicitAliases []FilterAlias, renderers []RendererAlias, fset *token.FileSet) (filterTable, rendererTable, error) {
 	if len(pkgPaths) == 0 && len(explicitAliases) == 0 && len(renderers) == 0 {
 		return filterTable{}, rendererTable{}, nil
 	}
@@ -117,7 +124,7 @@ func loadFilterTableFromTypes(byPath map[string]*types.Package, pkgPaths []strin
 		aliasPaths = append(aliasPaths, r.PkgPath)
 	}
 	aliases := filterAliases(aliasPaths)
-	harvested, err := harvestFromTypes(byPath, pkgPaths, explicitAliases, aliases)
+	harvested, err := harvestFromTypes(byPath, pkgPaths, explicitAliases, aliases, fset)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -145,7 +152,10 @@ func NewCachedResolverFromTypes(pkgs map[string]*types.Package, sizes types.Size
 		return nil, fmt.Errorf("codegen: bundled resolver requires a valid Go language version, got %q", goVersion)
 	}
 	filterPkgs = dedupFilterPkgs(filterPkgs)
-	table, rt, err := loadFilterTableFromTypes(pkgs, filterPkgs, aliases, nil)
+	// No real Fset here: pkgs is reconstructed from an embedded typebundle
+	// (the WASM/no-toolchain path), which carries no source file positions at
+	// all — filterEntry.pos simply stays at its zero value for every entry.
+	table, rt, err := loadFilterTableFromTypes(pkgs, filterPkgs, aliases, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codegen/emit.go
+++ b/internal/codegen/emit.go
@@ -157,7 +157,7 @@ func generateFile(file *ast.File, currentPkg *types.Package, resolved map[ast.No
 	for _, d := range file.Decls {
 		switch v := d.(type) {
 		case *ast.GoChunk:
-			specs, rest, _, err := splitChunk(v.Src)
+			specs, rest, bodyOff, err := splitChunk(v.Src)
 			if err != nil {
 				bag.Errorf(v.Pos(), v.End(), "invalid-syntax", "%s", strings.TrimPrefix(err.Error(), "codegen: "))
 				return nil, false
@@ -187,6 +187,13 @@ func generateFile(file *ast.File, currentPkg *types.Package, resolved map[ast.No
 				}
 			}
 			if rest != "" {
+				// Anchor at the body's own first byte (bodyOff into v.Src, past any
+				// hoisted imports), not v.Pos(): mirrors splitFileGoSource/
+				// buildSkeletonWithRecorder's skeleton-side `gc.Pos() +
+				// token.Pos(bodyOff)` anchor so a cross-module gd on a top-level
+				// var/func/type declared here resolves to its exact .gsx line
+				// instead of drifting by the size of the hoisted import block.
+				emitLine(&body, fset, v.Pos()+token.Pos(bodyOff))
 				body.WriteString(rest)
 				body.WriteString("\n\n")
 			}
@@ -245,12 +252,28 @@ func generateFile(file *ast.File, currentPkg *types.Package, resolved map[ast.No
 				switch p := part.(type) {
 				case ast.GoText:
 					src := p.Src
+					// start tracks how many leading bytes a stripped decorative paren
+					// removes from this part's authored text. The //line directive
+					// MUST anchor at p.Pos()+start, not p.Pos(): the stripped bytes
+					// (and any source lines they span) never reach the output, so
+					// anchoring at the unstripped position would map every following
+					// line — including a trailing top-level var/func chunk sharing
+					// this same GoWithElements region — one or more lines too early.
+					// Mirrors buildSkeletonWithRecorder's/emitTargetGoWithElements's
+					// identical GoText case (analyze.go, component_target_skeleton.go).
+					start := 0
 					if i > 0 && parenWrappable(v.Parts[i-1], shapes, i-1) {
-						src = goexprshape.StripLeadingParen(src)
+						start = len(src) - len(goexprshape.StripLeadingParen(src))
+						src = src[start:]
 					}
 					if i < len(v.Parts)-1 && parenWrappable(v.Parts[i+1], shapes, i+1) {
 						src = goexprshape.StripTrailingParen(src)
 					}
+					// Block-form directive (no newline): this GoText may attach
+					// directly to a preceding element/fragment's closing `}()` (the
+					// trailing `)` of a paren-wrapped `Wrap(<Foo/>)`) — a `//line`
+					// newline there would trip Go's automatic semicolon insertion.
+					emitBlockLine(&wbuf, fset, p.Pos()+token.Pos(start))
 					wbuf.WriteString(src)
 				case *ast.Element:
 					// A top-level Go-expression element literal has NO enclosing gsx
@@ -723,10 +746,11 @@ func emitRenderedNodeBody(b *bytes.Buffer, nodes []ast.Markup, currentPkg *types
 //
 // No emitLine here (unlike genComponent's declaration line): this wrapper
 // carries no user-authored token of its own — it's pure generator
-// boilerplate, same as a GoChunk's own raw body text, which also emits no
-// //line of its own (see generateFile's *ast.GoChunk case). genNode's OWN
-// emitLine call fires immediately below and maps the actual markup/
-// interpolation content, which is what matters.
+// boilerplate, unlike a GoChunk's or GoWithElements GoText's own raw body
+// text, which DOES carry a //line of its own (see generateFile's *ast.GoChunk
+// and *ast.GoWithElements cases). genNode's OWN emitLine call fires
+// immediately below and maps the actual markup/interpolation content, which
+// is what matters.
 //
 // Unlike a component's render closure, this one has NO surrounding component:
 // recvVar/recvTypeName are passed "" (no method-receiver dotted-tag
@@ -2439,6 +2463,23 @@ func emitValueSwitch(b *bytes.Buffer, vs *ast.ValueSwitch, tmp string, armExpr f
 func emitLine(b *bytes.Buffer, fset *token.FileSet, pos token.Pos) {
 	p := fset.Position(pos)
 	fmt.Fprintf(b, "//line %s:%d:%d\n", filepath.Base(p.Filename), p.Line, p.Column)
+}
+
+// emitBlockLine writes a BLOCK-form `/*line file:line:col*/` directive (no
+// trailing newline) mapping subsequent output to the gsx node's source
+// position — the shipped-emit counterpart of emitLine, for splice points that
+// are not at the start of a line. Unlike the `//line` form (which spans to
+// end of line and needs its own line), the block form is valid mid-expression,
+// so it does not force a newline that would trip Go's automatic semicolon
+// insertion when the directive is spliced directly against a preceding
+// element/fragment closure's trailing `}()` (e.g. the `)` of a paren-wrapped
+// `Wrap(<Foo/>)`). Mirrors emitSkeletonBlockLine (analyze.go), but — like
+// emitLine above and unlike the skeleton helper — base-names the filename:
+// this is shipped .x.go output, which must be byte-identical across machines
+// and temp-dir layouts, never carrying an absolute build-time path.
+func emitBlockLine(b *bytes.Buffer, fset *token.FileSet, pos token.Pos) {
+	p := fset.Position(pos)
+	fmt.Fprintf(b, "/*line %s:%d:%d*/", filepath.Base(p.Filename), p.Line, p.Column)
 }
 
 // emitRender writes the type-aware writer call for a single renderable value

--- a/internal/codegen/filters.go
+++ b/internal/codegen/filters.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"errors"
 	"fmt"
+	"go/token"
 	"go/types"
 	"sort"
 	"strings"
@@ -102,6 +103,21 @@ type filterEntry struct {
 	hasErr   bool
 	alias    string
 	pkgPath  string
+	// pos is the target func's declaration position, RESOLVED (Fset.Position,
+	// not a raw Fset-instance-relative token.Pos) at harvest time from the
+	// types.Func object the harvest already found (see harvestFromTypes) and
+	// whatever Fset the caller's types.Package values were type-checked
+	// against. Resolving immediately — rather than carrying the raw token.Pos
+	// forward — is what makes two INDEPENDENT harvests of the same filter
+	// (e.g. the go-list path and the types-based path compared byte-for-byte
+	// in filtertable_equiv_test.go) agree: a raw token.Pos is meaningless
+	// across two different *token.FileSet instances (same file, arbitrary
+	// different integer offsets), while the resolved Position (filename,
+	// line, column) is content-derived and so identical either way. The zero
+	// Position (Pos.IsValid() false) means no Fset was available to resolve
+	// against (e.g. the WASM/typebundle harvest path, which has no real
+	// source files at all).
+	pos token.Position
 }
 
 // filterTable maps a template-level filter name to its harvested entry. The
@@ -291,7 +307,15 @@ func harvestFilters(dir string, pkgPaths []string, explicitAliases []FilterAlias
 		}
 		typesByPath[r.PkgPath] = byPath[r.PkgPath].Types
 	}
-	harvested, err := harvestFromTypes(typesByPath, pkgPaths, explicitAliases, aliases)
+	// packages.Load shares ONE FileSet across every *packages.Package in a
+	// single call (confirmed via *packages.Package.Fset, which "provides
+	// position information for Types, TypesInfo, and Syntax" regardless of
+	// whether NeedSyntax was requested), so any loaded package's Fset works.
+	var fset *token.FileSet
+	if len(pkgs) > 0 {
+		fset = pkgs[0].Fset
+	}
+	harvested, err := harvestFromTypes(typesByPath, pkgPaths, explicitAliases, aliases, fset)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -498,8 +522,21 @@ func lowerFirst(s string) string {
 func filterCandidates(t funcTables) []FilterCandidate {
 	out := make([]FilterCandidate, 0, len(t.filters))
 	for name, e := range t.filters {
-		out = append(out, FilterCandidate{Name: name, Pkg: e.pkgPath, Func: e.funcName, WantsCtx: e.wantsCtx})
+		out = append(out, FilterCandidate{Name: name, Pkg: e.pkgPath, Func: e.funcName, WantsCtx: e.wantsCtx, Pos: e.pos})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
+}
+
+// funcPosition resolves fn's declaration position against fset, or the zero
+// token.Position when fset is nil (no Fset available at this harvest site —
+// e.g. a WASM/typebundle load with no real source files) or fn/its Pos are
+// invalid. Shared by every harvestFromTypes call site so a filterEntry always
+// carries an ALREADY-RESOLVED Position rather than a raw, Fset-instance-only
+// token.Pos (see filterEntry.pos for why that distinction matters).
+func funcPosition(fn *types.Func, fset *token.FileSet) token.Position {
+	if fset == nil || fn == nil || !fn.Pos().IsValid() {
+		return token.Position{}
+	}
+	return fset.Position(fn.Pos())
 }

--- a/internal/codegen/filters_test.go
+++ b/internal/codegen/filters_test.go
@@ -164,7 +164,7 @@ func harvestFixtureFromTypes(t *testing.T, source string) filterTable {
 		}
 	})
 
-	table, _, err := loadFilterTableFromTypes(byPath, []string{pkgPath}, nil, nil)
+	table, _, err := loadFilterTableFromTypes(byPath, []string{pkgPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("loadFilterTableFromTypes: %v", err)
 	}

--- a/internal/codegen/line_anchor_test.go
+++ b/internal/codegen/line_anchor_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	goast "go/ast"
+	goparser "go/parser"
 	"go/token"
 
 	gsxparser "github.com/gsxhq/gsx/parser"
@@ -192,6 +194,167 @@ func TestComponentFuncNameColumnAnchorSkeleton(t *testing.T) {
 
 	for _, name := range []string{"First", "Page", "Last"} {
 		assertFuncNameAnchorColumn(t, skel, lineAnchorSrc, name)
+	}
+}
+
+// topLevelGoChunkSrc puts a top-level var block AFTER a component so the
+// GoChunk's own //line anchor (not the component's) is what's under test.
+// Before the T2 fix, this var block carried no //line at all — emit.go wrote
+// GoChunk body text VERBATIM — so a cross-module gd/compiler error on a symbol
+// declared here resolved to whatever line the type-checker's raw (unmapped)
+// position happened to report, drifting within the .gsx.
+const topLevelGoChunkSrc = `package views
+
+component First() {
+	<p>hi</p>
+}
+
+var (
+	Label = "x"
+	Other = "y"
+)
+`
+
+// lineOf returns the 1-based source line whose trimmed text starts with prefix.
+func lineOf(t *testing.T, src, prefix string) int {
+	t.Helper()
+	for i, l := range strings.Split(src, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(l), prefix) {
+			return i + 1
+		}
+	}
+	t.Fatalf("line with prefix %q not found in src", prefix)
+	return 0
+}
+
+// TestTopLevelGoChunkLineAnchorCodegen verifies the GENERATED .x.go anchors a
+// plain top-level Go var block (an *ast.GoChunk with no embedded elements) to
+// its authored .gsx line via a //line directive — the T2 gap.
+func TestTopLevelGoChunkLineAnchorCodegen(t *testing.T) {
+	t.Parallel()
+	repoRoot, _ := filepath.Abs("../..")
+	tmp := t.TempDir()
+	writeFile(t, tmp, "go.mod", "module gsxb\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	pkgDir := filepath.Join(tmp, "views")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, pkgDir, "views.gsx", topLevelGoChunkSrc)
+
+	res, err := GenerateDirs(tmp, []string{pkgDir}, Options{FilterPkgs: []string{stdImportPath}}, nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	dr := res[pkgDir]
+	if hasDiagErrors(dr.Diags) {
+		t.Fatalf("generate: unexpected errors: %v", dr.Diags)
+	}
+	var gen strings.Builder
+	for _, b := range dr.Files {
+		gen.WriteString(string(b))
+	}
+
+	wantLine := lineOf(t, topLevelGoChunkSrc, "var (")
+	wantMarker := fmt.Sprintf("//line views.gsx:%d:1", wantLine)
+	if !strings.Contains(gen.String(), wantMarker) {
+		t.Fatalf("generated output missing %q anchor for the top-level var block:\n%s", wantMarker, gen.String())
+	}
+}
+
+// goWithElementsTrailingVarSrc mirrors gen's crossPkgValueDep e2e fixture: a
+// top-level func whose body embeds a decorative-paren-wrapped gsx element,
+// followed by a top-level var block sharing the SAME *ast.GoWithElements
+// region as the func's trailing GoText. This is the exact shape the f0f590e8
+// fix's anchoring recipe (part.Pos()+start after leading-paren-strip) targets
+// — an anchor that doesn't account for the stripped paren's bytes drifts the
+// var block's mapped line by however many source lines the paren wrap spans.
+const goWithElementsTrailingVarSrc = `package widget
+
+import "github.com/gsxhq/gsx"
+
+func icon(name string) func(attrs ...gsx.Attr) gsx.Node {
+	return func(attrs ...gsx.Attr) gsx.Node {
+		return (
+			<svg
+				width="24"
+				{ attrs... }
+			>
+				<title>{ name }</title>
+			</svg>
+		)
+	}
+}
+
+var (
+	Check = icon("check")
+	X     = icon("x")
+)
+`
+
+// TestGoWithElementsTrailingVarLineAnchorCodegen verifies the GENERATED .x.go
+// anchors a top-level var block that trails a decorative-paren-wrapped
+// embedded element — in the SAME *ast.GoWithElements region — to its exact
+// authored .gsx line. Codegen-level counterpart to gen's
+// TestDefinitionCrossModuleValueSourcesPresent e2e, which pins the same shape
+// end-to-end through cross-module go-to-definition.
+func TestGoWithElementsTrailingVarLineAnchorCodegen(t *testing.T) {
+	t.Parallel()
+	repoRoot, _ := filepath.Abs("../..")
+	tmp := t.TempDir()
+	writeFile(t, tmp, "go.mod", "module gsxc\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	pkgDir := filepath.Join(tmp, "widget")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, pkgDir, "named.gsx", goWithElementsTrailingVarSrc)
+
+	res, err := GenerateDirs(tmp, []string{pkgDir}, Options{FilterPkgs: []string{stdImportPath}}, nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	dr := res[pkgDir]
+	if hasDiagErrors(dr.Diags) {
+		t.Fatalf("generate: unexpected errors: %v", dr.Diags)
+	}
+	var gen strings.Builder
+	for _, b := range dr.Files {
+		gen.WriteString(string(b))
+	}
+
+	// Parse the generated .x.go the same way go/types (and so the LSP's
+	// go-to-definition) does: the standard go/scanner processes //line and
+	// block-form /*line*/ directives while tokenizing, so ast node positions
+	// resolved through THIS fset are already directive-mapped back to the
+	// .gsx — exactly the mechanism TestDefinitionCrossModuleValueSourcesPresent
+	// (gen/definition_crosspkg_value_e2e_test.go) exercises end-to-end via a
+	// published .x.go loaded from a separate module. There need be no fresh
+	// //line directive immediately before `var (`: a single anchor earlier in
+	// this same trailing GoText part maps every following line by newline
+	// counting, which is exactly what's under test here.
+	stdFset := token.NewFileSet()
+	stdFile, err := goparser.ParseFile(stdFset, "named.x.go", gen.String(), goparser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse generated output as plain Go: %v\n%s", err, gen.String())
+	}
+	xPos := token.NoPos
+	goast.Inspect(stdFile, func(n goast.Node) bool {
+		if vs, ok := n.(*goast.ValueSpec); ok {
+			for _, name := range vs.Names {
+				if name.Name == "X" {
+					xPos = name.Pos()
+				}
+			}
+		}
+		return true
+	})
+	if xPos == token.NoPos {
+		t.Fatalf("`X` value spec not found in generated output:\n%s", gen.String())
+	}
+	p := stdFset.Position(xPos)
+	wantLine := lineOf(t, goWithElementsTrailingVarSrc, "X     = icon")
+	if p.Filename != "named.gsx" || p.Line != wantLine {
+		t.Fatalf("X resolved to %s:%d, want named.gsx:%d (the authored var-block line) — directive:\n%s",
+			p.Filename, p.Line, wantLine, gen.String())
 	}
 }
 

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -1058,7 +1058,12 @@ func (m *Module) filterTableFromSource(pkgs []string) (filterTable, error) {
 	if err != nil {
 		return nil, err
 	}
-	table, _, err := loadFilterTableFromTypes(packages, pkgs, m.opts.Aliases, nil)
+	// configuredSourcePackages resolves every request (local or external)
+	// against the Module's own shared m.fset (see configuredSourceDeclResolver
+	// / externalImporter), the SAME Fset PackageResult.Fset publishes — so a
+	// filterEntry.pos captured here is directly usable, with no further
+	// resolution, by the LSP completion (T9/T10 lazy doc resolve).
+	table, _, err := loadFilterTableFromTypes(packages, pkgs, m.opts.Aliases, nil, m.fset)
 	return table, err
 }
 

--- a/internal/codegen/module.go
+++ b/internal/codegen/module.go
@@ -134,6 +134,7 @@ type Options struct {
 // NOT acquire analysisMu — those functions run within a held analysisMu and
 // re-acquiring would deadlock. True fine-grained concurrent analysis (multiple
 // roots in parallel or partial invalidation) is deferred to Phase 2.
+//
 // TryAnalyzeEphemeral is a non-blocking variant of the AnalyzeEphemeral entry
 // point: it acquires analysisMu via TryLock and returns acquired=false rather
 // than waiting when another entry point holds it. It composes with this
@@ -1300,27 +1301,6 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 		}
 		return nil, err
 	}
-	// Retention policy (P3, perf-hunt #2): this result is about to be cached in
-	// m.pkgResults and held for the life of the LSP session. checkSkeletonPackage
-	// populates Info.Scopes with one *types.Scope per func/block/if/for/switch,
-	// but the only retained-package consumer (importQualifierCandidates, via
-	// componentDeclPackage's ephemeral-then-retained fallback) reads only the
-	// *ast.File-keyed entries — prune to that subset before caching.
-	//
-	// MEASURED: this frees only the Info.Scopes index entries themselves (~1 MB
-	// on one-learning ui/), not the *types.Scope objects they point to — those
-	// remain fully reachable regardless, via res.Types.Scope()'s parent/children
-	// tree (go/types.NewScope unconditionally links every scope into that tree,
-	// independent of whether a Checker's Info records it — see scope.go). Types
-	// is retained for unrelated reasons (hover's qualifier, import resolution),
-	// so the ~96 MB the perf-hunt report attributed to "Info.Scopes" was actually
-	// pinned by Types all along; this policy narrows the supported/observable
-	// surface (and the small index overhead) without claiming a heap win it
-	// cannot deliver. See perf-hunt-2-report.md "P3 pass" for the measurement.
-	//
-	// AnalyzeEphemeral does NOT call this: its result is never cached, and the
-	// Go-completion scope walk (innermostScopeAt et al.) needs the full index.
-	retainFileScopesOnly(a.info)
 	res := &PackageResult{
 		Files:       map[string][]byte{},
 		GSXFset:     a.gsxFset,
@@ -1387,6 +1367,34 @@ func (m *Module) Package(dir string) (*PackageResult, error) {
 	// unused-import classification above (missingFromSkeletons). See
 	// MissingImport's doc for why the Name is left unresolved to an import path.
 	res.MissingImports = a.missingImports
+	// Retention policy (P3, perf-hunt #2): this result is about to be cached in
+	// m.pkgResults and held for the life of the LSP session. checkSkeletonPackage
+	// populates Info.Scopes with one *types.Scope per func/block/if/for/switch,
+	// but the only retained-package consumer (importQualifierCandidates, via
+	// componentDeclPackage's ephemeral-then-retained fallback) reads only the
+	// *ast.File-keyed entries — prune to that subset before caching.
+	//
+	// Called here, immediately before the cache write, rather than right after
+	// analyze returns: every other a.info consumer above (buildCrossNav,
+	// componentParamDeclarationFacts, componentParamBodyReferenceFacts) runs
+	// first, so none of them ever observes a pruned Info.Scopes. Positioning the
+	// prune any earlier would be a silent trap for a future consumer inserted
+	// between analyze and this line.
+	//
+	// MEASURED: this frees only the Info.Scopes index entries themselves (~1 MB
+	// on one-learning ui/), not the *types.Scope objects they point to — those
+	// remain fully reachable regardless, via res.Types.Scope()'s parent/children
+	// tree (go/types.NewScope unconditionally links every scope into that tree,
+	// independent of whether a Checker's Info records it — see scope.go). Types
+	// is retained for unrelated reasons (hover's qualifier, import resolution),
+	// so the ~96 MB the perf-hunt report attributed to "Info.Scopes" was actually
+	// pinned by Types all along; this policy narrows the supported/observable
+	// surface (and the small index overhead) without claiming a heap win it
+	// cannot deliver. See perf-hunt-2-report.md "P3 pass" for the measurement.
+	//
+	// AnalyzeEphemeral does NOT call this: its result is never cached, and the
+	// Go-completion scope walk (innermostScopeAt et al.) needs the full index.
+	retainFileScopesOnly(a.info)
 	m.mu.Lock()
 	m.pkgResults[dir] = res
 	m.mu.Unlock()

--- a/internal/codegen/module_diag_test.go
+++ b/internal/codegen/module_diag_test.go
@@ -38,6 +38,45 @@ func TestModulePackageSurfacesTypeErrors(t *testing.T) {
 	}
 }
 
+// TestModulePackageSurfacesWalkTimeDiagnostics is the P2 perf-hunt regression
+// test: Package's diagnostics-only generateFile call (module.go, gated on
+// len(a.typeErrs)==0 && !a.bag.HasErrors()) now passes diagnosticsOnly=true,
+// returning right after the component/decl walk instead of running the full
+// emit (import assembly, coalesceStaticWrites, format.Source). An unknown
+// pipe filter is a WALK-time diagnostic (filters.go's lowerPipe, added to bag
+// during that same walk, well before the skipped output-shaping stages) —
+// exactly the class of diagnostic diagnosticsOnly's early return must still
+// surface. The source here type-checks cleanly (bogusFilter is undefined only
+// as a FILTER, not a Go identifier — `x` alone is a valid string expression),
+// so this exercises the diagnosticsOnly branch, not the type-error branch
+// TestModulePackageSurfacesTypeErrors already covers.
+func TestModulePackageSurfacesWalkTimeDiagnostics(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	repoRoot, _ := filepath.Abs("../..")
+	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	pkgDir := filepath.Join(root, "page")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, pkgDir, "page.gsx", "package page\n\ncomponent Home(x string) {\n\t<div>{ x |> bogusFilter }</div>\n}\n")
+
+	m, _ := Open(Options{ModuleRoot: root, ModulePath: "example.com/app", FilterPkgs: []string{StdImportPath}})
+	pr, err := m.Package(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, d := range pr.Diags {
+		if strings.Contains(d.Message, "unknown filter") && strings.Contains(d.Message, "bogusFilter") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an 'unknown filter \"bogusFilter\"' diagnostic on the Package path; got %+v", pr.Diags)
+	}
+}
+
 // TestPackageOmitsSecondaryDiagsOnTypeError proves Package surfaces ONLY the
 // type-error diagnostic for a package that fails to type-check — not the spurious
 // secondary "could not resolve type of interpolation" diagnostics that running
@@ -255,5 +294,64 @@ func TestModuleInvalidateKeepsExternalWarm(t *testing.T) {
 	// ext importer must still be non-nil (warm, not cleared by Invalidate)
 	if m.ext == nil {
 		t.Fatalf("Invalidate wrongly cleared the external importer")
+	}
+}
+
+// TestStripGsxProbeWrappers pins the textual sanitization stripGsxunwrap's
+// treatment is extended to: the skeleton's harvest-probe wrapper calls
+// (_gsxuse/_gsxusen/_gsxuseq) must never appear verbatim in a message that
+// reaches stripGsxProbeWrappers, mirroring how stripGsxunwrap already handles
+// _gsxunwrap. "_gsxuse(" must not falsely match inside "_gsxusen("/
+// "_gsxuseq(" text (they share the "_gsxuse" prefix but continue with a
+// different character, never "(").
+func TestStripGsxProbeWrappers(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"_gsxuse(x) (no value) used as value", "x (no value) used as value"},
+		// _gsxusen is variadic (a keep-alive over several identifiers at once);
+		// stripping keeps every argument, not just one.
+		{"cannot use _gsxusen(a, b) (value of type int)", "cannot use a, b (value of type int)"},
+		{"invalid operation: _gsxuseq(a.b) is not addressable", "invalid operation: a.b is not addressable"},
+		{"two sibling wrappers: _gsxuse(a) vs _gsxuse(b)", "two sibling wrappers: a vs b"},
+		{"no wrapper here", "no wrapper here"},
+	}
+	for _, tc := range cases {
+		if got := stripGsxProbeWrappers(tc.in); got != tc.want {
+			t.Errorf("stripGsxProbeWrappers(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestModulePackageSanitizesGsxUseDiagLeak is the T11 fix from the LSP
+// completion design's probe (docs/superpowers/specs/2026-07-21-lsp-completion-design.md,
+// "Incidental (not fixed here, noted)"): `{{ x := }}` — a short var decl with
+// no RHS — produces a raw go/types error whose message quotes the skeleton's
+// internal _gsxuse(...) harvest-probe wrapper verbatim
+// (`_gsxuse(x) (no value) used as value`), because the error's POSITION falls
+// outside the probe span analyze's quietSpans suppression keys on, even though
+// its MESSAGE still names the probe. Package's surfaced diagnostics must never
+// expose that internal helper name to a user.
+func TestModulePackageSanitizesGsxUseDiagLeak(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	repoRoot, _ := filepath.Abs("../..")
+	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	pkgDir := filepath.Join(root, "page")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, pkgDir, "page.gsx", "package page\n\ncomponent Home() {\n\t{{ x := }}\n\t<div>{ x }</div>\n}\n")
+
+	m, _ := Open(Options{ModuleRoot: root, ModulePath: "example.com/app", FilterPkgs: []string{StdImportPath}})
+	pr, err := m.Package(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Diags) == 0 {
+		t.Fatal("expected diagnostics for `{{ x := }}` (short var decl with no RHS); got none")
+	}
+	for _, d := range pr.Diags {
+		if strings.Contains(d.Message, "_gsxuse") {
+			t.Fatalf("diagnostic leaks the internal _gsxuse probe wrapper name: %q", d.Message)
+		}
 	}
 }

--- a/internal/codegen/module_ephemeral_test.go
+++ b/internal/codegen/module_ephemeral_test.go
@@ -277,6 +277,81 @@ func TestAnalyzeEphemeralColdReanalyzeReflectsLiveBuffer(t *testing.T) {
 	}
 }
 
+// TestAnalyzeEphemeralRestoresPkgTypesCache exercises the snapshot/restore
+// path itself, which TestAnalyzeEphemeralColdReanalyzeReflectsLiveBuffer does
+// NOT: that test calls Invalidate before re-Package, and Invalidate itself
+// drops pkgTypes[dir] — so a restore bug (analyzeEphemeralLocked's defer in
+// module.go leaving the ephemeral-patched *types.Package cached instead of
+// putting prevTypes back) would go completely unobserved there.
+//
+// The baseline warm-up goes through Package(dir), like every sibling ephemeral
+// test — NOT typesPackage(dir) directly: typesPackage never calls applyDirty,
+// so the dirty flag SetOverride sets would still be live when AnalyzeEphemeral
+// runs its own applyDirty() and evict pkgTypes[dir] before the snapshot is
+// even taken, producing a false "restored to nothing" reading that has
+// nothing to do with the restore logic under test. Package(dir) clears that
+// dirty flag up front, so the pre-ephemeral snapshot genuinely captures the
+// live *types.Package.
+//
+// After that, this test never calls Invalidate/SetOverride/ClearOverride: it
+// reads m.pkgTypes[dir] directly (a direct typesPackage-cache consumer,
+// in-package so the unexported cache is reachable) and separately through the
+// public typesPackage(dir) entry point, both with no intervening
+// cache-dropping transition. The only mechanism that can make either see the
+// live package again is the defer in analyzeEphemeralLocked restoring
+// m.pkgTypes[dir] to its pre-call snapshot.
+func TestAnalyzeEphemeralRestoresPkgTypesCache(t *testing.T) {
+	m, dir, pagePath := newEphemeralTestModule(t)
+	live := []byte("package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name }</div>\n}\n")
+	m.SetOverride(pagePath, live)
+
+	if _, err := m.Package(dir); err != nil {
+		t.Fatalf("baseline Package: %v", err)
+	}
+	m.mu.Lock()
+	liveTypes := m.pkgTypes[dir]
+	m.mu.Unlock()
+	if liveTypes == nil {
+		t.Fatal("baseline Package did not populate pkgTypes[dir]; fixture broken")
+	}
+	if liveTypes.Scope().Lookup("Home") == nil {
+		t.Fatal("baseline pkgTypes missing the Home component; fixture broken")
+	}
+
+	// The ephemeral patch renames the component so a leaked or corrupted cache
+	// entry is trivially observable: "Home" would be gone, "HomePatched" present.
+	patched := []byte("package page\n\ncomponent HomePatched(user User) {\n\t<div>{ user.Name }</div>\n}\n")
+	if _, err := m.AnalyzeEphemeral(dir, pagePath, patched); err != nil {
+		t.Fatalf("AnalyzeEphemeral: %v", err)
+	}
+
+	// Direct cache read: no Invalidate/dirty transition happened above, so this
+	// can only be liveTypes if analyzeEphemeralLocked's defer actually restored
+	// it.
+	m.mu.Lock()
+	restored := m.pkgTypes[dir]
+	m.mu.Unlock()
+	if restored != liveTypes {
+		t.Fatal("pkgTypes[dir] is not the live *types.Package after AnalyzeEphemeral returned; the snapshot/restore left a different (likely ephemeral-patched, or evicted) package cached")
+	}
+	if restored.Scope().Lookup("Home") == nil {
+		t.Fatal("restored pkgTypes missing Home; cache holds the ephemeral-patched package, not the live buffer")
+	}
+	if restored.Scope().Lookup("HomePatched") != nil {
+		t.Fatal("restored pkgTypes contains HomePatched; the ephemeral buffer leaked into the persistent cache")
+	}
+
+	// Same story through the public entry point, still with no Invalidate call
+	// anywhere in this test.
+	again, err := m.typesPackage(dir)
+	if err != nil {
+		t.Fatalf("typesPackage after ephemeral: %v", err)
+	}
+	if again != liveTypes {
+		t.Fatal("typesPackage(dir) after AnalyzeEphemeral returned a package other than the pre-ephemeral live one")
+	}
+}
+
 func TestAnalyzeEphemeralDoesNotDirty(t *testing.T) {
 	m, dir, pagePath := newEphemeralTestModule(t)
 	m.SetOverride(pagePath, []byte("package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name }</div>\n}\n"))

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -1475,10 +1475,10 @@ func (m *Module) analyze(dir string, mi *moduleImporter, purpose analysisPurpose
 		if strings.HasSuffix(p.Filename, ".x.go") {
 			continue // synthetic skeleton position: no //line directive, so no valid .gsx location to report
 		}
-		msg := stripGsxunwrap(e.Msg)
+		msg := stripGsxProbeWrappers(stripGsxunwrap(e.Msg))
 		// Exact positional planning owns component inference diagnostics. Every
 		// retained skeleton error is therefore a native Go error and passes through
-		// verbatim after internal unwrap names are removed.
+		// verbatim after internal unwrap/probe wrapper names are removed.
 		bag.Add(diag.Diagnostic{Start: p, End: p, Severity: diag.Error, Message: msg, Source: "types"})
 		reportableFullTypeErrs = append(reportableFullTypeErrs, e)
 	}
@@ -1783,7 +1783,20 @@ type parseCacheEntry struct {
 // unchanged, and otherwise parses (into fset), normalizes, and caches a new
 // pristine tree before returning its clone. A parse error is returned as a
 // sourceDiagnosticsError and is never cached.
+//
+// Precondition: fset must be m.fset. A cache hit returns entry.file's clone
+// without touching fset at all — its token.Pos values were minted against
+// whichever fset was live at the ORIGINAL parse (always m.fset, per every
+// current caller; see parsePackageWithFset's callers). Every position the
+// Module hands out is required to resolve against the single Module-wide
+// m.fset (see Module's "FileSet" doc), so a caller passing a different fset
+// here would silently get back positions in the wrong FileSet on a cache hit
+// while appearing to work on a cache miss — the asymmetry this assertion
+// exists to catch immediately instead of downstream as corrupted positions.
 func (m *Module) parsedGSXFile(path string, src []byte, classifier *attrclass.Classifier, fset *token.FileSet) (*gsxast.File, error) {
+	if fset != m.fset {
+		panic("codegen: parsedGSXFile called with fset != m.fset; the per-file parse cache is keyed on m.fset-relative positions and a cache hit would silently return positions in the wrong FileSet")
+	}
 	hash := sha256.Sum256(src)
 	m.mu.Lock()
 	entry, ok := m.parseCache[path]
@@ -1823,6 +1836,8 @@ func (m *Module) parsedGSXFile(path string, src []byte, classifier *attrclass.Cl
 // parsePackageWithFset parses every .gsx in dir into the provided fset and
 // returns the private package owner for the one preprocessing transition. The
 // shared FileSet remains required for valid skeleton //line directives.
+// Precondition: fset must be m.fset — it is threaded straight through to
+// parsedGSXFile per file, which asserts this itself (see its doc).
 func (m *Module) parsePackageWithFset(dir string, fset *token.FileSet) (*parsedGSXPackage, error) {
 	paths := map[string]struct{}{}
 	m.mu.Lock()
@@ -1887,7 +1902,39 @@ func (m *Module) parsePackageWithFset(dir string, fset *token.FileSet) (*parsedG
 // type-checker do not expose the internal _gsxunwrap helper name to users.
 // Nested parentheses inside the argument are handled via bracket counting.
 func stripGsxunwrap(s string) string {
-	const prefix = "_gsxunwrap("
+	return stripGsxWrapperCall(s, "_gsxunwrap(")
+}
+
+// gsxProbeWrapperPrefixes are the skeleton's harvest-probe call names
+// (writeSkeletonCanonicalProbe et al. in analyze.go) that can leak into a raw
+// go/types error message the same way _gsxunwrap does. Ordinarily a type
+// error positioned inside one of these calls is suppressed entirely (analyze:
+// quietSpans, harvestProbeSpans) because the native operand context reports
+// the equivalent error — but a malformed statement immediately around a probe
+// (e.g. `{{ x := }}`, a short var decl with no RHS) can produce an error whose
+// POSITION falls outside the probe span while its MESSAGE still quotes the
+// probe call verbatim (`_gsxuse(x) (no value) used as value`), so position-based
+// suppression alone does not catch it. "_gsxuse(" is checked before the other
+// two so it does not need to special-case matching inside "_gsxusen("/
+// "_gsxuseq(" — those share the "_gsxuse" prefix but continue with 'n'/'q', not
+// '(', so "_gsxuse(" never matches inside them.
+var gsxProbeWrapperPrefixes = []string{"_gsxuse(", "_gsxusen(", "_gsxuseq("}
+
+// stripGsxProbeWrappers removes all occurrences of every gsxProbeWrapperPrefixes
+// call in s, replacing each with its argument — the same treatment
+// stripGsxunwrap gives _gsxunwrap, for the skeleton's other internal-only
+// wrapper names.
+func stripGsxProbeWrappers(s string) string {
+	for _, prefix := range gsxProbeWrapperPrefixes {
+		s = stripGsxWrapperCall(s, prefix)
+	}
+	return s
+}
+
+// stripGsxWrapperCall removes all occurrences of prefix+"...)" in s, replacing
+// each with its argument (the "..." content) via bracket counting over nested
+// parentheses. prefix must end in "(".
+func stripGsxWrapperCall(s, prefix string) string {
 	if !strings.Contains(s, prefix) {
 		return s
 	}
@@ -1910,7 +1957,7 @@ func stripGsxunwrap(s string) string {
 			}
 			j++
 		}
-		// s[i+len(prefix) : j-1] is the content inside _gsxunwrap(...)
+		// s[i+len(prefix) : j-1] is the content inside prefix(...)
 		b.WriteString(s[i+len(prefix) : j-1])
 		s = s[j:]
 	}

--- a/internal/codegen/parse_cache_test.go
+++ b/internal/codegen/parse_cache_test.go
@@ -2,7 +2,9 @@ package codegen
 
 import (
 	"bytes"
+	"go/token"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -78,4 +80,38 @@ func TestParseCacheServesIndependentASTs(t *testing.T) {
 	if f1 == f2 {
 		t.Fatal("two independent analyses shared the same *ast.File pointer; parse-cache clone-on-use is not isolating trees")
 	}
+}
+
+// TestParsedGSXFileRejectsForeignFset pins parsedGSXFile's precondition: fset
+// must be m.fset. A cache hit returns entry.file's clone without ever touching
+// the fset argument, so a caller passing any other *token.FileSet would
+// silently get back positions minted against m.fset while believing it used
+// its own — the assertion converts that latent corruption into an immediate,
+// loud panic instead.
+func TestParsedGSXFileRejectsForeignFset(t *testing.T) {
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	writeFile(t, root, "page/page.gsx", "package page\n\ncomponent Home() {\n\t<div>ok</div>\n}\n")
+
+	m, err := Open(Options{ModuleRoot: root, ModulePath: "example.com/app"})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("parsedGSXFile did not panic on a foreign fset")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "fset != m.fset") {
+			t.Fatalf("panic = %v, want a message naming the fset != m.fset precondition", r)
+		}
+	}()
+	foreign := token.NewFileSet()
+	_, _ = m.parsedGSXFile(filepath.Join(root, "page", "page.gsx"), []byte("package page\n"), nil, foreign)
 }

--- a/internal/codegen/resolve_functions.go
+++ b/internal/codegen/resolve_functions.go
@@ -48,7 +48,7 @@ func (m *Module) resolveFunctions() ([]FilterInfo, []RendererInfo, error) {
 	for _, r := range finalRendererAliases(m.opts.Renderers) {
 		aliasPaths = append(aliasPaths, r.PkgPath)
 	}
-	harvested, err := harvestFromTypes(functionPkgs, filterPkgs, m.opts.Aliases, filterAliases(aliasPaths))
+	harvested, err := harvestFromTypes(functionPkgs, filterPkgs, m.opts.Aliases, filterAliases(aliasPaths), m.fset)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/codegen/resolver.go
+++ b/internal/codegen/resolver.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"fmt"
+	"go/token"
 	"go/types"
 	goversion "go/version"
 	"os"
@@ -89,12 +90,18 @@ func newCachedResolver(moduleDir string, filterPkgs []string, aliases []FilterAl
 	}
 	m := map[string]*types.Package{}
 	var sizes types.Sizes
+	var fset *token.FileSet
 	packages.Visit(pkgs, nil, func(p *packages.Package) {
 		if p.Types != nil {
 			m[p.PkgPath] = p.Types
 		}
 		if sizes == nil && p.TypesSizes != nil {
 			sizes = p.TypesSizes
+		}
+		// packages.Load shares ONE FileSet across the whole load, so any
+		// visited package's Fset is the same instance.
+		if fset == nil {
+			fset = p.Fset
 		}
 	})
 	if sizes == nil {
@@ -103,7 +110,7 @@ func newCachedResolver(moduleDir string, filterPkgs []string, aliases []FilterAl
 	if goVersion == "" {
 		return nil, fmt.Errorf("codegen: cached resolver load returned no Go language version for %s", moduleDir)
 	}
-	table, rt, err := loadFilterTableFromTypes(m, filterPkgs, aliases, nil)
+	table, rt, err := loadFilterTableFromTypes(m, filterPkgs, aliases, nil, fset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codegen/results.go
+++ b/internal/codegen/results.go
@@ -212,4 +212,11 @@ type FilterCandidate struct {
 	Pkg      string // winning package import path
 	Func     string // exported Go func name, e.g. "Upper"
 	WantsCtx bool
+	// Pos is the target func's ALREADY-RESOLVED declaration position (see
+	// filterEntry.pos for why a resolved Position, not a raw token.Pos, is
+	// what makes two independent harvests of the same filter comparable). The
+	// zero Position (Pos.IsValid() false) means no Fset was available at the
+	// harvest site that produced this candidate (e.g. the WASM/typebundle
+	// path): the LSP completion path (Module-backed) always has one.
+	Pos token.Position
 }

--- a/internal/corpus/testdata/cases/attrs/attr_error_autounwrap.txtar
+++ b/internal/corpus/testdata/cases/attrs/attr_error_autounwrap.txtar
@@ -26,6 +26,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func buildHref(id string) (string, error) { return "/u/" + id, nil }
 func label(id string) (string, error)     { return "user " + id, nil }
 

--- a/internal/corpus/testdata/cases/attrs/attr_error_autounwrap_nested.txtar
+++ b/internal/corpus/testdata/cases/attrs/attr_error_autounwrap_nested.txtar
@@ -28,6 +28,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func href(id string) (string, error)  { return "/u/" + id, nil }
 func label(id string) (string, error) { return "user " + id, nil }
 

--- a/internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar
+++ b/internal/corpus/testdata/cases/attrs/bool_exact_dispatch_required.txtar
@@ -147,6 +147,7 @@ import (
 	_gsxsc "strconv"
 )
 
+//line input.gsx:9:1
 type Flag bool
 
 var anyFalse any = false

--- a/internal/corpus/testdata/cases/attrsonly/direct_factory_attrs_identifier.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/direct_factory_attrs_identifier.txtar
@@ -28,6 +28,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func label(attrs string) gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
@@ -37,7 +38,7 @@ func label(attrs string) gsx.Node {
 		_gsxgw.Text(string(attrs))
 		_gsxgw.S("</span>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:6:31*/
 }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/attrsonly/direct_factory_derived_forwarding.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/direct_factory_derived_forwarding.txtar
@@ -42,6 +42,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func drop(attrs []gsx.Attr, key string) []gsx.Attr {
 	var out []gsx.Attr
 	for _, a := range attrs {
@@ -72,7 +73,7 @@ func named(name string) func(attrs ...gsx.Attr) gsx.Node {
 			_gsxgw.Text(string(name))
 			_gsxgw.S("</svg>")
 			return _gsxgw.Err()
-		})
+		}) /*line input.gsx:17:86*/
 	}
 }
 

--- a/internal/corpus/testdata/cases/attrsonly/direct_factory_pipelined_forwarding.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/direct_factory_pipelined_forwarding.txtar
@@ -51,6 +51,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func named(name string) func(attrs ...gsx.Attr) gsx.Node {
 	return func(attrs ...gsx.Attr) gsx.Node {
 		return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
@@ -71,7 +72,7 @@ func named(name string) func(attrs ...gsx.Attr) gsx.Node {
 			_gsxgw.Text(string(name))
 			_gsxgw.S("</svg>")
 			return _gsxgw.Err()
-		})
+		}) /*line input.gsx:7:94*/
 	}
 }
 

--- a/internal/corpus/testdata/cases/attrsonly/direct_factory_variadic_forwarding.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/direct_factory_variadic_forwarding.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func named(name string) func(attrs ...gsx.Attr) gsx.Node {
 	return func(attrs ...gsx.Attr) gsx.Node {
 		return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
@@ -52,7 +53,7 @@ func named(name string) func(attrs ...gsx.Attr) gsx.Node {
 			_gsxgw.Text(string(name))
 			_gsxgw.S("</svg>")
 			return _gsxgw.Err()
-		})
+		}) /*line input.gsx:7:74*/
 	}
 }
 

--- a/internal/corpus/testdata/cases/attrsonly/f_literal_ordered_pair_order.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/f_literal_ordered_pair_order.txtar
@@ -84,6 +84,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type chipProps struct{ Attrs gsx.Attrs }
 
 //line input.gsx:7:1
@@ -101,6 +102,7 @@ func renderChip(p chipProps) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:9:1
 func Chip(attrs ...gsx.Attr) gsx.Node {
 	return renderChip(chipProps{Attrs: gsx.Attrs(attrs)})
 }

--- a/internal/corpus/testdata/cases/attrsonly/func_named_attrs.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/func_named_attrs.txtar
@@ -41,6 +41,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type pillProps struct {
 	Attrs gsx.Attrs
 }
@@ -60,6 +61,7 @@ func renderPill(p pillProps) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:13:1
 func Pill(attrs gsx.Attrs) gsx.Node {
 	return renderPill(pillProps{Attrs: attrs})
 }

--- a/internal/corpus/testdata/cases/attrsonly/merge_order.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/merge_order.txtar
@@ -36,6 +36,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type boxProps struct {
 	Attrs gsx.Attrs
 }
@@ -55,6 +56,7 @@ func renderBox(p boxProps) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:13:1
 func Box(attrs gsx.Attrs) gsx.Node {
 	return renderBox(boxProps{Attrs: attrs})
 }

--- a/internal/corpus/testdata/cases/attrsonly/named_slice_type.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/named_slice_type.txtar
@@ -49,6 +49,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type myAttrs []gsx.Attr
 
 type badgeProps struct {
@@ -70,6 +71,7 @@ func renderBadge(p badgeProps) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:15:1
 var Badge = func(a myAttrs) gsx.Node {
 	return renderBadge(badgeProps{Attrs: gsx.Attrs(a)})
 }

--- a/internal/corpus/testdata/cases/attrsonly/sibling_cf_class.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/sibling_cf_class.txtar
@@ -48,6 +48,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type iconProps struct {
 	Attrs gsx.Attrs
 }

--- a/internal/corpus/testdata/cases/attrsonly/unnamed_slice.txtar
+++ b/internal/corpus/testdata/cases/attrsonly/unnamed_slice.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type badgeProps struct {
 	Attrs gsx.Attrs
 }
@@ -62,6 +63,7 @@ func renderBadge(p badgeProps) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:13:1
 func Badge(attrs []gsx.Attr) gsx.Node {
 	return renderBadge(badgeProps{Attrs: gsx.Attrs(attrs)})
 }

--- a/internal/corpus/testdata/cases/class/merger_no_class.txtar
+++ b/internal/corpus/testdata/cases/class/merger_no_class.txtar
@@ -35,6 +35,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 // No class attribute anywhere — _gsxcm import must be omitted even though
 // class_merger is configured in gsx.toml.
 

--- a/internal/corpus/testdata/cases/class/multi_part_tuple_order.txtar
+++ b/internal/corpus/testdata/cases/class/multi_part_tuple_order.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 var trace []string
 
 //line input.gsx:5:1
@@ -64,6 +65,7 @@ func C() _gsxrt.Node {
 	})
 }
 
+//line input.gsx:9:1
 func first() string {
 	trace = append(trace, "first")
 	return "first"

--- a/internal/corpus/testdata/cases/class/part_tuple.txtar
+++ b/internal/corpus/testdata/cases/class/part_tuple.txtar
@@ -40,4 +40,5 @@ func C(v int) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:7:1
 func cls(v int) (string, error) { return "green", nil }

--- a/internal/corpus/testdata/cases/class/value_form_evaluation_order.txtar
+++ b/internal/corpus/testdata/cases/class/value_form_evaluation_order.txtar
@@ -27,6 +27,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 var state bool
 
 //line input.gsx:5:1
@@ -51,6 +52,7 @@ func C() _gsxrt.Node {
 	})
 }
 
+//line input.gsx:9:1
 func setState() string {
 	state = true
 	return "base"

--- a/internal/corpus/testdata/cases/class/value_switch_tuple.txtar
+++ b/internal/corpus/testdata/cases/class/value_switch_tuple.txtar
@@ -50,5 +50,6 @@ func Badge(variant int) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:10:1
 func cls(v int) (string, error) { return "green", nil }
 -- diagnostics.golden --

--- a/internal/corpus/testdata/cases/components/attrs_literal_merge_tuple.txtar
+++ b/internal/corpus/testdata/cases/components/attrs_literal_merge_tuple.txtar
@@ -30,6 +30,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func f() (string, error) { return "2", nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/components/child_class_evaluation_order.txtar
+++ b/internal/corpus/testdata/cases/components/child_class_evaluation_order.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 var state bool
 
 //line input.gsx:7:1
@@ -79,6 +80,7 @@ func Page() _gsxrt.Node {
 	})
 }
 
+//line input.gsx:13:1
 func setState() string {
 	state = true
 	return "base"

--- a/internal/corpus/testdata/cases/components/child_class_part_tuple.txtar
+++ b/internal/corpus/testdata/cases/components/child_class_part_tuple.txtar
@@ -67,6 +67,7 @@ func Page(v int) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:11:1
 func cls(v int) (string, error) { return "green", nil }
 -- render.golden --
 <div class="card base green">Hi</div>

--- a/internal/corpus/testdata/cases/components/child_class_value_arm_tuple.txtar
+++ b/internal/corpus/testdata/cases/components/child_class_value_arm_tuple.txtar
@@ -73,6 +73,7 @@ func Page(v int, flag bool) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:11:1
 func cls(v int) (string, error) { return "green", nil }
 -- render.golden --
 <div class="card base green">Hi</div>

--- a/internal/corpus/testdata/cases/components/child_prop_tuple_error.txtar
+++ b/internal/corpus/testdata/cases/components/child_prop_tuple_error.txtar
@@ -23,6 +23,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func lookup(s string) (string, error) { return s, nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/components/component_conditional_attr_lazy.txtar
+++ b/internal/corpus/testdata/cases/components/component_conditional_attr_lazy.txtar
@@ -33,6 +33,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type User struct {
 	Name string
 }

--- a/internal/corpus/testdata/cases/components/direct_helper_lexical_collision.txtar
+++ b/internal/corpus/testdata/cases/components/direct_helper_lexical_collision.txtar
@@ -67,6 +67,7 @@ func Page[_gsxrenderChild2 any](value _gsxrenderChild.Value) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:11:1
 func Invoke() gsx.Node { return Page[struct{}](lexicalValue()) }
 -- render.golden --
 <span>lexical</span>

--- a/internal/corpus/testdata/cases/components/generic_inferred_tag.txtar
+++ b/internal/corpus/testdata/cases/components/generic_inferred_tag.txtar
@@ -58,6 +58,7 @@ func _gsxrenderGreeting[V ~string, W any](ctx _gsxctx.Context, _gsxgw *_gsxrt.Wr
 	return _gsxgw.Err()
 }
 
+//line input.gsx:8:1
 type MyByte byte
 
 //line input.gsx:10:1

--- a/internal/corpus/testdata/cases/components/generic_uniform_constraint.txtar
+++ b/internal/corpus/testdata/cases/components/generic_uniform_constraint.txtar
@@ -28,6 +28,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type Slug string
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_error.txtar
+++ b/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_error.txtar
@@ -33,6 +33,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func maybeDecl(ok bool) (string, error) {
 	if !ok {
 		return "", errors.New("decl failed")

--- a/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_forms.txtar
+++ b/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_forms.txtar
@@ -36,6 +36,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func decl(s string) (string, error) { return s, nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_order.txtar
+++ b/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_order.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 var trace string
 
 func mark(label, value string) string {

--- a/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_renderer.txtar
+++ b/internal/corpus/testdata/cases/condmerge/nonforwarding_merge_renderer.txtar
@@ -51,6 +51,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func text(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/control_flow/if_init_error_handling.txtar
+++ b/internal/corpus/testdata/cases/control_flow/if_init_error_handling.txtar
@@ -25,6 +25,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func load(id string) (string, error) { return "loaded:" + id, nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/datajson/island_breakout.txtar
+++ b/internal/corpus/testdata/cases/datajson/island_breakout.txtar
@@ -24,6 +24,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type Cfg struct {
 	Note string
 }

--- a/internal/corpus/testdata/cases/datajson/island_value.txtar
+++ b/internal/corpus/testdata/cases/datajson/island_value.txtar
@@ -25,6 +25,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type Cfg struct {
 	Env  string
 	Beta bool

--- a/internal/corpus/testdata/cases/dquote-literals/f_value_var.txtar
+++ b/internal/corpus/testdata/cases/dquote-literals/f_value_var.txtar
@@ -28,9 +28,11 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var n = "x1"
 
-var g = "id-`" + string(n) + "`"
+var g = "id-`" + string(n) + "`" /*line input.gsx:5:21*/
 
 //line input.gsx:7:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/element-literals/call-arg.txtar
+++ b/internal/corpus/testdata/cases/element-literals/call-arg.txtar
@@ -56,12 +56,14 @@ func _gsxrenderFoo(ctx _gsxctx.Context, _gsxgw *_gsxrt.Writer) error {
 	return _gsxgw.Err()
 }
 
+/*line input.gsx:5:2*/
+
 var wrapped = Wrap(_gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:7:20
 	_gsxgw.NodeResult(_gsxrenderFoo(ctx, _gsxgw))
 	return _gsxgw.Err()
-}))
+}) /*line input.gsx:7:26*/)
 
 //line input.gsx:9:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/element-literals/component-tag.txtar
+++ b/internal/corpus/testdata/cases/element-literals/component-tag.txtar
@@ -52,12 +52,14 @@ func _gsxrenderBadge(ctx _gsxctx.Context, _gsxgw *_gsxrt.Writer, count int) erro
 	return _gsxgw.Err()
 }
 
+/*line input.gsx:5:2*/
+
 var badge = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:7:13
 	_gsxgw.NodeResult(_gsxrenderBadge(ctx, _gsxgw, 12))
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:7:32*/
 
 //line input.gsx:9:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/element-literals/func-local.txtar
+++ b/internal/corpus/testdata/cases/element-literals/func-local.txtar
@@ -48,6 +48,8 @@ func Noop() _gsxrt.Node {
 	})
 }
 
+/*line input.gsx:7:2*/
+
 func Greeting(name string) gsx.Node {
 	greeting := "Hi, " + name
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
@@ -61,5 +63,5 @@ func Greeting(name string) gsx.Node {
 		_gsxgw.Text(string(name))
 		_gsxgw.S(")</div>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:11:43*/
 }

--- a/internal/corpus/testdata/cases/element-literals/import-then-embed.txtar
+++ b/internal/corpus/testdata/cases/element-literals/import-then-embed.txtar
@@ -38,13 +38,14 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func render() gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:6:9
 		_gsxgw.S("<div>inline JSX</div>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:6:30*/
 }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/element-literals/interp-outer-scope.txtar
+++ b/internal/corpus/testdata/cases/element-literals/interp-outer-scope.txtar
@@ -33,6 +33,8 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var cls = "text-lg"
 var label = "Home"
 
@@ -46,7 +48,7 @@ var help = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw.Text(string(label))
 	_gsxgw.S("</span>")
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:6:48*/
 
 //line input.gsx:8:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/element-literals/method-receiver.txtar
+++ b/internal/corpus/testdata/cases/element-literals/method-receiver.txtar
@@ -48,6 +48,8 @@ func Noop() _gsxrt.Node {
 	})
 }
 
+/*line input.gsx:7:2*/
+
 type Person struct {
 	Name string
 }
@@ -61,5 +63,5 @@ func (p Person) Greeting() gsx.Node {
 		_gsxgw.Text(string(p.Name))
 		_gsxgw.S("!</div>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:14:38*/
 }

--- a/internal/corpus/testdata/cases/element-literals/multi-element-region.txtar
+++ b/internal/corpus/testdata/cases/element-literals/multi-element-region.txtar
@@ -53,13 +53,15 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var listing = []any{
 	_gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:4:2
 		_gsxgw.S("<span>a</span>")
 		return _gsxgw.Err()
-	}),
+	}), /*line input.gsx:4:16*/
 }
 
 var item = NavItem{Label: "Home", Icon: _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
@@ -69,7 +71,7 @@ var item = NavItem{Label: "Home", Icon: _gsxrt.Func(func(ctx _gsxctx.Context, _g
 //line input.gsx:9:3
 	_gsxgw.S("<path d=\"M0 0\"/></svg>")
 	return _gsxgw.Err()
-})}
+}) /*line input.gsx:11:2*/}
 
 //line input.gsx:13:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/element-literals/return.txtar
+++ b/internal/corpus/testdata/cases/element-literals/return.txtar
@@ -44,11 +44,13 @@ func Noop() _gsxrt.Node {
 	})
 }
 
+/*line input.gsx:7:2*/
+
 func Help() gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:10:9
 		_gsxgw.S("<div>hi</div>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:10:22*/
 }

--- a/internal/corpus/testdata/cases/element-literals/struct-field.txtar
+++ b/internal/corpus/testdata/cases/element-literals/struct-field.txtar
@@ -40,6 +40,8 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var item = NavItem{Label: "Home", Icon: _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:4:2
@@ -47,7 +49,7 @@ var item = NavItem{Label: "Home", Icon: _gsxrt.Func(func(ctx _gsxctx.Context, _g
 //line input.gsx:5:3
 	_gsxgw.S("<path d=\"M0 0\"/></svg>")
 	return _gsxgw.Err()
-})}
+}) /*line input.gsx:7:2*/}
 
 //line input.gsx:9:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/element-literals/text-apostrophe-multi.txtar
+++ b/internal/corpus/testdata/cases/element-literals/text-apostrophe-multi.txtar
@@ -30,18 +30,20 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var a = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:3:9
 	_gsxgw.S("<p>it's here</p>")
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:3:25*/
 var b = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:4:9
 	_gsxgw.S("<b>bold</b>")
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:4:20*/
 
 //line input.gsx:6:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/element-literals/text-go-keyword.txtar
+++ b/internal/corpus/testdata/cases/element-literals/text-go-keyword.txtar
@@ -44,6 +44,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 var X = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:6:2
@@ -53,7 +54,7 @@ var X = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 //line input.gsx:8:3
 	_gsxgw.S("<p>This is a test component.</p></div>")
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:10:2*/
 
 func local() gsx.Node {
 	n := _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
@@ -61,7 +62,7 @@ func local() gsx.Node {
 //line input.gsx:13:7
 		_gsxgw.S("<em>another component</em>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:13:33*/
 	return n
 }
 

--- a/internal/corpus/testdata/cases/element-literals/var.txtar
+++ b/internal/corpus/testdata/cases/element-literals/var.txtar
@@ -25,12 +25,14 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var help = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:3:12
 	_gsxgw.S("<a href=\"/help\" class=\"text-blue-600\">?</a>")
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:3:55*/
 
 //line input.gsx:5:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/fallthrough/composite_two_spreads.txtar
+++ b/internal/corpus/testdata/cases/fallthrough/composite_two_spreads.txtar
@@ -34,6 +34,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type props struct {
 	A gsx.Attrs
 	B gsx.Attrs

--- a/internal/corpus/testdata/cases/filterimport/user_plain_import_and_filter.txtar
+++ b/internal/corpus/testdata/cases/filterimport/user_plain_import_and_filter.txtar
@@ -44,6 +44,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 var label = filters.Label
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/filterimport/user_plain_import_no_filter.txtar
+++ b/internal/corpus/testdata/cases/filterimport/user_plain_import_no_filter.txtar
@@ -45,6 +45,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 var label = filters.Label
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/fragment-literals/call-arg.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/call-arg.txtar
@@ -42,12 +42,14 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:14*/
+
 var wrapped = wrap(_gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:3:22
 	_gsxgw.S("<b>x</b>")
 	return _gsxgw.Err()
-}))
+}) /*line input.gsx:3:33*/)
 
 //line input.gsx:5:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/fragment-literals/empty-nop.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/empty-nop.txtar
@@ -27,10 +27,12 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:14*/
+
 var nothing = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:3:20*/
 
 //line input.gsx:5:1
 func Host() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/fragment-literals/interp-func-local.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/interp-func-local.txtar
@@ -49,6 +49,8 @@ func Noop() _gsxrt.Node {
 	})
 }
 
+/*line input.gsx:7:2*/
+
 func Greeting(name string) gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
@@ -60,7 +62,7 @@ func Greeting(name string) gsx.Node {
 		_gsxgw.Text(string(name))
 		_gsxgw.S("</span>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:10:54*/
 }
 
 //line input.gsx:13:1

--- a/internal/corpus/testdata/cases/fragment-literals/interp-method-receiver.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/interp-method-receiver.txtar
@@ -51,6 +51,8 @@ func Noop() _gsxrt.Node {
 	})
 }
 
+/*line input.gsx:7:2*/
+
 type Card struct {
 	Title string
 }
@@ -64,7 +66,7 @@ func (c Card) View() gsx.Node {
 		_gsxgw.Text(string(c.Title))
 		_gsxgw.S("</h2>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:14:34*/
 }
 
 //line input.gsx:17:1

--- a/internal/corpus/testdata/cases/fragment-literals/loop-list.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/loop-list.txtar
@@ -52,6 +52,8 @@ func Noop() _gsxrt.Node {
 	})
 }
 
+/*line input.gsx:7:2*/
+
 func Items(xs []string) gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
@@ -64,7 +66,7 @@ func Items(xs []string) gsx.Node {
 			_gsxgw.S("</li>")
 		}
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:16:3*/
 }
 
 //line input.gsx:19:1

--- a/internal/corpus/testdata/cases/fragment-literals/return.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/return.txtar
@@ -53,6 +53,8 @@ func Noop() _gsxrt.Node {
 	})
 }
 
+/*line input.gsx:7:2*/
+
 func Panel() gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
@@ -61,7 +63,7 @@ func Panel() gsx.Node {
 //line input.gsx:10:25
 		_gsxgw.S("<p>Body</p>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:10:39*/
 }
 
 //line input.gsx:13:1

--- a/internal/corpus/testdata/cases/fragment-literals/struct-field.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/struct-field.txtar
@@ -36,12 +36,14 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:14*/
+
 var s = slot{Body: _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:3:22
 	_gsxgw.S("<i>hi</i>")
 	return _gsxgw.Err()
-})}
+}) /*line input.gsx:3:34*/}
 
 //line input.gsx:5:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/fragment-literals/var.txtar
+++ b/internal/corpus/testdata/cases/fragment-literals/var.txtar
@@ -28,6 +28,8 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:14*/
+
 var pair = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:3:14
@@ -35,7 +37,7 @@ var pair = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 //line input.gsx:3:30
 	_gsxgw.S("<span>two</span>")
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:3:49*/
 
 //line input.gsx:5:1
 func Host() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-css-literal/err_tuple_in_closure.txtar
+++ b/internal/corpus/testdata/cases/goexpr-css-literal/err_tuple_in_closure.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 func pick(c string) (string, error) {
 	if c == "" {
 		return "", errors.New("pick: empty input")

--- a/internal/corpus/testdata/cases/goexpr-css-literal/hostile_zgotmplz.txtar
+++ b/internal/corpus/testdata/cases/goexpr-css-literal/hostile_zgotmplz.txtar
@@ -32,8 +32,9 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func mk(color string) gsx.RawCSS {
-	return _gsxrt.RawCSS("color:" + _gsxrt.FilterCSS(string(color)))
+	return _gsxrt.RawCSS("color:" + _gsxrt.FilterCSS(string(color))) /*line input.gsx:6:28*/
 }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/goexpr-css-literal/rawcss_passthrough.txtar
+++ b/internal/corpus/testdata/cases/goexpr-css-literal/rawcss_passthrough.txtar
@@ -30,9 +30,10 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 var accent gsx.RawCSS = "color:red"
 
-var Combined = _gsxrt.RawCSS("base;" + string(accent))
+var Combined = _gsxrt.RawCSS("base;" + string(accent)) /*line input.gsx:7:35*/
 
 //line input.gsx:9:1
 func Page() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-css-literal/var_style_spread.txtar
+++ b/internal/corpus/testdata/cases/goexpr-css-literal/var_style_spread.txtar
@@ -33,8 +33,9 @@ import (
 	_gsxsc "strconv"
 )
 
+/*line input.gsx:5:1*/
 func mk(w int, color string) gsx.Attrs {
-	return gsx.Attrs{{Key: "style", Value: _gsxrt.RawCSS("width:" + _gsxrt.FilterCSS(_gsxsc.FormatInt(int64(w), 10)) + "px;color:" + _gsxrt.FilterCSS(string(color)))}}
+	return gsx.Attrs{{Key: "style", Value: _gsxrt.RawCSS("width:" + _gsxrt.FilterCSS(_gsxsc.FormatInt(int64(w), 10)) + "px;color:" + _gsxrt.FilterCSS(string(color))) /*line input.gsx:6:73*/}}
 }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/goexpr-f-literal/f_value_is_escaped_string.txtar
+++ b/internal/corpus/testdata/cases/goexpr-f-literal/f_value_is_escaped_string.txtar
@@ -26,7 +26,9 @@ import (
 	_gsxio "io"
 )
 
-func markup(x string) string { return "<b>" + string(x) + "</b>" }
+/*line input.gsx:1:14*/
+
+func markup(x string) string { return "<b>" + string(x) + "</b>" /*line input.gsx:3:53*/ }
 
 //line input.gsx:5:1
 func Host(x string) _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-f-literal/scope-local.txtar
+++ b/internal/corpus/testdata/cases/goexpr-f-literal/scope-local.txtar
@@ -31,8 +31,10 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 func makeGreeting(who string) string {
-	return "hi " + string(who)
+	return "hi " + string(who) /*line input.gsx:4:21*/
 }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-f-literal/var.txtar
+++ b/internal/corpus/testdata/cases/goexpr-f-literal/var.txtar
@@ -30,9 +30,11 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var name = "world"
 
-var greeting = "hello " + string(name)
+var greeting = "hello " + string(name) /*line input.gsx:5:32*/
 
 //line input.gsx:7:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-interp-tag/call-arg.txtar
+++ b/internal/corpus/testdata/cases/goexpr-interp-tag/call-arg.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-interp-tag/component-tag.txtar
+++ b/internal/corpus/testdata/cases/goexpr-interp-tag/component-tag.txtar
@@ -35,6 +35,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-interp-tag/scope-local.txtar
+++ b/internal/corpus/testdata/cases/goexpr-interp-tag/scope-local.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-interp-tag/sibling-mixed-type.txtar
+++ b/internal/corpus/testdata/cases/goexpr-interp-tag/sibling-mixed-type.txtar
@@ -36,6 +36,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-interp-tag/stages.txtar
+++ b/internal/corpus/testdata/cases/goexpr-interp-tag/stages.txtar
@@ -54,6 +54,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/attrs_map_spread.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/attrs_map_spread.txtar
@@ -37,10 +37,11 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func mkAttrs(id string) gsx.Attrs {
 	return gsx.Attrs{
-		{Key: "@click", Value: _gsxrt.RawJS("select(" + _gsxrt.EscapeJSVal(id) + ")")},
-		{Key: "x-data", Value: _gsxrt.RawJS("dialog(" + _gsxrt.EscapeJSVal(id) + ")")},
+		{Key: "@click", Value: _gsxrt.RawJS("select(" + _gsxrt.EscapeJSVal(id) + ")") /*line input.gsx:7:43*/},
+		{Key: "x-data", Value: _gsxrt.RawJS("dialog(" + _gsxrt.EscapeJSVal(id) + ")") /*line input.gsx:8:43*/},
 	}
 }
 

--- a/internal/corpus/testdata/cases/goexpr-js-literal/ctx_filter_in_closure.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/ctx_filter_in_closure.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func take(j gsx.RawJS) gsx.Node { return gsx.Raw(string(j)) }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/ctx_matrix.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/ctx_matrix.txtar
@@ -31,8 +31,9 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func mk(v string) gsx.RawJS {
-	return _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(v) + ", '" + _gsxrt.EscapeJSStr(string(v)) + "', `" + _gsxrt.EscapeJSTmpl(string(v)) + "`, /" + _gsxrt.EscapeJSRegexp(string(v)) + "/)")
+	return _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(v) + ", '" + _gsxrt.EscapeJSStr(string(v)) + "', `" + _gsxrt.EscapeJSTmpl(string(v)) + "`, /" + _gsxrt.EscapeJSRegexp(string(v)) + "/)") /*line input.gsx:6:46*/
 }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/dquote_form.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/dquote_form.txtar
@@ -32,9 +32,11 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var x = "a`b"
 
-var handler = _gsxrt.RawJS("save(`" + _gsxrt.EscapeJSTmpl(string(x)) + "`)")
+var handler = _gsxrt.RawJS("save(`" + _gsxrt.EscapeJSTmpl(string(x)) + "`)") /*line input.gsx:5:31*/
 
 //line input.gsx:7:1
 func Page() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-js-literal/err_and_pure_holes_in_closure.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/err_and_pure_holes_in_closure.txtar
@@ -44,6 +44,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func take(j gsx.RawJS) gsx.Node { return gsx.Raw(string(j)) }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/err_pipe_in_closure.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/err_pipe_in_closure.txtar
@@ -45,6 +45,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func take(j gsx.RawJS) gsx.Node { return gsx.Raw(string(j)) }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/err_pipe_in_closure_halt.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/err_pipe_in_closure_halt.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func take(j gsx.RawJS) gsx.Node { return gsx.Raw(string(j)) }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/eval_order_once.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/eval_order_once.txtar
@@ -37,6 +37,8 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var n int
 
 func next() int {
@@ -44,7 +46,7 @@ func next() int {
 	return n
 }
 
-var handler = _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(next()) + ", " + _gsxrt.EscapeJSVal(next()) + ")")
+var handler = _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(next()) + ", " + _gsxrt.EscapeJSVal(next()) + ")") /*line input.gsx:10:42*/
 
 //line input.gsx:12:1
 func Page() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-js-literal/func_return.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/func_return.txtar
@@ -34,8 +34,9 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func mk(id string) gsx.RawJS {
-	return _gsxrt.RawJS("open(" + _gsxrt.EscapeJSVal(id) + ")")
+	return _gsxrt.RawJS("open(" + _gsxrt.EscapeJSVal(id) + ")") /*line input.gsx:6:24*/
 }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/hostile.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/hostile.txtar
@@ -34,8 +34,9 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func mk(v string) gsx.RawJS {
-	return _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(v) + ", '" + _gsxrt.EscapeJSStr(string(v)) + "', `" + _gsxrt.EscapeJSTmpl(string(v)) + "`, /" + _gsxrt.EscapeJSRegexp(string(v)) + "/)")
+	return _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(v) + ", '" + _gsxrt.EscapeJSStr(string(v)) + "', `" + _gsxrt.EscapeJSTmpl(string(v)) + "`, /" + _gsxrt.EscapeJSRegexp(string(v)) + "/)") /*line input.gsx:6:46*/
 }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/nested_f_hole_toplevel.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/nested_f_hole_toplevel.txtar
@@ -28,7 +28,9 @@ import (
 	_gsxio "io"
 )
 
-var h = _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal("x") + ")")
+/*line input.gsx:1:13*/
+
+var h = _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal("x") + ")") /*line input.gsx:3:25*/
 
 //line input.gsx:5:1
 func Page() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-js-literal/pure_filter_toplevel.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/pure_filter_toplevel.txtar
@@ -39,7 +39,10 @@ import (
 	_gsxio "io"
 )
 
-func mk(v string) gsx.RawJS { return _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(_gsxf0.Shout((v))) + ")") }
+/*line input.gsx:5:1*/
+func mk(v string) gsx.RawJS {
+	return _gsxrt.RawJS("f(" + _gsxrt.EscapeJSVal(_gsxf0.Shout((v))) + ")") /*line input.gsx:5:58*/
+}
 
 //line input.gsx:7:1
 func Page(v string) _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-js-literal/rawjs_escaped_in_string.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/rawjs_escaped_in_string.txtar
@@ -33,9 +33,10 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 var h = gsx.RawJS("x') ; steal('")
 
-var handler = _gsxrt.RawJS("f('" + _gsxrt.EscapeJSStr(string(h)) + "')")
+var handler = _gsxrt.RawJS("f('" + _gsxrt.EscapeJSStr(string(h)) + "')") /*line input.gsx:7:28*/
 
 //line input.gsx:9:1
 func Page() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-js-literal/rawjs_passthrough_value.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/rawjs_passthrough_value.txtar
@@ -32,9 +32,10 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 var h = gsx.RawJS("inner()")
 
-var handler = _gsxrt.RawJS("wrap(" + _gsxrt.EscapeJSVal(h) + ")")
+var handler = _gsxrt.RawJS("wrap(" + _gsxrt.EscapeJSVal(h) + ")") /*line input.gsx:7:29*/
 
 //line input.gsx:9:1
 func Page() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-js-literal/rawjs_slice.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/rawjs_slice.txtar
@@ -33,9 +33,10 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 var name = "world"
 
-var vs = []gsx.RawJS{_gsxrt.RawJS("first()"), _gsxrt.RawJS("second(" + _gsxrt.EscapeJSVal(name) + ")")}
+var vs = []gsx.RawJS{_gsxrt.RawJS("first()") /*line input.gsx:7:33*/, _gsxrt.RawJS("second(" + _gsxrt.EscapeJSVal(name) + ")") /*line input.gsx:7:54*/}
 
 //line input.gsx:9:1
 func Uses() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-js-literal/renderer_hole.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/renderer_hole.txtar
@@ -90,15 +90,16 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:8:1*/
 func mkJSVal(s string, valid bool) pg.JSVal   { return pg.JSVal{String: s, Valid: valid} }
 func mkCSSVal(s string, valid bool) pg.CSSVal { return pg.CSSVal{String: s, Valid: valid} }
 
 func mkClick(val pg.JSVal) gsx.RawJS {
-	return _gsxrt.RawJS("save('" + _gsxrt.EscapeJSStr(string(_gsxf0.PgJS((val)))) + "')")
+	return _gsxrt.RawJS("save('" + _gsxrt.EscapeJSStr(string(_gsxf0.PgJS((val)))) + "')") /*line input.gsx:12:29*/
 }
 
 func mkColor(val pg.CSSVal) gsx.RawCSS {
-	return _gsxrt.RawCSS("color:" + _gsxrt.FilterCSS(string(_gsxf0.PgColor((val)))))
+	return _gsxrt.RawCSS("color:" + _gsxrt.FilterCSS(string(_gsxf0.PgColor((val))))) /*line input.gsx:16:28*/
 }
 
 //line input.gsx:19:1

--- a/internal/corpus/testdata/cases/goexpr-js-literal/var.txtar
+++ b/internal/corpus/testdata/cases/goexpr-js-literal/var.txtar
@@ -30,9 +30,11 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var id = "abc"
 
-var handler = _gsxrt.RawJS("save(" + _gsxrt.EscapeJSVal(id) + ")")
+var handler = _gsxrt.RawJS("save(" + _gsxrt.EscapeJSVal(id) + ")") /*line input.gsx:5:30*/
 
 //line input.gsx:7:1
 func Page() _gsxrt.Node {

--- a/internal/corpus/testdata/cases/goexpr-valueform-init/value_if_define_init.txtar
+++ b/internal/corpus/testdata/cases/goexpr-valueform-init/value_if_define_init.txtar
@@ -47,6 +47,7 @@ func Label() _gsxrt.Node {
 	})
 }
 
+//line input.gsx:7:1
 func ready() bool { return true }
 -- render.golden --
 <span class="base on">y</span>

--- a/internal/corpus/testdata/cases/imports/alias_gsx_import.txtar
+++ b/internal/corpus/testdata/cases/imports/alias_gsx_import.txtar
@@ -27,6 +27,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n g.Node) g.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/imports/component_and_user_gsx.txtar
+++ b/internal/corpus/testdata/cases/imports/component_and_user_gsx.txtar
@@ -29,6 +29,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/imports/css_literal_only.txtar
+++ b/internal/corpus/testdata/cases/imports/css_literal_only.txtar
@@ -18,6 +18,8 @@ import (
 	_gsxrt "github.com/gsxhq/gsx"
 )
 
+/*line input.gsx:1:13*/
+
 var c = "red"
 
-var S = _gsxrt.RawCSS("color:" + _gsxrt.FilterCSS(string(c)))
+var S = _gsxrt.RawCSS("color:" + _gsxrt.FilterCSS(string(c))) /*line input.gsx:5:24*/

--- a/internal/corpus/testdata/cases/imports/dot_gsx_import.txtar
+++ b/internal/corpus/testdata/cases/imports/dot_gsx_import.txtar
@@ -28,6 +28,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n Node) Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/imports/element_literal_var.txtar
+++ b/internal/corpus/testdata/cases/imports/element_literal_var.txtar
@@ -23,6 +23,8 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:1:13*/
+
 var X = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 	_gsxgw := _gsxrt.W(_gsxw)
 //line input.gsx:4:2
@@ -30,6 +32,6 @@ var X = _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 //line input.gsx:5:3
 	_gsxgw.S("<b>hi</b></div>")
 	return _gsxgw.Err()
-})
+}) /*line input.gsx:7:2*/
 
 var _ = X

--- a/internal/corpus/testdata/cases/imports/f_literal_only.txtar
+++ b/internal/corpus/testdata/cases/imports/f_literal_only.txtar
@@ -11,4 +11,6 @@ var S = f"hello world"
 
 package demo
 
-var S = "hello world"
+/*line input.gsx:1:13*/
+
+var S = "hello world" /*line input.gsx:3:23*/

--- a/internal/corpus/testdata/cases/imports/gsx_node_no_component.txtar
+++ b/internal/corpus/testdata/cases/imports/gsx_node_no_component.txtar
@@ -20,6 +20,7 @@ import (
 	"github.com/gsxhq/gsx"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 var _ = wrap

--- a/internal/corpus/testdata/cases/imports/js_literal_only.txtar
+++ b/internal/corpus/testdata/cases/imports/js_literal_only.txtar
@@ -18,6 +18,8 @@ import (
 	_gsxrt "github.com/gsxhq/gsx"
 )
 
+/*line input.gsx:1:13*/
+
 var name = "world"
 
-var H = _gsxrt.RawJS("greet(" + _gsxrt.EscapeJSVal(name) + ")")
+var H = _gsxrt.RawJS("greet(" + _gsxrt.EscapeJSVal(name) + ")") /*line input.gsx:5:27*/

--- a/internal/corpus/testdata/cases/imports/plain_go_only.txtar
+++ b/internal/corpus/testdata/cases/imports/plain_go_only.txtar
@@ -17,4 +17,5 @@ import (
 	"fmt"
 )
 
+//line input.gsx:5:1
 func Helper() string { return fmt.Sprintf("x%d", 1) }

--- a/internal/corpus/testdata/cases/imports/recv_named_gsx.txtar
+++ b/internal/corpus/testdata/cases/imports/recv_named_gsx.txtar
@@ -40,6 +40,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type widget struct {
 	Label string
 	Count int

--- a/internal/corpus/testdata/cases/imports/shadow_context.txtar
+++ b/internal/corpus/testdata/cases/imports/shadow_context.txtar
@@ -24,6 +24,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 var context = "shadowed"
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/imports/shadow_gsx_decl.txtar
+++ b/internal/corpus/testdata/cases/imports/shadow_gsx_decl.txtar
@@ -25,6 +25,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 var gsx = 7
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/imports/shadow_io.txtar
+++ b/internal/corpus/testdata/cases/imports/shadow_io.txtar
@@ -23,6 +23,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 var io = 3
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/imports/shadow_strconv.txtar
+++ b/internal/corpus/testdata/cases/imports/shadow_strconv.txtar
@@ -27,6 +27,7 @@ import (
 	_gsxsc "strconv"
 )
 
+//line input.gsx:3:1
 var strconv = "shadowed"
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/interpolation/string_slice.txtar
+++ b/internal/corpus/testdata/cases/interpolation/string_slice.txtar
@@ -34,6 +34,7 @@ import (
 	_gsxst "strings"
 )
 
+//line input.gsx:3:1
 type Tags []string
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/jsattr/value_tuple.txtar
+++ b/internal/corpus/testdata/cases/jsattr/value_tuple.txtar
@@ -30,6 +30,7 @@ func Page() _gsxrt.Node {
 	})
 }
 
+//line input.gsx:7:1
 func load() (string, error) { return "</script>\"", nil }
 -- render.golden --
 <div x-data="{ d: @{ load() } }">x</div>

--- a/internal/corpus/testdata/cases/lowertags/embedded_nested_component.txtar
+++ b/internal/corpus/testdata/cases/lowertags/embedded_nested_component.txtar
@@ -44,6 +44,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func wrap(n gsx.Node) gsx.Node { return n }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/multispread/cond_class_part_renderer.txtar
+++ b/internal/corpus/testdata/cases/multispread/cond_class_part_renderer.txtar
@@ -58,6 +58,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:11:1

--- a/internal/corpus/testdata/cases/multispread/variadic_attrs_operand.txtar
+++ b/internal/corpus/testdata/cases/multispread/variadic_attrs_operand.txtar
@@ -34,6 +34,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func named(name string) func(attrs ...gsx.Attr) gsx.Node {
 	return func(attrs ...gsx.Attr) gsx.Node {
 		return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
@@ -49,7 +50,7 @@ func named(name string) func(attrs ...gsx.Attr) gsx.Node {
 			_gsxgw.Text(string(name))
 			_gsxgw.S("</svg>")
 			return _gsxgw.Err()
-		})
+		}) /*line input.gsx:7:103*/
 	}
 }
 

--- a/internal/corpus/testdata/cases/nestedforward/attrsonly_callee.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/attrsonly_callee.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type dotProps struct {
 	Attrs gsx.Attrs
 }
@@ -62,6 +63,7 @@ func renderDot(p dotProps) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:13:1
 var Dot = func(attrs gsx.Attrs) gsx.Node {
 	return renderDot(dotProps{Attrs: attrs})
 }

--- a/internal/corpus/testdata/cases/nestedforward/case_d_hoist.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/case_d_hoist.txtar
@@ -41,6 +41,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func getAttrs() gsx.Attrs {
 	return gsx.Attrs{{Key: "data-g", Value: "g"}}
 }

--- a/internal/corpus/testdata/cases/nestedforward/css_hole.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/css_hole.txtar
@@ -38,6 +38,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func strAttr(a gsx.Attrs, key string) string {
 	v, _ := a.Get(key)
 	s, _ := v.(string)

--- a/internal/corpus/testdata/cases/nestedforward/method_callee.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/method_callee.txtar
@@ -37,6 +37,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type Site struct{}
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/nestedforward/ordered_literal_value.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/ordered_literal_value.txtar
@@ -41,6 +41,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func strAttr(a gsx.Attrs, key string) string {
 	v, _ := a.Get(key)
 	s, _ := v.(string)

--- a/internal/corpus/testdata/cases/nestedforward/prop_value.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/prop_value.txtar
@@ -41,6 +41,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func strAttr(a gsx.Attrs, key string) string {
 	v, _ := a.Get(key)
 	s, _ := v.(string)

--- a/internal/corpus/testdata/cases/nestedforward/reserved_attrs_callee.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/reserved_attrs_callee.txtar
@@ -40,6 +40,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func strAttr(a gsx.Attrs, key string) string {
 	v, _ := a.Get(key)
 	s, _ := v.(string)

--- a/internal/corpus/testdata/cases/nestedforward/stage_arg.txtar
+++ b/internal/corpus/testdata/cases/nestedforward/stage_arg.txtar
@@ -42,6 +42,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func strAttr(a gsx.Attrs, key string) string {
 	v, _ := a.Get(key)
 	s, _ := v.(string)

--- a/internal/corpus/testdata/cases/pipeerr/ordered_attrs_mid_stage.txtar
+++ b/internal/corpus/testdata/cases/pipeerr/ordered_attrs_mid_stage.txtar
@@ -96,6 +96,7 @@ func Page(csv string) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:9:1
 func shout() string { return "hi" }
 -- render.golden --
 <span>adahi</span>

--- a/internal/corpus/testdata/cases/props/byo_method_shared_props.txtar
+++ b/internal/corpus/testdata/cases/props/byo_method_shared_props.txtar
@@ -45,6 +45,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type pageData struct {
 	Title   string
 	Heading string

--- a/internal/corpus/testdata/cases/props/byo_method_trio.txtar
+++ b/internal/corpus/testdata/cases/props/byo_method_trio.txtar
@@ -52,6 +52,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type pageData struct {
 	Title   string
 	Section string

--- a/internal/corpus/testdata/cases/props/composite_param_children.txtar
+++ b/internal/corpus/testdata/cases/props/composite_param_children.txtar
@@ -33,6 +33,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type Props struct {
 	Variant string
 }

--- a/internal/corpus/testdata/cases/props/explicit_value_forwarding.txtar
+++ b/internal/corpus/testdata/cases/props/explicit_value_forwarding.txtar
@@ -44,6 +44,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type cardData struct {
 	Title string
 }

--- a/internal/corpus/testdata/cases/props/signature_shapes.txtar
+++ b/internal/corpus/testdata/cases/props/signature_shapes.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type Props struct {
 	Title string
 }

--- a/internal/corpus/testdata/cases/renderers/attr_basic.txtar
+++ b/internal/corpus/testdata/cases/renderers/attr_basic.txtar
@@ -54,6 +54,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/attr_error.txtar
+++ b/internal/corpus/testdata/cases/renderers/attr_error.txtar
@@ -60,6 +60,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/attr_error_cond.txtar
+++ b/internal/corpus/testdata/cases/renderers/attr_error_cond.txtar
@@ -69,6 +69,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:11:1

--- a/internal/corpus/testdata/cases/renderers/attr_url.txtar
+++ b/internal/corpus/testdata/cases/renderers/attr_url.txtar
@@ -57,6 +57,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/class_bare_cfarm.txtar
+++ b/internal/corpus/testdata/cases/renderers/class_bare_cfarm.txtar
@@ -55,6 +55,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/class_bare_cond.txtar
+++ b/internal/corpus/testdata/cases/renderers/class_bare_cond.txtar
@@ -58,6 +58,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:7:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/renderers/class_bare_ident.txtar
+++ b/internal/corpus/testdata/cases/renderers/class_bare_ident.txtar
@@ -62,6 +62,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:7:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 type box struct{ Cls pg.Text }

--- a/internal/corpus/testdata/cases/renderers/class_part.txtar
+++ b/internal/corpus/testdata/cases/renderers/class_part.txtar
@@ -54,6 +54,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/class_part_component.txtar
+++ b/internal/corpus/testdata/cases/renderers/class_part_component.txtar
@@ -70,6 +70,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:7:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/renderers/component_arg_negative.txtar
+++ b/internal/corpus/testdata/cases/renderers/component_arg_negative.txtar
@@ -56,6 +56,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/css_attr_hole.txtar
+++ b/internal/corpus/testdata/cases/renderers/css_attr_hole.txtar
@@ -60,6 +60,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:8:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:10:1

--- a/internal/corpus/testdata/cases/renderers/ctx_attr_url.txtar
+++ b/internal/corpus/testdata/cases/renderers/ctx_attr_url.txtar
@@ -62,6 +62,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/ctx_class_part.txtar
+++ b/internal/corpus/testdata/cases/renderers/ctx_class_part.txtar
@@ -66,6 +66,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:7:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/renderers/ctx_cond_attr.txtar
+++ b/internal/corpus/testdata/cases/renderers/ctx_cond_attr.txtar
@@ -71,6 +71,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:11:1

--- a/internal/corpus/testdata/cases/renderers/ctx_error.txtar
+++ b/internal/corpus/testdata/cases/renderers/ctx_error.txtar
@@ -61,6 +61,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/ctx_fallthrough_attr.txtar
+++ b/internal/corpus/testdata/cases/renderers/ctx_fallthrough_attr.txtar
@@ -69,6 +69,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:11:1

--- a/internal/corpus/testdata/cases/renderers/ctx_text.txtar
+++ b/internal/corpus/testdata/cases/renderers/ctx_text.txtar
@@ -59,6 +59,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/elem_class_cond.txtar
+++ b/internal/corpus/testdata/cases/renderers/elem_class_cond.txtar
@@ -57,6 +57,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/elem_class_cond_alignment.txtar
+++ b/internal/corpus/testdata/cases/renderers/elem_class_cond_alignment.txtar
@@ -59,6 +59,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/elem_class_cond_error.txtar
+++ b/internal/corpus/testdata/cases/renderers/elem_class_cond_error.txtar
@@ -57,6 +57,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/elem_style_cond.txtar
+++ b/internal/corpus/testdata/cases/renderers/elem_style_cond.txtar
@@ -52,6 +52,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/fallthrough_attr.txtar
+++ b/internal/corpus/testdata/cases/renderers/fallthrough_attr.txtar
@@ -71,6 +71,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:11:1

--- a/internal/corpus/testdata/cases/renderers/fallthrough_ordered_attr.txtar
+++ b/internal/corpus/testdata/cases/renderers/fallthrough_ordered_attr.txtar
@@ -64,6 +64,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:7:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:9:1

--- a/internal/corpus/testdata/cases/renderers/fliteral_attr.txtar
+++ b/internal/corpus/testdata/cases/renderers/fliteral_attr.txtar
@@ -55,6 +55,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/js_attr_hole.txtar
+++ b/internal/corpus/testdata/cases/renderers/js_attr_hole.txtar
@@ -60,6 +60,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:8:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:10:1

--- a/internal/corpus/testdata/cases/renderers/numeric_result.txtar
+++ b/internal/corpus/testdata/cases/renderers/numeric_result.txtar
@@ -56,6 +56,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkCount(n int, valid bool) pg.Count { return pg.Count{N: n, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/package_cross.txtar
+++ b/internal/corpus/testdata/cases/renderers/package_cross.txtar
@@ -51,6 +51,7 @@ import (
 	_gsxio "io"
 )
 
+/*line renderers.gsx:8:1*/
 func Timestamptz(v pg.Timestamptz) gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
@@ -60,7 +61,7 @@ func Timestamptz(v pg.Timestamptz) gsx.Node {
 		_gsxgw.Text(string(v.Label))
 		_gsxgw.S("</time>")
 		return _gsxgw.Err()
-	})
+	}) /*line renderers.gsx:9:31*/
 }
 
 //line renderers.gsx:12:1
@@ -88,6 +89,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func Sample(label string) pg.Timestamptz { return pg.Timestamptz{Label: label} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/package_local.txtar
+++ b/internal/corpus/testdata/cases/renderers/package_local.txtar
@@ -43,6 +43,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:8:1*/
 func Timestamptz(v pg.Timestamptz) gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
@@ -52,7 +53,7 @@ func Timestamptz(v pg.Timestamptz) gsx.Node {
 		_gsxgw.Text(string(v.Label))
 		_gsxgw.S("</time>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:9:31*/
 }
 
 func sample(label string) pg.Timestamptz { return pg.Timestamptz{Label: label} }

--- a/internal/corpus/testdata/cases/renderers/pointer.txtar
+++ b/internal/corpus/testdata/cases/renderers/pointer.txtar
@@ -58,6 +58,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 func mkTextPtr(s string, valid bool) *pg.Text {
 	v := mkText(s, valid)

--- a/internal/corpus/testdata/cases/renderers/script_hole.txtar
+++ b/internal/corpus/testdata/cases/renderers/script_hole.txtar
@@ -51,6 +51,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/srcset_hole.txtar
+++ b/internal/corpus/testdata/cases/renderers/srcset_hole.txtar
@@ -56,6 +56,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/style_css_literal_part.txtar
+++ b/internal/corpus/testdata/cases/renderers/style_css_literal_part.txtar
@@ -64,6 +64,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/style_error.txtar
+++ b/internal/corpus/testdata/cases/renderers/style_error.txtar
@@ -58,6 +58,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/style_hole.txtar
+++ b/internal/corpus/testdata/cases/renderers/style_hole.txtar
@@ -51,6 +51,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/style_part.txtar
+++ b/internal/corpus/testdata/cases/renderers/style_part.txtar
@@ -53,6 +53,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/text_basic.txtar
+++ b/internal/corpus/testdata/cases/renderers/text_basic.txtar
@@ -51,6 +51,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/text_error.txtar
+++ b/internal/corpus/testdata/cases/renderers/text_error.txtar
@@ -57,6 +57,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/tuple_then_renderer.txtar
+++ b/internal/corpus/testdata/cases/renderers/tuple_then_renderer.txtar
@@ -71,6 +71,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 func load(s string, valid bool) (pg.Text, error) {
 	if s == "" {
 		return pg.Text{}, errors.New("load: empty input")

--- a/internal/corpus/testdata/cases/renderers/valuecf_arm.txtar
+++ b/internal/corpus/testdata/cases/renderers/valuecf_arm.txtar
@@ -54,6 +54,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{String: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/renderers/wins_over_stringer.txtar
+++ b/internal/corpus/testdata/cases/renderers/wins_over_stringer.txtar
@@ -54,6 +54,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func mkText(s string, valid bool) pg.Text { return pg.Text{Value: s, Valid: valid} }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/reserved/plain_func_attrs_param_ok.txtar
+++ b/internal/corpus/testdata/cases/reserved/plain_func_attrs_param_ok.txtar
@@ -37,6 +37,7 @@ import (
 	_gsxio "io"
 )
 
+/*line input.gsx:5:1*/
 func Icon(attrs ...gsx.Attr) gsx.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
@@ -48,7 +49,7 @@ func Icon(attrs ...gsx.Attr) gsx.Node {
 		_gsxgw.Spread(ctx, _gsxv0, []string{"action", "cite", "data", "formaction", "href", "manifest", "ping", "poster", "src", "xlink:href"}, []string{"background"}, []string{"imagesrcset", "srcset"}, nil, []string{"class", "style"})
 		_gsxgw.S(">x</svg>")
 		return _gsxgw.Err()
-	})
+	}) /*line input.gsx:8:3*/
 }
 
 //line input.gsx:11:1

--- a/internal/corpus/testdata/cases/reserved/range_shadow_ok.txtar
+++ b/internal/corpus/testdata/cases/reserved/range_shadow_ok.txtar
@@ -33,6 +33,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func bags() []gsx.Attrs {
 	return []gsx.Attrs{
 		{{Key: "class", Value: "a"}},

--- a/internal/corpus/testdata/cases/reserved/shadow_and_free_mixed.txtar
+++ b/internal/corpus/testdata/cases/reserved/shadow_and_free_mixed.txtar
@@ -38,6 +38,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func bags() []gsx.Attrs {
 	return []gsx.Attrs{
 		{{Key: "class", Value: "a"}},

--- a/internal/corpus/testdata/cases/reserved/struct_key_not_trigger.txtar
+++ b/internal/corpus/testdata/cases/reserved/struct_key_not_trigger.txtar
@@ -27,6 +27,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type opt struct {
 	attrs int
 }

--- a/internal/corpus/testdata/cases/script/interp_comment_literal.txtar
+++ b/internal/corpus/testdata/cases/script/interp_comment_literal.txtar
@@ -28,6 +28,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type Config struct {
 	Tab string
 }

--- a/internal/corpus/testdata/cases/script/interp_value.txtar
+++ b/internal/corpus/testdata/cases/script/interp_value.txtar
@@ -28,6 +28,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type Config struct {
 	Tab string
 }

--- a/internal/corpus/testdata/cases/script/value_tuple.txtar
+++ b/internal/corpus/testdata/cases/script/value_tuple.txtar
@@ -38,6 +38,7 @@ func Page() _gsxrt.Node {
 	})
 }
 
+//line input.gsx:7:1
 func load() (string, error) { return "</script>", nil }
 -- render.golden --
 <script>const d = "\u003c/script\u003e";</script>

--- a/internal/corpus/testdata/cases/style/block_stringer.txtar
+++ b/internal/corpus/testdata/cases/style/block_stringer.txtar
@@ -28,6 +28,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type Color struct{ R, G, B int }
 
 func (c Color) String() string { return fmt.Sprintf("#%02x%02x%02x", c.R, c.G, c.B) }

--- a/internal/corpus/testdata/cases/style/block_tuple_error.txtar
+++ b/internal/corpus/testdata/cases/style/block_tuple_error.txtar
@@ -40,4 +40,5 @@ func C() _gsxrt.Node {
 	})
 }
 
+//line input.gsx:7:1
 func theme() (string, error) { return "x", nil }

--- a/internal/corpus/testdata/cases/style/part_tuple.txtar
+++ b/internal/corpus/testdata/cases/style/part_tuple.txtar
@@ -40,4 +40,5 @@ func C(v int) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:7:1
 func sty(v int) (string, error) { return "color: red", nil }

--- a/internal/corpus/testdata/cases/style/value_form_evaluation_order.txtar
+++ b/internal/corpus/testdata/cases/style/value_form_evaluation_order.txtar
@@ -27,6 +27,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 var calls int
 
 //line input.gsx:5:1
@@ -52,6 +53,7 @@ func C(label string) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:9:1
 func setState() string {
 	calls++
 	return "display: block"

--- a/internal/corpus/testdata/cases/tuple/child_prop_mixed.txtar
+++ b/internal/corpus/testdata/cases/tuple/child_prop_mixed.txtar
@@ -23,6 +23,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func greeting(name string) (string, error) { return "Hello " + name, nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/tuple/child_prop_multi.txtar
+++ b/internal/corpus/testdata/cases/tuple/child_prop_multi.txtar
@@ -24,6 +24,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func firstName(id string) (string, error) { return "First-" + id, nil }
 func lastName(id string) (string, error)  { return "Last-" + id, nil }
 

--- a/internal/corpus/testdata/cases/tuple/child_prop_node.txtar
+++ b/internal/corpus/testdata/cases/tuple/child_prop_node.txtar
@@ -26,6 +26,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func makeIcon(name string) (gsx.Node, error) { return gsx.Text("<" + name + ">"), nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/tuple/child_prop_single.txtar
+++ b/internal/corpus/testdata/cases/tuple/child_prop_single.txtar
@@ -22,6 +22,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func lookup(key string) (string, error) { return "val-" + key, nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/tuple/literal_and_tuple_mixed.txtar
+++ b/internal/corpus/testdata/cases/tuple/literal_and_tuple_mixed.txtar
@@ -25,6 +25,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func lookup(key string) (string, error) { return "title-" + key, nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/tuple/literal_typed_props.txtar
+++ b/internal/corpus/testdata/cases/tuple/literal_typed_props.txtar
@@ -27,6 +27,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 type Count int
 
 type Toggle bool

--- a/internal/corpus/testdata/cases/tuple/mixed_prop_pair_order.txtar
+++ b/internal/corpus/testdata/cases/tuple/mixed_prop_pair_order.txtar
@@ -34,6 +34,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func f(k string) (string, error) { return "f-" + k, nil }
 func g(k string) (string, error) { return "g-" + k, nil }
 func h(k string) (string, error) { return "h-" + k, nil }

--- a/internal/corpus/testdata/cases/tuple/ordered_mixed.txtar
+++ b/internal/corpus/testdata/cases/tuple/ordered_mixed.txtar
@@ -30,6 +30,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func f(k string) (string, error) { return "f-" + k, nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/tuple/ordered_multi.txtar
+++ b/internal/corpus/testdata/cases/tuple/ordered_multi.txtar
@@ -30,6 +30,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func f(k string) (string, error) { return "f-" + k, nil }
 func g(k string) (string, error) { return "g-" + k, nil }
 

--- a/internal/corpus/testdata/cases/tuple/ordered_single.txtar
+++ b/internal/corpus/testdata/cases/tuple/ordered_single.txtar
@@ -29,6 +29,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func sig(name string) (string, error) { return "{" + name + ":0}", nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/tuple/ordered_threaded.txtar
+++ b/internal/corpus/testdata/cases/tuple/ordered_threaded.txtar
@@ -33,6 +33,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func sig(name string) (string, error) { return "{" + name + ":0}", nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/tuple/ordered_ws.txtar
+++ b/internal/corpus/testdata/cases/tuple/ordered_ws.txtar
@@ -29,6 +29,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func sig(name string) (string, error) { return "{" + name + ":0}", nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/tuple/pos_attr_js.txtar
+++ b/internal/corpus/testdata/cases/tuple/pos_attr_js.txtar
@@ -24,6 +24,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func handler(action string) (string, error) { return "doThing('" + action + "')", nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/tuple/pos_children_slot.txtar
+++ b/internal/corpus/testdata/cases/tuple/pos_children_slot.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func makeText(tag string) (string, error) { return "[" + tag + "]", nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/tuple/pos_named_slot.txtar
+++ b/internal/corpus/testdata/cases/tuple/pos_named_slot.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func makeTitle(s string) (string, error) { return "-- " + s + " --", nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/tuple/pos_text_interp.txtar
+++ b/internal/corpus/testdata/cases/tuple/pos_text_interp.txtar
@@ -25,6 +25,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func greet(name string) (string, error) { return "Hello " + name, nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/tuple/t_int.txtar
+++ b/internal/corpus/testdata/cases/tuple/t_int.txtar
@@ -24,6 +24,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:3:1
 func count(n int) (int, error) { return n * 2, nil }
 
 //line input.gsx:5:1

--- a/internal/corpus/testdata/cases/tuple/t_nodeslice.txtar
+++ b/internal/corpus/testdata/cases/tuple/t_nodeslice.txtar
@@ -31,6 +31,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func makeItems(n int) ([]gsx.Node, error) {
 	return []gsx.Node{gsx.Text("item")}, nil
 }

--- a/internal/corpus/testdata/cases/tuple/t_stringer.txtar
+++ b/internal/corpus/testdata/cases/tuple/t_stringer.txtar
@@ -34,6 +34,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 func makeLabel(s string) (myLabel, error) { return myLabel{text: "[" + s + "]"}, nil }
 
 //line input.gsx:7:1

--- a/internal/corpus/testdata/cases/urlattrs/bag_custom_rule.txtar
+++ b/internal/corpus/testdata/cases/urlattrs/bag_custom_rule.txtar
@@ -37,6 +37,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type widgetProps struct {
 	Attrs gsx.Attrs
 }

--- a/internal/corpus/testdata/cases/urlattrs/bag_hx_get.txtar
+++ b/internal/corpus/testdata/cases/urlattrs/bag_hx_get.txtar
@@ -38,6 +38,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type ctrlProps struct {
 	Attrs gsx.Attrs
 }

--- a/internal/corpus/testdata/cases/urlattrs/bag_prefix_forced.txtar
+++ b/internal/corpus/testdata/cases/urlattrs/bag_prefix_forced.txtar
@@ -40,6 +40,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type navProps struct {
 	Attrs gsx.Attrs
 }

--- a/internal/corpus/testdata/cases/urlattrs/bag_prefix_rule.txtar
+++ b/internal/corpus/testdata/cases/urlattrs/bag_prefix_rule.txtar
@@ -38,6 +38,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type navProps struct {
 	Attrs gsx.Attrs
 }

--- a/internal/corpus/testdata/cases/urlattrs/bag_rawurl.txtar
+++ b/internal/corpus/testdata/cases/urlattrs/bag_rawurl.txtar
@@ -35,6 +35,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type linkProps struct {
 	Attrs gsx.Attrs
 }

--- a/internal/corpus/testdata/cases/urlattrs/bag_src_image_split.txtar
+++ b/internal/corpus/testdata/cases/urlattrs/bag_src_image_split.txtar
@@ -46,6 +46,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type imgProps struct {
 	Attrs gsx.Attrs
 }

--- a/internal/corpus/testdata/cases/verbatim/attrs_defined_forwarding.txtar
+++ b/internal/corpus/testdata/cases/verbatim/attrs_defined_forwarding.txtar
@@ -32,6 +32,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type LocalAttrs []gsx.Attr
 
 func bag(id string) LocalAttrs {

--- a/internal/corpus/testdata/cases/verbatim/attrs_shapes.txtar
+++ b/internal/corpus/testdata/cases/verbatim/attrs_shapes.txtar
@@ -117,6 +117,7 @@ func _gsxrenderShell(ctx _gsxctx.Context, _gsxgw *_gsxrt.Writer, attrs gsx.Attrs
 	return _gsxgw.Err()
 }
 
+//line input.gsx:13:1
 type LocalAttrs []gsx.Attr
 
 //line input.gsx:15:1
@@ -163,6 +164,7 @@ func _gsxrenderVariadic(ctx _gsxctx.Context, _gsxgw *_gsxrt.Writer, attrs ...gsx
 	return _gsxgw.Err()
 }
 
+//line input.gsx:23:1
 func computedBag() gsx.Attrs {
 	return gsx.Attrs{{Key: "data-k", Value: "v"}}
 }

--- a/internal/corpus/testdata/cases/verbatim/callable_origins.txtar
+++ b/internal/corpus/testdata/cases/verbatim/callable_origins.txtar
@@ -67,6 +67,7 @@ func Line(label string) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:9:1
 func Free(label string) gsx.Node { return Line(label) }
 
 type rowFunc = func(label string) gsx.Node

--- a/internal/corpus/testdata/cases/verbatim/core_positional.txtar
+++ b/internal/corpus/testdata/cases/verbatim/core_positional.txtar
@@ -67,6 +67,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:9:1
 type Level int
 type Letter rune
 

--- a/internal/corpus/testdata/cases/verbatim/direct_go_signature.txtar
+++ b/internal/corpus/testdata/cases/verbatim/direct_go_signature.txtar
@@ -35,6 +35,7 @@ import (
 	_gsxio "io"
 )
 
+//line input.gsx:5:1
 type History struct{ Label string }
 
 //line input.gsx:7:1
@@ -50,4 +51,5 @@ func Page(h History) _gsxrt.Node {
 	})
 }
 
+//line input.gsx:11:1
 var _ func(History) gsx.Node = Page

--- a/internal/lsp/analysis.go
+++ b/internal/lsp/analysis.go
@@ -189,4 +189,11 @@ type FilterCandidate struct {
 	Pkg      string // winning package import path
 	Func     string // exported Go func name, e.g. "Upper"
 	WantsCtx bool
+	// Pos is the filter target func's declaration position (its Fset-resolved
+	// go/token.Position, computed once at analysis time from the SAME shared
+	// Fset every other completion/nav feature trusts — see codegen's
+	// filterEntry.pos), used to fetch its doc comment lazily via
+	// completionItem/resolve (filterItems). The zero Position (Pos.IsValid()
+	// false) means no position was resolved — filterItems then omits Data.
+	Pos token.Position
 }

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -103,7 +103,7 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// type expected at the cursor sorts ahead of the rest within its locality
 	// tier. Fails silent (nil, no boost) outside the derivable subset.
 	expected := expectedTypeAt(eph, cc, skel, skelPos, exprStartOff, path)
-	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, expected, text, start, end, s.enc, path)
+	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, expected, text, start, end, s.enc, path, src)
 	if len(items) == 0 {
 		return emptyCompletion()
 	}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -102,7 +102,7 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// Expected-type ranking (never filtering): a candidate whose type matches the
 	// type expected at the cursor sorts ahead of the rest within its locality
 	// tier. Fails silent (nil, no boost) outside the derivable subset.
-	expected := expectedTypeAt(eph, cc, skel, skelPos, exprStartOff)
+	expected := expectedTypeAt(eph, cc, skel, skelPos, exprStartOff, path)
 	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, expected, text, start, end, s.enc)
 	if len(items) == 0 {
 		return emptyCompletion()

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -103,7 +103,7 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// type expected at the cursor sorts ahead of the rest within its locality
 	// tier. Fails silent (nil, no boost) outside the derivable subset.
 	expected := expectedTypeAt(eph, cc, skel, skelPos, exprStartOff, path)
-	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, expected, text, start, end, s.enc)
+	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, expected, text, start, end, s.enc, path)
 	if len(items) == 0 {
 		return emptyCompletion()
 	}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -99,7 +99,11 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 		return emptyCompletion()
 	}
 	start, end := completionTokenSpan(text, off, false)
-	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, text, start, end, s.enc)
+	// Expected-type ranking (never filtering): a candidate whose type matches the
+	// type expected at the cursor sorts ahead of the rest within its locality
+	// tier. Fails silent (nil, no boost) outside the derivable subset.
+	expected := expectedTypeAt(eph, cc, skel, skelPos, exprStartOff)
+	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, expected, text, start, end, s.enc)
 	if len(items) == 0 {
 		return emptyCompletion()
 	}

--- a/internal/lsp/completion_context.go
+++ b/internal/lsp/completion_context.go
@@ -257,9 +257,9 @@ func openTagEnd(src []byte, from int) int {
 
 // skipBraced returns the byte offset just past the balanced {expr} value that
 // begins at src[i] (src[i] is the opening '{'). Nested braces are balanced and
-// interior Go string/rune/raw-string literals are skipped so a '}' inside a
-// literal does not close the value early. Runs to len(src) on an unbalanced
-// value.
+// interior Go string/rune/raw-string literals and `//`/`/* */` comments are
+// skipped so a '}' inside a literal or comment does not close the value early.
+// Runs to len(src) on an unbalanced value.
 func skipBraced(src []byte, i int) int {
 	depth := 0
 	for i < len(src) {
@@ -275,11 +275,44 @@ func skipBraced(src []byte, i int) int {
 			}
 		case '"', '\'', '`':
 			i = skipGoString(src, i)
+		case '/':
+			switch {
+			case i+1 < len(src) && src[i+1] == '/':
+				i = skipLineComment(src, i)
+			case i+1 < len(src) && src[i+1] == '*':
+				i = skipBlockComment(src, i)
+			default:
+				i++
+			}
 		default:
 			i++
 		}
 	}
 	return i
+}
+
+// skipLineComment returns the byte offset just past the `//` line comment
+// that begins at src[i] (src[i] is the first '/') — the offset of the
+// terminating newline, or len(src) if the comment runs to EOF.
+func skipLineComment(src []byte, i int) int {
+	for i < len(src) && src[i] != '\n' {
+		i++
+	}
+	return i
+}
+
+// skipBlockComment returns the byte offset just past the `/* … */` comment
+// that begins at src[i] (src[i] is the '/'). Runs to len(src) on an
+// unterminated comment.
+func skipBlockComment(src []byte, i int) int {
+	i += 2 // consume "/*"
+	for i < len(src) {
+		if src[i] == '*' && i+1 < len(src) && src[i+1] == '/' {
+			return i + 2
+		}
+		i++
+	}
+	return len(src)
 }
 
 // skipGoString returns the byte offset just past the Go string, rune, or raw

--- a/internal/lsp/completion_context_test.go
+++ b/internal/lsp/completion_context_test.go
@@ -190,3 +190,31 @@ func TestClassifyCompletionContextFields(t *testing.T) {
 		}
 	})
 }
+
+// TestOpenTagEndSkipsComments pins skipBraced's comment handling: a `}` or
+// `>` inside a `//` or `/* */` comment nested in an ExprAttr's {expr} value
+// must not be mistaken for the value's closing brace or the open tag's
+// closing '>'. Without comment-aware skipping, the comment's own '}' closes
+// the brace early and a stray '>' still inside the comment text then
+// terminates the tag scan early too — both cases below regress to that wrong,
+// earlier '>' if skipBraced stops recognizing comments.
+func TestOpenTagEndSkipsComments(t *testing.T) {
+	cases := []struct {
+		name, src string
+	}{
+		{"block comment with brace and angle bracket", `<div title={ /* } > */ x }>`},
+		{"line comment with brace and angle bracket", "<div title={ // } >\n\tx }>"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			want := strings.LastIndexByte(tc.src, '>')
+			if want < 0 {
+				t.Fatal("fixture has no '>'")
+			}
+			if got := openTagEnd(src, 0); got != want {
+				t.Fatalf("openTagEnd = %d, want %d (the tag's real closing '>'); src=%q", got, want, tc.src)
+			}
+		})
+	}
+}

--- a/internal/lsp/completion_docs.go
+++ b/internal/lsp/completion_docs.go
@@ -1,0 +1,342 @@
+package lsp
+
+import (
+	goast "go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strconv"
+	"strings"
+	"sync"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+)
+
+// This file implements T9+T10 of the completion batch: Go doc comments on
+// completion candidates. Documentation is doc-comment text ONLY (rendered as
+// markdown via markdownDoc) — Detail already carries the rendered signature
+// (goObjectPresentation), so Documentation never repeats it.
+//
+// Two independent mechanisms, split by where the declaring source lives:
+//
+//   - EAGER (authoredDoc, below): an object declared in the CURRENT package's
+//     own analyzed .gsx source. The declaring GoChunk/GoWithElements is
+//     already in memory (pkg.Files), so its doc is extracted synchronously and
+//     placed directly on the CompletionItem. Reuses the EXACT byte-for-byte
+//     recovery reconstruction textDocument/documentSymbol already proved
+//     (reconstructGoChunk/reconstructGoWithElements in symbols.go) rather than
+//     a second hand-rolled fragment parser — GoWithElements decls (a var
+//     initializer with an embedded element) need that reconstruction's
+//     newline-preserving placeholders to parse at all.
+//
+//   - LAZY (see completion_resolve.go): everything else — imported dependency
+//     symbols, pipeline filters. Attaching CompletionItem.Data{file,line} at
+//     list-build time and deferring the file read + parse to
+//     completionItem/resolve keeps a full completion list (hundreds of
+//     stdlib symbols) from paying a per-candidate file read+parse; only the
+//     one item the user actually selects pays that cost.
+//
+// chunkDocCache/depDocCache below are content-addressed, so identical source
+// text always yields the identical cached doc — safe to share across
+// concurrent requests and even across process-wide test runs without any
+// invalidation logic (a changed chunk simply misses the cache and
+// overwrites the stale entry).
+
+// declDocsByLine walks a *recovery-parsed* Go file's top-level declarations —
+// funcs (including methods, via FuncDecl.Recv), types, vars, consts, and
+// struct fields — and returns EVERY declaration's doc-comment group, keyed by
+// its defining identifier's line (via lineOf). lineOf abstracts the
+// position→line mapping so the same walk serves both the eager path (mapping
+// back through a partialGoSource reconstruction to REAL .gsx lines) and a
+// plain full-file parse (mapping directly via the parse's own FileSet, no
+// reconstruction).
+//
+// Building the FULL map in one pass — rather than searching for one target
+// line — matters beyond convenience: a single GoChunk/GoWithElements
+// (equally, a single real .go file) commonly holds MULTIPLE declarations
+// (e.g. a struct type immediately followed by a method on it, merged into one
+// GoChunk with no Component decl between them to split it). Caching a single
+// (chunk, targetLine) -> doc answer, keyed only by chunk identity/content,
+// would let an unrelated declaration's doc leak onto a DIFFERENT line's
+// lookup the moment both live in the same reconstructed text and the cache
+// is consulted a second time for the other line — an actual bug caught while
+// writing this: a struct field's lookup returned its sibling method's doc,
+// because both hashed to the same cache entry. Computing the whole line->doc
+// map once and caching THAT (chunkDocCache) removes the collision entirely.
+//
+// Doc-comment attachment mirrors go/ast + gofmt precedence: a GenDecl with
+// exactly one Spec attributes ITS OWN leading Doc to that spec when the spec
+// has no more specific Doc of its own (`// Foo is ...\nvar Foo = 1` records
+// the comment as the GenDecl's Doc, not the ValueSpec's).
+func declDocsByLine(decls []goast.Decl, lineOf func(*goast.Ident) (int, bool)) map[int]string {
+	out := map[int]string{}
+	set := func(id *goast.Ident, cg *goast.CommentGroup) {
+		line, ok := lineOf(id)
+		if !ok {
+			return
+		}
+		if text := docText(cg); text != "" {
+			out[line] = text
+		}
+	}
+	for _, d := range decls {
+		switch decl := d.(type) {
+		case *goast.FuncDecl:
+			if decl.Name != nil {
+				set(decl.Name, decl.Doc)
+			}
+		case *goast.GenDecl:
+			single := len(decl.Specs) == 1
+			for _, sp := range decl.Specs {
+				switch spec := sp.(type) {
+				case *goast.ValueSpec:
+					doc := spec.Doc
+					if doc == nil && single {
+						doc = decl.Doc
+					}
+					for _, name := range spec.Names {
+						set(name, doc)
+					}
+				case *goast.TypeSpec:
+					doc := spec.Doc
+					if doc == nil && single {
+						doc = decl.Doc
+					}
+					if spec.Name != nil {
+						set(spec.Name, doc)
+					}
+					st, ok := spec.Type.(*goast.StructType)
+					if !ok || st.Fields == nil {
+						continue
+					}
+					for _, field := range st.Fields.List {
+						for _, name := range field.Names {
+							set(name, field.Doc)
+						}
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// docText renders a possibly-nil comment group as trimmed markdown text (""
+// for nil — CommentGroup.Text() already strips comment markers).
+func docText(cg *goast.CommentGroup) string {
+	if cg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cg.Text())
+}
+
+// coveringDeclReconstruction finds the .gsx File decl (GoChunk or
+// GoWithElements) whose span covers 1-based REAL .gsx source line
+// targetLine and reconstructs its verbatim Go text via the same proven
+// byte-exact recovery reconstruction textDocument/documentSymbol uses.
+// Returns ok=false when no covering decl is found or the reconstruction is
+// rejected (a structural mismatch symbols.go would also reject).
+// declLine is the covering decl's own span-START line — the chunkDocCache
+// key, so edits inside a large chunk still hit the SAME cache slot.
+func coveringDeclReconstruction(file *gsxast.File, fset *token.FileSet, source []byte, targetLine int) (reconstructed partialGoSource, tokenFile *token.File, declLine int, ok bool) {
+	for _, d := range file.Decls {
+		switch decl := d.(type) {
+		case *gsxast.GoChunk:
+			if !spanCoversLine(fset, decl.Pos(), decl.End(), targetLine) {
+				continue
+			}
+			reconstructed, tokenFile, ok = reconstructGoChunk(fset, source, decl)
+			return reconstructed, tokenFile, fset.Position(decl.Pos()).Line, ok
+		case *gsxast.GoWithElements:
+			if !spanCoversLine(fset, decl.Pos(), decl.End(), targetLine) {
+				continue
+			}
+			reconstructed, tokenFile, ok = reconstructGoWithElements(fset, source, decl)
+			return reconstructed, tokenFile, fset.Position(decl.Pos()).Line, ok
+		}
+	}
+	return partialGoSource{}, nil, 0, false
+}
+
+// spanCoversLine reports whether 1-based line is actually spanned by
+// [pos, end) — end treated as EXCLUSIVE, so the line of end itself is only
+// counted when end owns at least one byte on it (end's column > 1).
+// Naively using fset.Position(end).Line as the inclusive upper bound is
+// wrong whenever a decl's exclusive end lands exactly at column 1 of the
+// FOLLOWING line (the common case: a GoChunk immediately followed by a
+// `component` decl, with no gap — end sits at the first byte of "component",
+// which token.Position still reports as being ON that line): a real bug this
+// caught, where a package-scope component's line was wrongly credited to the
+// PRECEDING GoChunk, and its doc lookup was satisfied by the chunk's cache
+// entry it happened to also collide with, returning the WRONG declaration's
+// doc.
+func spanCoversLine(fset *token.FileSet, pos, end token.Pos, line int) bool {
+	lo := fset.Position(pos).Line
+	if line < lo {
+		return false
+	}
+	endPos := fset.Position(end)
+	hi := endPos.Line
+	if endPos.Column == 1 && hi > lo {
+		hi-- // end owns no bytes on its own line; the decl's real last line is hi-1.
+	}
+	return line <= hi
+}
+
+// docsFromReconstruction parses partialGoWrapPrefix+reconstructed.text WITH
+// comments and returns EVERY declaration's doc text, keyed by the REAL .gsx
+// line its name identifier maps back to (via reconstructed.sourceOffset, the
+// SAME position-mapping partialGoSymbols trusts for LSP navigation). A
+// recovery parse can synthesize identifiers on malformed input, so —
+// mirroring partialGoSymbols' mapIdent — every identifier position is proven
+// to originate from one verbatim authored segment before it can match.
+func docsFromReconstruction(sourceFset *token.FileSet, sourceTokenFile *token.File, reconstructed partialGoSource) map[int]string {
+	gfset := token.NewFileSet()
+	gf, _ := parser.ParseFile(gfset, "recovery.go", partialGoWrapPrefix+reconstructed.text.String(), parser.ParseComments|parser.AllErrors|parser.SkipObjectResolution)
+	if gf == nil {
+		return nil
+	}
+	parsedTokenFile := gfset.File(gf.Pos())
+	if parsedTokenFile == nil {
+		return nil
+	}
+	lineOf := func(ident *goast.Ident) (int, bool) {
+		if ident == nil || gfset.File(ident.Pos()) != parsedTokenFile || gfset.File(ident.End()) != parsedTokenFile {
+			return 0, false
+		}
+		parsedStart := parsedTokenFile.Offset(ident.Pos()) - len(partialGoWrapPrefix)
+		parsedEnd := parsedTokenFile.Offset(ident.End()) - len(partialGoWrapPrefix)
+		sourceStart, _, ok := reconstructed.linearSourceSpan(parsedStart, parsedEnd)
+		if !ok || sourceStart < 0 || sourceStart > sourceTokenFile.Size() {
+			return 0, false
+		}
+		return sourceFset.Position(sourceTokenFile.Pos(sourceStart)).Line, true
+	}
+	return declDocsByLine(gf.Decls, lineOf)
+}
+
+// completionDocFor computes the Documentation/Data pair for one completion
+// candidate object — the single decision point for the design's uniform
+// eager-vs-lazy rule: an object whose OWN declaring package is the package
+// under analysis (obj.Pkg() == pkg.Types) is "authored" and gets eager
+// Documentation (authoredDoc, extracted from the already-in-memory .gsx
+// source); every other object with a resolvable position — an imported
+// dependency's func/type/var/const, a pipeline filter's target func — gets a
+// lazy Data{file,line} payload instead, deferring the file read+parse to
+// completionItem/resolve. An object with no resolvable position (a builtin,
+// `nil`, a synthesized object) gets neither.
+//
+// Applying the SAME object-identity check to every candidate class (package
+// scope, imported package members, same-package struct/receiver members) is
+// what makes "same-package MEMBER items follow the same rule" (decision #2)
+// automatic: a member's authored-ness is a property of the member object
+// itself, not of which completion path found it.
+func completionDocFor(pkg *Package, obj types.Object, source []byte) (*MarkupContent, *completionResolveData) {
+	if pkg == nil || pkg.Fset == nil || obj == nil || !obj.Pos().IsValid() {
+		return nil, nil
+	}
+	if pkg.Types != nil && obj.Pkg() == pkg.Types {
+		// Authored in THIS package: eager-only. A miss (the //line position
+		// didn't map into a decl this pass could reconstruct — e.g. source
+		// wasn't supplied) fails soft to no documentation: the resolved
+		// position here is a .gsx path, never a valid completionItem/resolve
+		// target (resolvablePath requires a real .go file), so there is no
+		// useful Data to fall back to.
+		if doc, ok := authoredDoc(pkg, obj, source); ok {
+			return markdownDoc(doc), nil
+		}
+		return nil, nil
+	}
+	pos := pkg.Fset.Position(obj.Pos())
+	if pos.Filename == "" || pos.Line <= 0 {
+		return nil, nil
+	}
+	return nil, &completionResolveData{File: pos.Filename, Line: pos.Line}
+}
+
+// authoredDoc extracts obj's doc comment from THIS package's own analyzed
+// .gsx source (caller has already checked obj.Pkg() == pkg.Types). This
+// object-identity check matters beyond a cheap filter: pkg.Fset.Position can
+// //line-map a DIFFERENT package's component-value object back to THAT
+// package's .gsx (see objectSourceLocation's docs) — chasing that here would
+// be wrong, because that source lives in the OTHER package's Files map, and
+// pkg.Files only holds THIS package's own parsed files.
+//
+// source must be the exact bytes pkg.Files were parsed from (the analysis
+// that produced pkg): reconstruction matches gsxast byte spans against it,
+// so any divergence (a stale or different buffer) fails the reconstruction's
+// own invariant checks and returns ok=false — never wrong output, just no doc.
+func authoredDoc(pkg *Package, obj types.Object, source []byte) (string, bool) {
+	if pkg == nil || pkg.GSXFset == nil || obj == nil || len(source) == 0 {
+		return "", false
+	}
+	pos := pkg.Fset.Position(obj.Pos())
+	if pos.Line <= 0 || !strings.HasSuffix(pos.Filename, ".gsx") {
+		return "", false
+	}
+	file := pkg.Files[pos.Filename]
+	if file == nil {
+		return "", false
+	}
+	return globalChunkDocCache.doc(file, pkg.GSXFset, source, pos.Filename, pos.Line)
+}
+
+// chunkDocCache memoizes eager current-package doc extraction, content-keyed
+// so a repeated completion request over an UNCHANGED declaration skips the
+// recovery parse entirely. Keyed by (path, declaration start line); the
+// cached reconstructed source text is compared on every lookup, so an edited
+// declaration simply misses and overwrites — no version/generation tracking
+// needed, and no possibility of serving stale text. Safe for concurrent use;
+// shared process-wide (not per-Server), which is sound for the same reason:
+// entries are self-validating by content, so cross-request/cross-test
+// sharing only ever saves work, never returns a wrong answer.
+type chunkDocCache struct {
+	mu      sync.Mutex
+	entries map[string]chunkDocEntry
+	// parses counts actual recovery-parse calls (cache misses only) — test-only
+	// observability for the "second completion doesn't re-parse" cache
+	// contract (see chunkDocCache.doc).
+	parses int
+}
+
+type chunkDocEntry struct {
+	src  string         // the exact reconstructed source text this entry was parsed from
+	docs map[int]string // every declaration's doc in this chunk, keyed by REAL .gsx line
+}
+
+var globalChunkDocCache = &chunkDocCache{entries: map[string]chunkDocEntry{}}
+
+// doc returns the doc text for the declaration covering targetLine in file
+// (an authored .gsx AST already resolved to belong to path), using fset+source
+// for reconstruction. path+declLine key the cache; declLine is the SPAN START
+// line of the covering decl (found once here, then reused as the cache key),
+// and the cached VALUE is the whole chunk's line->doc map (not a single
+// line's answer) — see declDocsByLine's doc comment for why caching a
+// single-line answer is unsound whenever a chunk holds more than one
+// declaration. An edit inside the chunk changes its reconstructed text, so
+// the content check below simply misses and overwrites; no version tracking
+// needed.
+func (c *chunkDocCache) doc(file *gsxast.File, fset *token.FileSet, source []byte, path string, targetLine int) (string, bool) {
+	reconstructed, tokenFile, declLine, ok := coveringDeclReconstruction(file, fset, source, targetLine)
+	if !ok {
+		return "", false
+	}
+	reconstructedSrc := reconstructed.text.String()
+	key := path + "#" + strconv.Itoa(declLine)
+
+	c.mu.Lock()
+	entry, hit := c.entries[key]
+	c.mu.Unlock()
+	if hit && entry.src == reconstructedSrc {
+		text, found := entry.docs[targetLine]
+		return text, found
+	}
+
+	docs := docsFromReconstruction(fset, tokenFile, reconstructed)
+	c.mu.Lock()
+	c.entries[key] = chunkDocEntry{src: reconstructedSrc, docs: docs}
+	c.parses++
+	c.mu.Unlock()
+	text, found := docs[targetLine]
+	return text, found
+}

--- a/internal/lsp/completion_docs_test.go
+++ b/internal/lsp/completion_docs_test.go
@@ -1,0 +1,227 @@
+package lsp
+
+import (
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestCompletionDocEagerScopeCandidate covers T9's eager path for a
+// package-scope (tierPackage) candidate: a documented top-level func offered
+// at a bare package-scope cursor (goCompletionItems, pkg.Types.Scope()
+// directly, mirroring TestGoCompletionItemsStatementMemberDispatch's use of
+// the real scope) carries Documentation inline — no Data, no round trip.
+// The sibling `component Home` (an authored but UNDOCUMENTED package-scope
+// func) is asserted to carry neither Documentation nor Data, pinning the
+// "authored, no comment -> no doc at all" case from the SAME pass.
+func TestCompletionDocEagerScopeCandidate(t *testing.T) {
+	const src = `package page
+
+// Greeting renders a friendly hello to name.
+func Greeting(name string) string {
+	return "Hello, " + name
+}
+
+component Home() {
+	<div>hi</div>
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	items := goCompletionItems(pkg, pkg.Types.Scope(), nil, token.NoPos, false, nil, src, 0, 0, encUTF8, path, []byte(src))
+
+	var greeting, home *CompletionItem
+	for i := range items {
+		switch items[i].Label {
+		case "Greeting":
+			greeting = &items[i]
+		case "Home":
+			home = &items[i]
+		}
+	}
+	if greeting == nil {
+		t.Fatal("scope completion missing package-scope func `Greeting`")
+	}
+	if greeting.Documentation == nil {
+		t.Fatal("`Greeting` has a doc comment but Documentation is nil")
+	}
+	if !strings.Contains(greeting.Documentation.Value, "Greeting renders a friendly hello") {
+		t.Errorf("`Greeting` Documentation = %q, want it to contain the doc comment text", greeting.Documentation.Value)
+	}
+	if greeting.Documentation.Kind != "markdown" {
+		t.Errorf("`Greeting` Documentation.Kind = %q, want \"markdown\"", greeting.Documentation.Kind)
+	}
+	if greeting.Data != nil {
+		t.Errorf("`Greeting` is authored in this package: eager Documentation must not ALSO carry lazy Data; got %+v", greeting.Data)
+	}
+
+	if home == nil {
+		t.Fatal("scope completion missing package-scope component `Home`")
+	}
+	if home.Documentation != nil {
+		t.Errorf("`Home` has no doc comment but Documentation = %+v, want nil", home.Documentation)
+	}
+	if home.Data != nil {
+		t.Errorf("`Home` is authored (eager-only): a doc miss must not fall back to lazy Data; got %+v", home.Data)
+	}
+}
+
+// TestCompletionDocEagerMemberCandidate covers decision #2 (same-package
+// MEMBER items follow the eager rule too): a documented method on a
+// same-package receiver type, reached via statementMemberItems' `.`-cursor
+// path (mirroring TestStatementMemberItemsGoBlockTrailingDot), carries eager
+// Documentation. The sibling field `Label` (authored, no doc) carries
+// neither Documentation nor Data, alongside it in the same member list.
+func TestCompletionDocEagerMemberCandidate(t *testing.T) {
+	const src = `package page
+
+type Widget struct {
+	Label string
+}
+
+// Render returns the widget's label as markup text.
+func (w Widget) Render() string {
+	return w.Label
+}
+
+component Home(w Widget) {
+	{{ _ = w.Render }}
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	nameOff := strings.Index(src, "w.Render") + len("w.")
+
+	items, ok := statementMemberItems(pkg, path, src, nameOff, nameOff, encUTF8, []byte(src))
+	if !ok {
+		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
+	}
+	var render, label *CompletionItem
+	for i := range items {
+		switch items[i].Label {
+		case "Render":
+			render = &items[i]
+		case "Label":
+			label = &items[i]
+		}
+	}
+	if render == nil {
+		t.Fatalf("member completion missing method `Render`; items=%+v", items)
+	}
+	if render.Documentation == nil {
+		t.Fatal("`Render` has a doc comment but Documentation is nil")
+	}
+	if !strings.Contains(render.Documentation.Value, "Render returns the widget's label") {
+		t.Errorf("`Render` Documentation = %q, want it to contain the doc comment text", render.Documentation.Value)
+	}
+	if render.Data != nil {
+		t.Errorf("`Render` is authored: eager Documentation must not ALSO carry lazy Data; got %+v", render.Data)
+	}
+
+	if label == nil {
+		t.Fatalf("member completion missing field `Label`; items=%+v", items)
+	}
+	if label.Documentation != nil {
+		t.Errorf("`Label` has no doc comment but Documentation = %+v, want nil", label.Documentation)
+	}
+	if label.Data != nil {
+		t.Errorf("`Label` is authored (eager-only): a doc miss must not fall back to lazy Data; got %+v", label.Data)
+	}
+}
+
+// TestCompletionDocEagerGoWithElementsDecl covers the GoWithElements decl
+// class explicitly required by the design's test plan: a package-level var
+// initialized to an embedded element literal (`var Banner = <div>...</div>`,
+// a *gsxast.GoWithElements — NOT a plain GoChunk) with a doc comment still
+// resolves its doc eagerly, proving the byte-exact recovery reconstruction
+// (reconstructGoWithElements, shared with textDocument/documentSymbol) is
+// exercised, not just the simpler GoChunk path.
+func TestCompletionDocEagerGoWithElementsDecl(t *testing.T) {
+	const src = `package page
+
+// Banner is a small reusable markup fragment.
+var Banner = <div>banner</div>
+
+component Home() {
+	<div>{ Banner }</div>
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	items := goCompletionItems(pkg, pkg.Types.Scope(), nil, token.NoPos, false, nil, src, 0, 0, encUTF8, path, []byte(src))
+
+	var banner *CompletionItem
+	for i := range items {
+		if items[i].Label == "Banner" {
+			banner = &items[i]
+		}
+	}
+	if banner == nil {
+		t.Fatalf("scope completion missing package-scope var `Banner`; items=%+v", items)
+	}
+	if banner.Documentation == nil {
+		t.Fatal("`Banner` (a GoWithElements decl) has a doc comment but Documentation is nil")
+	}
+	if !strings.Contains(banner.Documentation.Value, "Banner is a small reusable markup fragment") {
+		t.Errorf("`Banner` Documentation = %q, want it to contain the doc comment text", banner.Documentation.Value)
+	}
+	if banner.Data != nil {
+		t.Errorf("`Banner` is authored: eager Documentation must not ALSO carry lazy Data; got %+v", banner.Data)
+	}
+}
+
+// TestChunkDocCacheReuseAcrossRequests covers the "second completion in the
+// same file doesn't re-parse chunks" cache contract (chunkDocCache.doc):
+// two goCompletionItems passes over the IDENTICAL pkg/source (simulating two
+// completion requests over an unchanged buffer) must not re-run the
+// recovery parse the second time — globalChunkDocCache.parses (a
+// cache-miss-only counter) must stay flat across the second pass, while both
+// passes still report the identical Documentation.
+func TestChunkDocCacheReuseAcrossRequests(t *testing.T) {
+	const src = `package page
+
+// Greeting renders a friendly hello to name.
+func Greeting(name string) string {
+	return "Hello, " + name
+}
+
+component Home() {
+	<div>hi</div>
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+
+	docOf := func(items []CompletionItem) *MarkupContent {
+		for _, it := range items {
+			if it.Label == "Greeting" {
+				return it.Documentation
+			}
+		}
+		return nil
+	}
+
+	globalChunkDocCache.mu.Lock()
+	before := globalChunkDocCache.parses
+	globalChunkDocCache.mu.Unlock()
+
+	items1 := goCompletionItems(pkg, pkg.Types.Scope(), nil, token.NoPos, false, nil, src, 0, 0, encUTF8, path, []byte(src))
+	globalChunkDocCache.mu.Lock()
+	afterFirst := globalChunkDocCache.parses
+	globalChunkDocCache.mu.Unlock()
+	if afterFirst <= before {
+		t.Fatalf("first completion pass: chunkDocCache parses did not increase (before=%d after=%d)", before, afterFirst)
+	}
+
+	items2 := goCompletionItems(pkg, pkg.Types.Scope(), nil, token.NoPos, false, nil, src, 0, 0, encUTF8, path, []byte(src))
+	globalChunkDocCache.mu.Lock()
+	afterSecond := globalChunkDocCache.parses
+	globalChunkDocCache.mu.Unlock()
+	if afterSecond != afterFirst {
+		t.Errorf("second completion pass over an UNCHANGED chunk re-parsed: parses %d -> %d, want no change", afterFirst, afterSecond)
+	}
+
+	d1, d2 := docOf(items1), docOf(items2)
+	if d1 == nil || d2 == nil {
+		t.Fatalf("Greeting Documentation missing on one of the two passes: pass1=%+v pass2=%+v", d1, d2)
+	}
+	if d1.Value != d2.Value {
+		t.Errorf("Greeting Documentation differs across cached/uncached passes: %q vs %q", d1.Value, d2.Value)
+	}
+}

--- a/internal/lsp/completion_expected.go
+++ b/internal/lsp/completion_expected.go
@@ -1,0 +1,202 @@
+package lsp
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+)
+
+// expectedTypeAt derives the type the Go cursor is expected to produce, for
+// ranking (never filtering) candidates — a candidate whose type matches sorts
+// ahead of the rest WITHIN its locality tier. It implements only the
+// cheaply-sound cases and fails silent (returns nil, no boost) otherwise.
+//
+// DERIVATION SUBSET (v1):
+//   - Inner call argument `{ f(▮) }` / `title={ f(▮) }`: the innermost enclosing
+//     CallExpr WITHIN the bridged hole expression drives the expected type — the
+//     callee's parameter at the cursor's argument index (variadic tail handled).
+//     This is derivable from the bridged skel alone (no enclosing-statement
+//     context needed). Selector-receiver positions are naturally excluded: a
+//     cursor on `X` in `X.m()` sits before the call's `(`, so no call matches.
+//   - Component attr value hole `title={ ▮ }`: the bound parameter's type, read
+//     from the ephemeral ComponentCalls fact keyed by the ExprAttr under the
+//     cursor.
+//
+// The inner-call case is tried FIRST so that `title={ f(▮) }` ranks on f's
+// parameter (the immediate position) rather than title's type.
+//
+// DELIBERATELY SKIPPED (need enclosing-statement / AST-path context the bridge
+// does not retain, or are too broad to rank on):
+//   - Cross-statement positions: assignment RHS (LHS type), `return` result type,
+//     binary-operand type, top-level call argument where the hole IS the argument
+//     rather than containing the call. The bridge hands us only the hole's own
+//     skeleton expr, not its enclosing skeleton statement, so these are
+//     unreachable without retaining whole skeleton files.
+//   - Interp render position `{ ▮ }` top-level: expected = "renderable", too broad
+//     to rank on — skipped (spec 1c).
+func expectedTypeAt(eph *Package, cc completionContext, skel ast.Expr, skelPos token.Pos, exprStartOff int) types.Type {
+	if eph == nil || eph.Info == nil {
+		return nil
+	}
+	// Inner call argument, most specific — try first.
+	if t := innerCallArgExpectedType(eph.Info, skel, skelPos); t != nil {
+		return t
+	}
+	// Component attr value hole: the bound parameter's declared type.
+	if _, ok := cc.node.(*gsxast.ExprAttr); ok {
+		if t := componentAttrExpectedType(eph, exprStartOff); t != nil {
+			return t
+		}
+	}
+	return nil
+}
+
+// componentAttrExpectedType returns the declared type of the component parameter
+// bound to the ExprAttr whose value expression starts at byte offset
+// exprStartOff, or nil when no planned component call binds such an attribute.
+// The ComponentCalls facts are keyed by authored *gsxast.Element and their
+// Params by the exact authored *gsxast.ExprAttr, so matching the attribute's
+// value-expression start offset (stable across the classifier's and the
+// ephemeral analysis's independent parses of identical bytes) pins the binding.
+func componentAttrExpectedType(eph *Package, exprStartOff int) types.Type {
+	if eph == nil || eph.GSXFset == nil || eph.ComponentCalls == nil {
+		return nil
+	}
+	for _, fact := range eph.ComponentCalls {
+		for attr, param := range fact.Params {
+			ea, ok := attr.(*gsxast.ExprAttr)
+			if !ok || !ea.ExprPos.IsValid() || param.Var == nil {
+				continue
+			}
+			if eph.GSXFset.Position(ea.ExprPos).Offset == exprStartOff {
+				return param.Var.Type()
+			}
+		}
+	}
+	return nil
+}
+
+// innerCallArgExpectedType finds the innermost *ast.CallExpr in root whose
+// argument region ( `(` .. `)` ] contains pos, and returns the callee
+// parameter type at the cursor's argument index. Returns nil when the cursor is
+// not inside a call's argument list, the callee has no resolvable signature (a
+// type conversion `T(x)`, an unresolved name), or the argument index has no
+// parameter. root is the bridged hole expression and pos the cursor's skeleton
+// position; both live in the ephemeral Info's universe, so the resolved
+// parameter type is directly comparable to candidate types.
+func innerCallArgExpectedType(info *types.Info, root ast.Expr, pos token.Pos) types.Type {
+	if info == nil || root == nil || !pos.IsValid() {
+		return nil
+	}
+	var best *ast.CallExpr
+	ast.Inspect(root, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		// The cursor must sit within the argument region: strictly after the
+		// opening paren and at or before the closing paren (a completion cursor
+		// sits after the last typed byte). A cursor on the callee/receiver is
+		// before Lparen and so never matches — selector-receiver irrelevance.
+		if pos <= call.Lparen || pos > call.Rparen {
+			return true
+		}
+		// Innermost wins: prefer the call with the tightest paren span.
+		if best == nil || (call.Lparen >= best.Lparen && call.Rparen <= best.Rparen) {
+			best = call
+		}
+		return true
+	})
+	if best == nil {
+		return nil
+	}
+	tv, ok := info.Types[best.Fun]
+	if !ok || tv.Type == nil {
+		return nil
+	}
+	sig, ok := tv.Type.Underlying().(*types.Signature)
+	if !ok {
+		return nil
+	}
+	return paramTypeAt(sig, callArgIndexAt(best, pos))
+}
+
+// callArgIndexAt returns the positional argument index the cursor at pos falls
+// in: the index of the first argument whose End is at or after pos, or len(Args)
+// when pos is past every argument (the next, not-yet-typed positional slot).
+func callArgIndexAt(call *ast.CallExpr, pos token.Pos) int {
+	for i, arg := range call.Args {
+		if pos <= arg.End() {
+			return i
+		}
+	}
+	return len(call.Args)
+}
+
+// paramTypeAt returns the type of the idx-th positional parameter of sig,
+// resolving the variadic tail: an index at or past the final variadic parameter
+// yields that parameter's element type (each variadic argument has the element
+// type, not the slice type). Returns nil for a non-variadic overflow (more
+// arguments than parameters) or an empty signature.
+func paramTypeAt(sig *types.Signature, idx int) types.Type {
+	params := sig.Params()
+	n := params.Len()
+	if n == 0 || idx < 0 {
+		return nil
+	}
+	if idx < n-1 {
+		return params.At(idx).Type()
+	}
+	last := params.At(n - 1)
+	if sig.Variadic() {
+		if s, ok := last.Type().(*types.Slice); ok {
+			return s.Elem()
+		}
+	}
+	if idx == n-1 {
+		return last.Type()
+	}
+	return nil
+}
+
+// typeMatches reports whether a candidate of type candType satisfies the
+// expected type at the cursor: directly assignable, or — for a function
+// candidate — its single result is assignable (calling it satisfies the
+// position). Both types must come from the same go/types universe (the ephemeral
+// Info) for AssignableTo to be sound; the callers guarantee this.
+func typeMatches(candType, expected types.Type) bool {
+	if candType == nil || expected == nil {
+		return false
+	}
+	if types.AssignableTo(candType, expected) {
+		return true
+	}
+	if sig, ok := candType.Underlying().(*types.Signature); ok {
+		if res := sig.Results(); res.Len() == 1 && types.AssignableTo(res.At(0).Type(), expected) {
+			return true
+		}
+	}
+	return false
+}
+
+// rankedSortText builds a completion item's SortText. With no expected type in
+// play (expected == nil) it is byte-identical to the historical
+// fmt.Sprintf("%02d%s", tier, label) — the no-regression contract for every
+// context that derives no expected type. With an expected type it inserts a
+// single match digit AFTER the tier digits and BEFORE the label: '0' when the
+// candidate's type matches, '1' otherwise. This keeps locality tiers dominant
+// (a matched package-scope item never outranks an unmatched local) while
+// refining the order WITHIN a tier so type-matching candidates lead their ties.
+func rankedSortText(tier int, label string, expected, candType types.Type) string {
+	if expected == nil {
+		return fmt.Sprintf("%02d%s", tier, label)
+	}
+	bit := byte('1')
+	if typeMatches(candType, expected) {
+		bit = '0'
+	}
+	return fmt.Sprintf("%02d%c%s", tier, bit, label)
+}

--- a/internal/lsp/completion_expected.go
+++ b/internal/lsp/completion_expected.go
@@ -37,7 +37,7 @@ import (
 //     unreachable without retaining whole skeleton files.
 //   - Interp render position `{ ▮ }` top-level: expected = "renderable", too broad
 //     to rank on — skipped (spec 1c).
-func expectedTypeAt(eph *Package, cc completionContext, skel ast.Expr, skelPos token.Pos, exprStartOff int) types.Type {
+func expectedTypeAt(eph *Package, cc completionContext, skel ast.Expr, skelPos token.Pos, exprStartOff int, path string) types.Type {
 	if eph == nil || eph.Info == nil {
 		return nil
 	}
@@ -47,7 +47,7 @@ func expectedTypeAt(eph *Package, cc completionContext, skel ast.Expr, skelPos t
 	}
 	// Component attr value hole: the bound parameter's declared type.
 	if _, ok := cc.node.(*gsxast.ExprAttr); ok {
-		if t := componentAttrExpectedType(eph, exprStartOff); t != nil {
+		if t := componentAttrExpectedType(eph, exprStartOff, path); t != nil {
 			return t
 		}
 	}
@@ -56,13 +56,21 @@ func expectedTypeAt(eph *Package, cc completionContext, skel ast.Expr, skelPos t
 
 // componentAttrExpectedType returns the declared type of the component parameter
 // bound to the ExprAttr whose value expression starts at byte offset
-// exprStartOff, or nil when no planned component call binds such an attribute.
-// The ComponentCalls facts are keyed by authored *gsxast.Element and their
-// Params by the exact authored *gsxast.ExprAttr, so matching the attribute's
-// value-expression start offset (stable across the classifier's and the
-// ephemeral analysis's independent parses of identical bytes) pins the binding.
-func componentAttrExpectedType(eph *Package, exprStartOff int) types.Type {
-	if eph == nil || eph.GSXFset == nil || eph.ComponentCalls == nil {
+// exprStartOff IN THE FILE at path, or nil when no planned component call
+// binds such an attribute. The ComponentCalls facts are keyed by authored
+// *gsxast.Element and their Params by the exact authored *gsxast.ExprAttr, so
+// matching the attribute's value-expression start offset (stable across the
+// classifier's and the ephemeral analysis's independent parses of identical
+// bytes) pins the binding WITHIN a file. But ComponentCalls is package-wide —
+// AnalyzeEphemeral analyzes the whole directory, substituting only path's
+// bytes — so every sibling .gsx file's facts share the same map. Two sibling
+// files can have attr-value holes landing at the same in-file byte offset
+// (plausible given shared boilerplate prefixes), so the offset alone is not a
+// unique key: it must be paired with a check that the attr's own file is
+// path, or the match is nondeterministic across ComponentCalls' (randomized)
+// map iteration order.
+func componentAttrExpectedType(eph *Package, exprStartOff int, path string) types.Type {
+	if eph == nil || eph.GSXFset == nil || eph.ComponentCalls == nil || path == "" {
 		return nil
 	}
 	for _, fact := range eph.ComponentCalls {
@@ -71,7 +79,8 @@ func componentAttrExpectedType(eph *Package, exprStartOff int) types.Type {
 			if !ok || !ea.ExprPos.IsValid() || param.Var == nil {
 				continue
 			}
-			if eph.GSXFset.Position(ea.ExprPos).Offset == exprStartOff {
+			pos := eph.GSXFset.Position(ea.ExprPos)
+			if pos.Offset == exprStartOff && samePath(pos.Filename, path) {
 				return param.Var.Type()
 			}
 		}
@@ -115,6 +124,18 @@ func innerCallArgExpectedType(info *types.Info, root ast.Expr, pos token.Pos) ty
 	}
 	tv, ok := info.Types[best.Fun]
 	if !ok || tv.Type == nil {
+		return nil
+	}
+	// A type conversion T(x) records its callee as a TYPE in go/types.Info
+	// (tv.IsType() true), never as a value — even when T's underlying type is
+	// itself a function signature (e.g. `type Handler func(int) string`, the
+	// http.HandlerFunc idiom). The structural Underlying()-is-*Signature check
+	// below can't distinguish that from a real call, so it must be gated on
+	// IsType() first: a conversion's "signature" belongs to the target type,
+	// not to a callable being invoked, and boosting on it would derive the
+	// named type's own first parameter as the expected type — wrong. Decline
+	// the boost for any conversion; only a genuine call reaches paramTypeAt.
+	if tv.IsType() {
 		return nil
 	}
 	sig, ok := tv.Type.Underlying().(*types.Signature)

--- a/internal/lsp/completion_expected_test.go
+++ b/internal/lsp/completion_expected_test.go
@@ -380,7 +380,7 @@ func f() {
 	scope := innermostScopeAt(pkg, pos)
 
 	str := types.Typ[types.String]
-	items := goCompletionItems(pkg, scope, nil, pos, false, str, src, off, off, encUTF8)
+	items := goCompletionItems(pkg, scope, nil, pos, false, str, src, off, off, encUTF8, "")
 	sort := map[string]string{}
 	for _, it := range items {
 		sort[it.Label] = it.SortText
@@ -410,7 +410,7 @@ func f() {
 	}
 
 	// No-expected-type: byte-identical to the historical tier-only form.
-	plain := goCompletionItems(pkg, scope, nil, pos, false, nil, src, off, off, encUTF8)
+	plain := goCompletionItems(pkg, scope, nil, pos, false, nil, src, off, off, encUTF8, "")
 	for _, it := range plain {
 		if it.Label == "sLocal" && it.SortText != "05sLocal" {
 			t.Errorf("no-expected sLocal SortText = %q, want byte-identical \"05sLocal\"", it.SortText)

--- a/internal/lsp/completion_expected_test.go
+++ b/internal/lsp/completion_expected_test.go
@@ -1,0 +1,248 @@
+package lsp
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+	gsxparser "github.com/gsxhq/gsx/parser"
+)
+
+// TestTypeMatches pins the match predicate: direct assignability, a func
+// candidate whose single result is assignable (calling it satisfies the
+// position), and the negative cases (mismatched value, multi-result func, nil).
+func TestTypeMatches(t *testing.T) {
+	str := types.Typ[types.String]
+	i := types.Typ[types.Int]
+	strFunc := types.NewSignatureType(nil, nil, nil, types.NewTuple(),
+		types.NewTuple(types.NewVar(token.NoPos, nil, "", str)), false)
+	twoResFunc := types.NewSignatureType(nil, nil, nil, types.NewTuple(),
+		types.NewTuple(types.NewVar(token.NoPos, nil, "", str), types.NewVar(token.NoPos, nil, "", i)), false)
+
+	cases := []struct {
+		name           string
+		cand, expected types.Type
+		want           bool
+	}{
+		{"string-to-string", str, str, true},
+		{"int-to-string", i, str, false},
+		{"func-result-matches", strFunc, str, true},
+		{"func-result-mismatch", strFunc, i, false},
+		{"multi-result-func-no-match", twoResFunc, str, false},
+		{"nil-candidate", nil, str, false},
+		{"nil-expected", str, nil, false},
+	}
+	for _, c := range cases {
+		if got := typeMatches(c.cand, c.expected); got != c.want {
+			t.Errorf("%s: typeMatches = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestParamTypeAt covers positional and variadic parameter resolution: an
+// in-range index returns its own type, the variadic tail returns the element
+// type, and a non-variadic overflow returns nil.
+func TestParamTypeAt(t *testing.T) {
+	str := types.Typ[types.String]
+	i := types.Typ[types.Int]
+	// (s string, nums ...int)
+	variadic := types.NewSignatureType(nil, nil, nil, types.NewTuple(
+		types.NewVar(token.NoPos, nil, "s", str),
+		types.NewVar(token.NoPos, nil, "nums", types.NewSlice(i)),
+	), nil, true)
+	// (a string, b int)
+	fixed := types.NewSignatureType(nil, nil, nil, types.NewTuple(
+		types.NewVar(token.NoPos, nil, "a", str),
+		types.NewVar(token.NoPos, nil, "b", i),
+	), nil, false)
+
+	if got := paramTypeAt(variadic, 0); got != str {
+		t.Errorf("variadic idx 0 = %v, want string", got)
+	}
+	if got := paramTypeAt(variadic, 1); got != i {
+		t.Errorf("variadic idx 1 (tail) = %v, want int (element type)", got)
+	}
+	if got := paramTypeAt(variadic, 5); got != i {
+		t.Errorf("variadic idx 5 (tail) = %v, want int (element type)", got)
+	}
+	if got := paramTypeAt(fixed, 1); got != i {
+		t.Errorf("fixed idx 1 = %v, want int", got)
+	}
+	if got := paramTypeAt(fixed, 2); got != nil {
+		t.Errorf("fixed overflow idx 2 = %v, want nil", got)
+	}
+}
+
+// TestInnerCallArgExpectedType checks the inner call-arg derivation over a real
+// type-checked package: a cursor inside `f(▮)` yields f's first parameter type,
+// and a cursor inside the second argument yields the second parameter type.
+func TestInnerCallArgExpectedType(t *testing.T) {
+	src := `package p
+
+func f(s string, n int) {}
+
+var _ = f("a", 3)
+`
+	pkg, tf := buildSyntheticPackage(t, src)
+
+	// Cursor on the first argument literal "a".
+	firstOff := strings.Index(src, `f("a"`) + len(`f("`)
+	got := innerCallArgExpectedType(pkg.Info, callRootAt(t, pkg), tf.Pos(firstOff))
+	if got == nil || got.String() != "string" {
+		t.Errorf("arg 0 expected type = %v, want string", got)
+	}
+
+	// Cursor on the second argument literal 3.
+	secondOff := strings.Index(src, `"a", 3`) + len(`"a", `)
+	got = innerCallArgExpectedType(pkg.Info, callRootAt(t, pkg), tf.Pos(secondOff))
+	if got == nil || got.String() != "int" {
+		t.Errorf("arg 1 expected type = %v, want int", got)
+	}
+}
+
+// TestInnerCallArgSelectorReceiverIrrelevant pins selector-receiver
+// irrelevance: a cursor on the RECEIVER of `x.M()` is before the call's `(` and
+// so derives no expected type.
+func TestInnerCallArgSelectorReceiverIrrelevant(t *testing.T) {
+	src := `package p
+
+type T struct{}
+
+func (T) M(s string) {}
+
+var v T
+var _ = v.M("a")
+`
+	pkg, tf := buildSyntheticPackage(t, src)
+	// Cursor on the receiver `v` in `v.M(...)`.
+	recvOff := strings.Index(src, "v.M(") + 1 // on `v`, before the dot
+	if got := innerCallArgExpectedType(pkg.Info, callRootAt(t, pkg), tf.Pos(recvOff)); got != nil {
+		t.Errorf("receiver cursor derived expected type %v, want nil", got)
+	}
+}
+
+// callRootAt returns the *ast.CallExpr recorded in pkg.Info.Types (there is
+// exactly one in the fixtures above) as the bridged hole root.
+func callRootAt(t *testing.T, pkg *Package) ast.Expr {
+	t.Helper()
+	for expr := range pkg.Info.Types {
+		if call, ok := expr.(*ast.CallExpr); ok {
+			return call
+		}
+	}
+	t.Fatal("no CallExpr in Info.Types")
+	return nil
+}
+
+// TestComponentAttrExpectedType checks that a cursor in a component attr value
+// hole `title={ ▮ }` derives the bound parameter's declared type from the
+// ComponentCalls fact.
+func TestComponentAttrExpectedType(t *testing.T) {
+	src := "package page\n\ncomponent Home() {\n\t<Card title={x}/>\n}\n"
+	fset := token.NewFileSet()
+	f, err := gsxparser.ParseFile(fset, "page.gsx", []byte(src), 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	var el *gsxast.Element
+	var ea *gsxast.ExprAttr
+	gsxast.Inspect(f, func(n gsxast.Node) bool {
+		switch v := n.(type) {
+		case *gsxast.Element:
+			el = v
+		case *gsxast.ExprAttr:
+			ea = v
+		}
+		return true
+	})
+	if el == nil || ea == nil {
+		t.Fatalf("element/ExprAttr not found (el=%v ea=%v)", el, ea)
+	}
+
+	titleVar := types.NewVar(token.NoPos, nil, "title", types.Typ[types.String])
+	pkg := &Package{
+		GSXFset: fset,
+		Files:   map[string]*gsxast.File{"page.gsx": f},
+		Info:    &types.Info{},
+		ComponentCalls: map[*gsxast.Element]ComponentCallFact{
+			el: {Params: map[gsxast.Attr]ComponentParamFact{
+				ea: {Name: "title", Var: titleVar},
+			}},
+		},
+	}
+	exprStartOff := fset.Position(ea.ExprPos).Offset
+	got := componentAttrExpectedType(pkg, exprStartOff)
+	if got == nil || got.String() != "string" {
+		t.Errorf("componentAttrExpectedType = %v, want string", got)
+	}
+	// A non-matching offset derives nothing.
+	if got := componentAttrExpectedType(pkg, exprStartOff+999); got != nil {
+		t.Errorf("componentAttrExpectedType at wrong offset = %v, want nil", got)
+	}
+}
+
+// TestGoCompletionItemsExpectedRanking is the core ranking assertion: with a
+// string expected type, a string local sorts ahead of an int local (both stay
+// in tierLocal), and both outrank a matching package-scope string (locality
+// dominates match). With no expected type the SortText is byte-identical to the
+// tier-only form.
+func TestGoCompletionItemsExpectedRanking(t *testing.T) {
+	src := `package p
+
+var pkgStr = "z"
+
+func f() {
+	sLocal := "a"
+	nLocal := 3
+	_ = sLocal
+	_ = nLocal
+	println(sLocal, nLocal)
+}
+`
+	pkg, tf := buildSyntheticPackage(t, src)
+	// Cursor at the println line — all three names (sLocal, nLocal, pkgStr) visible.
+	off := strings.Index(src, "println(")
+	pos := tf.Pos(off)
+	scope := innermostScopeAt(pkg, pos)
+
+	str := types.Typ[types.String]
+	items := goCompletionItems(pkg, scope, nil, pos, false, str, src, off, off, encUTF8)
+	sort := map[string]string{}
+	for _, it := range items {
+		sort[it.Label] = it.SortText
+	}
+	sStr, nStr, pStr := sort["sLocal"], sort["nLocal"], sort["pkgStr"]
+	if sStr == "" || nStr == "" || pStr == "" {
+		t.Fatalf("missing candidates: sLocal=%q nLocal=%q pkgStr=%q", sStr, nStr, pStr)
+	}
+	// Both locals stay in tierLocal (prefix "05"); the matching string local
+	// carries the '0' match digit, the int local the '1'.
+	if !strings.HasPrefix(sStr, "050") {
+		t.Errorf("sLocal SortText = %q, want tierLocal matched prefix \"050\"", sStr)
+	}
+	if !strings.HasPrefix(nStr, "051") {
+		t.Errorf("nLocal SortText = %q, want tierLocal unmatched prefix \"051\"", nStr)
+	}
+	if sStr >= nStr {
+		t.Errorf("matched string local %q must sort before unmatched int local %q", sStr, nStr)
+	}
+	// Locality dominates: the unmatched int LOCAL still sorts before the matched
+	// package-scope string (tierPackage "30").
+	if nStr >= pStr {
+		t.Errorf("int local %q must sort before matched package-scope string %q (locality dominates)", nStr, pStr)
+	}
+	if !strings.HasPrefix(pStr, "300") {
+		t.Errorf("pkgStr SortText = %q, want tierPackage matched prefix \"300\"", pStr)
+	}
+
+	// No-expected-type: byte-identical to the historical tier-only form.
+	plain := goCompletionItems(pkg, scope, nil, pos, false, nil, src, off, off, encUTF8)
+	for _, it := range plain {
+		if it.Label == "sLocal" && it.SortText != "05sLocal" {
+			t.Errorf("no-expected sLocal SortText = %q, want byte-identical \"05sLocal\"", it.SortText)
+		}
+	}
+}

--- a/internal/lsp/completion_expected_test.go
+++ b/internal/lsp/completion_expected_test.go
@@ -124,6 +124,97 @@ var _ = v.M("a")
 	}
 }
 
+// TestInnerCallArgExpectedTypeConversionExcluded is the regression test for
+// the reviewed type-conversion misclassification: T(x) where T's underlying
+// type is itself a function signature (the http.HandlerFunc idiom) must NOT
+// be treated as a call. Before the fix, the structural
+// Underlying()-is-*Signature check alone couldn't distinguish a conversion's
+// callee from a real call's, so `Handler(mk(▮))` derived Handler's own first
+// parameter type (int) instead of correctly deriving nothing.
+func TestInnerCallArgExpectedTypeConversionExcluded(t *testing.T) {
+	src := `package p
+
+type Handler func(int) string
+
+func mk(n int) Handler { return nil }
+
+var h = Handler(mk(3))
+`
+	pkg, tf := buildSyntheticPackage(t, src)
+	// Cursor inside mk's argument list — mk is a genuine call, so this must
+	// still resolve to mk's own parameter type (int), unaffected by the fix.
+	mkOff := strings.Index(src, "mk(3)") + len("mk(")
+	got := innerCallArgExpectedType(pkg.Info, callConversionRootAt(t, pkg), tf.Pos(mkOff))
+	if got == nil || got.String() != "int" {
+		t.Errorf("plain call mk(▮) expected type = %v, want int (unaffected by the conversion fix)", got)
+	}
+
+	// Cursor inside the OUTER conversion Handler(...)'s argument list, but
+	// past mk(3)'s own closing paren would be ambiguous; instead assert the
+	// conversion itself, isolated, derives no expected type.
+	convSrc := `package p
+
+type Handler func(int) string
+
+func mk() Handler { return nil }
+
+var h = Handler(mk())
+`
+	pkg2, tf2 := buildSyntheticPackage(t, convSrc)
+	convOff := strings.Index(convSrc, "Handler(mk())") + len("Handler(")
+	if got := innerCallArgExpectedType(pkg2.Info, callConversionRootAt(t, pkg2), tf2.Pos(convOff)); got != nil {
+		t.Errorf("conversion Handler(▮) expected type = %v, want nil (conversions are excluded)", got)
+	}
+}
+
+// callConversionRootAt returns the outermost *ast.CallExpr recorded in
+// pkg.Info.Types — the bridged hole root that ast.Inspect walks to find the
+// innermost enclosing call. Fixtures above have exactly one top-level
+// expression statement (`var h = ...`), so the outermost CallExpr by Lparen
+// position is the correct root to hand innerCallArgExpectedType (mirroring
+// how the real bridge hands the whole hole expression, not a pre-selected
+// inner call).
+func callConversionRootAt(t *testing.T, pkg *Package) ast.Expr {
+	t.Helper()
+	var outer *ast.CallExpr
+	for expr := range pkg.Info.Types {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		if outer == nil || call.Lparen < outer.Lparen {
+			outer = call
+		}
+	}
+	if outer == nil {
+		t.Fatal("no CallExpr in Info.Types")
+	}
+	return outer
+}
+
+// TestTypeMatchesNAryFuncResult pins the n-ary func-result-match design
+// decision explicitly (previously only a niladic func was covered): a func
+// candidate's own arity is irrelevant to the match — only its single result's
+// assignability matters, mirroring IDEs suggesting e.g. strconv.Itoa at an
+// int-argument, string-expected position.
+func TestTypeMatchesNAryFuncResult(t *testing.T) {
+	str := types.Typ[types.String]
+	i := types.Typ[types.Int]
+	b := types.Typ[types.Bool]
+	// func(int, bool) string — n-ary (arity 2), single string result.
+	nAryFunc := types.NewSignatureType(nil, nil, nil, types.NewTuple(
+		types.NewVar(token.NoPos, nil, "", i),
+		types.NewVar(token.NoPos, nil, "", b),
+	), types.NewTuple(types.NewVar(token.NoPos, nil, "", str)), false)
+
+	if !typeMatches(nAryFunc, str) {
+		t.Errorf("n-ary func(int, bool) string must match string-expected position (arity irrelevant to result-match)")
+	}
+	if typeMatches(nAryFunc, i) {
+		t.Errorf("n-ary func(int, bool) string must NOT match int-expected position")
+	}
+}
+
 // callRootAt returns the *ast.CallExpr recorded in pkg.Info.Types (there is
 // exactly one in the fixtures above) as the bridged hole root.
 func callRootAt(t *testing.T, pkg *Package) ast.Expr {
@@ -174,13 +265,93 @@ func TestComponentAttrExpectedType(t *testing.T) {
 		},
 	}
 	exprStartOff := fset.Position(ea.ExprPos).Offset
-	got := componentAttrExpectedType(pkg, exprStartOff)
+	got := componentAttrExpectedType(pkg, exprStartOff, "page.gsx")
 	if got == nil || got.String() != "string" {
 		t.Errorf("componentAttrExpectedType = %v, want string", got)
 	}
 	// A non-matching offset derives nothing.
-	if got := componentAttrExpectedType(pkg, exprStartOff+999); got != nil {
+	if got := componentAttrExpectedType(pkg, exprStartOff+999, "page.gsx"); got != nil {
 		t.Errorf("componentAttrExpectedType at wrong offset = %v, want nil", got)
+	}
+	// A matching offset but wrong file derives nothing either.
+	if got := componentAttrExpectedType(pkg, exprStartOff, "other.gsx"); got != nil {
+		t.Errorf("componentAttrExpectedType at right offset, wrong file = %v, want nil", got)
+	}
+}
+
+// TestComponentAttrExpectedTypeCrossFileOffsetCollision is the regression test
+// for the reviewed cross-file offset-collision bug: two sibling .gsx files in
+// the same package (ComponentCalls is package-wide, not per-file) each have a
+// component attr value hole whose in-file byte offset coincides. Before the
+// fix, componentAttrExpectedType matched by offset alone, so which file's
+// bound-parameter type came back depended on Go's randomized map iteration
+// order over ComponentCalls — nondeterministically wrong on some runs. With
+// the file-identity check, the match must be deterministic and correct for
+// both files on every run (run with -count=10 to catch map-order flakes).
+func TestComponentAttrExpectedTypeCrossFileOffsetCollision(t *testing.T) {
+	// Identical prefix length up to the hole in both files so the ExprAttr's
+	// value-expression start offset coincides across files: same tag (`<Card `,
+	// 6 bytes) followed by an equal-length attr name (`title=` / `xtitl=`, both
+	// 6 bytes).
+	srcA := "package page\n\ncomponent A() {\n\t<Card title={x}/>\n}\n"
+	srcB := "package page\n\ncomponent B() {\n\t<Card xtitl={x}/>\n}\n"
+
+	fset := token.NewFileSet()
+	fA, err := gsxparser.ParseFile(fset, "a.gsx", []byte(srcA), 0)
+	if err != nil {
+		t.Fatalf("ParseFile a.gsx: %v", err)
+	}
+	fB, err := gsxparser.ParseFile(fset, "b.gsx", []byte(srcB), 0)
+	if err != nil {
+		t.Fatalf("ParseFile b.gsx: %v", err)
+	}
+
+	findAttr := func(f *gsxast.File) (*gsxast.Element, *gsxast.ExprAttr) {
+		var el *gsxast.Element
+		var ea *gsxast.ExprAttr
+		gsxast.Inspect(f, func(n gsxast.Node) bool {
+			switch v := n.(type) {
+			case *gsxast.Element:
+				el = v
+			case *gsxast.ExprAttr:
+				ea = v
+			}
+			return true
+		})
+		return el, ea
+	}
+	elA, eaA := findAttr(fA)
+	elB, eaB := findAttr(fB)
+	if elA == nil || eaA == nil || elB == nil || eaB == nil {
+		t.Fatalf("element/ExprAttr not found (elA=%v eaA=%v elB=%v eaB=%v)", elA, eaA, elB, eaB)
+	}
+	offA := fset.Position(eaA.ExprPos).Offset
+	offB := fset.Position(eaB.ExprPos).Offset
+	if offA != offB {
+		t.Fatalf("fixture invariant broken: offA=%d offB=%d must coincide", offA, offB)
+	}
+
+	strVar := types.NewVar(token.NoPos, nil, "title", types.Typ[types.String])
+	intVar := types.NewVar(token.NoPos, nil, "xtitl", types.Typ[types.Int])
+	pkg := &Package{
+		GSXFset: fset,
+		Files:   map[string]*gsxast.File{"a.gsx": fA, "b.gsx": fB},
+		Info:    &types.Info{},
+		ComponentCalls: map[*gsxast.Element]ComponentCallFact{
+			elA: {Params: map[gsxast.Attr]ComponentParamFact{eaA: {Name: "title", Var: strVar}}},
+			elB: {Params: map[gsxast.Attr]ComponentParamFact{eaB: {Name: "xtitl", Var: intVar}}},
+		},
+	}
+
+	for i := range 50 {
+		gotA := componentAttrExpectedType(pkg, offA, "a.gsx")
+		if gotA == nil || gotA.String() != "string" {
+			t.Fatalf("iteration %d: file a.gsx at offset %d = %v, want string", i, offA, gotA)
+		}
+		gotB := componentAttrExpectedType(pkg, offB, "b.gsx")
+		if gotB == nil || gotB.String() != "int" {
+			t.Fatalf("iteration %d: file b.gsx at offset %d = %v, want int", i, offB, gotB)
+		}
 	}
 }
 

--- a/internal/lsp/completion_expected_test.go
+++ b/internal/lsp/completion_expected_test.go
@@ -380,7 +380,7 @@ func f() {
 	scope := innermostScopeAt(pkg, pos)
 
 	str := types.Typ[types.String]
-	items := goCompletionItems(pkg, scope, nil, pos, false, str, src, off, off, encUTF8, "")
+	items := goCompletionItems(pkg, scope, nil, pos, false, str, src, off, off, encUTF8, "", nil)
 	sort := map[string]string{}
 	for _, it := range items {
 		sort[it.Label] = it.SortText
@@ -410,7 +410,7 @@ func f() {
 	}
 
 	// No-expected-type: byte-identical to the historical tier-only form.
-	plain := goCompletionItems(pkg, scope, nil, pos, false, nil, src, off, off, encUTF8, "")
+	plain := goCompletionItems(pkg, scope, nil, pos, false, nil, src, off, off, encUTF8, "", nil)
 	for _, it := range plain {
 		if it.Label == "sLocal" && it.SortText != "05sLocal" {
 			t.Errorf("no-expected sLocal SortText = %q, want byte-identical \"05sLocal\"", it.SortText)

--- a/internal/lsp/completion_go.go
+++ b/internal/lsp/completion_go.go
@@ -89,10 +89,19 @@ func innermostScopeAt(pkg *Package, pos token.Pos) *types.Scope {
 // offset to. Instead it matches each recorded scope's start position — mapped
 // back to the .gsx through the skeleton's //line directives (pkg.Fset.Position)
 // — against the authored path and offset, and keeps the smallest span that
-// contains off. Falls back to the package scope when nothing maps back (a
-// top-level position between declarations, whose enclosing scope is the file
-// scope, is not //line-mapped to the .gsx and so is not matched here — a known
-// v1 limitation: imported names do not complete inside a bare GoChunk position).
+// contains off.
+//
+// A cursor sitting BETWEEN top-level declarations (whitespace inside a GoChunk,
+// not inside any func body) is contained by no func/block scope: only the file
+// scope encloses it, and the file scope's Pos/End span the package clause and
+// EOF, which are NOT //line-mapped to the .gsx (they lie in the skeleton's
+// unmapped prologue), so the span match above misses it. When that happens the
+// fallback finds the skeleton file scope whose GoChunk-derived decls //line-map
+// to the authored path (fileScopeForAuthoredPath) — the file scope parents to
+// the package scope and contributes the file's imported package names, so a
+// bare GoChunk position completes imports (tierImported), package decls, and
+// (via statementCtx) the Go keywords. Package-scope fallback only when no file
+// maps back at all.
 func innermostScopeAtAuthored(pkg *Package, path string, off int) *types.Scope {
 	if pkg == nil || pkg.Info == nil || pkg.Fset == nil {
 		if pkg != nil && pkg.Types != nil {
@@ -120,9 +129,44 @@ func innermostScopeAtAuthored(pkg *Package, path string, off int) *types.Scope {
 		}
 	}
 	if best == nil {
+		if fs := fileScopeForAuthoredPath(pkg, path); fs != nil {
+			return fs
+		}
 		return pkg.Types.Scope()
 	}
 	return best
+}
+
+// fileScopeForAuthoredPath returns the go/types file scope of the skeleton
+// *ast.File that lowers the authored .gsx at path, or nil when none is found.
+// The mapping uses the //line directives the skeleton already carries: each
+// top-level GoChunk body (a user helper func/type/var) is emitted under a
+// //line directive to its .gsx position (codegen's splitFileGoSource +
+// emitSkeletonLine), so the decls parsed from it report the authored path via
+// pkg.Fset.Position. A file scope is keyed in Info.Scopes by its *ast.File; the
+// file whose first .gsx-mapped decl matches path owns that authored source.
+// (Component-generated funcs sit on unmapped skeleton signature lines and so do
+// not match — only genuine GoChunk decls do, which is exactly the population a
+// bare GoChunk position lives among.)
+func fileScopeForAuthoredPath(pkg *Package, path string) *types.Scope {
+	if pkg == nil || pkg.Info == nil || pkg.Fset == nil {
+		return nil
+	}
+	for node, scope := range pkg.Info.Scopes {
+		f, ok := node.(*ast.File)
+		if !ok {
+			continue
+		}
+		for _, d := range f.Decls {
+			if !d.Pos().IsValid() {
+				continue
+			}
+			if samePath(pkg.Fset.Position(d.Pos()).Filename, path) {
+				return scope
+			}
+		}
+	}
+	return nil
 }
 
 // samePath compares two filesystem paths for scope-authored matching. The

--- a/internal/lsp/completion_go.go
+++ b/internal/lsp/completion_go.go
@@ -252,12 +252,19 @@ func scopeCandidates(pkg *Package, scope *types.Scope, pos token.Pos) []scopedOb
 // type-matching candidates ahead of the rest WITHIN their locality tier
 // (rankedSortText). expected == nil leaves every SortText byte-identical to the
 // historical tier-only form.
-func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos token.Pos, statementCtx bool, expected types.Type, text string, start, end int, enc encoding, path string) []CompletionItem {
-	if items, ok := memberCompletionItems(pkg, skel, pos, expected, text, start, end, enc); ok {
+//
+// source is the exact bytes pkg's Files were parsed from (T9/T10 doc
+// comments): a current-package candidate's eager Documentation is extracted
+// by reconstructing its owning GoChunk/GoWithElements against these bytes
+// (completionDocFor/authoredDoc), so source must be byte-identical to what
+// produced pkg — the ephemeral analysis's own (possibly phantom-patched)
+// buffer, never a stale/live buffer that may have since diverged.
+func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos token.Pos, statementCtx bool, expected types.Type, text string, start, end int, enc encoding, path string, source []byte) []CompletionItem {
+	if items, ok := memberCompletionItems(pkg, skel, pos, expected, text, start, end, enc, source); ok {
 		return items // member path: committed even when empty (no scope fallback)
 	}
 	if statementCtx {
-		if items, ok := statementMemberItems(pkg, path, text, start, end, enc); ok {
+		if items, ok := statementMemberItems(pkg, path, text, start, end, enc, source); ok {
 			return items // statement member path: committed even when empty
 		}
 	}
@@ -266,7 +273,9 @@ func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos toke
 	for _, cand := range scopeCandidates(pkg, scope, pos) {
 		kind, detail := goObjectPresentation(cand.obj, qf)
 		name := cand.obj.Name()
-		item := newCompletionItem(text, start, end, enc, name, name, kind, cand.tier, detail, nil)
+		doc, data := completionDocFor(pkg, cand.obj, source)
+		item := newCompletionItem(text, start, end, enc, name, name, kind, cand.tier, detail, doc)
+		item.Data = data
 		if expected != nil {
 			item.SortText = rankedSortText(cand.tier, name, expected, cand.obj.Type())
 		}
@@ -411,7 +420,7 @@ func enclosingSelector(root ast.Node, id *ast.Ident) *ast.SelectorExpr {
 // carries the match digit ranking type-matching members ahead within their
 // (member-depth) tier; nil leaves the SortText byte-identical to the tier-only
 // form.
-func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, expected types.Type, text string, start, end int, enc encoding) ([]CompletionItem, bool) {
+func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, expected types.Type, text string, start, end int, enc encoding, source []byte) ([]CompletionItem, bool) {
 	if skel == nil || pkg == nil || pkg.Info == nil {
 		return nil, false
 	}
@@ -446,7 +455,7 @@ func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, expected 
 	if !ok || tv.Type == nil {
 		return nil, true // selector found but no type info: member path, empty
 	}
-	return valueMemberItems(pkg, tv.Type, expected, text, start, end, enc), true
+	return valueMemberItems(pkg, tv.Type, expected, text, start, end, enc, source), true
 }
 
 // packageMemberItems enumerates the exported names of an imported package pn as
@@ -464,7 +473,9 @@ func packageMemberItems(pkg *Package, pn *types.PkgName, expected types.Type, te
 			continue
 		}
 		kind, detail := goObjectPresentation(obj, qf)
-		item := newCompletionItem(text, start, end, enc, name, name, kind, tierImported, detail, nil)
+		doc, data := completionDocFor(pkg, obj, nil) // an imported package's own member is never authored in THIS package
+		item := newCompletionItem(text, start, end, enc, name, name, kind, tierImported, detail, doc)
+		item.Data = data
 		if expected != nil {
 			item.SortText = rankedSortText(tierImported, name, expected, obj.Type())
 		}
@@ -477,7 +488,12 @@ func packageMemberItems(pkg *Package, pn *types.PkgName, expected types.Type, te
 // (fields/methods via memberCandidates) as CompletionItems replacing [start,
 // end) in text, tiered tierMember+depth clamped below tierPackage. Shared by the
 // skeleton selector member path and the statement-position member path.
-func valueMemberItems(pkg *Package, recv types.Type, expected types.Type, text string, start, end int, enc encoding) []CompletionItem {
+// source is threaded to completionDocFor for the (decision #2) uniform rule: a
+// member whose OWN object is authored in this package (e.g. a receiver type
+// declared in this same .gsx) gets eager Documentation exactly like a
+// tierPackage candidate; every other member (an imported dependency's type)
+// gets a lazy Data payload instead.
+func valueMemberItems(pkg *Package, recv types.Type, expected types.Type, text string, start, end int, enc encoding, source []byte) []CompletionItem {
 	qf := qualifierFor(pkg)
 	var items []CompletionItem
 	for _, m := range memberCandidates(recv, pkg.Types) {
@@ -487,7 +503,9 @@ func valueMemberItems(pkg *Package, recv types.Type, expected types.Type, text s
 		}
 		kind, detail := goObjectPresentation(m.obj, qf)
 		name := m.obj.Name()
-		item := newCompletionItem(text, start, end, enc, name, name, kind, tier, detail, nil)
+		doc, data := completionDocFor(pkg, m.obj, source)
+		item := newCompletionItem(text, start, end, enc, name, name, kind, tier, detail, doc)
+		item.Data = data
 		if expected != nil {
 			item.SortText = rankedSortText(tier, name, expected, m.obj.Type())
 		}
@@ -531,7 +549,7 @@ func valueMemberItems(pkg *Package, recv types.Type, expected types.Type, text s
 // always nil: a member's expected type is not derivable across a statement
 // boundary (matches the existing skeleton member path's statement-context
 // behavior, which also passes nil).
-func statementMemberItems(pkg *Package, path, text string, start, end int, enc encoding) ([]CompletionItem, bool) {
+func statementMemberItems(pkg *Package, path, text string, start, end int, enc encoding, source []byte) ([]CompletionItem, bool) {
 	if pkg == nil || pkg.SourceIndex == nil || start == 0 || start > len(text) || text[start-1] != '.' {
 		return nil, false
 	}
@@ -559,7 +577,7 @@ func statementMemberItems(pkg *Package, path, text string, start, end int, enc e
 	if recv == nil {
 		return nil, true
 	}
-	return valueMemberItems(pkg, recv, nil, text, start, end, enc), true
+	return valueMemberItems(pkg, recv, nil, text, start, end, enc, source), true
 }
 
 // isGoSpaceByte reports whether b is a Go-source whitespace byte (space, tab,

--- a/internal/lsp/completion_go.go
+++ b/internal/lsp/completion_go.go
@@ -249,8 +249,13 @@ func scopeCandidates(pkg *Package, scope *types.Scope, pos token.Pos) []scopedOb
 // `{{ x.▮ }}` or a GoChunk `x.▮` cannot find its selector and falls through to
 // the scope path. Recovering the selector from Info.Types alone (by byte range)
 // was rejected as too loose to be sound with the facts these bridges retain.
-func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos token.Pos, statementCtx bool, text string, start, end int, enc encoding) []CompletionItem {
-	if items, ok := memberCompletionItems(pkg, skel, pos, text, start, end, enc); ok {
+// expected is the type the cursor is expected to produce (see expectedTypeAt);
+// when non-nil every item's SortText carries a match digit that ranks
+// type-matching candidates ahead of the rest WITHIN their locality tier
+// (rankedSortText). expected == nil leaves every SortText byte-identical to the
+// historical tier-only form.
+func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos token.Pos, statementCtx bool, expected types.Type, text string, start, end int, enc encoding) []CompletionItem {
+	if items, ok := memberCompletionItems(pkg, skel, pos, expected, text, start, end, enc); ok {
 		return items // member path: committed even when empty (no scope fallback)
 	}
 	qf := qualifierFor(pkg)
@@ -258,11 +263,19 @@ func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos toke
 	for _, cand := range scopeCandidates(pkg, scope, pos) {
 		kind, detail := goObjectPresentation(cand.obj, qf)
 		name := cand.obj.Name()
-		items = append(items, newCompletionItem(text, start, end, enc, name, name, kind, cand.tier, detail, nil))
+		item := newCompletionItem(text, start, end, enc, name, name, kind, cand.tier, detail, nil)
+		if expected != nil {
+			item.SortText = rankedSortText(cand.tier, name, expected, cand.obj.Type())
+		}
+		items = append(items, item)
 	}
 	if statementCtx {
 		for _, kw := range goKeywords {
-			items = append(items, newCompletionItem(text, start, end, enc, kw, kw, ciKindKeyword, tierKeyword, "keyword", nil))
+			item := newCompletionItem(text, start, end, enc, kw, kw, ciKindKeyword, tierKeyword, "keyword", nil)
+			if expected != nil {
+				item.SortText = rankedSortText(tierKeyword, kw, expected, nil) // a keyword has no type: never a match
+			}
+			items = append(items, item)
 		}
 	}
 	return items
@@ -391,7 +404,11 @@ func enclosingSelector(root ast.Node, id *ast.Ident) *ast.SelectorExpr {
 // resolves to an imported package name the exported package members are offered
 // (tierImported); otherwise the type of X drives memberCandidates, tiered
 // tierMember+depth clamped below tierPackage.
-func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, text string, start, end int, enc encoding) ([]CompletionItem, bool) {
+// expected mirrors goCompletionItems: when non-nil each member item's SortText
+// carries the match digit ranking type-matching members ahead within their
+// (member-depth) tier; nil leaves the SortText byte-identical to the tier-only
+// form.
+func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, expected types.Type, text string, start, end int, enc encoding) ([]CompletionItem, bool) {
 	if skel == nil || pkg == nil || pkg.Info == nil {
 		return nil, false
 	}
@@ -426,7 +443,11 @@ func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, text stri
 					continue
 				}
 				kind, detail := goObjectPresentation(obj, qf)
-				items = append(items, newCompletionItem(text, start, end, enc, name, name, kind, tierImported, detail, nil))
+				item := newCompletionItem(text, start, end, enc, name, name, kind, tierImported, detail, nil)
+				if expected != nil {
+					item.SortText = rankedSortText(tierImported, name, expected, obj.Type())
+				}
+				items = append(items, item)
 			}
 			return items, true
 		}
@@ -445,7 +466,11 @@ func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, text stri
 		}
 		kind, detail := goObjectPresentation(m.obj, qf)
 		name := m.obj.Name()
-		items = append(items, newCompletionItem(text, start, end, enc, name, name, kind, tier, detail, nil))
+		item := newCompletionItem(text, start, end, enc, name, name, kind, tier, detail, nil)
+		if expected != nil {
+			item.SortText = rankedSortText(tier, name, expected, m.obj.Type())
+		}
+		items = append(items, item)
 	}
 	return items, true
 }

--- a/internal/lsp/completion_go.go
+++ b/internal/lsp/completion_go.go
@@ -235,28 +235,31 @@ func scopeCandidates(pkg *Package, scope *types.Scope, pos token.Pos) []scopedOb
 }
 
 // goCompletionItems builds the completion list for a Go cursor. skel is the
-// bridged skeleton expression (nil for the GoBlock/GoChunk bridges — see the
-// member gap note below); pos is the cursor's skeleton position (invalid for the
-// GoChunk bridge). DISPATCH: when the cursor at pos sits on the Sel of a selector
-// `X.Sel` in skel, the member path enumerates X's members (fields/methods, or an
-// imported package's exported names); otherwise the scope path enumerates every
-// visible object via scopeCandidates and, when statementCtx is set
-// (GoBlock/GoChunk positions), appends the Go statement keywords. Items replace
-// the [start, end) token span in text.
+// bridged skeleton expression (nil for the GoBlock/GoChunk bridges, which have
+// no skeleton selector to walk — see statementMemberItems below); pos is the
+// cursor's skeleton position (invalid for the GoChunk bridge). DISPATCH: when
+// the cursor at pos sits on the Sel of a selector `X.Sel` in skel, the member
+// path enumerates X's members (fields/methods, or an imported package's
+// exported names); when skel is nil and statementCtx is set, the AUTHORED-text
+// member path (statementMemberItems) takes over for a `.`-cursor; otherwise the
+// scope path enumerates every visible object via scopeCandidates and, when
+// statementCtx is set (GoBlock/GoChunk positions), appends the Go statement
+// keywords. Items replace the [start, end) token span in text. path is the
+// authored .gsx path, needed by statementMemberItems to key pkg.SourceIndex.
 //
-// KNOWN GAP (v1): skel is non-nil only on the ExprMap and sigType bridges; the
-// GoBlock/CtrlMap and GoChunk bridges return nil skel, so a member cursor like
-// `{{ x.▮ }}` or a GoChunk `x.▮` cannot find its selector and falls through to
-// the scope path. Recovering the selector from Info.Types alone (by byte range)
-// was rejected as too loose to be sound with the facts these bridges retain.
 // expected is the type the cursor is expected to produce (see expectedTypeAt);
 // when non-nil every item's SortText carries a match digit that ranks
 // type-matching candidates ahead of the rest WITHIN their locality tier
 // (rankedSortText). expected == nil leaves every SortText byte-identical to the
 // historical tier-only form.
-func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos token.Pos, statementCtx bool, expected types.Type, text string, start, end int, enc encoding) []CompletionItem {
+func goCompletionItems(pkg *Package, scope *types.Scope, skel ast.Expr, pos token.Pos, statementCtx bool, expected types.Type, text string, start, end int, enc encoding, path string) []CompletionItem {
 	if items, ok := memberCompletionItems(pkg, skel, pos, expected, text, start, end, enc); ok {
 		return items // member path: committed even when empty (no scope fallback)
+	}
+	if statementCtx {
+		if items, ok := statementMemberItems(pkg, path, text, start, end, enc); ok {
+			return items // statement member path: committed even when empty
+		}
 	}
 	qf := qualifierFor(pkg)
 	var items []CompletionItem
@@ -429,27 +432,12 @@ func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, expected 
 	if sel == nil {
 		return nil, false
 	}
-	qf := qualifierFor(pkg)
 
 	// Package member: X is an imported package name. Uses records the PkgName;
 	// Info.Types does not (a package name is not a value), so check Uses first.
 	if xid, ok := sel.X.(*ast.Ident); ok {
 		if pn, ok := pkg.Info.Uses[xid].(*types.PkgName); ok {
-			scope := pn.Imported().Scope()
-			var items []CompletionItem
-			for _, name := range scope.Names() {
-				obj := scope.Lookup(name)
-				if obj == nil || !obj.Exported() || isReservedGsxInternal(name) {
-					continue
-				}
-				kind, detail := goObjectPresentation(obj, qf)
-				item := newCompletionItem(text, start, end, enc, name, name, kind, tierImported, detail, nil)
-				if expected != nil {
-					item.SortText = rankedSortText(tierImported, name, expected, obj.Type())
-				}
-				items = append(items, item)
-			}
-			return items, true
+			return packageMemberItems(pkg, pn, expected, text, start, end, enc), true
 		}
 	}
 
@@ -458,8 +446,41 @@ func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, expected 
 	if !ok || tv.Type == nil {
 		return nil, true // selector found but no type info: member path, empty
 	}
+	return valueMemberItems(pkg, tv.Type, expected, text, start, end, enc), true
+}
+
+// packageMemberItems enumerates the exported names of an imported package pn as
+// CompletionItems replacing [start, end) in text, tiered tierImported. Shared by
+// the skeleton selector member path (memberCompletionItems) and the
+// statement-position member path (statementMemberItems), since both resolve to
+// the same *types.PkgName receiver shape once the receiver is identified.
+func packageMemberItems(pkg *Package, pn *types.PkgName, expected types.Type, text string, start, end int, enc encoding) []CompletionItem {
+	qf := qualifierFor(pkg)
+	scope := pn.Imported().Scope()
 	var items []CompletionItem
-	for _, m := range memberCandidates(tv.Type, pkg.Types) {
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if obj == nil || !obj.Exported() || isReservedGsxInternal(name) {
+			continue
+		}
+		kind, detail := goObjectPresentation(obj, qf)
+		item := newCompletionItem(text, start, end, enc, name, name, kind, tierImported, detail, nil)
+		if expected != nil {
+			item.SortText = rankedSortText(tierImported, name, expected, obj.Type())
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+// valueMemberItems enumerates the selectable members of receiver type recv
+// (fields/methods via memberCandidates) as CompletionItems replacing [start,
+// end) in text, tiered tierMember+depth clamped below tierPackage. Shared by the
+// skeleton selector member path and the statement-position member path.
+func valueMemberItems(pkg *Package, recv types.Type, expected types.Type, text string, start, end int, enc encoding) []CompletionItem {
+	qf := qualifierFor(pkg)
+	var items []CompletionItem
+	for _, m := range memberCandidates(recv, pkg.Types) {
 		tier := tierMember + m.depth
 		if tier >= tierPackage {
 			tier = tierPackage - 1 // clamp to 29: member items never reach tierPackage
@@ -472,7 +493,85 @@ func memberCompletionItems(pkg *Package, skel ast.Expr, pos token.Pos, expected 
 		}
 		items = append(items, item)
 	}
-	return items, true
+	return items
+}
+
+// statementMemberItems resolves a member cursor in a GoBlock/GoChunk STATEMENT
+// position — a context with no skeleton selector for memberCompletionItems to
+// walk. It detects the member position directly from AUTHORED text:
+// text[start-1] == '.' (start is the completion token's start from
+// completionTokenSpan, which never includes the dot itself). The receiver's
+// type is then resolved via pkg.SourceIndex.At, the SAME offset-keyed,
+// innermost-preferred lookup hover and go-to-definition already trust, at the
+// receiver's last byte (recEnd: the byte immediately before the dot, walked
+// back over any whitespace between the receiver expression and the dot).
+//
+// occ.Object.(*types.PkgName) is a package receiver (`strings.▮`); otherwise
+// occ.Object.Type() is an identifier receiver's type, and — when there is no
+// Object at all — occ.HasTypeValue's TypeAndValue.Type is an expression
+// receiver's type (a call, index, or selector-chain result, resolved via its
+// recorded Expression occurrence). Complex receivers are therefore handled
+// opportunistically: when no occurrence covers recEnd, or it carries neither an
+// Object nor a recorded type, the member path is still committed but empty
+// (fail-soft, never wrong).
+//
+// The EPHEMERAL pkg.SourceIndex is used directly, WITHOUT the MatchesSource
+// gate hover/definition apply against a RETAINED package's index and a
+// possibly-since-changed buffer. Here pkg is the fresh ephemeral analysis of
+// THIS request's (possibly phantom-patched) buffer, built from src — and the
+// phantom patch (goContextCompletion) only ever inserts a byte AT the cursor.
+// recEnd is strictly before start, which is at or before the cursor, so every
+// byte the lookup can land on is identical between the original text (used
+// here to compute recEnd) and the patched buffer the index was built from: the
+// index is sound for this lookup by construction, and gating on MatchesSource
+// would wrongly reject the patched buffer for the trailing-dot case.
+//
+// Returns ok=true (member path committed, possibly empty) once text[start-1] is
+// a '.'; ok=false otherwise, so the statement scope path applies. expected is
+// always nil: a member's expected type is not derivable across a statement
+// boundary (matches the existing skeleton member path's statement-context
+// behavior, which also passes nil).
+func statementMemberItems(pkg *Package, path, text string, start, end int, enc encoding) ([]CompletionItem, bool) {
+	if pkg == nil || pkg.SourceIndex == nil || start == 0 || start > len(text) || text[start-1] != '.' {
+		return nil, false
+	}
+	recEnd := start - 2 // the byte immediately before the dot
+	for recEnd >= 0 && isGoSpaceByte(text[recEnd]) {
+		recEnd--
+	}
+	if recEnd < 0 {
+		return nil, true // member path committed; no receiver byte to resolve
+	}
+	occ, ok := pkg.SourceIndex.At(path, recEnd)
+	if !ok {
+		return nil, true
+	}
+	if pn, ok := occ.Object.(*types.PkgName); ok {
+		return packageMemberItems(pkg, pn, nil, text, start, end, enc), true
+	}
+	var recv types.Type
+	switch {
+	case occ.Object != nil:
+		recv = occ.Object.Type()
+	case occ.HasTypeValue:
+		recv = occ.TypeAndValue.Type
+	}
+	if recv == nil {
+		return nil, true
+	}
+	return valueMemberItems(pkg, recv, nil, text, start, end, enc), true
+}
+
+// isGoSpaceByte reports whether b is a Go-source whitespace byte (space, tab,
+// CR, LF). statementMemberItems uses it to walk back over whitespace sitting
+// between a receiver expression and the dot when computing recEnd.
+func isGoSpaceByte(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
 }
 
 // goObjectPresentation maps a go/types object to its LSP completion kind and a

--- a/internal/lsp/completion_go.go
+++ b/internal/lsp/completion_go.go
@@ -144,7 +144,7 @@ func innermostScopeAtAuthored(pkg *Package, path string, off int) *types.Scope {
 // //line directive to its .gsx position (codegen's splitFileGoSource +
 // emitSkeletonLine), so the decls parsed from it report the authored path via
 // pkg.Fset.Position. A file scope is keyed in Info.Scopes by its *ast.File; the
-// file whose first .gsx-mapped decl matches path owns that authored source.
+// file whose decls //line-map to path owns that authored source.
 // (Component-generated funcs sit on unmapped skeleton signature lines and so do
 // not match — only genuine GoChunk decls do, which is exactly the population a
 // bare GoChunk position lives among.)

--- a/internal/lsp/completion_go.go
+++ b/internal/lsp/completion_go.go
@@ -55,11 +55,6 @@ func fileScopeSet(pkg *Package) map[*types.Scope]bool {
 	return set
 }
 
-// isFileScope reports whether s is a file scope of the analyzed package.
-func isFileScope(pkg *Package, s *types.Scope) bool {
-	return fileScopeSet(pkg)[s]
-}
-
 // innermostScopeAt returns the smallest go/types scope containing pos, then
 // descends to the innermost scope at pos within it (Scope.Innermost). It reads
 // only Info.Scopes, whose positions live in skeleton (pkg.Fset) coordinates —

--- a/internal/lsp/completion_go_test.go
+++ b/internal/lsp/completion_go_test.go
@@ -201,6 +201,111 @@ func TestFileScopeForAuthoredPathUnknownPath(t *testing.T) {
 	}
 }
 
+// buildSyntheticTwoFilePackage type-checks TWO plain Go sources together as one
+// package (mirroring a real two-.gsx-file package: distinct skeleton files that
+// share one types.Check call), each carrying its own //line directive so its
+// decls report a distinct authored path via pkg.Fset.Position — exactly the
+// production geometry buildMappedSkeleton/splitFileGoSource produce per .gsx
+// file (see fileScopeForAuthoredPath's doc comment).
+func buildSyntheticTwoFilePackage(t *testing.T, srcA, srcB string) *Package {
+	t.Helper()
+	fset := token.NewFileSet()
+	fileA, err := parser.ParseFile(fset, "pA.go", srcA, 0)
+	if err != nil {
+		t.Fatalf("parse A: %v", err)
+	}
+	fileB, err := parser.ParseFile(fset, "pB.go", srcB, 0)
+	if err != nil {
+		t.Fatalf("parse B: %v", err)
+	}
+	info := &types.Info{
+		Types:  map[ast.Expr]types.TypeAndValue{},
+		Defs:   map[*ast.Ident]types.Object{},
+		Uses:   map[*ast.Ident]types.Object{},
+		Scopes: map[ast.Node]*types.Scope{},
+	}
+	conf := types.Config{Importer: importer.Default(), Error: func(error) {}}
+	tpkg, _ := conf.Check("p", fset, []*ast.File{fileA, fileB}, info)
+	return &Package{Types: tpkg, Info: info, Fset: fset}
+}
+
+// TestFileScopeForAuthoredPathTwoFiles pins the regression class the T4 review
+// (.superpowers/sdd/batch2-t4-report.md, finding (e)) flagged as UNCOVERED:
+// with two .gsx files in one package carrying DIFFERENT imports, the
+// fileScopeForAuthoredPath fallback must return the file whose OWN decls map to
+// the requested path — never the sibling file's scope, which would leak the
+// wrong file's imported package names into completion. Before this test,
+// nothing in the committed suite would fail if fileScopeForAuthoredPath ever
+// returned the wrong file's scope in a multi-file package (buildSyntheticPackage
+// only ever builds a single *ast.File); this promotes the reviewer's throwaway
+// two-file probe into a permanent pin, covering both the direct helper and its
+// innermostScopeAtAuthored caller (the actual completion entry point).
+func TestFileScopeForAuthoredPathTwoFiles(t *testing.T) {
+	srcA := `package p
+
+import "strings"
+
+//line a.gsx:1:1
+func helperA() string { return "a" }
+`
+	srcB := `package p
+
+import "os"
+
+//line b.gsx:1:1
+func helperB() string { return "b" }
+`
+	pkg := buildSyntheticTwoFilePackage(t, srcA, srcB)
+
+	scopeA := fileScopeForAuthoredPath(pkg, "a.gsx")
+	scopeB := fileScopeForAuthoredPath(pkg, "b.gsx")
+	if scopeA == nil {
+		t.Fatal("fileScopeForAuthoredPath(a.gsx) returned nil")
+	}
+	if scopeB == nil {
+		t.Fatal("fileScopeForAuthoredPath(b.gsx) returned nil")
+	}
+	if scopeA == scopeB {
+		t.Fatal("fileScopeForAuthoredPath returned the SAME scope for two different authored paths")
+	}
+
+	namesOf := func(scope *types.Scope) map[string]bool {
+		names := map[string]bool{}
+		for _, c := range scopeCandidates(pkg, scope, token.NoPos) {
+			names[c.obj.Name()] = true
+		}
+		return names
+	}
+	namesA := namesOf(scopeA)
+	namesB := namesOf(scopeB)
+
+	if !namesA["strings"] {
+		t.Errorf("a.gsx scope missing its own import `strings`; got %v", namesA)
+	}
+	if namesA["os"] {
+		t.Errorf("a.gsx scope offers `os` — the WRONG file's scope leaked b.gsx's import; got %v", namesA)
+	}
+	if !namesB["os"] {
+		t.Errorf("b.gsx scope missing its own import `os`; got %v", namesB)
+	}
+	if namesB["strings"] {
+		t.Errorf("b.gsx scope offers `strings` — the WRONG file's scope leaked a.gsx's import; got %v", namesB)
+	}
+
+	// innermostScopeAtAuthored is the actual completion entry point: a
+	// between-decls cursor (off=0, before either file's mapped func body) has no
+	// enclosing func/block scope, so it must reach the same per-file scope
+	// through the fallback — not the package scope, and not the other file's.
+	authoredA := innermostScopeAtAuthored(pkg, "a.gsx", 0)
+	authoredB := innermostScopeAtAuthored(pkg, "b.gsx", 0)
+	if authoredA != scopeA {
+		t.Errorf("innermostScopeAtAuthored(a.gsx, 0) = %v, want the direct fileScopeForAuthoredPath(a.gsx) result %v", authoredA, scopeA)
+	}
+	if authoredB != scopeB {
+		t.Errorf("innermostScopeAtAuthored(b.gsx, 0) = %v, want the direct fileScopeForAuthoredPath(b.gsx) result %v", authoredB, scopeB)
+	}
+}
+
 // TestMemberCandidates exercises the method-set + embedded-field BFS over a
 // synthetic type, asserting promotion depth and the unexported-visibility gate.
 func TestMemberCandidates(t *testing.T) {

--- a/internal/lsp/completion_go_test.go
+++ b/internal/lsp/completion_go_test.go
@@ -494,7 +494,7 @@ func TestMemberCompletionItemsDepthClampDeepChain(t *testing.T) {
 	if sel == nil {
 		t.Fatal("v.F0 selector not found in Info.Types")
 	}
-	items, ok := memberCompletionItems(pkg, sel, sel.Sel.Pos(), src, 0, 0, encUTF8)
+	items, ok := memberCompletionItems(pkg, sel, sel.Sel.Pos(), nil, src, 0, 0, encUTF8)
 	if !ok {
 		t.Fatal("memberCompletionItems did not take the member path")
 	}

--- a/internal/lsp/completion_go_test.go
+++ b/internal/lsp/completion_go_test.go
@@ -413,6 +413,15 @@ func TestMemberDispatch(t *testing.T) {
 	}
 }
 
+// isFileScope reports whether s is a file scope of the analyzed package. It
+// has no production caller (production code goes through fileScopeSet
+// directly, e.g. completion_gsx.go's importQualifierCandidates) — kept here,
+// test-local, purely to give TestIsFileScope's fileScopeSet coverage a named
+// single-scope assertion.
+func isFileScope(pkg *Package, s *types.Scope) bool {
+	return fileScopeSet(pkg)[s]
+}
+
 func TestIsFileScope(t *testing.T) {
 	src := `package p
 

--- a/internal/lsp/completion_go_test.go
+++ b/internal/lsp/completion_go_test.go
@@ -494,7 +494,7 @@ func TestMemberCompletionItemsDepthClampDeepChain(t *testing.T) {
 	if sel == nil {
 		t.Fatal("v.F0 selector not found in Info.Types")
 	}
-	items, ok := memberCompletionItems(pkg, sel, sel.Sel.Pos(), nil, src, 0, 0, encUTF8)
+	items, ok := memberCompletionItems(pkg, sel, sel.Sel.Pos(), nil, src, 0, 0, encUTF8, nil)
 	if !ok {
 		t.Fatal("memberCompletionItems did not take the member path")
 	}
@@ -638,7 +638,7 @@ component Home(user User) {
 	pkg, path := analyzedLSPPackage(t, src)
 	nameOff := strings.Index(src, "user.Name") + len("user.")
 
-	items, ok := statementMemberItems(pkg, path, src, nameOff, nameOff, encUTF8)
+	items, ok := statementMemberItems(pkg, path, src, nameOff, nameOff, encUTF8, nil)
 	if !ok {
 		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
 	}
@@ -677,7 +677,7 @@ component Home(user User) {
 	nameOff := strings.Index(src, "user.Name") + len("user.")
 	start, end := nameOff, nameOff+2 // simulated "Na" prefix
 
-	items, ok := statementMemberItems(pkg, path, src, start, end, encUTF8)
+	items, ok := statementMemberItems(pkg, path, src, start, end, encUTF8, nil)
 	if !ok {
 		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
 	}
@@ -724,7 +724,7 @@ component Home() {
 	pkg, path := analyzedLSPPackage(t, src)
 	nameOff := strings.Index(src, "u.Name") + len("u.")
 
-	items, ok := statementMemberItems(pkg, path, src, nameOff, nameOff, encUTF8)
+	items, ok := statementMemberItems(pkg, path, src, nameOff, nameOff, encUTF8, nil)
 	if !ok {
 		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
 	}
@@ -757,7 +757,7 @@ component Home() {
 	pkg, path := analyzedLSPPackage(t, src)
 	off := strings.Index(src, "strings.ToUpper") + len("strings.")
 
-	items, ok := statementMemberItems(pkg, path, src, off, off, encUTF8)
+	items, ok := statementMemberItems(pkg, path, src, off, off, encUTF8, nil)
 	if !ok {
 		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
 	}
@@ -802,7 +802,7 @@ component Home() {
 	pkg, path := analyzedLSPPackage(t, src)
 	off := strings.Index(src, "mk().Name") + len("mk().")
 
-	items, ok := statementMemberItems(pkg, path, src, off, off, encUTF8)
+	items, ok := statementMemberItems(pkg, path, src, off, off, encUTF8, nil)
 	if !ok {
 		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
 	}
@@ -831,7 +831,7 @@ component Home() {
 `
 	pkg, path := analyzedLSPPackage(t, src)
 	off := strings.Index(src, "x := 1") + len("x")
-	if _, ok := statementMemberItems(pkg, path, src, off, off, encUTF8); ok {
+	if _, ok := statementMemberItems(pkg, path, src, off, off, encUTF8, nil); ok {
 		t.Error("statementMemberItems ok=true at a non-`.` cursor")
 	}
 
@@ -839,11 +839,11 @@ component Home() {
 	if synth.SourceIndex != nil {
 		t.Fatal("synthetic package unexpectedly has a SourceIndex")
 	}
-	if _, ok := statementMemberItems(synth, "p.go", "x.Y", 2, 2, encUTF8); ok {
+	if _, ok := statementMemberItems(synth, "p.go", "x.Y", 2, 2, encUTF8, nil); ok {
 		t.Error("statementMemberItems ok=true with a nil SourceIndex")
 	}
 
-	if _, ok := statementMemberItems(nil, "p.go", "x.Y", 2, 2, encUTF8); ok {
+	if _, ok := statementMemberItems(nil, "p.go", "x.Y", 2, 2, encUTF8, nil); ok {
 		t.Error("statementMemberItems ok=true with a nil pkg")
 	}
 }
@@ -870,7 +870,7 @@ component Home(user User) {
 	pkg, path := analyzedLSPPackage(t, src)
 	nameOff := strings.Index(src, "user.Name") + len("user.")
 
-	items := goCompletionItems(pkg, pkg.Types.Scope(), nil, token.NoPos, true, nil, src, nameOff, nameOff, encUTF8, path)
+	items := goCompletionItems(pkg, pkg.Types.Scope(), nil, token.NoPos, true, nil, src, nameOff, nameOff, encUTF8, path, nil)
 	labels := map[string]bool{}
 	for _, it := range items {
 		labels[it.Label] = true

--- a/internal/lsp/completion_go_test.go
+++ b/internal/lsp/completion_go_test.go
@@ -612,3 +612,277 @@ var global = 1
 		t.Error("package scope wrongly classified as a file scope")
 	}
 }
+
+// TestStatementMemberItemsGoBlockTrailingDot drives statementMemberItems
+// directly against a REAL analyzed package (analyzedLSPPackage, real
+// SourceIndex from the codegen pipeline) at a member cursor sitting inside a
+// `{{ }}` GoBlock statement. The underlying source is fully valid Go
+// (`user.Name`, not a broken prefix — analyzedLSPPackage demands zero
+// diagnostics), and the "trailing dot, nothing typed yet" cursor is SIMULATED
+// by choosing start=end=the byte right after the dot: statementMemberItems
+// only reads text[start-1] and walks backward from there, so it never looks at
+// what (if anything) text carries at/after start, matching how a real
+// trailing-dot cursor is a zero-width completionTokenSpan over live text.
+func TestStatementMemberItemsGoBlockTrailingDot(t *testing.T) {
+	const src = `package page
+
+type User struct {
+	Name string
+	Age  int
+}
+
+component Home(user User) {
+	{{ _ = user.Name }}
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	nameOff := strings.Index(src, "user.Name") + len("user.")
+
+	items, ok := statementMemberItems(pkg, path, src, nameOff, nameOff, encUTF8)
+	if !ok {
+		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
+	}
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	for _, name := range []string{"Name", "Age"} {
+		if !labels[name] {
+			t.Errorf("GoBlock trailing-dot member %q missing; labels=%v", name, labels)
+		}
+	}
+	if labels["user"] {
+		t.Errorf("member position must not offer scope locals; got `user`: %v", labels)
+	}
+}
+
+// TestStatementMemberItemsGoBlockPrefixed drives the typed-prefix variant
+// (`user.Na▮`, simulated the same way — start/end pick out "Na" while the
+// underlying valid source still carries the full "Name") and asserts the
+// returned item's TextEdit replaces ONLY the simulated [start,end) token span,
+// never the receiver or the dot.
+func TestStatementMemberItemsGoBlockPrefixed(t *testing.T) {
+	const src = `package page
+
+type User struct {
+	Name string
+	Age  int
+}
+
+component Home(user User) {
+	{{ _ = user.Name }}
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	nameOff := strings.Index(src, "user.Name") + len("user.")
+	start, end := nameOff, nameOff+2 // simulated "Na" prefix
+
+	items, ok := statementMemberItems(pkg, path, src, start, end, encUTF8)
+	if !ok {
+		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
+	}
+	var nameItem *CompletionItem
+	for i := range items {
+		if items[i].Label == "Name" {
+			nameItem = &items[i]
+		}
+	}
+	if nameItem == nil {
+		t.Fatalf("prefixed member `Name` missing; items=%+v", items)
+	}
+	if nameItem.TextEdit == nil {
+		t.Fatal("Name item has no TextEdit")
+	}
+	wantStart := rangeForSpan(src, start, end, encUTF8).Start
+	wantEnd := rangeForSpan(src, start, end, encUTF8).End
+	if nameItem.TextEdit.Range.Start != wantStart || nameItem.TextEdit.Range.End != wantEnd {
+		t.Errorf("Name edit range = %+v, want [%+v,%+v) (the simulated prefix span only)",
+			nameItem.TextEdit.Range, wantStart, wantEnd)
+	}
+}
+
+// TestStatementMemberItemsGoChunk mirrors the GoBlock trailing-dot test but at
+// a member cursor inside a top-level GoChunk function body — the OTHER
+// statement bridge with no skeleton selector (GoBlock/CtrlMap and GoChunk both
+// return nil skel from goCompletionBridge).
+func TestStatementMemberItemsGoChunk(t *testing.T) {
+	const src = `package page
+
+type User struct {
+	Name string
+	Age  int
+}
+
+func greet(u User) string {
+	return u.Name
+}
+
+component Home() {
+	<div></div>
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	nameOff := strings.Index(src, "u.Name") + len("u.")
+
+	items, ok := statementMemberItems(pkg, path, src, nameOff, nameOff, encUTF8)
+	if !ok {
+		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
+	}
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	for _, name := range []string{"Name", "Age"} {
+		if !labels[name] {
+			t.Errorf("GoChunk member %q missing; labels=%v", name, labels)
+		}
+	}
+}
+
+// TestStatementMemberItemsPackageReceiver drives an imported-package receiver
+// (`strings.▮`) through statementMemberItems inside a GoBlock: the receiver's
+// SourceIndex occurrence resolves to a *types.PkgName, taking the
+// packageMemberItems branch (tierImported), the same branch memberCompletionItems
+// takes for the skeleton selector path.
+func TestStatementMemberItemsPackageReceiver(t *testing.T) {
+	const src = `package page
+
+import "strings"
+
+component Home() {
+	{{ x := strings.ToUpper("a") }}
+	<div>{x}</div>
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	off := strings.Index(src, "strings.ToUpper") + len("strings.")
+
+	items, ok := statementMemberItems(pkg, path, src, off, off, encUTF8)
+	if !ok {
+		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
+	}
+	labels := map[string]string{}
+	for _, it := range items {
+		labels[it.Label] = it.SortText
+	}
+	for _, name := range []string{"ToUpper", "ToLower", "Contains"} {
+		sortText, ok := labels[name]
+		if !ok {
+			t.Errorf("imported-package member %q missing; got %v", name, labels)
+			continue
+		}
+		if !strings.HasPrefix(sortText, "40") {
+			t.Errorf("%q SortText = %q, want tierImported prefix \"40\"", name, sortText)
+		}
+	}
+}
+
+// TestStatementMemberItemsCallReceiver pins the OBSERVED behavior of a
+// non-identifier (call-expression) receiver, per the design's "opportunistic,
+// fail-soft" treatment: SourceIndex records an Expression occurrence for every
+// ast.Expr with recorded type info, so `mk().▮` resolves through that
+// occurrence's TypeAndValue exactly like an identifier receiver would — there
+// is no dedicated carve-out, and this test pins that the mechanism used
+// (occ.HasTypeValue, no occ.Object) actually fires for a call receiver rather
+// than silently degrading to an empty list.
+func TestStatementMemberItemsCallReceiver(t *testing.T) {
+	const src = `package page
+
+type User struct {
+	Name string
+	Age  int
+}
+
+func mk() User { return User{} }
+
+component Home() {
+	{{ _ = mk().Name }}
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	off := strings.Index(src, "mk().Name") + len("mk().")
+
+	items, ok := statementMemberItems(pkg, path, src, off, off, encUTF8)
+	if !ok {
+		t.Fatal("statementMemberItems returned ok=false at a `.`-cursor")
+	}
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	for _, name := range []string{"Name", "Age"} {
+		if !labels[name] {
+			t.Errorf("call-receiver member %q missing (observed opportunistic resolution failed); labels=%v", name, labels)
+		}
+	}
+}
+
+// TestStatementMemberItemsNotMemberPosition pins the ok=false fallthrough: no
+// `.` immediately before start (a plain scope-identifier cursor), a nil
+// SourceIndex (a package with no built index), and a nil pkg all decline the
+// statement member path so the caller's scope fallback applies.
+func TestStatementMemberItemsNotMemberPosition(t *testing.T) {
+	const src = `package page
+
+component Home() {
+	{{ x := 1 }}
+	<div>{x}</div>
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	off := strings.Index(src, "x := 1") + len("x")
+	if _, ok := statementMemberItems(pkg, path, src, off, off, encUTF8); ok {
+		t.Error("statementMemberItems ok=true at a non-`.` cursor")
+	}
+
+	synth, _ := buildSyntheticPackage(t, "package p\n\nvar x = 1\n")
+	if synth.SourceIndex != nil {
+		t.Fatal("synthetic package unexpectedly has a SourceIndex")
+	}
+	if _, ok := statementMemberItems(synth, "p.go", "x.Y", 2, 2, encUTF8); ok {
+		t.Error("statementMemberItems ok=true with a nil SourceIndex")
+	}
+
+	if _, ok := statementMemberItems(nil, "p.go", "x.Y", 2, 2, encUTF8); ok {
+		t.Error("statementMemberItems ok=true with a nil pkg")
+	}
+}
+
+// TestGoCompletionItemsStatementMemberDispatch drives goCompletionItems itself
+// (not statementMemberItems directly) to pin the WIRING: with skel=nil and
+// statementCtx=true at a `.`-cursor, the statement member path is tried after
+// the (no-op, skel-nil) skeleton member path and BEFORE the scope+keyword
+// fallback — the returned items are members only, never scope locals or Go
+// keywords, exactly like the skeleton member path's existing "committed even
+// when empty, no scope fallback" contract.
+func TestGoCompletionItemsStatementMemberDispatch(t *testing.T) {
+	const src = `package page
+
+type User struct {
+	Name string
+	Age  int
+}
+
+component Home(user User) {
+	{{ _ = user.Name }}
+}
+`
+	pkg, path := analyzedLSPPackage(t, src)
+	nameOff := strings.Index(src, "user.Name") + len("user.")
+
+	items := goCompletionItems(pkg, pkg.Types.Scope(), nil, token.NoPos, true, nil, src, nameOff, nameOff, encUTF8, path)
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	for _, name := range []string{"Name", "Age"} {
+		if !labels[name] {
+			t.Errorf("goCompletionItems statement-member dispatch missing %q; labels=%v", name, labels)
+		}
+	}
+	for _, unwanted := range []string{"user", "return", "if", "for"} {
+		if labels[unwanted] {
+			t.Errorf("goCompletionItems statement-member dispatch leaked scope/keyword item %q; labels=%v", unwanted, labels)
+		}
+	}
+}

--- a/internal/lsp/completion_go_test.go
+++ b/internal/lsp/completion_go_test.go
@@ -141,6 +141,66 @@ func g() {
 	}
 }
 
+// TestInnermostScopeAtAuthoredBetweenDecls pins that a cursor sitting BETWEEN
+// top-level declarations (not inside any func body) resolves to the file scope,
+// so imported package names, package-scope decls, and keywords all complete
+// there. The //line directive reproduces the production geometry a real GoChunk
+// has: the file scope's package clause stays on the skeleton path ("p.go")
+// while the GoChunk-derived decl maps back to the authored .gsx — so the file
+// scope's own span is filtered out of the direct match and only the
+// fileScopeForAuthoredPath fallback can recover it.
+func TestInnermostScopeAtAuthoredBetweenDecls(t *testing.T) {
+	src := `package p
+
+import "strings"
+
+//line home.gsx:5:1
+func helper() string { return "a" }
+`
+	pkg, _ := buildSyntheticPackage(t, src)
+
+	// off is an authored-coordinate position that lies in no func/block span
+	// (before helper's mapped body), forcing the between-decls fallback.
+	scope := innermostScopeAtAuthored(pkg, "home.gsx", 1)
+	if scope == nil {
+		t.Fatal("innermostScopeAtAuthored returned nil")
+	}
+	// It must be the file scope, not the package scope: fileScopeSet recognizes
+	// it, so imported names earn tierImported.
+	if !fileScopeSet(pkg)[scope] {
+		t.Fatalf("scope between decls is not the file scope (got package scope? %v)", scope == pkg.Types.Scope())
+	}
+
+	tier := map[string]int{}
+	for _, c := range scopeCandidates(pkg, scope, token.NoPos) {
+		tier[c.obj.Name()] = c.tier
+	}
+	if got, ok := tier["strings"]; !ok || got != tierImported {
+		t.Errorf("imported name `strings` tier = %d (present=%v), want tierImported (%d)", got, ok, tierImported)
+	}
+	if got, ok := tier["helper"]; !ok || got != tierPackage {
+		t.Errorf("package decl `helper` tier = %d (present=%v), want tierPackage (%d)", got, ok, tierPackage)
+	}
+	// Universe names remain visible (keywords are added by goCompletionItems, not
+	// scopeCandidates, and are exercised in the e2e test).
+	if _, ok := tier["error"]; !ok {
+		t.Error("universe name `error` missing from bare GoChunk scope")
+	}
+}
+
+// TestFileScopeForAuthoredPathUnknownPath pins the fallback boundary: a path
+// that no skeleton file maps to yields nil, so innermostScopeAtAuthored can
+// fall through to the package scope rather than mis-attributing a file scope.
+func TestFileScopeForAuthoredPathUnknownPath(t *testing.T) {
+	pkg, _ := buildSyntheticPackage(t, "package p\n\nimport \"strings\"\n\nvar _ = strings.Title\n")
+	if fs := fileScopeForAuthoredPath(pkg, "nonexistent.gsx"); fs != nil {
+		t.Errorf("fileScopeForAuthoredPath returned a scope for an unmapped path: %v", fs)
+	}
+	if got := innermostScopeAtAuthored(pkg, "nonexistent.gsx", 0); got != pkg.Types.Scope() {
+		t.Errorf("innermostScopeAtAuthored for unmapped path = %v, want package scope", got)
+	}
+}
+
 // TestMemberCandidates exercises the method-set + embedded-field BFS over a
 // synthetic type, asserting promotion depth and the unexported-visibility gate.
 func TestMemberCandidates(t *testing.T) {

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -568,7 +568,7 @@ func (s *Server) attrNameCompletion(cc completionContext, path, text string, off
 	htmxEnabled := slices.Contains(s.dirURLPresets(dir, eph), "htmx")
 
 	if ephEl != nil && ephEl.IsComponent {
-		items := componentAttrItems(eph, ephEl, htmxEnabled, text, start, end, s.enc)
+		items := componentAttrItems(eph, ephEl, htmxEnabled, text, start, end, s.enc, s.snippetSupport)
 		if len(items) == 0 {
 			return emptyCompletion()
 		}
@@ -578,7 +578,7 @@ func (s *Server) attrNameCompletion(cc completionContext, path, text string, off
 	// HTML element (confirmed non-component, or analysis is a shell): offer HTML
 	// attribute names computed purely from the classification element — no codegen
 	// facts needed, so this works even when the ephemeral analysis failed.
-	items := htmlAttrItems(cc.element, cc.element.Tag, htmxEnabled, tierContext, text, start, end, s.enc)
+	items := htmlAttrItems(cc.element, cc.element.Tag, htmxEnabled, tierContext, text, start, end, s.enc, s.snippetSupport)
 	if len(items) == 0 {
 		return emptyCompletion()
 	}
@@ -690,7 +690,9 @@ func reservedComponentAttrName(name string) bool {
 //
 // label = param name, kind = ciKindField, detail = the param's type via
 // qualifierFor, tier = tierContext. newText is the plain name — no `={}`
-// snippet in v1, per the task-13 spec.
+// snippet in v1, per the task-13 spec — and this stays true regardless of
+// snippet: a component's own named params are never quote-value inserts, so
+// there is no cursor-inside-quotes position to gate on.
 //
 // When the signature also declares an "attrs" catch-all parameter
 // (signatureHasAttrsCatchAll — component_signature.go's roleAttrs, e.g.
@@ -698,15 +700,17 @@ func reservedComponentAttrName(name string) bool {
 // attributes to whatever element it ultimately renders, so the candidate set
 // is extended with the HTML GLOBAL attribute set (htmldata.GlobalAttributes,
 // plus hx-* when htmxEnabled) via htmlAttrItems — the SAME boolean/insert/
-// present-attr/own-token logic the plain-HTML attrTagName path uses, single-
-// sourced rather than reimplemented here. There is no per-tag contribution:
-// which concrete element receives the forwarded bag is unknowable from the
-// call site (tagName ""), so only globals are offered — see htmlAttrItems'
-// doc for how an unmatched tagName collapses to globals-only. Forwarded items
-// sort at tierSecondary so the component's own named params (tierContext)
-// lead; a name collision with an already-offered named param (e.g. a
-// component that happens to declare a "class" prop) is skipped so the same
-// label never appears twice with two different insert behaviors.
+// present-attr/own-token/snippet logic the plain-HTML attrTagName path uses,
+// single-sourced rather than reimplemented here (snippet threads straight
+// through so `name="$1"` applies here too, gated on the same client
+// capability). There is no per-tag contribution: which concrete element
+// receives the forwarded bag is unknowable from the call site (tagName ""),
+// so only globals are offered — see htmlAttrItems' doc for how an unmatched
+// tagName collapses to globals-only. Forwarded items sort at tierSecondary so
+// the component's own named params (tierContext) lead; a name collision with
+// an already-offered named param (e.g. a component that happens to declare a
+// "class" prop) is skipped so the same label never appears twice with two
+// different insert behaviors.
 //
 // No signature-with-attrs → unchanged: named params only. An unknown attr
 // would be rejected by the planner at build time, so offering HTML attrs
@@ -714,7 +718,7 @@ func reservedComponentAttrName(name string) bool {
 //
 // No fact for el (the call was never planned — a broken tag, an unresolved
 // target, ...) returns nil: fail-soft, never a guess.
-func componentAttrItems(pkg *Package, el *gsxast.Element, htmxEnabled bool, text string, start, end int, enc encoding) []CompletionItem {
+func componentAttrItems(pkg *Package, el *gsxast.Element, htmxEnabled bool, text string, start, end int, enc encoding, snippet bool) []CompletionItem {
 	if pkg == nil || el == nil {
 		return nil
 	}
@@ -761,7 +765,7 @@ func componentAttrItems(pkg *Package, el *gsxast.Element, htmxEnabled bool, text
 
 	if signatureHasAttrsCatchAll(sig) {
 		named := offeredNames(items)
-		for _, g := range htmlAttrItems(el, "", htmxEnabled, tierSecondary, text, start, end, enc) {
+		for _, g := range htmlAttrItems(el, "", htmxEnabled, tierSecondary, text, start, end, enc, snippet) {
 			if named[g.Label] {
 				continue
 			}

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -32,7 +32,17 @@ func filterItems(filters []FilterCandidate, text string, start, end int, enc enc
 		if f.WantsCtx {
 			detail += " (ctx)"
 		}
-		items = append(items, newCompletionItem(text, start, end, enc, f.Name, f.Name, ciKindOperator, tierContext, detail, nil))
+		item := newCompletionItem(text, start, end, enc, f.Name, f.Name, ciKindOperator, tierContext, detail, nil)
+		// Filter target funcs are always declared outside the analyzed
+		// package (the filter registry, not this file's own scope), so their
+		// doc — like any imported symbol's — is fetched lazily via
+		// completionItem/resolve; f.Pos was resolved once at analysis time
+		// (see codegen's filterEntry.pos / FilterCandidate.Pos), not
+		// re-looked-up per completion request.
+		if f.Pos.IsValid() && f.Pos.Filename != "" {
+			item.Data = &completionResolveData{File: f.Pos.Filename, Line: f.Pos.Line}
+		}
+		items = append(items, item)
 	}
 	return items
 }

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -1,10 +1,12 @@
 package lsp
 
 import (
+	"go/token"
 	"go/types"
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 
 	gsxast "github.com/gsxhq/gsx/ast"
 	"github.com/gsxhq/gsx/internal/tagcallable"
@@ -100,7 +102,7 @@ func (s *Server) tagCompletion(cc completionContext, path, text string, off int,
 
 	var items []CompletionItem
 	if pkg := s.componentDeclPackage(filepath.Dir(path), path, r.src); pkg != nil {
-		items = componentTagItems(pkg, cc.qualifier, capitalizedPrefix, text, start, end, s.enc)
+		items = componentTagItems(pkg, cc.qualifier, capitalizedPrefix, path, off, text, start, end, s.enc)
 	}
 	if cc.qualifier == "" {
 		items = append(items, htmlTagItems(capitalizedPrefix, text, start, end, s.enc)...)
@@ -150,9 +152,19 @@ func (s *Server) componentDeclPackage(dir, path string, src []byte) *Package {
 // "."+Name for a plain function component — a LEADING dot, not a bare name —
 // and RecvType+"."+Name for a receiver/method component. Every key therefore
 // contains a dot; componentNameItems' exclusion rule keys off the dot's
-// POSITION (index 0), not off dot-presence. Receiver components need a
-// receiver expression before the tag can resolve and are excluded from v1
-// (spec follow-up).
+// POSITION (index 0), not off dot-presence.
+//
+// A method component is offered at a QUALIFIED cursor `<recv.▮` when the
+// qualifier resolves to an in-scope VALUE binding (the receiver var, a
+// parameter, or a package-scope var) whose type has method components —
+// receiverVarComponentItems. That resolution runs FIRST, before import-
+// qualifier resolution, mirroring Go's own scoping: an in-scope value binding
+// shadows a same-named import, so `<Q.▮` refers to the binding's methods, never
+// the package's components, whenever Q resolves to a var (even if that var's
+// type declares no method components). Only when Q does NOT resolve to a value
+// binding does the import-qualifier path below run. Method components are NOT
+// enumerated at a BARE `<▮` cursor (that would require offering every in-scope
+// receiver/param var as a qualifier — a scope explosion deferred past v1).
 //
 // Both branches additionally scan for component VALUES — package-scope
 // vars/funcs (like `var X = named("x")` in a plain Go sibling package) that
@@ -177,17 +189,25 @@ func (s *Server) componentDeclPackage(dir, path string, src []byte) *Package {
 // caller / htmlTagItems, not here. The parameter is retained so the signature
 // documents the merge contract and the tests pin that components stay tierContext
 // either way.
-func componentTagItems(pkg *Package, qualifier string, capitalizedPrefix bool, text string, start, end int, enc encoding) []CompletionItem {
+func componentTagItems(pkg *Package, qualifier string, capitalizedPrefix bool, path string, off int, text string, start, end int, enc encoding) []CompletionItem {
 	if pkg == nil || pkg.Types == nil {
 		return nil
 	}
 	if qualifier != "" {
-		path, ok := importQualifierCandidates(pkg)[qualifier]
+		// Go-scoping precedence: a value binding named qualifier shadows a
+		// same-named import, so try receiver/param/var resolution first. resolved
+		// == true means qualifier IS an in-scope value binding — stop here even
+		// when its type declares no method components (the binding still shadows
+		// any import, per Go).
+		if items, resolved := receiverVarComponentItems(pkg, qualifier, path, off, text, start, end, enc); resolved {
+			return items
+		}
+		impPath, ok := importQualifierCandidates(pkg)[qualifier]
 		if !ok {
 			return nil
 		}
-		items := componentNameItems(pkg, path, text, start, end, enc)
-		if target := importedPackageAt(pkg, path); target != nil {
+		items := componentNameItems(pkg, impPath, text, start, end, enc)
+		if target := importedPackageAt(pkg, impPath); target != nil {
 			items = append(items, componentValueNameItems(target, offeredNames(items), true, text, start, end, enc)...)
 		}
 		return items
@@ -195,6 +215,156 @@ func componentTagItems(pkg *Package, qualifier string, capitalizedPrefix bool, t
 	items := componentNameItems(pkg, pkg.Types.Path(), text, start, end, enc)
 	items = append(items, componentValueNameItems(pkg.Types, offeredNames(items), false, text, start, end, enc)...)
 	items = append(items, importQualifierItems(pkg, text, start, end, enc)...)
+	return items
+}
+
+// receiverVarComponentItems resolves a qualified tag cursor `<qualifier.▮`
+// against the in-scope VALUE bindings visible from the enclosing component,
+// and offers the method components declared on the binding's type. It returns
+// (items, resolved): resolved reports whether qualifier named an in-scope value
+// binding (a *types.Var — receiver, parameter, or package-scope var). When
+// resolved is true the caller must NOT fall through to import-qualifier
+// resolution, even if items is empty: a value binding shadows a same-named
+// import (Go scoping), so `<qualifier.▮` can only mean that binding's methods.
+// When resolved is false (qualifier is an import PkgName, or resolves to
+// nothing) the caller proceeds to the import-qualifier path.
+//
+// The scope is the enclosing component's generated-func scope, located WITHOUT
+// relying on authored-offset↔skeleton-offset alignment (which does not hold —
+// pkg.Fset.Position offsets are skeleton offsets, not authored ones, so
+// innermostScopeAtAuthored's containment branch never fires for a markup
+// cursor). Instead: find the enclosing *gsxast.Component by authored span
+// (pkg.GSXFset), then seed innermostScopeAt with the skeleton position of any
+// of that component's signature-type spans (pkg.SigTypes) — every param/receiver
+// type sits inside the one generated FuncType scope that binds the receiver var
+// and parameters. LookupParent from there walks up to package/file scope, so a
+// package-scope var also resolves. A component with no signature types (no
+// receiver, no params) falls back to the package scope, which still resolves a
+// package-scope var. Body-LOCAL bindings (a var declared in a `{{ }}` GoBlock
+// inside the body) live in a nested block scope not on this ancestry chain and
+// are a documented v1 gap — receiver and parameter bindings, the method-
+// component idiom, are covered.
+func receiverVarComponentItems(pkg *Package, qualifier, path string, off int, text string, start, end int, enc encoding) ([]CompletionItem, bool) {
+	if pkg.Info == nil {
+		return nil, false
+	}
+	scope := componentBodyScope(pkg, path, off)
+	if scope == nil {
+		return nil, false
+	}
+	_, obj := scope.LookupParent(qualifier, token.NoPos)
+	v, ok := obj.(*types.Var)
+	if !ok {
+		return nil, false
+	}
+	typeName, pkgPath, ok := namedTypeOf(v.Type())
+	if !ok {
+		// qualifier IS a value binding (it shadows any import), but its type is
+		// not a named type that can carry method components: resolved, no items.
+		return nil, true
+	}
+	return methodComponentItems(pkg, pkgPath, typeName, text, start, end, enc), true
+}
+
+// componentBodyScope returns the go/types scope of the generated func for the
+// component enclosing the authored cursor (path, off), or the package scope when
+// no enclosing component signature can seed it. See receiverVarComponentItems.
+func componentBodyScope(pkg *Package, path string, off int) *types.Scope {
+	c := enclosingComponentAt(pkg, path, off)
+	if c != nil {
+		for _, st := range pkg.SigTypes[c] {
+			if st.SkelTyp != nil && st.SkelTyp.Pos().IsValid() {
+				return innermostScopeAt(pkg, st.SkelTyp.Pos())
+			}
+		}
+	}
+	if pkg.Types != nil {
+		return pkg.Types.Scope()
+	}
+	return nil
+}
+
+// enclosingComponentAt returns the *gsxast.Component in the analysis AST for
+// path whose authored span (pkg.GSXFset coordinates) contains off, or nil. Top-
+// level components never nest, so the smallest-span tie-break is only defensive.
+func enclosingComponentAt(pkg *Package, path string, off int) *gsxast.Component {
+	if pkg.GSXFset == nil {
+		return nil
+	}
+	f := pkg.Files[path]
+	if f == nil {
+		for p, ff := range pkg.Files {
+			if samePath(p, path) {
+				f = ff
+				break
+			}
+		}
+	}
+	if f == nil {
+		return nil
+	}
+	var best *gsxast.Component
+	bestSpan := 1 << 30
+	for _, d := range f.Decls {
+		c, ok := d.(*gsxast.Component)
+		if !ok {
+			continue
+		}
+		lo := pkg.GSXFset.Position(c.Pos()).Offset
+		hi := pkg.GSXFset.Position(c.End()).Offset
+		if off < lo || off > hi {
+			continue
+		}
+		if span := hi - lo; span < bestSpan {
+			best = c
+			bestSpan = span
+		}
+	}
+	return best
+}
+
+// namedTypeOf reduces a value's type to the bare name and package path of the
+// named type that carries its methods: a pointer is dereferenced (a `*T`
+// receiver var still names method components keyed on `T` — codegen's parseRecv
+// strips the leading `*`), and an alias is unwrapped. Returns ok == false for a
+// non-named type or one with no package (a builtin), which can carry no method
+// components.
+func namedTypeOf(t types.Type) (typeName, pkgPath string, ok bool) {
+	if ptr, isPtr := types.Unalias(t).(*types.Pointer); isPtr {
+		t = ptr.Elem()
+	}
+	named, isNamed := types.Unalias(t).(*types.Named)
+	if !isNamed {
+		return "", "", false
+	}
+	tn := named.Obj()
+	if tn == nil || tn.Pkg() == nil {
+		return "", "", false
+	}
+	return tn.Name(), tn.Pkg().Path(), true
+}
+
+// methodComponentItems offers one item per method component declared on the type
+// named typeName in pkgPath — ComponentDecls keys of the form typeName+"."+Name.
+// pkgPath matches cross-package too: method components on an imported type are
+// keyed by their declaring (== the type's) package path. kind is ciKindClass and
+// tier tierContext, consistent with componentNameItems (a tag, not a call).
+func methodComponentItems(pkg *Package, pkgPath, typeName string, text string, start, end int, enc encoding) []CompletionItem {
+	prefix := typeName + "."
+	var names []string
+	for key := range pkg.ComponentDecls {
+		if key.PackagePath != pkgPath {
+			continue
+		}
+		if name, ok := strings.CutPrefix(key.ComponentKey, prefix); ok && name != "" && !strings.Contains(name, ".") {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	items := make([]CompletionItem, 0, len(names))
+	for _, name := range names {
+		items = append(items, newCompletionItem(text, start, end, enc, name, name, ciKindClass, tierContext, "", nil))
+	}
 	return items
 }
 

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -44,9 +44,23 @@ func filterItems(filters []FilterCandidate, text string, start, end int, enc enc
 // (not r.src), so an empty stage naturally yields a zero-width [off,off) span
 // with nothing typed to filter on or leak into the edit.
 func (s *Server) pipeStageCompletion(cc completionContext, path, text string, off int, r repairResult) CompletionList {
-	filters := s.pipeFilters(filepath.Dir(path), path, r.src)
-	if len(filters) == 0 {
+	pkg := s.pipeFilterPackage(filepath.Dir(path), path, r.src)
+	if pkg == nil || len(pkg.Filters) == 0 {
 		return emptyCompletion()
+	}
+	filters := pkg.Filters
+	// Typed narrowing: keep only filters whose subject parameter accepts the
+	// type flowing into this pipeline stage. compatiblePipeFilters fails OPEN —
+	// returns ok=false — whenever that type (or the cursor's pipeline node)
+	// cannot be resolved, so an uncertain analysis offers the full list rather
+	// than hiding candidates. cc.exprPos is the seed span in the repair parse's
+	// coordinates; the seed sits before the cursor's repair insertion, so its
+	// byte offset bridges unchanged into the ephemeral analysis package.
+	if r.fset != nil && cc.exprPos.IsValid() {
+		seedOff := r.fset.Position(cc.exprPos).Offset
+		if narrowed, ok := compatiblePipeFilters(pkg, path, seedOff, off, filters); ok {
+			filters = narrowed
+		}
 	}
 	start, end := completionTokenSpan(text, off, false)
 	items := filterItems(filters, text, start, end, s.enc)
@@ -56,26 +70,28 @@ func (s *Server) pipeStageCompletion(cc completionContext, path, text string, of
 	return CompletionList{IsIncomplete: false, Items: items}
 }
 
-// pipeFilters resolves the pipe-filter table for dir. It prefers one
-// ephemeral analysis of the (possibly mid-edit) buffer src, so a filter
-// registered by an edit still only in the buffer completes immediately. When
-// that comes back a shell — the analyzer errored, or returned a
-// diagnostics-only Package with both Info and Filters empty (parse/analyze
-// failure) — it falls back to the retained s.pkgs[dir] snapshot: filter NAMES
-// are position-independent, so serving a stale retained list under staleness
-// is safe. Both empty (or absent) yields nil, and pipeStageCompletion turns
-// that into an empty list — fail soft, never an error.
-func (s *Server) pipeFilters(dir, path string, src []byte) []FilterCandidate {
+// pipeFilterPackage resolves the analyzed package backing a pipe-stage cursor.
+// It prefers one ephemeral analysis of the (possibly mid-edit) buffer src, so a
+// filter registered by an edit still only in the buffer completes immediately,
+// AND so the package carries the live Info/Types/ExprMap that typed narrowing
+// (compatiblePipeFilters) reads. When that comes back a shell — the analyzer
+// errored, or returned a diagnostics-only Package with both Info and Filters
+// empty (parse/analyze failure) — it falls back to the retained s.pkgs[dir]
+// snapshot: filter NAMES are position-independent, so serving a stale retained
+// list is safe (typed narrowing simply fails open against a stale package's
+// facts). Both empty (or absent) yields nil, and pipeStageCompletion turns that
+// into an empty list — fail soft, never an error.
+func (s *Server) pipeFilterPackage(dir, path string, src []byte) *Package {
 	// Non-blocking (see goContextCompletion): under contention acquired=false
 	// (eph nil) falls through to the retained snapshot below — filter NAMES are
 	// position-independent, so a stale list is a safe, instant answer rather than
 	// a whole-server stall.
 	eph, acquired, err := s.analyzer.AnalyzeEphemeralNonBlocking(dir, path, src)
 	if acquired && err == nil && eph != nil && (eph.Info != nil || len(eph.Filters) > 0) {
-		return eph.Filters
+		return eph
 	}
 	if pkg := s.pkgs[dir]; pkg != nil {
-		return pkg.Filters
+		return pkg
 	}
 	return nil
 }

--- a/internal/lsp/completion_gsx_pipe_type_test.go
+++ b/internal/lsp/completion_gsx_pipe_type_test.go
@@ -1,0 +1,315 @@
+package lsp
+
+import (
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/codegen"
+)
+
+// analyzeForPipe builds a throwaway module (go.mod + optional sibling Go files +
+// one page.gsx), analyzes the page package TOLERATING diagnostics (a mid-edit
+// pipeline with an unknown trailing stage type-errors by design), and returns
+// the resulting LSP Package, the page path, and the resolved filter candidates.
+// It mirrors adaptPackageResult for the fields typed pipe-filter narrowing reads
+// (Info, Types, ExprMap, GSXFiles, Filters).
+func analyzeForPipe(t *testing.T, files map[string]string, filterPkgs []string, gsxSrc string) (*Package, string, []FilterCandidate) {
+	t.Helper()
+	root := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, content string) {
+		full := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module example.com/app\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+repoRoot+"\n")
+	for name, content := range files {
+		write(name, content)
+	}
+	write("page/page.gsx", gsxSrc)
+
+	if len(filterPkgs) == 0 {
+		filterPkgs = []string{codegen.StdImportPath}
+	}
+	m, err := codegen.Open(codegen.Options{ModuleRoot: root, ModulePath: "example.com/app", FilterPkgs: filterPkgs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr, err := m.Package(filepath.Join(root, "page"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	filters := make([]FilterCandidate, len(pr.Filters))
+	for i, f := range pr.Filters {
+		filters[i] = FilterCandidate{Name: f.Name, Pkg: f.Pkg, Func: f.Func, WantsCtx: f.WantsCtx}
+	}
+	pkg := &Package{
+		GSXFset: pr.GSXFset,
+		Fset:    pr.Fset,
+		Info:    pr.Info,
+		Types:   pr.Types,
+		Files:   pr.GSXFiles,
+		ExprMap: pr.ExprMap,
+	}
+	return pkg, filepath.Join(root, "page", "page.gsx"), filters
+}
+
+// pipeCursor computes the (seedOff, off) pair compatiblePipeFilters needs for a
+// cursor sitting immediately after stageMarker, whose pipeline seed is the
+// unique substring seedExpr.
+func pipeCursor(t *testing.T, src, seedExpr, stageMarker string) (seedOff, off int) {
+	t.Helper()
+	seedOff = strings.Index(src, seedExpr)
+	if seedOff < 0 {
+		t.Fatalf("seed %q not found", seedExpr)
+	}
+	m := strings.Index(src, stageMarker)
+	if m < 0 {
+		t.Fatalf("stage marker %q not found", stageMarker)
+	}
+	return seedOff, m + len(stageMarker)
+}
+
+func filterNameSet(filters []FilterCandidate) map[string]bool {
+	m := make(map[string]bool, len(filters))
+	for _, f := range filters {
+		m[f.Name] = true
+	}
+	return m
+}
+
+const pipeUser = `package page
+
+type User struct {
+	Name  string
+	Age   int
+	Tags  []string
+	Blob  []byte
+}
+
+`
+
+// TestCompatiblePipeFiltersStringSeed: a string-typed seed offers string-subject
+// filters (upper), the any-subject filter (printf) and the generic filter
+// (default), and excludes filters whose subject is []string (join) or []byte
+// (dataURL). A companion valid pipe (`join`) imports std into the skeleton
+// universe so candidate signatures resolve.
+func TestCompatiblePipeFiltersStringSeed(t *testing.T) {
+	src := pipeUser + "component Home(user User) {\n\t<div>{ user.Tags |> join(\", \") }{ user.Name |> zz }</div>\n}\n"
+	pkg, path, filters := analyzeForPipe(t, nil, nil, src)
+	seedOff, off := pipeCursor(t, src, "user.Name", "|> zz")
+	got, ok := compatiblePipeFilters(pkg, path, seedOff, off, filters)
+	if !ok {
+		t.Fatal("compatiblePipeFilters ok=false, want true (string seed resolves)")
+	}
+	labels := filterNameSet(got)
+	for _, want := range []string{"upper", "printf", "default", "urlquery"} {
+		if !labels[want] {
+			t.Errorf("string seed: filter %q missing; got %v", want, labels)
+		}
+	}
+	for _, excl := range []string{"join", "dataURL"} {
+		if labels[excl] {
+			t.Errorf("string seed: filter %q offered but subject is incompatible; got %v", excl, labels)
+		}
+	}
+}
+
+// TestCompatiblePipeFiltersIntSeed: an int-typed seed offers only the any-subject
+// (printf) and generic (default) filters; every string-subject filter (upper,
+// urlquery) and the []string/[]byte-subject filters (join, dataURL) are excluded.
+func TestCompatiblePipeFiltersIntSeed(t *testing.T) {
+	src := pipeUser + "component Home(user User) {\n\t<div>{ user.Tags |> join(\", \") }{ user.Age |> zz }</div>\n}\n"
+	pkg, path, filters := analyzeForPipe(t, nil, nil, src)
+	seedOff, off := pipeCursor(t, src, "user.Age", "|> zz")
+	got, ok := compatiblePipeFilters(pkg, path, seedOff, off, filters)
+	if !ok {
+		t.Fatal("compatiblePipeFilters ok=false, want true (int seed resolves)")
+	}
+	labels := filterNameSet(got)
+	for _, want := range []string{"printf", "default"} {
+		if !labels[want] {
+			t.Errorf("int seed: filter %q missing; got %v", want, labels)
+		}
+	}
+	for _, excl := range []string{"upper", "urlquery", "join", "dataURL"} {
+		if labels[excl] {
+			t.Errorf("int seed: filter %q offered but subject is incompatible; got %v", excl, labels)
+		}
+	}
+}
+
+// TestCompatiblePipeFiltersSecondStage: a second-stage cursor resolves its
+// incoming type from the PRECEDING filter's result (upper → string), not from
+// the raw pipe node, and narrows accordingly — string-subject filters offered,
+// []string/[]byte-subject filters excluded. The stronger "result type differs
+// from the seed type" proof lives in TestCompatiblePipeFiltersErrFilterMidPipe
+// (toStr: int → string). A no-args preceding stage is used deliberately: a
+// preceding stage that carries ARGS combined with an unknown trailing stage
+// currently yields an empty analysis (a codegen edge), which simply routes to
+// the full-list fail-open.
+func TestCompatiblePipeFiltersSecondStage(t *testing.T) {
+	src := pipeUser + "component Home(user User) {\n\t<div>{ user.Tags |> join(\", \") }{ user.Name |> upper |> zz }</div>\n}\n"
+	pkg, path, filters := analyzeForPipe(t, nil, nil, src)
+	seedOff, off := pipeCursor(t, src, "user.Name", "|> zz")
+	got, ok := compatiblePipeFilters(pkg, path, seedOff, off, filters)
+	if !ok {
+		t.Fatal("compatiblePipeFilters ok=false, want true (upper result resolves)")
+	}
+	labels := filterNameSet(got)
+	if !labels["upper"] {
+		t.Errorf("second stage: upper missing — incoming should be upper's string result; got %v", labels)
+	}
+	for _, excl := range []string{"join", "dataURL"} {
+		if labels[excl] {
+			t.Errorf("second stage: %q offered but string is not assignable to its subject; got %v", excl, labels)
+		}
+	}
+}
+
+// TestCompatiblePipeFiltersUnresolvableFailsOpen: an untyped/invalid seed (a
+// non-existent field) cannot yield an incoming type, so narrowing fails OPEN —
+// ok=false — and the caller offers the full list.
+func TestCompatiblePipeFiltersUnresolvableFailsOpen(t *testing.T) {
+	src := pipeUser + "component Home(user User) {\n\t<div>{ user.Bogus |> zz }</div>\n}\n"
+	pkg, path, filters := analyzeForPipe(t, nil, nil, src)
+	seedOff, off := pipeCursor(t, src, "user.Bogus", "|> zz")
+	if _, ok := compatiblePipeFilters(pkg, path, seedOff, off, filters); ok {
+		t.Fatal("compatiblePipeFilters ok=true, want false (broken seed must fail open)")
+	}
+}
+
+const ctxErrFilters = `package myf
+
+import "context"
+
+// CtxUpper takes the ambient context first, then a string subject.
+func CtxUpper(ctx context.Context, s string) string { return s }
+
+// NeedInt has an int subject.
+func NeedInt(n int) string { return "" }
+
+// ToStr is an (R, error) filter: int subject, string result.
+func ToStr(n int) (string, error) { return "", nil }
+`
+
+// TestCompatiblePipeFiltersCtxSubjectIndex: a ctx-taking filter's SUBJECT is
+// parameter 1 (after context.Context), so a string seed offers ctxUpper (string
+// subject) and excludes needInt (int subject) and toStr (int subject). Exercises
+// rule 3 end to end. A companion valid pipe imports the custom filter package.
+func TestCompatiblePipeFiltersCtxSubjectIndex(t *testing.T) {
+	files := map[string]string{"myf/myf.go": ctxErrFilters}
+	pkgs := []string{codegen.StdImportPath, "example.com/app/myf"}
+	src := pipeUser + "component Home(user User) {\n\t<div>{ user.Age |> needInt }{ user.Name |> zz }</div>\n}\n"
+	pkg, path, filters := analyzeForPipe(t, files, pkgs, src)
+	seedOff, off := pipeCursor(t, src, "user.Name", "|> zz")
+	got, ok := compatiblePipeFilters(pkg, path, seedOff, off, filters)
+	if !ok {
+		t.Fatal("compatiblePipeFilters ok=false, want true")
+	}
+	labels := filterNameSet(got)
+	if !labels["ctxUpper"] {
+		t.Errorf("ctx filter: ctxUpper missing — its subject (param 1) is string; got %v", labels)
+	}
+	for _, excl := range []string{"needInt", "toStr"} {
+		if labels[excl] {
+			t.Errorf("ctx filter: %q offered but its int subject rejects a string seed; got %v", excl, labels)
+		}
+	}
+}
+
+// TestCompatiblePipeFiltersErrFilterMidPipe: an (R, error) filter chains its R
+// into the next stage. `int |> toStr |> ▮` has string incoming (toStr's string
+// result), so upper/ctxUpper are offered and the int-subject needInt is excluded.
+// Exercises rule 4 end to end.
+func TestCompatiblePipeFiltersErrFilterMidPipe(t *testing.T) {
+	files := map[string]string{"myf/myf.go": ctxErrFilters}
+	pkgs := []string{codegen.StdImportPath, "example.com/app/myf"}
+	src := pipeUser + "component Home(user User) {\n\t<div>{ user.Age |> needInt }{ user.Age |> toStr |> zz }</div>\n}\n"
+	pkg, path, filters := analyzeForPipe(t, files, pkgs, src)
+	// Second occurrence of user.Age is the cursor pipe's seed.
+	first := strings.Index(src, "user.Age")
+	seedOff := strings.Index(src[first+1:], "user.Age") + first + 1
+	off := strings.Index(src, "|> zz") + len("|> zz")
+	got, ok := compatiblePipeFilters(pkg, path, seedOff, off, filters)
+	if !ok {
+		t.Fatal("compatiblePipeFilters ok=false, want true (toStr string result resolves)")
+	}
+	labels := filterNameSet(got)
+	for _, want := range []string{"upper", "ctxUpper"} {
+		if !labels[want] {
+			t.Errorf("err filter mid-pipe: %q missing — incoming should be toStr's string result; got %v", want, labels)
+		}
+	}
+	if labels["needInt"] {
+		t.Errorf("err filter mid-pipe: needInt offered but string is not assignable to its int subject; got %v", labels)
+	}
+}
+
+// TestFilterSubjectType pins the subject-parameter index rules: parameter 0 for
+// a ctx-less filter, parameter 1 for a ctx-taking one, and the ELEMENT type when
+// the subject is itself the trailing variadic parameter.
+func TestFilterSubjectType(t *testing.T) {
+	// filterSubjectType keys off the wantsCtx flag, not the leading parameter's
+	// concrete type, so a stand-in stands in for context.Context here.
+	ctxType := types.Typ[types.Bool]
+	str := types.Typ[types.String]
+	newParam := func(ts ...types.Type) *types.Tuple {
+		vars := make([]*types.Var, len(ts))
+		for i, ty := range ts {
+			vars[i] = types.NewVar(token.NoPos, nil, "", ty)
+		}
+		return types.NewTuple(vars...)
+	}
+	res := newParam(str)
+
+	// ctx-less: subject is param 0.
+	sig := types.NewSignatureType(nil, nil, nil, newParam(str), res, false)
+	if got, ok := filterSubjectType(sig, false); !ok || got != str {
+		t.Errorf("ctx-less subject = %v, %v; want string", got, ok)
+	}
+	// ctx-taking: subject is param 1.
+	sig = types.NewSignatureType(nil, nil, nil, newParam(ctxType, str), res, false)
+	if got, ok := filterSubjectType(sig, true); !ok || got != str {
+		t.Errorf("ctx subject = %v, %v; want string (param 1)", got, ok)
+	}
+	// variadic subject: element type.
+	sig = types.NewSignatureType(nil, nil, nil, newParam(types.NewSlice(str)), res, true)
+	if got, ok := filterSubjectType(sig, false); !ok || got != str {
+		t.Errorf("variadic subject = %v, %v; want string element", got, ok)
+	}
+}
+
+// TestSubjectAccepts pins the compatibility rule: a type-parameter subject always
+// accepts, an any/interface subject accepts anything, an exact match accepts, and
+// a concrete mismatch is rejected.
+func TestSubjectAccepts(t *testing.T) {
+	str := types.Typ[types.String]
+	i := types.Typ[types.Int]
+	anyIface := types.NewInterfaceType(nil, nil) // empty interface == any
+
+	tp := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "T", nil), types.NewInterfaceType(nil, nil))
+	if !subjectAccepts(tp, i) {
+		t.Error("type-parameter subject must accept any incoming type")
+	}
+	if !subjectAccepts(anyIface, i) {
+		t.Error("any subject must accept int")
+	}
+	if !subjectAccepts(str, str) {
+		t.Error("string subject must accept string")
+	}
+	if subjectAccepts(str, i) {
+		t.Error("string subject must reject int")
+	}
+}

--- a/internal/lsp/completion_gsx_recv_test.go
+++ b/internal/lsp/completion_gsx_recv_test.go
@@ -1,0 +1,240 @@
+package lsp
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/sourceintel"
+	gsxparser "github.com/gsxhq/gsx/parser"
+)
+
+// methodComponentFixture assembles a Package with the two-fset geometry the
+// real analyzer produces: an authored gsx AST (GSXFset) that carries the
+// *gsxast.Component spans a tag cursor is located against, and an independently
+// type-checked skeleton (Fset/Info) whose per-component generated func binds the
+// receiver var. SigTypes bridges a component to a skeleton signature-type
+// position inside that func's scope — exactly the retained fact
+// receiverVarComponentItems consumes. ComponentDecls carries a plain component
+// (".Card"), a value-receiver method component ("UsersPage.Row"), and a
+// pointer-receiver method component ("Form.Submit") on a second type.
+//
+// gsxSrc is returned so callers compute cursor offsets by substring into the
+// Page component body, where `p` is the UsersPage receiver and `f` a *Form param.
+func methodComponentFixture(t *testing.T) (pkg *Package, gsxSrc string) {
+	t.Helper()
+
+	// Skeleton: one generated func per component. `_page`'s receiver is the
+	// UsersPage receiver var `p`; it also takes a `*Form`-typed param `f`, so a
+	// param-typed value binding is exercised alongside the receiver.
+	skel := `package page
+
+type UsersPage struct{ Title string }
+type Form struct{ Name string }
+
+func (p UsersPage) _row(x string) { _ = p; _ = x }
+
+func (p UsersPage) _page(f *Form) { _ = p; _ = f }
+
+func (f *Form) _submit() { _ = f }
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "page.x.go", skel, 0)
+	if err != nil {
+		t.Fatalf("parse skeleton: %v", err)
+	}
+	info := &types.Info{
+		Types:  map[ast.Expr]types.TypeAndValue{},
+		Defs:   map[*ast.Ident]types.Object{},
+		Uses:   map[*ast.Ident]types.Object{},
+		Scopes: map[ast.Node]*types.Scope{},
+	}
+	conf := types.Config{Importer: importer.Default(), Error: func(error) {}}
+	tpkg, _ := conf.Check("example.com/app/page", fset, []*ast.File{file}, info)
+
+	// A signature-type expr inside `_page`'s FuncType scope (the receiver type),
+	// the seed receiverVarComponentItems uses to reach that scope.
+	var pageRecvType ast.Expr
+	for _, d := range file.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			continue
+		}
+		if fn.Name.Name == "_page" {
+			pageRecvType = fn.Recv.List[0].Type
+		}
+	}
+	if pageRecvType == nil {
+		t.Fatal("skeleton missing _page receiver type")
+	}
+
+	// Authored gsx: the enclosing method component body holds the `<p.` cursor.
+	gsxSrc = "package page\n\n" +
+		"component (p UsersPage) Row(x string) {\n\t<span>{x}</span>\n}\n\n" +
+		"component (p UsersPage) Page(f *Form) {\n\t<div><p.Row x=\"a\"/></div>\n}\n"
+	gsxFset := token.NewFileSet()
+	gsxFile, err := gsxparser.ParseFile(gsxFset, "page.gsx", []byte(gsxSrc), 0)
+	if err != nil {
+		t.Fatalf("parse gsx: %v", err)
+	}
+	var pageComp *gsxast.Component
+	for _, d := range gsxFile.Decls {
+		if c, ok := d.(*gsxast.Component); ok && c.Name == "Page" {
+			pageComp = c
+		}
+	}
+	if pageComp == nil {
+		t.Fatal("gsx source missing Page component")
+	}
+
+	pkg = &Package{
+		Types:   tpkg,
+		Info:    info,
+		Fset:    fset,
+		GSXFset: gsxFset,
+		Files:   map[string]*gsxast.File{"page.gsx": gsxFile},
+		SigTypes: map[*gsxast.Component][]SigTypeRef{
+			pageComp: {{GSXPos: pageComp.RecvPos, SkelTyp: pageRecvType}},
+		},
+		ComponentDecls: map[ComponentDeclKey][]sourceintel.VersionedSpan{
+			{PackagePath: "example.com/app/page", ComponentKey: ".Card"}:          nil,
+			{PackagePath: "example.com/app/page", ComponentKey: "UsersPage.Row"}:  nil,
+			{PackagePath: "example.com/app/page", ComponentKey: "UsersPage.Grid"}: nil,
+			{PackagePath: "example.com/app/page", ComponentKey: "Form.Submit"}:    nil,
+		},
+	}
+	return pkg, gsxSrc
+}
+
+// TestReceiverVarTagResolvesMethodComponents pins the primary case: inside a
+// method component `Page`, a `<p.▮` cursor where `p` is the receiver var offers
+// the method components declared on p's type (UsersPage), as ciKindClass tag
+// items at tierContext — never the plain component (".Card") or the other type's
+// method (Form.Submit).
+func TestReceiverVarTagResolvesMethodComponents(t *testing.T) {
+	pkg, src := methodComponentFixture(t)
+	off := strings.Index(src, "<p.Row") + len("<p.")
+	items := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8)
+	got := map[string]int{}
+	for _, it := range items {
+		got[it.Label] = it.Kind
+	}
+	if len(got) != 2 {
+		t.Fatalf("labels = %v, want exactly [Grid Row]", got)
+	}
+	for _, name := range []string{"Row", "Grid"} {
+		kind, ok := got[name]
+		if !ok {
+			t.Errorf("item %q missing from `<p.` completion", name)
+		} else if kind != ciKindClass {
+			t.Errorf("item %q kind = %d, want ciKindClass", name, kind)
+		}
+	}
+	if _, ok := got["Card"]; ok {
+		t.Errorf("plain component Card leaked into `<p.` completion")
+	}
+	if _, ok := got["Submit"]; ok {
+		t.Errorf("other type's method Submit leaked into `<p.` completion")
+	}
+	for _, it := range items {
+		if !strings.HasPrefix(it.SortText, "05") {
+			t.Errorf("item %q SortText = %q, want tierContext (05) prefix", it.Label, it.SortText)
+		}
+	}
+}
+
+// TestParamVarTagResolvesMethodComponents pins that a PARAMETER binding (the
+// `*Form`-typed param `f` of Page) resolves too, dereferencing the pointer to
+// key method components on the bare type name (codegen's parseRecv strips `*`).
+func TestParamVarTagResolvesMethodComponents(t *testing.T) {
+	pkg, src := methodComponentFixture(t)
+	off := strings.Index(src, "<p.Row") + len("<p.")
+	items := componentTagItems(pkg, "f", false, "page.gsx", off, "", 0, 0, encUTF8)
+	if len(items) != 1 || items[0].Label != "Submit" {
+		t.Fatalf("items = %+v, want exactly [Submit] for the *Form param `f`", items)
+	}
+	if items[0].Kind != ciKindClass {
+		t.Errorf("Submit kind = %d, want ciKindClass", items[0].Kind)
+	}
+}
+
+// TestReceiverVarUnknownQualifierEmpty pins that a qualifier resolving to no
+// in-scope value binding and no import yields an empty list (not a panic).
+func TestReceiverVarUnknownQualifierEmpty(t *testing.T) {
+	pkg, src := methodComponentFixture(t)
+	off := strings.Index(src, "<p.Row") + len("<p.")
+	if items := componentTagItems(pkg, "zzz", false, "page.gsx", off, "", 0, 0, encUTF8); len(items) != 0 {
+		t.Fatalf("items = %+v, want empty for an unresolvable qualifier", items)
+	}
+}
+
+// TestReceiverVarShadowsImport pins the Go-scoping precedence: when a qualifier
+// names BOTH an in-scope value binding and an import, the binding wins — the
+// import's components are never offered. Here `p` (the receiver var) shadows a
+// same-named imported package that declares a `.Button` component; `<p.▮` must
+// offer UsersPage's methods, not Button.
+func TestReceiverVarShadowsImport(t *testing.T) {
+	pkg, src := methodComponentFixture(t)
+	// Attach an import named "p" that declares a component, as importQualifierCandidates would surface it.
+	imp := types.NewPackage("example.com/app/pkgp", "p")
+	imp.MarkComplete()
+	pkg.Types.SetImports([]*types.Package{imp})
+	pkg.ComponentDecls[ComponentDeclKey{PackagePath: "example.com/app/pkgp", ComponentKey: ".Button"}] = nil
+
+	off := strings.Index(src, "<p.Row") + len("<p.")
+	items := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8)
+	for _, it := range items {
+		if it.Label == "Button" {
+			t.Fatalf("import component Button leaked past the shadowing receiver var: %+v", items)
+		}
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want the receiver var's methods [Grid Row]", items)
+	}
+}
+
+// TestReceiverVarBindingWithoutMethodsStopsFallback pins that once a qualifier
+// resolves to a value binding whose type declares NO method components, the
+// import fallback still does NOT run (the binding shadows the import): an empty
+// list, not the import's components. `p`'s type here is stripped of method
+// components, yet the same-named import's Button must stay hidden.
+func TestReceiverVarBindingWithoutMethodsStopsFallback(t *testing.T) {
+	pkg, src := methodComponentFixture(t)
+	delete(pkg.ComponentDecls, ComponentDeclKey{PackagePath: "example.com/app/page", ComponentKey: "UsersPage.Row"})
+	delete(pkg.ComponentDecls, ComponentDeclKey{PackagePath: "example.com/app/page", ComponentKey: "UsersPage.Grid"})
+	imp := types.NewPackage("example.com/app/pkgp", "p")
+	imp.MarkComplete()
+	pkg.Types.SetImports([]*types.Package{imp})
+	pkg.ComponentDecls[ComponentDeclKey{PackagePath: "example.com/app/pkgp", ComponentKey: ".Button"}] = nil
+
+	off := strings.Index(src, "<p.Row") + len("<p.")
+	if items := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8); len(items) != 0 {
+		t.Fatalf("items = %+v, want empty (receiver var shadows import even with no methods)", items)
+	}
+}
+
+// TestImportQualifierStillWinsWhenNotShadowed pins the fallback: a qualifier
+// that is NOT an in-scope value binding still resolves through the import path.
+func TestImportQualifierStillWinsWhenNotShadowed(t *testing.T) {
+	src := `package p
+
+import myui "strings"
+
+var _ = myui.ToUpper
+`
+	pkg, _ := buildSyntheticPackage(t, src)
+	pkg.ComponentDecls = map[ComponentDeclKey][]sourceintel.VersionedSpan{
+		{PackagePath: "strings", ComponentKey: ".Button"}: nil,
+	}
+	// No Files/GSXFset/SigTypes: enclosingComponentAt finds nothing, the package
+	// scope has no `myui` var, so resolution declines and the import path runs.
+	items := componentTagItems(pkg, "myui", false, "page.gsx", 10, "", 0, 0, encUTF8)
+	if len(items) != 1 || items[0].Label != "Button" {
+		t.Fatalf("items = %+v, want [Button] via import fallback", items)
+	}
+}

--- a/internal/lsp/completion_gsx_test.go
+++ b/internal/lsp/completion_gsx_test.go
@@ -707,7 +707,7 @@ func TestComponentAttrItems(t *testing.T) {
 	// Cursor position unrelated to the "title" attr's own span (e.g. right
 	// after the tag name, in the whitespace before "title").
 	cursor := strings.Index(src, "<Card") + len("<Card")
-	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8, false)
 
 	if len(items) != 1 {
 		t.Fatalf("items = %+v, want exactly 1 (count)", items)
@@ -783,7 +783,7 @@ func TestComponentAttrItemsExcludesGoOnlyVariadic(t *testing.T) {
 	}
 
 	cursor := strings.Index(src, "<Card") + len("<Card")
-	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8, false)
 
 	if len(items) != 1 {
 		t.Fatalf("items = %+v, want exactly 1 (count)", items)
@@ -805,7 +805,7 @@ func TestComponentAttrItemsCursorOnBoundAttrStaysOffered(t *testing.T) {
 
 	nameStart := strings.Index(src, "title")
 	nameEnd := nameStart + len("title")
-	items := componentAttrItems(pkg, el, false, src, nameStart, nameEnd, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, nameStart, nameEnd, encUTF8, false)
 
 	labels := map[string]bool{}
 	for _, it := range items {
@@ -840,17 +840,17 @@ func TestComponentAttrItemsNoFact(t *testing.T) {
 		return true
 	})
 	pkg := &Package{GSXFset: fset, Files: map[string]*gsxast.File{"page.gsx": f}, ComponentCalls: map[*gsxast.Element]ComponentCallFact{}}
-	if items := componentAttrItems(pkg, el, false, src, 0, 0, encUTF8); items != nil {
+	if items := componentAttrItems(pkg, el, false, src, 0, 0, encUTF8, false); items != nil {
 		t.Fatalf("items = %+v, want nil (no planned call fact)", items)
 	}
 }
 
 // TestComponentAttrItemsNilGuards checks that a nil pkg or nil el fails soft.
 func TestComponentAttrItemsNilGuards(t *testing.T) {
-	if items := componentAttrItems(nil, &gsxast.Element{}, false, "", 0, 0, encUTF8); items != nil {
+	if items := componentAttrItems(nil, &gsxast.Element{}, false, "", 0, 0, encUTF8, false); items != nil {
 		t.Fatalf("items = %+v, want nil for nil pkg", items)
 	}
-	if items := componentAttrItems(&Package{}, nil, false, "", 0, 0, encUTF8); items != nil {
+	if items := componentAttrItems(&Package{}, nil, false, "", 0, 0, encUTF8, false); items != nil {
 		t.Fatalf("items = %+v, want nil for nil el", items)
 	}
 }
@@ -917,7 +917,7 @@ func TestComponentAttrItemsAttrsCatchAllOffersHTMLGlobals(t *testing.T) {
 	pkg, el := componentAttrsCatchAllFixture(t, src, "icon.Bell", sig, nil)
 
 	cursor := strings.Index(src, "<icon.Bell") + len("<icon.Bell")
-	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8, false)
 
 	byLabel := map[string]CompletionItem{}
 	for _, it := range items {
@@ -952,6 +952,55 @@ func TestComponentAttrItemsAttrsCatchAllOffersHTMLGlobals(t *testing.T) {
 	}
 }
 
+// TestComponentAttrItemsAttrsCatchAllSnippetThreadsThrough checks that
+// snippet=true reaches the forwarded HTML-globals branch (threaded through to
+// the nested htmlAttrItems call): the value global `class` inserts
+// `class="$1"` with InsertTextFormat = Snippet, same as the plain-HTML path.
+// A NAMED component parameter, by contrast, is never a quote-value insert
+// (per the task-13 "no `={}` snippet" rule for named params) and must stay a
+// bare-name insert with InsertTextFormat unset even under snippet support —
+// this is the one deliberate place componentAttrItems does NOT apply the
+// gate, so pin it here alongside the branch that does.
+func TestComponentAttrItemsAttrsCatchAllSnippetThreadsThrough(t *testing.T) {
+	src := "package page\n\ncomponent Home() {\n\t<icon.Bell/>\n}\n"
+	params := types.NewTuple(
+		types.NewVar(token.NoPos, nil, "title", types.Typ[types.String]),
+		types.NewVar(token.NoPos, nil, "attrs", types.NewSlice(types.Typ[types.Int])),
+	)
+	sig := types.NewSignatureType(nil, nil, nil, params, nil, true)
+	pkg, el := componentAttrsCatchAllFixture(t, src, "icon.Bell", sig, nil)
+
+	cursor := strings.Index(src, "<icon.Bell") + len("<icon.Bell")
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8, true)
+
+	byLabel := map[string]CompletionItem{}
+	for _, it := range items {
+		byLabel[it.Label] = it
+	}
+
+	class, ok := byLabel["class"]
+	if !ok {
+		t.Fatalf("labels = %v, want forwarded global %q offered", byLabel, "class")
+	}
+	if class.TextEdit == nil || class.TextEdit.NewText != `class="$1"` {
+		t.Errorf("class.TextEdit = %+v, want NewText %q", class.TextEdit, `class="$1"`)
+	}
+	if class.InsertTextFormat != insertTextFormatSnippet {
+		t.Errorf("class.InsertTextFormat = %d, want insertTextFormatSnippet (2)", class.InsertTextFormat)
+	}
+
+	title, ok := byLabel["title"]
+	if !ok {
+		t.Fatalf("labels = %v, want named param %q offered", byLabel, "title")
+	}
+	if title.TextEdit == nil || title.TextEdit.NewText != "title" {
+		t.Errorf("title.TextEdit = %+v, want bare NewText %q (named params never snippet)", title.TextEdit, "title")
+	}
+	if title.InsertTextFormat != 0 {
+		t.Errorf("title.InsertTextFormat = %d, want 0 (named params never snippet)", title.InsertTextFormat)
+	}
+}
+
 // TestComponentAttrItemsNoAttrsCatchAllNoHTMLGlobals checks the negative
 // case: a plain-props signature with no "attrs" catch-all offers only the
 // named params — no HTML globals leak in (an unknown attribute would be
@@ -966,7 +1015,7 @@ func TestComponentAttrItemsNoAttrsCatchAllNoHTMLGlobals(t *testing.T) {
 	pkg, el := componentAttrsCatchAllFixture(t, src, "Card", sig, nil)
 
 	cursor := strings.Index(src, "<Card") + len("<Card")
-	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8, false)
 
 	labels := map[string]bool{}
 	for _, it := range items {
@@ -999,7 +1048,7 @@ func TestComponentAttrItemsAttrsCatchAllPresentAttrExcluded(t *testing.T) {
 	// Cursor elsewhere (right after the tag name): "class" already present,
 	// must be excluded.
 	elsewhere := strings.Index(src, "<icon.Bell") + len("<icon.Bell")
-	items := componentAttrItems(pkg, el, false, src, elsewhere, elsewhere, encUTF8)
+	items := componentAttrItems(pkg, el, false, src, elsewhere, elsewhere, encUTF8, false)
 	for _, it := range items {
 		if it.Label == "class" {
 			t.Fatalf("items = %+v, must exclude already-present %q", items, "class")
@@ -1009,7 +1058,7 @@ func TestComponentAttrItemsAttrsCatchAllPresentAttrExcluded(t *testing.T) {
 	// Cursor ON the "class" token itself: carve-out keeps it offered.
 	nameStart := strings.Index(src, "class")
 	nameEnd := nameStart + len("class")
-	onToken := componentAttrItems(pkg, el, false, src, nameStart, nameEnd, encUTF8)
+	onToken := componentAttrItems(pkg, el, false, src, nameStart, nameEnd, encUTF8, false)
 	found := false
 	for _, it := range onToken {
 		if it.Label == "class" {
@@ -1033,14 +1082,14 @@ func TestComponentAttrItemsAttrsCatchAllHTMXGated(t *testing.T) {
 	pkg, el := componentAttrsCatchAllFixture(t, src, "icon.Bell", sig, nil)
 	cursor := strings.Index(src, "<icon.Bell") + len("<icon.Bell")
 
-	off := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8)
+	off := componentAttrItems(pkg, el, false, src, cursor, cursor, encUTF8, false)
 	for _, it := range off {
 		if strings.HasPrefix(it.Label, "hx-") {
 			t.Fatalf("items = %+v, must NOT offer hx-* when htmxEnabled=false", off)
 		}
 	}
 
-	on := componentAttrItems(pkg, el, true, src, cursor, cursor, encUTF8)
+	on := componentAttrItems(pkg, el, true, src, cursor, cursor, encUTF8, false)
 	foundHx := false
 	for _, it := range on {
 		if strings.HasPrefix(it.Label, "hx-") {

--- a/internal/lsp/completion_gsx_test.go
+++ b/internal/lsp/completion_gsx_test.go
@@ -270,7 +270,7 @@ func componentTagFixturePackage() *Package {
 // qualifiers (sorted) — deterministic despite ComponentDecls being a map.
 func TestComponentTagItemsBareCursor(t *testing.T) {
 	pkg := componentTagFixturePackage()
-	items := componentTagItems(pkg, "", false, "", 0, 0, encUTF8)
+	items := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
 	if len(items) != 2 {
 		t.Fatalf("len(items) = %d, want 2: %+v", len(items), items)
 	}
@@ -297,7 +297,7 @@ func TestComponentTagItemsBareCursor(t *testing.T) {
 // package's plain component ("Button"), dot-free.
 func TestComponentTagItemsQualified(t *testing.T) {
 	pkg := componentTagFixturePackage()
-	items := componentTagItems(pkg, "ui", false, "", 0, 0, encUTF8)
+	items := componentTagItems(pkg, "ui", false, "", 0, "", 0, 0, encUTF8)
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d, want 1: %+v", len(items), items)
 	}
@@ -313,7 +313,7 @@ func TestComponentTagItemsQualified(t *testing.T) {
 // matching no import's Name() yields an empty list, not a panic.
 func TestComponentTagItemsQualifiedUnknownImport(t *testing.T) {
 	pkg := componentTagFixturePackage()
-	if items := componentTagItems(pkg, "nope", false, "", 0, 0, encUTF8); len(items) != 0 {
+	if items := componentTagItems(pkg, "nope", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("items = %+v, want empty for an unresolvable qualifier", items)
 	}
 }
@@ -325,7 +325,7 @@ func TestComponentTagItemsNilTypesFailsSoft(t *testing.T) {
 	pkg := &Package{ComponentDecls: map[ComponentDeclKey][]sourceintel.VersionedSpan{
 		{PackagePath: "example.com/app/page", ComponentKey: ".Card"}: nil,
 	}}
-	if items := componentTagItems(pkg, "", false, "", 0, 0, encUTF8); len(items) != 0 {
+	if items := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("items = %+v, want empty when pkg.Types is nil", items)
 	}
 }
@@ -352,17 +352,17 @@ var _ = myui.ToUpper
 		{PackagePath: "strings", ComponentKey: ".Button"}: nil,
 	}
 
-	items := componentTagItems(pkg, "myui", false, "", 0, 0, encUTF8)
+	items := componentTagItems(pkg, "myui", false, "", 0, "", 0, 0, encUTF8)
 	if len(items) != 1 || items[0].Label != "Button" {
 		t.Fatalf("qualifier=%q items = %+v, want exactly [Button]", "myui", items)
 	}
 
 	// The declared name ("strings") must NOT resolve — only the alias does.
-	if items := componentTagItems(pkg, "strings", false, "", 0, 0, encUTF8); len(items) != 0 {
+	if items := componentTagItems(pkg, "strings", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("qualifier=%q items = %+v, want empty (declared name is not the local name)", "strings", items)
 	}
 
-	bareItems := componentTagItems(pkg, "", false, "", 0, 0, encUTF8)
+	bareItems := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
 	var qualItem *CompletionItem
 	for i := range bareItems {
 		if bareItems[i].Kind == ciKindModule {
@@ -456,7 +456,7 @@ func buildIconValueComponentFixture() *Package {
 // ciKindClass), BadParam/WrongResult/unexp are not.
 func TestComponentValueNameItemsQualified(t *testing.T) {
 	pkg := buildIconValueComponentFixture()
-	items := componentTagItems(pkg, "icon", false, "", 0, 0, encUTF8)
+	items := componentTagItems(pkg, "icon", false, "", 0, "", 0, 0, encUTF8)
 	got := map[string]CompletionItem{}
 	for _, it := range items {
 		got[it.Label] = it
@@ -485,7 +485,7 @@ func TestComponentValueNameItemsQualified(t *testing.T) {
 // though it has zero ComponentDecls entries.
 func TestComponentValueNameItemsBareCursorLocal(t *testing.T) {
 	pkg := buildIconValueComponentFixture()
-	items := componentTagItems(pkg, "", false, "", 0, 0, encUTF8)
+	items := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
 	var local, qual *CompletionItem
 	for i := range items {
 		switch items[i].Label {
@@ -518,7 +518,7 @@ func TestComponentValueNameItemsDedup(t *testing.T) {
 	pkg.ComponentDecls = map[ComponentDeclKey][]sourceintel.VersionedSpan{
 		{PackagePath: "github.com/tespkg/one-learning/ds/icon", ComponentKey: ".X"}: nil,
 	}
-	items := componentTagItems(pkg, "icon", false, "", 0, 0, encUTF8)
+	items := componentTagItems(pkg, "icon", false, "", 0, "", 0, 0, encUTF8)
 	count := 0
 	for _, it := range items {
 		if it.Label == "X" {

--- a/internal/lsp/completion_html.go
+++ b/internal/lsp/completion_html.go
@@ -45,7 +45,11 @@ func htmlTagItems(prefixCapitalized bool, text string, start, end int, enc encod
 // that gsx.IsBooleanAttr classifies as boolean — insert the bare name (`hidden`):
 // their presence alone is the value. Every other attribute inserts `name=""`
 // with FilterText = name, so the client keeps matching against the name the user
-// typed while the edit drops the cursor inside the quotes' worth of text.
+// typed while the edit drops the cursor inside the quotes' worth of text — or,
+// when snippet is true (the client advertised snippetSupport), `name="$1"`
+// with InsertTextFormat = Snippet, so the cursor lands INSIDE the quotes
+// instead of after them. Boolean attributes are unaffected either way: there
+// are no quotes for a cursor to land inside.
 //
 // el is the CLASSIFICATION-parse element (repairAtCursor's own parse of the
 // cursor buffer). Unlike the component path this needs no ephemeral-analysis
@@ -61,7 +65,7 @@ func htmlTagItems(prefixCapitalized bool, text string, start, end int, enc encod
 // rank this list against sibling candidates: tierContext for the direct HTML
 // path, tierSecondary for the forwarded-globals path so real component params
 // sort first.
-func htmlAttrItems(el *gsxast.Element, tagName string, htmxEnabled bool, tier int, text string, start, end int, enc encoding) []CompletionItem {
+func htmlAttrItems(el *gsxast.Element, tagName string, htmxEnabled bool, tier int, text string, start, end int, enc encoding, snippet bool) []CompletionItem {
 	// typed is the attribute-name token the cursor sits on. When a present
 	// attribute's lowercase name exact-matches it, that attribute must stay
 	// offered rather than be excluded as "already present" — the cursor is
@@ -102,12 +106,23 @@ func htmlAttrItems(el *gsxast.Element, tagName string, htmxEnabled bool, tier in
 		seen[lower] = true
 		if attr.Boolean() || gsx.IsBooleanAttr(attr.Name) {
 			// Presence-only: insert the bare name.
-			items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, attr.Name, ciKindField, tier, markdownDoc(attr.Doc)))
+			items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, attr.Name, ciKindField, tier, markdownDoc(attr.Doc), insertTextFormatPlainText))
 			continue
 		}
-		// Value attribute: insert `name=""`, but keep FilterText = name so the
-		// client matches against the typed name, not the `=""` suffix.
-		items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, attr.Name+`=""`, ciKindField, tier, markdownDoc(attr.Doc)))
+		// Value attribute: insert `name=""` (or `name="$1"` under snippet
+		// support), but keep FilterText = name so the client matches against
+		// the typed name, not the inserted suffix. attr.Name is a dataset
+		// attribute name (letters/digits/dash only, never `$`), so there is no
+		// literal-`$` escaping concern in the snippet body here — an
+		// interpolated VALUE would need `$`→`\$` escaping, but no caller ever
+		// puts one in this position.
+		newText := attr.Name + `=""`
+		format := insertTextFormatPlainText
+		if snippet {
+			newText = attr.Name + `="$1"`
+			format = insertTextFormatSnippet
+		}
+		items = append(items, htmlAttrItem(text, start, end, enc, attr.Name, newText, ciKindField, tier, markdownDoc(attr.Doc), format))
 	}
 	return items
 }
@@ -168,11 +183,18 @@ func valueSetFor(tagName, attrName string) string {
 
 // htmlAttrItem builds an attribute-name completion item. It differs from
 // newCompletionItem in one way that matters: for a value attribute newText is
-// `name=""` but FilterText must stay the bare name so the client matches the
-// user's typed prefix against the name, not the `=""` insertion. newText == the
-// name for a boolean attribute, in which case FilterText is left unset (the
-// client falls back to the label).
-func htmlAttrItem(text string, start, end int, enc encoding, name, newText string, kind int, tier int, doc *MarkupContent) CompletionItem {
+// `name=""` (or `name="$1"`) but FilterText must stay the bare name so the
+// client matches the user's typed prefix against the name, not the inserted
+// suffix. newText == the name for a boolean attribute, in which case
+// FilterText is left unset (the client falls back to the label).
+//
+// insertTextFormat is insertTextFormatPlainText for every caller except a
+// snippet-support value-attribute insert, which passes insertTextFormatSnippet.
+// PlainText is the LSP-assumed default, so it is deliberately left off the
+// wire (CompletionItem.InsertTextFormat's zero value, elided by omitempty)
+// rather than sent as an explicit `"insertTextFormat":1` on every single
+// item — only a Snippet insert ever needs the field at all.
+func htmlAttrItem(text string, start, end int, enc encoding, name, newText string, kind int, tier int, doc *MarkupContent, insertTextFormat int) CompletionItem {
 	item := CompletionItem{
 		Label:         name,
 		Kind:          kind,
@@ -182,6 +204,9 @@ func htmlAttrItem(text string, start, end int, enc encoding, name, newText strin
 			Range:   rangeForSpan(text, start, end, enc),
 			NewText: newText,
 		},
+	}
+	if insertTextFormat != insertTextFormatPlainText {
+		item.InsertTextFormat = insertTextFormat
 	}
 	if newText != name {
 		item.FilterText = name

--- a/internal/lsp/completion_html_test.go
+++ b/internal/lsp/completion_html_test.go
@@ -88,7 +88,7 @@ func TestHTMLTagItems(t *testing.T) {
 // attributes remain offered.
 func TestHTMLAttrItemsExcludesPresent(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div class=\"x\"/>\n}\n", "div")
-	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8, false)
 	labels := labelSet(items)
 	if labels["class"] {
 		t.Errorf("attr list still offers already-present `class`: %v", labels)
@@ -111,7 +111,7 @@ func TestHTMLAttrItemsCursorOnPresentAttrStaysOffered(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div class=\"x\" id=\"y\"/>\n}\n", "div")
 
 	text := "class"
-	items := htmlAttrItems(el, "div", false, tierContext, text, 0, len(text), encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, text, 0, len(text), encUTF8, false)
 	labels := labelSet(items)
 	if !labels["class"] {
 		t.Errorf("labels = %v, want `class` offered (cursor is on its own token)", labels)
@@ -125,7 +125,7 @@ func TestHTMLAttrItemsCursorOnPresentAttrStaysOffered(t *testing.T) {
 	}
 
 	for _, typed := range []string{"cl", ""} {
-		items := htmlAttrItems(el, "div", false, tierContext, typed, 0, len(typed), encUTF8)
+		items := htmlAttrItems(el, "div", false, tierContext, typed, 0, len(typed), encUTF8, false)
 		labels := labelSet(items)
 		if labels["class"] {
 			t.Errorf("typed %q: labels = %v, want `class` excluded (not an exact match)", typed, labels)
@@ -140,7 +140,7 @@ func TestHTMLAttrItemsCursorOnPresentAttrStaysOffered(t *testing.T) {
 // dataset valueSet "v") inserts the bare name with no `=""` and no FilterText.
 func TestHTMLAttrItemsBooleanBareName(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div/>\n}\n", "div")
-	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8, false)
 	hidden := itemByLabel(items, "hidden")
 	if hidden == nil {
 		t.Fatal("attr list missing boolean `hidden`")
@@ -158,7 +158,7 @@ func TestHTMLAttrItemsBooleanBareName(t *testing.T) {
 // the client keeps matching against the typed name, not the `=""` suffix.
 func TestHTMLAttrItemsValueInsertsEquals(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div/>\n}\n", "div")
-	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8, false)
 	class := itemByLabel(items, "class")
 	if class == nil {
 		t.Fatal("attr list missing value attr `class`")
@@ -171,11 +171,50 @@ func TestHTMLAttrItemsValueInsertsEquals(t *testing.T) {
 	}
 }
 
+// TestHTMLAttrItemsSnippetInsertsTabstop checks the snippet-gated path: with
+// snippet=true, a value attribute (`class`) inserts `class="$1"` with
+// InsertTextFormat = Snippet (so the cursor lands inside the quotes) and
+// FilterText UNCHANGED (still the bare name, matching the non-snippet case) —
+// while a boolean attribute (`hidden`) stays a bare, unformatted insert:
+// there are no quotes for a snippet tabstop to land inside.
+func TestHTMLAttrItemsSnippetInsertsTabstop(t *testing.T) {
+	el := parseElement(t, "package p\ncomponent C() {\n\t<div/>\n}\n", "div")
+	items := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8, true)
+
+	class := itemByLabel(items, "class")
+	if class == nil {
+		t.Fatal("attr list missing value attr `class`")
+	}
+	if class.TextEdit == nil || class.TextEdit.NewText != `class="$1"` {
+		t.Errorf("class.TextEdit = %+v, want NewText %q", class.TextEdit, `class="$1"`)
+	}
+	if class.InsertTextFormat != insertTextFormatSnippet {
+		t.Errorf("class.InsertTextFormat = %d, want insertTextFormatSnippet (2)", class.InsertTextFormat)
+	}
+	if class.FilterText != "class" {
+		t.Errorf("class.FilterText = %q, want %q (unchanged by snippet)", class.FilterText, "class")
+	}
+
+	hidden := itemByLabel(items, "hidden")
+	if hidden == nil {
+		t.Fatal("attr list missing boolean `hidden`")
+	}
+	if hidden.TextEdit == nil || hidden.TextEdit.NewText != "hidden" {
+		t.Errorf("hidden.TextEdit = %+v, want bare NewText %q even with snippet support", hidden.TextEdit, "hidden")
+	}
+	if hidden.InsertTextFormat != 0 {
+		t.Errorf("hidden.InsertTextFormat = %d, want 0 (PlainText/omitted; no quotes to tabstop into)", hidden.InsertTextFormat)
+	}
+	if hidden.FilterText != "" {
+		t.Errorf("hidden.FilterText = %q, want empty (bare name == label)", hidden.FilterText)
+	}
+}
+
 // TestHTMLAttrItemsInputType checks the per-tag attribute path: `type` on
 // <input> is an enumerated (non-boolean) attribute, so it inserts `type=""`.
 func TestHTMLAttrItemsInputType(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<input/>\n}\n", "input")
-	items := htmlAttrItems(el, "input", false, tierContext, "", 0, 0, encUTF8)
+	items := htmlAttrItems(el, "input", false, tierContext, "", 0, 0, encUTF8, false)
 	typ := itemByLabel(items, "type")
 	if typ == nil {
 		t.Fatal("input attr list missing `type`")
@@ -190,12 +229,12 @@ func TestHTMLAttrItemsInputType(t *testing.T) {
 func TestHTMLAttrItemsHTMXGated(t *testing.T) {
 	el := parseElement(t, "package p\ncomponent C() {\n\t<div/>\n}\n", "div")
 
-	off := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8)
+	off := htmlAttrItems(el, "div", false, tierContext, "", 0, 0, encUTF8, false)
 	if labelSet(off)["hx-get"] {
 		t.Errorf("hx-get offered with htmx disabled")
 	}
 
-	on := htmlAttrItems(el, "div", true, tierContext, "", 0, 0, encUTF8)
+	on := htmlAttrItems(el, "div", true, tierContext, "", 0, 0, encUTF8, false)
 	hxGet := itemByLabel(on, "hx-get")
 	if hxGet == nil {
 		t.Fatalf("hx-get NOT offered with htmx enabled")
@@ -303,6 +342,41 @@ func TestAttrNameCompletionHTMLPath(t *testing.T) {
 	}
 	if class := itemByLabel(items, "class"); class == nil || class.TextEdit.NewText != `class=""` {
 		t.Errorf("class must insert `class=\"\"`; got %+v", class)
+	}
+}
+
+// TestAttrNameCompletionHTMLPathSnippet drives the same HTML attribute-name
+// position as TestAttrNameCompletionHTMLPath, but through an initialize frame
+// that advertises snippetSupport (snippetInitFrame). The end-to-end wiring
+// under test: handleInitialize captures the capability onto s.snippetSupport,
+// which reaches htmlAttrItems via attrNameCompletion — so `class` now inserts
+// `class="$1"` with InsertTextFormat = Snippet, while `hidden` (no quotes to
+// place a cursor inside) is unaffected.
+func TestAttrNameCompletionHTMLPathSnippet(t *testing.T) {
+	uri := "file:///m/a.gsx"
+	text := "package p\n\ncomponent C() {\n\t<div ></div>\n}\n"
+	off := strings.Index(text, "<div ") + len("<div ")
+	pos := positionForByteOffset(text, off, encUTF16)
+
+	a := tagCompletionAnalyzer{ephPkg: &Package{}}
+	out := drive(t, a, snippetInitFrame()+didOpenFrame(uri, text)+
+		completionFrame(2, uri, pos)+exitFrame())
+	items := decodeCompletionItems(t, out, 2)
+
+	class := itemByLabel(items, "class")
+	if class == nil || class.TextEdit == nil || class.TextEdit.NewText != `class="$1"` {
+		t.Fatalf("class must insert `class=\"$1\"` under snippetSupport; got %+v", class)
+	}
+	if class.InsertTextFormat != insertTextFormatSnippet {
+		t.Errorf("class.InsertTextFormat = %d, want insertTextFormatSnippet (2)", class.InsertTextFormat)
+	}
+
+	hidden := itemByLabel(items, "hidden")
+	if hidden == nil || hidden.TextEdit == nil || hidden.TextEdit.NewText != "hidden" {
+		t.Errorf("hidden must still insert the bare name under snippetSupport; got %+v", hidden)
+	}
+	if hidden.InsertTextFormat != 0 {
+		t.Errorf("hidden.InsertTextFormat = %d, want 0 (no quotes to tabstop into)", hidden.InsertTextFormat)
 	}
 }
 

--- a/internal/lsp/completion_resolve.go
+++ b/internal/lsp/completion_resolve.go
@@ -1,0 +1,221 @@
+package lsp
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// handleCompletionResolve answers completionItem/resolve (T10): the client
+// sends back one CompletionItem — verbatim, Data included — that it received
+// from an earlier textDocument/completion reply, and expects the same item
+// back with Documentation filled in. Every failure mode replies the item
+// UNCHANGED (fail soft: resolve is advisory, never an error) — no Data (the
+// item's doc was already eager, or it carries none), a Data.File that fails
+// the resolvablePath security gate, or a malformed Data payload (decoded
+// separately as json.RawMessage below specifically so a malformed "data"
+// value degrades to "item unchanged, Data dropped" rather than losing the
+// whole item — see the field-shadowing comment on the anonymous struct).
+//
+// resolve is deliberately ANALYZER-FREE: Data{file,line} is a location the
+// server itself already resolved via go/packages or //line-mapped skeleton
+// coordinates at list-build time (see completion_go.go/completion_gsx.go), so
+// answering it is pure file I/O — read the file (cached; dependency files are
+// immutable within a session), parse it with comments, and extract the doc
+// comment at that line. No Package/Analyzer lookup, no re-analysis.
+func (s *Server) handleCompletionResolve(f frame) error {
+	// raw.Data (json.RawMessage, depth 0) shadows the embedded
+	// CompletionItem.Data (*completionResolveData, depth 1, same "data" json
+	// tag) per encoding/json's shallowest-field-wins rule, so "data" always
+	// decodes into raw.Data here regardless of its shape — a malformed Data
+	// value can never fail the unmarshal of the REST of the item.
+	var raw struct {
+		CompletionItem
+		Data json.RawMessage `json:"data,omitempty"`
+	}
+	if err := json.Unmarshal(f.Params, &raw); err != nil {
+		return s.reply(f.ID, CompletionItem{})
+	}
+	item := raw.CompletionItem
+	item.Data = nil
+	if len(raw.Data) == 0 || string(raw.Data) == "null" {
+		return s.reply(f.ID, item)
+	}
+	var data completionResolveData
+	if err := json.Unmarshal(raw.Data, &data); err != nil {
+		return s.reply(f.ID, item) // malformed Data: rest of the item unchanged
+	}
+	if !s.resolvablePath(data.File) {
+		return s.reply(f.ID, item)
+	}
+	if doc, ok := s.depDocs.doc(data.File, data.Line); ok {
+		item.Documentation = markdownDoc(doc)
+	}
+	return s.reply(f.ID, item)
+}
+
+// resolvablePath is the SECURITY gate for completionItem/resolve.
+//
+// THREAT MODEL: CompletionItem.Data round-trips through the CLIENT — that is
+// the LSP contract (textDocument/completion emits it, completionItem/resolve
+// receives it back unchanged). A hostile or merely buggy client is therefore
+// free to send completionItem/resolve with an ARBITRARY {file,line} pair the
+// server never emitted. If the handler blindly read whatever path it was
+// given and returned the text found there as "documentation", it would be a
+// generic file-exfiltration primitive: any file readable by the gsx-lsp
+// process — source code, credentials, anything — could be read back through
+// an otherwise read-only, advisory completion reply.
+//
+// THE GATE: only serve resolve for a path that is (a) an absolute path
+// ending in ".go", AND (b) located under one of a small set of roots the
+// server itself could ever have legitimately emitted a position under:
+//   - GOMODCACHE (third-party dependency source, and — when the analyzed
+//     module pins a toolchain via `go`/`toolchain` directives — the
+//     downloaded toolchain's own stdlib source, which Go also places under
+//     GOMODCACHE as golang.org/toolchain@..., not GOROOT)
+//   - GOROOT (the running gsx binary's own toolchain stdlib, for the common
+//     case where no separate toolchain download applies)
+//   - every negotiated workspace's Go module roots (s.workspaceModules) — the
+//     user's own source, already fully readable by every other LSP feature
+//     (hover, go-to-definition, etc.)
+//
+// Anything else — an absolute path elsewhere on disk, a relative path, a
+// path that Cleans to escape one of the roots via "..", or a non-.go suffix —
+// is rejected outright, with NO file read attempted.
+func (s *Server) resolvablePath(path string) bool {
+	if path == "" || !strings.HasSuffix(path, ".go") || !filepath.IsAbs(path) {
+		return false
+	}
+	clean := filepath.Clean(path)
+	for _, root := range s.resolveRoots() {
+		if root != "" && underRoot(clean, root) {
+			return true
+		}
+	}
+	return false
+}
+
+// underRoot reports whether clean path p is root itself or a descendant of
+// root, comparing Cleaned paths so a "root/../elsewhere" escape is rejected
+// (filepath.Rel below would report a leading ".." for it, which is excluded).
+func underRoot(p, root string) bool {
+	root = filepath.Clean(root)
+	if p == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// resolveRoots returns the full allow-list for resolvablePath: GOMODCACHE,
+// GOROOT, and this server's current negotiated workspace module roots.
+// Recomputed on every call rather than memoized: goModCacheDir/build.Default
+// are plain env/in-memory lookups (no filesystem access, no subprocess), so
+// there is no measurable cost to paying it fresh per resolve request — and
+// staying fresh is what lets GOMODCACHE/GOPATH be overridden per-test (or, in
+// principle, mid-session) without a stale first-call value sticking for the
+// rest of the process. GOROOT comes from go/build.Default.GOROOT (honors a
+// GOROOT env override, else the toolchain's compiled-in default) rather than
+// runtime.GOROOT() — deprecated since Go 1.24 precisely because it reflects
+// the BUILDING toolchain's root, not necessarily the one that type-checked
+// the analyzed module if the binary was copied elsewhere.
+func (s *Server) resolveRoots() []string {
+	roots := make([]string, 0, 2+len(s.workspaceModules))
+	roots = append(roots, goModCacheDir(), build.Default.GOROOT)
+	roots = append(roots, s.workspaceModules...)
+	return roots
+}
+
+// goModCacheDir returns the effective GOMODCACHE directory without invoking
+// `go env` (a subprocess per lookup is not warranted for a value that only
+// changes with the environment): GOMODCACHE if explicitly set, otherwise Go's
+// documented default of the first GOPATH entry's pkg/mod (GOPATH itself
+// defaulting to ~/go when unset) — see `go help environment`. Returns "" only
+// when even the home directory cannot be determined, in which case that empty
+// root is simply never matched (resolvablePath skips empty roots).
+func goModCacheDir() string {
+	if v := os.Getenv("GOMODCACHE"); v != "" {
+		return filepath.Clean(v)
+	}
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		gopath = filepath.Join(home, "go")
+	}
+	if i := strings.IndexRune(gopath, os.PathListSeparator); i >= 0 {
+		gopath = gopath[:i]
+	}
+	if gopath == "" {
+		return ""
+	}
+	return filepath.Join(gopath, "pkg", "mod")
+}
+
+// depDocCache caches completionItem/resolve's dependency-file doc lookups by
+// absolute file path. Files under GOMODCACHE/GOROOT are immutable within a
+// session (a module-cache entry is content-addressed; the running toolchain's
+// stdlib does not change under a live server), so a hit never needs
+// invalidation — this mirrors gopls's own module-cache caching assumption.
+type depDocCache struct {
+	mu      sync.Mutex
+	byPath  map[string]*ast.File
+	fileSet map[string]*token.FileSet // paired 1:1 with byPath, same key
+}
+
+func newDepDocCache() *depDocCache {
+	return &depDocCache{byPath: map[string]*ast.File{}, fileSet: map[string]*token.FileSet{}}
+}
+
+// doc returns the doc-comment text of the declaration whose name identifier
+// sits on 1-based line in the real Go file at absPath, parsing (and caching)
+// the file on first use. ok=false when the file cannot be read/parsed, or no
+// declaration's identifier lands on line, or that declaration has no doc
+// comment.
+func (c *depDocCache) doc(absPath string, line int) (string, bool) {
+	f, fset, ok := c.parsed(absPath)
+	if !ok {
+		return "", false
+	}
+	lineOf := func(id *ast.Ident) (int, bool) {
+		if id == nil {
+			return 0, false
+		}
+		return fset.Position(id.Pos()).Line, true
+	}
+	text, found := declDocsByLine(f.Decls, lineOf)[line]
+	return text, found
+}
+
+func (c *depDocCache) parsed(absPath string) (*ast.File, *token.FileSet, bool) {
+	c.mu.Lock()
+	f, hit := c.byPath[absPath]
+	fset := c.fileSet[absPath]
+	c.mu.Unlock()
+	if hit {
+		return f, fset, f != nil
+	}
+
+	fset = token.NewFileSet()
+	f, err := parser.ParseFile(fset, absPath, nil, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		f = nil // cache the miss too — an unreadable/unparseable dep file stays that way
+	}
+
+	c.mu.Lock()
+	c.byPath[absPath] = f
+	c.fileSet[absPath] = fset
+	c.mu.Unlock()
+	return f, fset, f != nil
+}

--- a/internal/lsp/completion_resolve_test.go
+++ b/internal/lsp/completion_resolve_test.go
@@ -1,0 +1,222 @@
+package lsp
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// callResolve drives one completionItem/resolve request straight at
+// handleCompletionResolve (no full initialize/didOpen dance needed: the
+// handler is analyzer-free, see its doc comment) and returns the decoded
+// reply item.
+func callResolve(t *testing.T, params any) CompletionItem {
+	t.Helper()
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	srv := NewServer(nil, &out, nilAnalyzer{})
+	if err := srv.handleCompletionResolve(frame{ID: json.RawMessage("7"), Params: data}); err != nil {
+		t.Fatalf("handleCompletionResolve: %v", err)
+	}
+	msgs := readFrames(t, out.String())
+	if len(msgs) != 1 {
+		t.Fatalf("got %d frames, want 1: %s", len(msgs), out.String())
+	}
+	var item CompletionItem
+	if err := json.Unmarshal(msgs[0]["result"], &item); err != nil {
+		t.Fatalf("decode result: %v (%s)", err, msgs[0]["result"])
+	}
+	return item
+}
+
+// writeGoFile writes a real .go file with a documented func and returns its
+// absolute path plus the 1-based line of the func's name identifier.
+func writeGoFile(t *testing.T, dir, name string) (path string, line int) {
+	t.Helper()
+	const content = "package dep\n\n// Greet returns a friendly hello for name.\nfunc Greet(name string) string {\n\treturn \"hello \" + name\n}\n"
+	path = filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path, 4 // "func Greet(..." is line 4
+}
+
+// TestHandleCompletionResolveNoDataUnchanged: an item with no Data comes
+// back byte-for-byte unchanged (no Documentation fabricated).
+func TestHandleCompletionResolveNoDataUnchanged(t *testing.T) {
+	item := callResolve(t, map[string]any{"label": "Foo", "detail": "func()"})
+	if item.Label != "Foo" || item.Detail != "func()" {
+		t.Errorf("item = %+v, want Label=Foo Detail=func() unchanged", item)
+	}
+	if item.Documentation != nil {
+		t.Errorf("item.Documentation = %+v, want nil (no Data to resolve)", item.Documentation)
+	}
+}
+
+// TestHandleCompletionResolveMalformedDataUnchanged: a "data" value that
+// does not match {file,line} (here, a bare string instead of an object)
+// leaves the rest of the item untouched — no crash, no fabricated doc, and
+// critically no file read is attempted (there is no interpretable path).
+func TestHandleCompletionResolveMalformedDataUnchanged(t *testing.T) {
+	item := callResolve(t, map[string]any{"label": "Bar", "data": "not-an-object"})
+	if item.Label != "Bar" {
+		t.Errorf("item.Label = %q, want %q (rest of item preserved despite malformed Data)", item.Label, "Bar")
+	}
+	if item.Documentation != nil {
+		t.Errorf("item.Documentation = %+v, want nil (malformed Data must not resolve)", item.Documentation)
+	}
+}
+
+// TestHandleCompletionResolveOutsideAllowedRootsRejected pins the SECURITY
+// gate (resolvablePath): a real, readable, well-formed {file,line} payload
+// pointing at a sentinel .go file OUTSIDE every allowed root (GOMODCACHE,
+// GOROOT, workspace module roots) must be rejected — Documentation stays
+// nil, proving no file read was even attempted for a location the server
+// itself could never have emitted.
+func TestHandleCompletionResolveOutsideAllowedRootsRejected(t *testing.T) {
+	// Point GOMODCACHE somewhere else entirely so the sentinel (under a
+	// DIFFERENT temp dir) is provably outside it; resolveRoots reads the env
+	// fresh on every call (no process-wide memoization), so t.Setenv is
+	// sufficient and self-reverting.
+	t.Setenv("GOMODCACHE", t.TempDir())
+	outsideDir := t.TempDir()
+	path, line := writeGoFile(t, outsideDir, "dep/dep.go")
+
+	item := callResolve(t, map[string]any{
+		"label": "Greet",
+		"data":  map[string]any{"file": path, "line": line},
+	})
+	if item.Documentation != nil {
+		t.Errorf("resolve on a path outside every allowed root returned Documentation = %+v, want nil (rejected)", item.Documentation)
+	}
+}
+
+// TestHandleCompletionResolveWithinGOMODCACHERoundTrips is the positive
+// counterpart: a {file,line} payload for a real, documented func sitting
+// UNDER a (test-pointed) GOMODCACHE resolves successfully end to end.
+func TestHandleCompletionResolveWithinGOMODCACHERoundTrips(t *testing.T) {
+	modCache := t.TempDir()
+	t.Setenv("GOMODCACHE", modCache)
+	path, line := writeGoFile(t, modCache, "example.com/dep@v1.0.0/dep.go")
+
+	item := callResolve(t, map[string]any{
+		"label": "Greet",
+		"data":  map[string]any{"file": path, "line": line},
+	})
+	if item.Documentation == nil {
+		t.Fatal("resolve on a path under GOMODCACHE returned nil Documentation, want the func's doc comment")
+	}
+	if got := item.Documentation.Value; got != "Greet returns a friendly hello for name." {
+		t.Errorf("Documentation.Value = %q, want the doc comment text", got)
+	}
+}
+
+// TestResolvablePathRejectsNonGoSuffix pins the .go-suffix half of the gate
+// independent of the root check: even a path physically under GOMODCACHE is
+// rejected if it doesn't end in ".go" (e.g. a go.sum, a vendored asset).
+func TestResolvablePathRejectsNonGoSuffix(t *testing.T) {
+	modCache := t.TempDir()
+	t.Setenv("GOMODCACHE", modCache)
+	path := filepath.Join(modCache, "example.com/dep@v1.0.0/go.sum")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not go source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	srv := NewServer(nil, &out, nilAnalyzer{})
+	if srv.resolvablePath(path) {
+		t.Errorf("resolvablePath(%q) = true, want false (not a .go file)", path)
+	}
+}
+
+// TestResolvablePathRejectsRelativeAndEscapingPaths pins two more gate
+// edge cases: a relative path (never something the server itself would
+// publish — every position comes from an Fset, always absolute) and a
+// "root/../../elsewhere.go" escape that Cleans outside the root.
+func TestResolvablePathRejectsRelativeAndEscapingPaths(t *testing.T) {
+	modCache := t.TempDir()
+	t.Setenv("GOMODCACHE", modCache)
+	var out bytes.Buffer
+	srv := NewServer(nil, &out, nilAnalyzer{})
+
+	if srv.resolvablePath("relative/dep.go") {
+		t.Error("resolvablePath accepted a relative path, want rejected")
+	}
+	escaped := filepath.Join(modCache, "..", "..", "escaped.go")
+	if srv.resolvablePath(escaped) {
+		t.Errorf("resolvablePath(%q) = true, want false (escapes GOMODCACHE via ..)", escaped)
+	}
+}
+
+// TestResolvablePathAllowsWorkspaceModuleRoot proves the third allow-list
+// bucket (negotiated workspace module roots, s.workspaceModules) admits a
+// real .go file under the user's own module — the same trust boundary every
+// other read-intelligence feature (hover, go-to-definition) already crosses.
+func TestResolvablePathAllowsWorkspaceModuleRoot(t *testing.T) {
+	// GOMODCACHE pointed elsewhere so this test exercises the workspace-root
+	// bucket specifically, not an accidental GOMODCACHE containment.
+	t.Setenv("GOMODCACHE", t.TempDir())
+	moduleRoot := t.TempDir()
+	path, line := writeGoFile(t, moduleRoot, "pkg/dep.go")
+
+	var out bytes.Buffer
+	srv := NewServer(nil, &out, nilAnalyzer{})
+	srv.workspaceModules = []string{moduleRoot}
+	if !srv.resolvablePath(path) {
+		t.Fatalf("resolvablePath(%q) = false, want true (under a workspace module root)", path)
+	}
+
+	if err := srv.handleCompletionResolve(frame{ID: json.RawMessage("1"), Params: mustMarshal(t, map[string]any{
+		"label": "Greet",
+		"data":  map[string]any{"file": path, "line": line},
+	})}); err != nil {
+		t.Fatal(err)
+	}
+	msgs := readFrames(t, out.String())
+	if len(msgs) != 1 {
+		t.Fatalf("got %d frames, want 1", len(msgs))
+	}
+	var item CompletionItem
+	if err := json.Unmarshal(msgs[0]["result"], &item); err != nil {
+		t.Fatal(err)
+	}
+	if item.Documentation == nil {
+		t.Error("workspace-module-root resolve returned nil Documentation, want the func's doc comment")
+	}
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// TestInitializeAdvertisesCompletionResolveProvider pins T10's protocol
+// capability flag: initialize must advertise completionProvider.resolveProvider.
+func TestInitializeAdvertisesCompletionResolveProvider(t *testing.T) {
+	out := drive(t, nilAnalyzer{}, initFrame()+exitFrame())
+	var res initializeResult
+	if err := json.Unmarshal(responseByID(t, out, 1)["result"], &res); err != nil {
+		t.Fatal(err)
+	}
+	got := res.Capabilities.CompletionProvider
+	if got == nil {
+		t.Fatalf("initialize result missing completionProvider:\n%s", out)
+	}
+	if !got.ResolveProvider {
+		t.Error("completionProvider.resolveProvider = false, want true")
+	}
+}

--- a/internal/lsp/completion_test.go
+++ b/internal/lsp/completion_test.go
@@ -17,6 +17,27 @@ func completionFrame(id int, uri string, position Position) string {
 	})
 }
 
+// snippetInitFrame builds an initialize frame that explicitly opts into
+// textDocument.completion.completionItem.snippetSupport, mirroring
+// dynamicRenameInitializeFrame's per-capability pattern (watched_files_test.go)
+// for the completion capability. Tests that want the plain `name=""` behavior
+// keep using the bare initFrame() (no capabilities at all), which is also how
+// every pre-existing completion test proves the no-regression case: the
+// capability defaults to false when never advertised.
+func snippetInitFrame() string {
+	return jsonFrame(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{
+			"capabilities": map[string]any{
+				"textDocument": map[string]any{
+					"completion": map[string]any{
+						"completionItem": map[string]any{"snippetSupport": true},
+					},
+				},
+			},
+		},
+	})
+}
+
 // TestInitializeAdvertisesCompletionTriggerCharacters checks the initialize
 // result advertises completionProvider with the exact trigger character set,
 // in order: element/attribute-name dot, tag open/close, string-attribute

--- a/internal/lsp/pipe.go
+++ b/internal/lsp/pipe.go
@@ -58,6 +58,261 @@ func unwrapParens(e ast.Expr) ast.Expr {
 	}
 }
 
+// bridgePipeNodeBySeed locates, in pkg.Files[path], the pipeline-carrying node
+// whose seed span (the primary nodeNavSpans span) starts at byte offset seedOff.
+// It bridges a completion cursor — classified against the repair parse (distinct
+// node pointers) — to the semantically equivalent node in the ephemeral analysis
+// package, whose ExprMap/Info carry the type facts. The seed sits BEFORE the
+// repair insertion point, so its offset is identical in both parses (bytes
+// before the insertion never move). nil when no pipeline node's seed matches.
+func bridgePipeNodeBySeed(pkg *Package, path string, seedOff int) gsxast.Node {
+	f := pkg.Files[path]
+	if f == nil || pkg.GSXFset == nil {
+		return nil
+	}
+	var found gsxast.Node
+	inspectWithEmbedded(f, func(n gsxast.Node) bool {
+		if found != nil {
+			return false
+		}
+		if len(pipeStages(n)) == 0 {
+			return true
+		}
+		spans, _ := nodeNavSpans(n)
+		if len(spans) == 0 || !spans[0].pos.IsValid() {
+			return true
+		}
+		if pkg.GSXFset.Position(spans[0].pos).Offset == seedOff {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// cursorStageIndex returns the 0-based index of the pipeline stage the cursor
+// (authored byte offset off) sits on: the LAST stage whose filter-name start is
+// at or before off. Stages are left-to-right, and the cursor stage is the
+// rightmost one begun at or before the cursor — an at-boundary end-of-token
+// cursor (`|> up▮`) and a repair-healed empty stage (`|> ▮` → `_`) both resolve
+// to that stage. ok=false when no stage begins at or before off (a cursor before
+// the first stage — not a real pipe-stage completion position).
+func cursorStageIndex(pkg *Package, node gsxast.Node, off int) (int, bool) {
+	if pkg.GSXFset == nil {
+		return 0, false
+	}
+	idx := -1
+	for i, st := range pipeStages(node) {
+		if !st.NamePos.IsValid() {
+			continue
+		}
+		if pkg.GSXFset.Position(st.NamePos).Offset <= off {
+			idx = i
+		}
+	}
+	if idx < 0 {
+		return 0, false
+	}
+	return idx, true
+}
+
+// pipeIncomingType returns the Go type flowing INTO the pipeline stage at
+// stageIdx, resolved in the ephemeral skeleton's type universe (the same
+// universe pkg.Info/pkg.Types live in, so a later types.AssignableTo against a
+// filter's subject parameter is sound). Stage 0's incoming type is the seed
+// expression's type; a later stage's is the RESULT type of the immediately
+// preceding filter (its first result — an (R, error) filter chains its R).
+// ok=false — the fail-open signal — when the type cannot be resolved: an
+// untyped/invalid seed, a preceding filter whose package is not imported into
+// the skeleton universe, or a generic (type-parameter) result that cannot be
+// soundly narrowed against.
+func pipeIncomingType(pkg *Package, node gsxast.Node, stageIdx int, filters []FilterCandidate) (types.Type, bool) {
+	if stageIdx == 0 {
+		return pipeSeedType(pkg, node)
+	}
+	stages := pipeStages(node)
+	if stageIdx-1 >= len(stages) {
+		return nil, false
+	}
+	sig := pipeFilterSignature(pkg, stages[stageIdx-1].Name, filters)
+	if sig == nil || sig.Results().Len() == 0 {
+		return nil, false
+	}
+	t := sig.Results().At(0).Type()
+	if !resolvableIncomingType(t) {
+		return nil, false
+	}
+	return t, true
+}
+
+// pipeSeedType returns the type of the pipeline's seed expression. When the
+// lowered skeleton is a nested filter-call chain (every stage resolved) the seed
+// is walkPipe's innermost expression; when the pipeline failed to lower — the
+// common completion case, where the cursor stage is an unknown/partial filter
+// and codegen falls the whole pipeline back to the bare seed (see analyze.go's
+// probeExpr) — ExprMap[node] IS the seed expression. Both are looked up in
+// Info.Types. ok=false when untyped or invalid.
+func pipeSeedType(pkg *Package, node gsxast.Node) (types.Type, bool) {
+	skel := pkg.ExprMap[node]
+	if skel == nil || pkg.Info == nil {
+		return nil, false
+	}
+	seed := skel
+	if _, _, s, ok := walkPipe(skel, len(pipeStages(node))); ok && s != nil {
+		seed = s
+	}
+	tv, ok := pkg.Info.Types[seed]
+	if !ok || !resolvableIncomingType(tv.Type) {
+		return nil, false
+	}
+	return tv.Type, true
+}
+
+// resolvableIncomingType reports whether t is a concrete type a subject-parameter
+// compatibility check can soundly narrow against: not nil, not the invalid type,
+// and not an un-instantiated type parameter (a generic result flows into the next
+// stage as a type parameter, which cannot be soundly matched — fail open).
+func resolvableIncomingType(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	if b, ok := t.(*types.Basic); ok && b.Kind() == types.Invalid {
+		return false
+	}
+	if _, ok := types.Unalias(t).(*types.TypeParam); ok {
+		return false
+	}
+	return true
+}
+
+// pipeFilterSignature resolves the *types.Signature of the filter registered
+// under the template-level name, by matching it to its FilterCandidate (which
+// carries the winning package path and Go func name) and looking that func up in
+// the ephemeral skeleton universe. nil when the name is unknown or its package
+// is not imported into the skeleton (see filterFuncSignature).
+func pipeFilterSignature(pkg *Package, name string, filters []FilterCandidate) *types.Signature {
+	for _, f := range filters {
+		if f.Name == name {
+			return filterFuncSignature(pkg, f.Pkg, f.Func)
+		}
+	}
+	return nil
+}
+
+// filterFuncSignature looks up the exported func funcName in the package pkgPath
+// as it is imported into the ephemeral skeleton's type universe (pkg.Types'
+// direct imports), returning its signature. The skeleton imports a filter
+// package ONLY when some pipeline successfully lowered against it, so a filter
+// whose package is absent from this universe resolves to nil — the caller treats
+// that as a per-candidate fail-open (offer it), never as an exclusion. Resolving
+// here (rather than in the separate filter-table load universe) keeps the
+// signature's parameter types identity-comparable with pipeIncomingType, which
+// is drawn from this same universe.
+func filterFuncSignature(pkg *Package, pkgPath, funcName string) *types.Signature {
+	target := importedPackageAt(pkg, pkgPath)
+	if target == nil {
+		return nil
+	}
+	fn, ok := target.Scope().Lookup(funcName).(*types.Func)
+	if !ok {
+		return nil
+	}
+	sig, _ := fn.Type().(*types.Signature)
+	return sig
+}
+
+// filterSubjectType returns the type of a filter's SUBJECT parameter — the one
+// gsx binds the piped value to. That is parameter 0, or parameter 1 when the
+// filter takes the ambient context.Context first (wantsCtx). When the subject is
+// itself the trailing variadic parameter (`func(vs ...string) R`), the piped
+// value binds to one element, so the element type is returned. ok=false when the
+// signature has no subject parameter at the expected index.
+func filterSubjectType(sig *types.Signature, wantsCtx bool) (types.Type, bool) {
+	idx := 0
+	if wantsCtx {
+		idx = 1
+	}
+	n := sig.Params().Len()
+	if idx >= n {
+		return nil, false
+	}
+	t := sig.Params().At(idx).Type()
+	if sig.Variadic() && idx == n-1 {
+		if slice, ok := t.(*types.Slice); ok {
+			t = slice.Elem()
+		}
+	}
+	return t, true
+}
+
+// subjectAccepts reports whether a value of type incoming may flow into a filter
+// whose subject parameter is subject. A type-parameter subject (a generic filter
+// like `default[T comparable]`) can instantiate to the incoming type, so it is
+// always accepted; otherwise standard Go assignability decides — which already
+// admits an `any`/interface subject (printf) and an interface the incoming type
+// implements.
+func subjectAccepts(subject, incoming types.Type) bool {
+	if _, ok := types.Unalias(subject).(*types.TypeParam); ok {
+		return true
+	}
+	return types.AssignableTo(incoming, subject)
+}
+
+// pipeFilterAccepts reports whether candidate f should be offered for a stage
+// whose incoming type is incoming. It resolves f's signature in the skeleton
+// universe and checks its subject parameter against incoming. A filter whose
+// package is not imported into the universe, or whose signature lacks a subject
+// parameter, is offered unconditionally — the per-candidate fail-open that keeps
+// narrowing a refinement, never a gate that can hide a candidate on uncertainty.
+func pipeFilterAccepts(pkg *Package, f FilterCandidate, incoming types.Type) bool {
+	sig := filterFuncSignature(pkg, f.Pkg, f.Func)
+	if sig == nil {
+		return true
+	}
+	subject, ok := filterSubjectType(sig, f.WantsCtx)
+	if !ok {
+		return true
+	}
+	return subjectAccepts(subject, incoming)
+}
+
+// compatiblePipeFilters narrows filters to those whose subject parameter accepts
+// the type flowing into the pipeline stage under the cursor. It returns
+// (narrowed, true) only when the whole chain up to the cursor stage was
+// type-resolved; otherwise (nil, false) — the FAIL-OPEN signal telling the
+// caller to offer the full, unnarrowed list. Fail-open covers a missing/shell
+// analysis, a cursor that does not bridge to an analyzed pipeline node, an
+// unresolvable stage index, and an undeterminable incoming type (broken seed,
+// unimported preceding filter, generic previous result). Individual candidates
+// whose own package is not imported still pass through (pipeFilterAccepts's
+// per-candidate fail-open), so narrowing never hides a filter merely because its
+// signature could not be resolved.
+func compatiblePipeFilters(pkg *Package, path string, seedOff, off int, filters []FilterCandidate) ([]FilterCandidate, bool) {
+	if pkg == nil || pkg.Info == nil || pkg.Types == nil || pkg.GSXFset == nil {
+		return nil, false
+	}
+	node := bridgePipeNodeBySeed(pkg, path, seedOff)
+	if node == nil {
+		return nil, false
+	}
+	stageIdx, ok := cursorStageIndex(pkg, node, off)
+	if !ok {
+		return nil, false
+	}
+	incoming, ok := pipeIncomingType(pkg, node, stageIdx, filters)
+	if !ok {
+		return nil, false
+	}
+	out := make([]FilterCandidate, 0, len(filters))
+	for _, f := range filters {
+		if pipeFilterAccepts(pkg, f, incoming) {
+			out = append(out, f)
+		}
+	}
+	return out, true
+}
+
 func pipeStages(node gsxast.Node) []gsxast.PipeStage {
 	switch e := node.(type) {
 	case *gsxast.Interp:

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -59,12 +59,26 @@ type clientCapabilities struct {
 }
 
 type textDocumentCapabilities struct {
-	Rename renameClientCapabilities `json:"rename"`
+	Rename     renameClientCapabilities     `json:"rename"`
+	Completion completionClientCapabilities `json:"completion"`
 }
 
 type renameClientCapabilities struct {
 	DynamicRegistration bool `json:"dynamicRegistration"`
 	PrepareSupport      bool `json:"prepareSupport"`
+}
+
+type completionClientCapabilities struct {
+	CompletionItem completionItemClientCapabilities `json:"completionItem"`
+}
+
+// completionItemClientCapabilities carries the one completion-item capability
+// gsx currently reads: whether the client can render a snippet's `$1`
+// tabstops and place the cursor accordingly. Gated on this rather than
+// assumed, per the LSP spec — a client that never sets it would otherwise see
+// a literal `$1` typed into the buffer.
+type completionItemClientCapabilities struct {
+	SnippetSupport bool `json:"snippetSupport"`
 }
 
 type generalCapabilities struct {
@@ -344,7 +358,26 @@ type CompletionItem struct {
 	SortText      string         `json:"sortText,omitempty"`
 	FilterText    string         `json:"filterText,omitempty"`
 	TextEdit      *TextEdit      `json:"textEdit,omitempty"`
+	// InsertTextFormat selects how the client interprets TextEdit.NewText:
+	// insertTextFormatPlainText (the default; omitted so the field disappears
+	// entirely for every item that does not opt in) or insertTextFormatSnippet,
+	// which lets NewText carry `$1`/`$0` tabstops. Only ever set to the snippet
+	// value, and only when the negotiated client capability
+	// (textDocument.completion.completionItem.snippetSupport) says the client
+	// can render one — see Server.snippetSupport.
+	InsertTextFormat int `json:"insertTextFormat,omitempty"`
 }
+
+// LSP InsertTextFormat constants (textDocument/completion).
+const (
+	insertTextFormatPlainText = 1 // PlainText: NewText is inserted verbatim.
+	// insertTextFormatSnippet marks NewText as an LSP snippet: `$1`, `$2`, ...
+	// are tabstops the client cycles through, an unnumbered `$0` (or the
+	// implicit end of the snippet when no `$0` appears) is the final cursor
+	// position. gsx only ever emits a single `$1` tabstop, so there is no `$0`
+	// to place and no risk of tabstop-ordering ambiguity.
+	insertTextFormatSnippet = 2
+)
 
 // LSP CompletionItemKind constants used across completion tasks.
 const (

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -331,9 +331,35 @@ type SymbolInformation struct {
 
 // CompletionOptions advertises completion support and the characters that
 // re-trigger it as the user types (beyond the client's default identifier
-// trigger).
+// trigger). ResolveProvider advertises completionItem/resolve support: the
+// client may send back a completion item (with its Data untouched) to fetch
+// documentation lazily rather than eagerly on every item in a full list.
 type CompletionOptions struct {
 	TriggerCharacters []string `json:"triggerCharacters,omitempty"`
+	ResolveProvider   bool     `json:"resolveProvider,omitempty"`
+}
+
+// completionResolveData is the payload CompletionItem.Data carries for a
+// candidate whose documentation is fetched lazily via completionItem/resolve
+// rather than filled in eagerly at list-build time (see completion_docs.go
+// and completion_resolve.go). The LSP client round-trips CompletionItem.Data
+// through completionItem/resolve UNCHANGED — it is never interpreted or
+// mutated by the client — so encoding it as a plain typed struct (rather than
+// json.RawMessage) lets encoding/json marshal it on the way out and unmarshal
+// it directly back into the same shape on the way in, with no intermediate
+// any/RawMessage re-encoding step in either direction.
+//
+// File+Line is a location the SERVER computed from its own analysis (a real
+// go/token position it already resolved via go/packages or //line-mapped
+// skeleton coordinates) — NEVER a client-supplied path. Because Data
+// round-trips through the client, a hostile or buggy client could still send
+// an ARBITRARY {file,line} pair with completionItem/resolve; the handler
+// (handleCompletionResolve) treats File as untrusted input and revalidates it
+// against an allow-list before reading anything — see resolvablePath in
+// completion_resolve.go for the threat model and the gate itself.
+type completionResolveData struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
 }
 
 type completionParams struct {
@@ -358,6 +384,10 @@ type CompletionItem struct {
 	SortText      string         `json:"sortText,omitempty"`
 	FilterText    string         `json:"filterText,omitempty"`
 	TextEdit      *TextEdit      `json:"textEdit,omitempty"`
+	// Data carries a lazy-doc lookup payload (see completionResolveData) that
+	// the client returns unchanged with a completionItem/resolve request. nil
+	// for every item whose Documentation (if any) was already filled in eagerly.
+	Data *completionResolveData `json:"data,omitempty"`
 	// InsertTextFormat selects how the client interprets TextEdit.NewText:
 	// insertTextFormatPlainText (the default; omitted so the field disappears
 	// entirely for every item that does not opt in) or insertTextFormatSnippet,

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -143,6 +143,11 @@ type Server struct {
 
 	moduleSyms map[string]moduleSymbolCache // normalized module root → lazy workspace-symbol index
 
+	// depDocs caches completionItem/resolve's dependency-file doc extraction
+	// (see completion_resolve.go): module-cache/GOROOT source files are
+	// immutable within a session, so entries never need invalidation.
+	depDocs *depDocCache
+
 	workspaceFolders         []workspaceFolder   // normalized initialized file workspace folders
 	workspaceRoots           []string            // normalized absolute folder paths
 	workspaceModules         []string            // sorted Go module roots owned by workspaceRoots
@@ -205,6 +210,7 @@ func NewServer(r io.Reader, w io.Writer, a Analyzer) *Server {
 		workspaceViewValid:       false,
 		pendingClientRequests:    map[string]func(frame) error{},
 		moduleSyms:               map[string]moduleSymbolCache{},
+		depDocs:                  newDepDocCache(),
 		workspaceModuleOwners:    map[string]string{},
 		workspaceModulePaths:     map[string]string{},
 		pendingWorkspaceMetadata: map[string]struct{}{},
@@ -332,6 +338,8 @@ func (s *Server) handle(f frame) error {
 		return s.handleHover(f)
 	case "textDocument/completion":
 		return s.handleCompletion(f)
+	case "completionItem/resolve":
+		return s.handleCompletionResolve(f)
 	case "textDocument/formatting":
 		return s.handleFormatting(f)
 	case "textDocument/codeAction":
@@ -387,7 +395,7 @@ func (s *Server) handleInitialize(f frame) error {
 		RenameProvider:             nil,
 		DocumentFormattingProvider: true,
 		HoverProvider:              true,
-		CompletionProvider:         &CompletionOptions{TriggerCharacters: []string{".", "<", ">", "\"", "|"}},
+		CompletionProvider:         &CompletionOptions{TriggerCharacters: []string{".", "<", ">", "\"", "|"}, ResolveProvider: true},
 		DocumentSymbolProvider:     true,
 		WorkspaceSymbolProvider:    true,
 		CodeActionProvider:         &CodeActionOptions{CodeActionKinds: []string{organizeImportsKind, quickFixKind}},

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -125,9 +125,15 @@ type Server struct {
 	renameDynamicRegistration bool
 	renamePrepareSupport      bool
 	renameRegistrationActive  bool
-	diskViewValid             bool
-	workspaceViewValid        bool
-	pendingClientRequests     map[string]func(frame) error
+	// snippetSupport mirrors the client's textDocument.completion.completionItem
+	// .snippetSupport capability, captured once at initialize. When true, value-
+	// taking attribute completions insert a `$1` tabstop inside the quotes
+	// (InsertTextFormat = Snippet) instead of the plain `name=""` insert — see
+	// htmlAttrItem.
+	snippetSupport        bool
+	diskViewValid         bool
+	workspaceViewValid    bool
+	pendingClientRequests map[string]func(frame) error
 
 	moduleRefs        []CrossRef                 // whole-module cross-reference index (lazy; find-references)
 	moduleRefsValid   bool                       // false ⇒ rebuild on next references request
@@ -356,6 +362,7 @@ func (s *Server) handleInitialize(f frame) error {
 	s.watchDynamicRegistration = p.Capabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration
 	s.renameDynamicRegistration = p.Capabilities.TextDocument.Rename.DynamicRegistration
 	s.renamePrepareSupport = p.Capabilities.TextDocument.Rename.PrepareSupport
+	s.snippetSupport = p.Capabilities.TextDocument.Completion.CompletionItem.SnippetSupport
 	var folders []workspaceFolder
 	switch {
 	case p.WorkspaceFolders != nil:

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -288,61 +288,87 @@ func (s *partialGoSource) linearSourceSpan(parsedStart, parsedEnd int) (int, int
 	return 0, 0, false
 }
 
-// partialGoChunkSymbols parses a GoChunk's verbatim source in recovery mode and
-// emits only declarations represented by the returned partial Go AST.
-func partialGoChunkSymbols(file *gsxast.File, fset *token.FileSet, source []byte, chunk *gsxast.GoChunk) []Symbol {
+// reconstructGoChunk builds the byte-exact recovery reconstruction of a
+// GoChunk's verbatim source — the shared first half of partialGoChunkSymbols,
+// extracted so completion_docs.go's doc-comment extractor (which needs the
+// SAME proven byte-for-byte reconstruction, not a second hand-rolled one) can
+// call it without pulling in Symbol-specific parsing.
+func reconstructGoChunk(fset *token.FileSet, source []byte, chunk *gsxast.GoChunk) (partialGoSource, *token.File, bool) {
 	tokenFile := fset.File(chunk.Pos())
 	if tokenFile == nil || tokenFile.Size() != len(source) {
-		return nil
+		return partialGoSource{}, nil, false
 	}
 	start := tokenFile.Offset(chunk.Pos())
 	end := tokenFile.Offset(chunk.End())
 	if start < 0 || end < start || end > len(source) || chunk.Src != string(source[start:end]) {
-		return nil
+		return partialGoSource{}, nil, false
 	}
 	var reconstructed partialGoSource
 	if !reconstructed.appendAuthored(chunk.Src, start, end) {
+		return partialGoSource{}, nil, false
+	}
+	return reconstructed, tokenFile, true
+}
+
+// partialGoChunkSymbols parses a GoChunk's verbatim source in recovery mode and
+// emits only declarations represented by the returned partial Go AST.
+func partialGoChunkSymbols(file *gsxast.File, fset *token.FileSet, source []byte, chunk *gsxast.GoChunk) []Symbol {
+	reconstructed, tokenFile, ok := reconstructGoChunk(fset, source, chunk)
+	if !ok {
 		return nil
 	}
 	return partialGoSymbols(file.Package, fset, tokenFile, source, reconstructed)
 }
 
-func partialGoWithElementsSymbols(file *gsxast.File, fset *token.FileSet, source []byte, declaration *gsxast.GoWithElements) []Symbol {
+// reconstructGoWithElements builds the byte-exact recovery reconstruction of a
+// GoWithElements declaration (GoText parts verbatim, embedded element/fragment
+// parts as newline-preserving placeholders) — the shared first half of
+// partialGoWithElementsSymbols, extracted for the same reason as
+// reconstructGoChunk above.
+func reconstructGoWithElements(fset *token.FileSet, source []byte, declaration *gsxast.GoWithElements) (partialGoSource, *token.File, bool) {
 	tokenFile := fset.File(declaration.Pos())
 	if tokenFile == nil || tokenFile.Size() != len(source) {
-		return nil
+		return partialGoSource{}, nil, false
 	}
 	declarationStart := tokenFile.Offset(declaration.Pos())
 	declarationEnd := tokenFile.Offset(declaration.End())
 	if declarationStart < 0 || declarationEnd < declarationStart || declarationEnd > len(source) {
-		return nil
+		return partialGoSource{}, nil, false
 	}
 	var reconstructed partialGoSource
 	cursor := declarationStart
 	for _, part := range declaration.Parts {
 		if fset.File(part.Pos()) != tokenFile || fset.File(part.End()) != tokenFile {
-			return nil
+			return partialGoSource{}, nil, false
 		}
 		start := tokenFile.Offset(part.Pos())
 		end := tokenFile.Offset(part.End())
 		if start != cursor || end < start || end > declarationEnd {
-			return nil
+			return partialGoSource{}, nil, false
 		}
 		switch part := part.(type) {
 		case gsxast.GoText:
 			if part.Src != string(source[start:end]) || !reconstructed.appendAuthored(part.Src, start, end) {
-				return nil
+				return partialGoSource{}, nil, false
 			}
 		case *gsxast.Element, *gsxast.Fragment, *gsxast.EmbeddedInterp:
 			if !reconstructed.appendExpressionPlaceholder(source, start, end) {
-				return nil
+				return partialGoSource{}, nil, false
 			}
 		default:
-			return nil
+			return partialGoSource{}, nil, false
 		}
 		cursor = end
 	}
 	if cursor != declarationEnd || reconstructed.text.Len() != declarationEnd-declarationStart {
+		return partialGoSource{}, nil, false
+	}
+	return reconstructed, tokenFile, true
+}
+
+func partialGoWithElementsSymbols(file *gsxast.File, fset *token.FileSet, source []byte, declaration *gsxast.GoWithElements) []Symbol {
+	reconstructed, tokenFile, ok := reconstructGoWithElements(fset, source, declaration)
+	if !ok {
 		return nil
 	}
 	return partialGoSymbols(file.Package, fset, tokenFile, source, reconstructed)


### PR DESCRIPTION
## Summary

Batch 2a of the completion-todos closure — seven reviewed pieces (each with its own adversarial review; two required fix passes, both re-reviewed):

- **Hygiene sweep** (`45793c72`): comment-aware braced-value scanner; `_gsxuse`-family diag sanitization (generalized `stripGsxWrapperCall`); precise `pkgTypes` snapshot/restore test; clone-exhaustiveness test (mutation-verified); `retainFileScopesOnly` moved to the cache-store boundary; fset precondition assert; ROADMAP parity.
- **`//line` for top-level Go chunks** (`38a441d5`): shipped `.x.go` now anchors plain GoChunk/GoWithElements text — cross-module gd on component values is exact-line (e2e upgraded from file-only to exact assertions); 202 goldens regenerated (directive-only + gofmt reflow, all 32 non-directive lines individually root-caused in review). Mid-task catch: a naive reuse of the skeleton's emitter would have leaked absolute build paths into shipped output — dedicated base-named `emitBlockLine` instead.
- **Snippet placeholders** (`7618f766`): `class="$1"` with `InsertTextFormat=2`, strictly gated on client `snippetSupport`; byte-identical without it.
- **GoChunk imported names** (`2eace7f8`+test): bare positions between top-level decls now reach the file scope (imports complete); per-file scope isolation pinned by a mutation-verified two-file test.
- **Method-component tags** (`b8b2eef0`): `<p.▮` resolves the receiver var via a SigTypes scope bridge and offers `ComponentDecls` `"Type.Name"` methods; Go-faithful shadowing (var beats import); mid-edit heals via the existing trailing-dot repair.
- **Typed pipe filtering** (`aba3f280`): filters narrowed by `AssignableTo(incoming, subject)` resolved entirely in the ephemeral universe (sound named-type identity); strict fail-open discipline — uncertainty never hides candidates; review verified codegen applies no subject coercion, so narrowing can never exclude a shape codegen accepts.
- **Expected-type ranking** (`686c9f56`+`2c6249ad`): within-tier boost (locality still dominates) for inner call-args and component-attr holes; review caught and fixed a cross-file offset-collision nondeterminism and a named-func-type conversion misclassification, both revert-probed.

Remaining (next round): `{{ x.▮ }}` member-completion bridging design, Go doc comments on candidates (skeleton comment retention), `completionItem/resolve`.

## Testing

`make ci` green at head (incl. regenerated goldens + drift gate). Every task shipped unit + e2e coverage; reviews independently re-ran suites and revert-probed load-bearing guards.

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa