### PR TITLE
Auto-import completion: unimported qualifiers and package names

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -680,7 +680,36 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   GOMODCACHE/workspace-root) in internal/lsp; e2e (eager doc on a fixture
   symbol, stdlib `strings.HasPrefix` resolve round trip, filter `upper`→
   std.Upper resolve round trip) in gen/lsp_completion_docs_e2e_test.go.
-  **Follow-ups:** auto-import completion (own design); snippet placeholders;
+  **Auto-import completion** — DONE (design `batch3-autoimport-design.md`).
+  Option 1: an unimported qualifier in member position (`fmt.▮`, `strings.ToUp▮`)
+  — the last fallback after the ordinary member dispatch resolves nothing —
+  resolves the qualifier to import path(s) via `ResolveImportCandidates` (~100µs
+  warm) and offers that package's exported symbols, each with an eager
+  `additionalTextEdits` that adds the import on accept. Option 2: a bare
+  identifier also offers unimported package NAMES (kind Module) whose name has
+  the typed prefix, ranked at a new bottom tier (`tierUnimported` = 70, below
+  every in-scope name and keyword), each with its own import edit; a name that
+  already names an in-scope item is suppressed (no shadowing `os/user` over a
+  local `user`). Precedence: in-scope binding > import qualifier > unimported
+  (`undefinedQualifier` gates on a total `SourceIndex.At` miss). The import edit
+  is a NARROW import-region `TextEdit` in original-doc coordinates (common-prefix/
+  suffix diff of the target chunk via `importEditFor` + gsxfmt's exported
+  `AddChunkImports`/`ChunkHasImports`), NOT the whole-document code-action edit
+  which would illegally overlap the completion edit; it refuses rather than emit
+  an overlapping edit. `labelDetails` is capability-gated: the import path goes in
+  `labelDetails.description` when the client supports it, else the detail string.
+  New codegen seam (serialized on `analysisMu`, off the `Package()` hot path like
+  `ResolveImportCandidates`): `Module.PackageExportedSymbols(path)` →
+  name/kind/type-string tuples from the loaded dep graph (or gc export data for a
+  graph-absent std package), and `Module.ImportablePackageNames(dir)` → the
+  internal-visibility-filtered name universe. Surfaced through
+  `Analyzer.ExportedSymbols`/`ImportablePackages`. Tests: unit (import-edit exact
+  bytes for no-block/existing-block/leading-chunk + already-imported no-op +
+  overlap refusal, qualifier extraction, per-path ambiguity, labelDetails both
+  ways, tier + prefix cap) in internal/lsp + internal/codegen; e2e (unimported
+  `strings.▮` → ToUpper with an import edit that reparses cleanly, bare
+  package-name item, imported-package precedence) in gen.
+  **Follow-ups:** snippet placeholders;
   body-local value bindings as method-component qualifiers (declared in a
   `{{ }}` block, a v1 gap); `Component.Doc` — component-tag completion/hover
   still show only the rendered signature (`renderComponentSig`), never a doc

--- a/gen/lsp.go
+++ b/gen/lsp.go
@@ -1063,6 +1063,73 @@ func (a lspAnalyzer) ResolveImport(dir, name, symbol string) []string {
 	return m.ResolveImportCandidates(dir, name, symbol)
 }
 
+// ExportedSymbols returns the exported top-level symbols of the package at
+// importPath, for auto-import completion of an unimported qualifier. Best-effort
+// like ResolveImport: a module that cannot be opened yields nothing.
+func (a lspAnalyzer) ExportedSymbols(dir, importPath string) []lsp.ImportSymbol {
+	root, modPath, err := moduleRoot(dir)
+	if err != nil {
+		return nil
+	}
+	merged := resolveConfigBestEffort(dir, a.optCfg, a.warnw)
+	m, _, err := a.module(root, modPath, merged)
+	if err != nil {
+		return nil
+	}
+	syms := m.PackageExportedSymbols(importPath)
+	if len(syms) == 0 {
+		return nil
+	}
+	out := make([]lsp.ImportSymbol, len(syms))
+	for i, sym := range syms {
+		out[i] = lsp.ImportSymbol{Name: sym.Name, Kind: importSymbolKind(sym.Kind), Detail: sym.Detail}
+	}
+	return out
+}
+
+// ImportablePackages returns every package dir could import (name + path), for
+// auto-import package-name completion. Best-effort like ExportedSymbols.
+func (a lspAnalyzer) ImportablePackages(dir string) []lsp.ImportablePackage {
+	root, modPath, err := moduleRoot(dir)
+	if err != nil {
+		return nil
+	}
+	merged := resolveConfigBestEffort(dir, a.optCfg, a.warnw)
+	m, _, err := a.module(root, modPath, merged)
+	if err != nil {
+		return nil
+	}
+	pkgs := m.ImportablePackageNames(dir)
+	if len(pkgs) == 0 {
+		return nil
+	}
+	out := make([]lsp.ImportablePackage, len(pkgs))
+	for i, pkg := range pkgs {
+		out[i] = lsp.ImportablePackage{Name: pkg.Name, Path: pkg.Path}
+	}
+	return out
+}
+
+// importSymbolKind adapts codegen's coarse SymbolKind to the LSP's mirror enum.
+// The two enums are parallel by design (each package owns its own so neither
+// depends on the other); this explicit switch is the single translation seam.
+func importSymbolKind(k codegen.SymbolKind) lsp.SymbolKind {
+	switch k {
+	case codegen.SymbolFunc:
+		return lsp.SymbolFunc
+	case codegen.SymbolVar:
+		return lsp.SymbolVar
+	case codegen.SymbolConst:
+		return lsp.SymbolConst
+	case codegen.SymbolTypeStruct:
+		return lsp.SymbolTypeStruct
+	case codegen.SymbolTypeInterface:
+		return lsp.SymbolTypeInterface
+	default:
+		return lsp.SymbolTypeOther
+	}
+}
+
 // resolveConfigBestEffort resolves the LSP's effective config: it discovers a
 // gsx.toml from dir (walking up, bounded by .git/module root) and merges it under
 // optCfg — exactly as resolveConfig does for generate/info — but for the LSP it

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -1968,6 +1968,47 @@ func TestAutoImportCompletionE2E(t *testing.T) {
 		}
 	})
 
+	// Option 1, statement position: `{{ strings. }}` (a GoBlock, not an Interp)
+	// where strings is unimported → ToUpper offered with an import edit, exactly
+	// as the expression-position `{ strings. }` case above. Auto-import's
+	// text-level qualifier/edit machinery is node-kind-agnostic, but the
+	// classifier routes GoBlock through a different rule (nodeNavSpans, not the
+	// Interp rule) — exercise it directly rather than relying on the expression
+	// case as a stand-in for every Go-expr context.
+	t.Run("statement position unimported qualifier", func(t *testing.T) {
+		source := "package page\n\ncomponent Home() {\n\t{{ strings. }}\n}\n"
+		cursor := strings.Index(source, "strings.") + len("strings.")
+		items := runHTMLCompletionE2E(t, nil, source, cursor)
+		var up *lsp.CompletionItem
+		for i := range items {
+			if items[i].Label == "ToUpper" {
+				up = &items[i]
+			}
+		}
+		if up == nil {
+			labels := map[string]bool{}
+			for _, it := range items {
+				labels[it.Label] = true
+			}
+			t.Fatalf("unimported statement-position `strings.` did not offer ToUpper; labels=%v", labels)
+		}
+		if len(up.AdditionalTextEdits) != 1 {
+			t.Fatalf("ToUpper AdditionalTextEdits = %d, want 1 (the import)", len(up.AdditionalTextEdits))
+		}
+		all := append([]lsp.TextEdit{*up.TextEdit}, up.AdditionalTextEdits...)
+		got := applyLSPEdits(source, all)
+		if !strings.Contains(got, "import \"strings\"") {
+			t.Errorf("applied doc missing import \"strings\":\n%s", got)
+		}
+		if !strings.Contains(got, "strings.ToUpper") {
+			t.Errorf("applied doc missing strings.ToUpper:\n%s", got)
+		}
+		fset := token.NewFileSet()
+		if f, err := gsxparser.ParseFile(fset, "page.gsx", got, 0); f == nil || err != nil {
+			t.Errorf("applied doc does not reparse: err=%v\n%s", err, got)
+		}
+	})
+
 	// Option 2: bare `{ fm }` offers the package name `fmt` at the bottom tier
 	// with an import edit.
 	t.Run("unimported package name", func(t *testing.T) {

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"bytes"
 	"encoding/json"
+	"go/token"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"unicode"
+
+	gsxparser "github.com/gsxhq/gsx/parser"
 
 	"github.com/gsxhq/gsx/internal/lsp"
 )
@@ -1869,4 +1872,154 @@ func assertEmptyCompletionNoError(t *testing.T, output string, id int) {
 	if len(list.Items) != 0 {
 		t.Fatalf("completion id %d = %d items, want 0 (fail-soft empty): %+v", id, len(list.Items), list.Items)
 	}
+}
+
+// posToByteOffsetASCII converts an LSP (line, character) to a byte offset for an
+// ASCII buffer (the auto-import fixtures are ASCII, so a UTF-16 code unit is one
+// byte). Used to apply completion edits and reparse.
+func posToByteOffsetASCII(src string, line, character int) int {
+	off := 0
+	for range line {
+		nl := strings.IndexByte(src[off:], '\n')
+		if nl < 0 {
+			return len(src)
+		}
+		off += nl + 1
+	}
+	return off + character
+}
+
+// applyLSPEdits applies non-overlapping LSP TextEdits to src (rightmost first).
+func applyLSPEdits(src string, edits []lsp.TextEdit) string {
+	type off struct {
+		start, end int
+		text       string
+	}
+	os := make([]off, len(edits))
+	for i, e := range edits {
+		os[i] = off{
+			start: posToByteOffsetASCII(src, e.Range.Start.Line, e.Range.Start.Character),
+			end:   posToByteOffsetASCII(src, e.Range.End.Line, e.Range.End.Character),
+			text:  e.NewText,
+		}
+	}
+	for i := 1; i < len(os); i++ {
+		for j := i; j > 0 && os[j].start > os[j-1].start; j-- {
+			os[j], os[j-1] = os[j-1], os[j]
+		}
+	}
+	out := src
+	for _, o := range os {
+		out = out[:o.start] + o.text + out[o.end:]
+	}
+	return out
+}
+
+// TestAutoImportCompletionE2E drives auto-import completion end to end through
+// the JSON-RPC server: an unimported qualifier's symbols (Option 1) and
+// unimported package names (Option 2), each carrying an import
+// additionalTextEdit that — applied together with the main edit — yields a
+// document that reparses cleanly with the import present.
+func TestAutoImportCompletionE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+
+	// Option 1: `{ strings. }` where strings is unimported → ToUpper offered with
+	// an import edit.
+	t.Run("unimported qualifier symbols", func(t *testing.T) {
+		source := "package page\n\ncomponent Home() {\n\t<div>{ strings. }</div>\n}\n"
+		cursor := strings.Index(source, "strings.") + len("strings.")
+		items := runHTMLCompletionE2E(t, nil, source, cursor)
+		var up *lsp.CompletionItem
+		for i := range items {
+			if items[i].Label == "ToUpper" {
+				up = &items[i]
+			}
+		}
+		if up == nil {
+			labels := map[string]bool{}
+			for _, it := range items {
+				labels[it.Label] = true
+			}
+			t.Fatalf("unimported `strings.` did not offer ToUpper; labels=%v", labels)
+		}
+		if len(up.AdditionalTextEdits) != 1 {
+			t.Fatalf("ToUpper AdditionalTextEdits = %d, want 1 (the import)", len(up.AdditionalTextEdits))
+		}
+		// Apply the symbol edit + import edit and reparse: the import must land and
+		// the whole document must parse.
+		all := append([]lsp.TextEdit{*up.TextEdit}, up.AdditionalTextEdits...)
+		got := applyLSPEdits(source, all)
+		if !strings.Contains(got, "import \"strings\"") {
+			t.Errorf("applied doc missing import \"strings\":\n%s", got)
+		}
+		if !strings.Contains(got, "strings.ToUpper") {
+			t.Errorf("applied doc missing strings.ToUpper:\n%s", got)
+		}
+		fset := token.NewFileSet()
+		if f, err := gsxparser.ParseFile(fset, "page.gsx", got, 0); f == nil || err != nil {
+			t.Errorf("applied doc does not reparse: err=%v\n%s", err, got)
+		}
+		// Without labelDetails capability (runHTMLCompletionE2E negotiates none),
+		// the import path is carried in the detail string.
+		if up.Detail != "strings" {
+			t.Errorf("ToUpper detail = %q, want import path \"strings\" (labelDetails fallback)", up.Detail)
+		}
+	})
+
+	// Option 2: bare `{ fm }` offers the package name `fmt` at the bottom tier
+	// with an import edit.
+	t.Run("unimported package name", func(t *testing.T) {
+		source := "package page\n\ncomponent Home() {\n\t<div>{ fm }</div>\n}\n"
+		cursor := strings.Index(source, "{ fm }") + len("{ fm")
+		items := runHTMLCompletionE2E(t, nil, source, cursor)
+		var fm *lsp.CompletionItem
+		for i := range items {
+			if items[i].Label == "fmt" {
+				fm = &items[i]
+			}
+		}
+		if fm == nil {
+			t.Fatalf("bare `fm` did not offer package name fmt; got %d items", len(items))
+		}
+		if fm.Kind != 9 { // ciKindModule
+			t.Errorf("fmt kind = %d, want Module(9)", fm.Kind)
+		}
+		if !strings.HasPrefix(fm.SortText, "70") {
+			t.Errorf("fmt SortText = %q, want tierUnimported prefix \"70\"", fm.SortText)
+		}
+		if len(fm.AdditionalTextEdits) != 1 {
+			t.Fatalf("fmt AdditionalTextEdits = %d, want 1", len(fm.AdditionalTextEdits))
+		}
+		got := applyLSPEdits(source, append([]lsp.TextEdit{*fm.TextEdit}, fm.AdditionalTextEdits...))
+		if !strings.Contains(got, "import \"fmt\"") || !strings.Contains(got, "{ fmt }") {
+			t.Errorf("applied package-name doc wrong:\n%s", got)
+		}
+		fset := token.NewFileSet()
+		if f, err := gsxparser.ParseFile(fset, "page.gsx", got, 0); f == nil || err != nil {
+			t.Errorf("applied doc does not reparse: err=%v\n%s", err, got)
+		}
+	})
+
+	// Precedence: an already-imported package is unaffected — `strings.` offers
+	// real members with NO import edit (the import qualifier resolves; auto-import
+	// never fires).
+	t.Run("imported package unaffected", func(t *testing.T) {
+		source := "package page\n\nimport \"strings\"\n\ncomponent Home() {\n\t<div>{ strings. }</div>\n\t<span>{ strings.ToLower(\"x\") }</span>\n}\n"
+		cursor := strings.Index(source, "{ strings. }") + len("{ strings.")
+		items := runHTMLCompletionE2E(t, nil, source, cursor)
+		var up *lsp.CompletionItem
+		for i := range items {
+			if items[i].Label == "ToUpper" {
+				up = &items[i]
+			}
+		}
+		if up == nil {
+			t.Fatalf("imported `strings.` did not offer ToUpper")
+		}
+		if len(up.AdditionalTextEdits) != 0 {
+			t.Errorf("imported member ToUpper carries an import edit %v, want none (already imported)", up.AdditionalTextEdits)
+		}
+	})
 }

--- a/internal/codegen/export_symbols.go
+++ b/internal/codegen/export_symbols.go
@@ -1,0 +1,208 @@
+package codegen
+
+import (
+	"go/types"
+	"slices"
+	"strings"
+
+	"github.com/gsxhq/gsx/internal/codegen/stdpath"
+)
+
+// SymbolKind is a coarse classification of an exported package-level symbol,
+// carried out of the codegen graph to the LSP without leaking a *types.Object.
+// The LSP maps it to an LSP CompletionItemKind. Only the categories a package's
+// top-level exported scope can hold are represented (no method / package-name /
+// builtin — those never appear at package scope).
+type SymbolKind int
+
+const (
+	SymbolFunc SymbolKind = iota
+	SymbolVar
+	SymbolConst
+	SymbolTypeStruct
+	SymbolTypeInterface
+	SymbolTypeOther // named non-struct/interface type, alias, or basic type
+)
+
+// ExportedSymbol is one exported top-level declaration of a package, described
+// by value (name, coarse kind, formatted type/signature) so the caller never
+// touches a graph *types.Object outside the analysis lock.
+type ExportedSymbol struct {
+	Name   string
+	Kind   SymbolKind
+	Detail string
+}
+
+// PackageName is one importable package: its declared name (the qualifier a
+// file would use) and its import path.
+type PackageName struct {
+	Name string
+	Path string
+}
+
+// PackageExportedSymbols returns the exported top-level declarations of the
+// package at importPath — for auto-import completion of an UNIMPORTED qualifier
+// (`fmt.▮` where fmt is not yet imported). Like ResolveImportCandidates it is a
+// user-triggered slow path (never the Package() hot path) and serializes the
+// whole read on analysisMu against one analysis snapshot: candidate names,
+// package identities, scopes, and the shared FileSet must all come from the same
+// generation.
+//
+// The symbols come from the LOADED module dependency graph — a COMPLETE
+// *types.Package whose scope is populated even though the asking .gsx file does
+// not import it (the graph is packages.Load's full transitive closure, a
+// superset of what any single file imports) — or, for a std package the graph
+// never reached, from cached gc export data (the one expensive branch,
+// ~46–78ms cold per distinct package, ~90µs warm thereafter). A main-module
+// source package resolves through the source declaration resolver. An
+// unknown/unloadable/incomplete path returns nil.
+//
+// Detail is formatted with every package qualified by its own name (no "current
+// package" here, since the asking file does not import this one), matching how
+// packageMemberItems renders an imported package's members.
+func (m *Module) PackageExportedSymbols(importPath string) []ExportedSymbol {
+	if importPath == "" {
+		return nil
+	}
+	m.analysisMu.Lock()
+	defer m.analysisMu.Unlock()
+	m.maybeRebuildFset()
+	m.applyDirty()
+
+	pkg := m.exportSymbolPackage(importPath)
+	if pkg == nil || !pkg.Complete() {
+		return nil
+	}
+	scope := pkg.Scope()
+	qf := func(p *types.Package) string { return p.Name() }
+	var out []ExportedSymbol
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if obj == nil || !obj.Exported() {
+			continue
+		}
+		out = append(out, ExportedSymbol{
+			Name:   name,
+			Kind:   classifyExportedSymbol(obj),
+			Detail: exportedSymbolDetail(obj, qf),
+		})
+	}
+	slices.SortFunc(out, func(a, b ExportedSymbol) int { return strings.Compare(a.Name, b.Name) })
+	return out
+}
+
+// exportSymbolPackage resolves importPath to a complete *types.Package via the
+// same three sources ResolveImportCandidates's packageExports uses, in the same
+// precedence: an already-loaded external graph package (free, in-memory), a
+// main-module source package (rebuilt through the source declaration resolver),
+// or cached gc export data (the stdlib-table-only tail). Called under
+// analysisMu.
+func (m *Module) exportSymbolPackage(importPath string) *types.Package {
+	graph := m.depGraphPackages()
+	if pkg, ok := graph[importPath]; ok {
+		return pkg
+	}
+	external, err := m.externalImporter()
+	if err == nil {
+		m.mu.Lock()
+		_, local := m.sourcePackageDirs[importPath]
+		m.mu.Unlock()
+		if local {
+			resolver := newSourceDeclResolver(m, external)
+			pkg, err := resolver.Import(importPath)
+			if err != nil {
+				return nil
+			}
+			return pkg
+		}
+	}
+	pkg, err := m.importExportData(importPath)
+	if err != nil {
+		return nil
+	}
+	return pkg
+}
+
+// classifyExportedSymbol maps a package-level exported object to a coarse
+// SymbolKind. It mirrors the LSP's goObjectPresentation kind logic for the
+// object categories that can appear at package scope.
+func classifyExportedSymbol(obj types.Object) SymbolKind {
+	switch o := obj.(type) {
+	case *types.Func:
+		return SymbolFunc
+	case *types.Var:
+		return SymbolVar
+	case *types.Const:
+		return SymbolConst
+	case *types.TypeName:
+		switch types.Unalias(o.Type()).Underlying().(type) {
+		case *types.Struct:
+			return SymbolTypeStruct
+		case *types.Interface:
+			return SymbolTypeInterface
+		default:
+			return SymbolTypeOther
+		}
+	default:
+		return SymbolVar
+	}
+}
+
+// exportedSymbolDetail formats an object's type/signature string, mirroring the
+// LSP's goObjectPresentation detail: a func/const/type shows its full object
+// string, a var shows just its type.
+func exportedSymbolDetail(obj types.Object, qf types.Qualifier) string {
+	switch o := obj.(type) {
+	case *types.Var:
+		return types.TypeString(o.Type(), qf)
+	default:
+		return types.ObjectString(obj, qf)
+	}
+}
+
+// ImportablePackageNames returns every package that dir could import: its
+// declared name and import path, from the loaded dependency graph and the baked
+// stdlib table, filtered by Go's internal-visibility rule (stdpath.InternalVisible)
+// for dir and excluding dir's own package (a self-import would be invalid Go).
+//
+// User-triggered slow path (auto-import package-name completion), serialized on
+// analysisMu like ResolveImportCandidates. All lookups, never a filesystem scan.
+// The result may be large (~1000 for a real module); the caller prefix-filters.
+func (m *Module) ImportablePackageNames(dir string) []PackageName {
+	m.analysisMu.Lock()
+	defer m.analysisMu.Unlock()
+	m.maybeRebuildFset()
+	m.applyDirty()
+
+	importerPath, _ := importPathForDir(m.opts.ModuleRoot, m.opts.ModulePath, dir)
+	graph := m.depGraphPackages()
+	names := m.importCandidatePackageNames(graph)
+
+	seen := map[string]bool{}
+	var out []PackageName
+	add := func(path, name string) {
+		if name == "" || path == "" || path == importerPath || seen[path] {
+			return
+		}
+		if !stdpath.InternalVisible(path, importerPath) {
+			return
+		}
+		seen[path] = true
+		out = append(out, PackageName{Name: name, Path: path})
+	}
+	for path, name := range names {
+		add(path, name)
+	}
+	for name, paths := range stdlibIndex {
+		for _, path := range paths {
+			add(path, name)
+		}
+	}
+	slices.SortFunc(out, func(a, b PackageName) int {
+		if a.Name != b.Name {
+			return strings.Compare(a.Name, b.Name)
+		}
+		return strings.Compare(a.Path, b.Path)
+	})
+	return out
+}

--- a/internal/codegen/export_symbols_test.go
+++ b/internal/codegen/export_symbols_test.go
@@ -1,0 +1,126 @@
+package codegen
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// symbolNames extracts the Name field of every ExportedSymbol.
+func symbolNames(syms []ExportedSymbol) []string {
+	out := make([]string, len(syms))
+	for i, s := range syms {
+		out[i] = s.Name
+	}
+	return out
+}
+
+// TestPackageExportedSymbolsStdlib enumerates a std package's exported scope
+// from the loaded dep graph (strings is reachable transitively), with kinds and
+// details, even though the asking .gsx does not import it.
+func TestPackageExportedSymbolsStdlib(t *testing.T) {
+	m, _ := newMissingModule(t, "package u\n\nvar xx = <p>hi</p>\n")
+	syms := m.PackageExportedSymbols("strings")
+	if len(syms) == 0 {
+		t.Fatal("strings exported symbols = none")
+	}
+	names := symbolNames(syms)
+	for _, want := range []string{"ToUpper", "Contains", "NewReplacer", "Builder", "Replacer"} {
+		if !slices.Contains(names, want) {
+			t.Errorf("strings missing exported symbol %q; got %v", want, names[:min(len(names), 12)])
+		}
+	}
+	// Sorted by name.
+	if !slices.IsSortedFunc(syms, func(a, b ExportedSymbol) int { return strings.Compare(a.Name, b.Name) }) {
+		t.Errorf("exported symbols not sorted by name")
+	}
+	// No unexported names leak.
+	for _, s := range syms {
+		if s.Name == "" || (s.Name[0] >= 'a' && s.Name[0] <= 'z') {
+			t.Errorf("leaked unexported/empty symbol %q", s.Name)
+		}
+	}
+	// Kinds and details are populated for representative symbols.
+	by := map[string]ExportedSymbol{}
+	for _, s := range syms {
+		by[s.Name] = s
+	}
+	// Detail qualifies every package by its name (the file does not import
+	// strings), matching how packageMemberItems renders an imported package's
+	// members: "func strings.ToUpper(s string) string".
+	if s := by["ToUpper"]; s.Kind != SymbolFunc || !strings.HasPrefix(s.Detail, "func strings.ToUpper(") {
+		t.Errorf("ToUpper = {kind %d, detail %q}, want func kind + qualified signature", s.Kind, s.Detail)
+	}
+	if s := by["Builder"]; s.Kind != SymbolTypeStruct {
+		t.Errorf("Builder kind = %d, want SymbolTypeStruct", s.Kind)
+	}
+}
+
+// TestPackageExportedSymbolsGraphPackage enumerates a non-std dep-graph package
+// (the gsx runtime) present in the module's build graph.
+func TestPackageExportedSymbolsGraphPackage(t *testing.T) {
+	m, _ := newMissingModule(t, "package u\n\nvar xx = <p>hi</p>\n")
+	syms := m.PackageExportedSymbols("github.com/gsxhq/gsx")
+	if len(syms) == 0 {
+		t.Fatal("gsx runtime exported symbols = none")
+	}
+	if !slices.Contains(symbolNames(syms), "Node") {
+		t.Errorf("gsx runtime missing exported `Node`; got %v", symbolNames(syms))
+	}
+}
+
+// TestPackageExportedSymbolsUnknown: an unresolvable path yields nil, never a
+// panic.
+func TestPackageExportedSymbolsUnknown(t *testing.T) {
+	m, _ := newMissingModule(t, "package u\n\nvar xx = <p>hi</p>\n")
+	if got := m.PackageExportedSymbols("no/such/pkg/anywhere"); got != nil {
+		t.Fatalf("unknown path = %v, want nil", got)
+	}
+	if got := m.PackageExportedSymbols(""); got != nil {
+		t.Fatalf("empty path = %v, want nil", got)
+	}
+}
+
+// TestImportablePackageNames returns name+path pairs from the graph and stdlib
+// table, internal-visibility filtered, sorted, without the asking package
+// itself.
+func TestImportablePackageNames(t *testing.T) {
+	m, dir := newMissingModule(t, "package u\n\nvar xx = <p>hi</p>\n")
+	pkgs := m.ImportablePackageNames(dir)
+	if len(pkgs) == 0 {
+		t.Fatal("importable packages = none")
+	}
+	byPath := map[string]string{}
+	for _, p := range pkgs {
+		byPath[p.Path] = p.Name
+	}
+	for path, wantName := range map[string]string{
+		"fmt":           "fmt",
+		"strings":       "strings",
+		"net/http":      "http",
+		"math/rand/v2":  "rand",
+		"encoding/json": "json",
+		"html/template": "template",
+	} {
+		if got, ok := byPath[path]; !ok {
+			t.Errorf("importable packages missing %q", path)
+		} else if got != wantName {
+			t.Errorf("%q name = %q, want %q", path, got, wantName)
+		}
+	}
+	// Sorted by (name, path).
+	if !slices.IsSortedFunc(pkgs, func(a, b PackageName) int {
+		if a.Name != b.Name {
+			return strings.Compare(a.Name, b.Name)
+		}
+		return strings.Compare(a.Path, b.Path)
+	}) {
+		t.Error("importable packages not sorted")
+	}
+	// The asking package itself is never offered.
+	for _, p := range pkgs {
+		if p.Path == "example.com/u" {
+			t.Errorf("self-package offered as importable: %+v", p)
+		}
+	}
+}

--- a/internal/gsxfmt/imports.go
+++ b/internal/gsxfmt/imports.go
@@ -244,6 +244,25 @@ func addChunkImports(src string, add []ImportRef) (string, bool) {
 	return preserveTrailing(src, stripped), true
 }
 
+// ChunkHasImports reports whether a Go chunk's source declares at least one
+// import. Exported for the LSP's auto-import completion, which locates the
+// import-holding chunk directly (for a narrow import-region edit) instead of
+// going through the whole-file formatter.
+func ChunkHasImports(src string) bool { return chunkHasImports(src) }
+
+// AddChunkImports adds a single default import of path to a Go chunk's source,
+// returning the rewritten source and whether it changed (false when path is
+// already imported, or src is not standalone-valid Go). It is the narrow
+// primitive behind auto-import completion's import edit.
+//
+// HARD CONTRACT: the import binds the package's OWN name — never an alias. An
+// aliased import synthesized here could collide with a name already bound to a
+// different path and emit invalid Go, the same contract the code-action path
+// documents.
+func AddChunkImports(src, path string) (string, bool) {
+	return addChunkImports(src, []ImportRef{{Path: path}})
+}
+
 // reorderImports rewrites the imports of every GoChunk in f, in place, to
 // goimports' canonical form. Non-GoChunk decls are skipped: imports never live
 // in a GoWithElements region, because the parser peels a leading import run into

--- a/internal/lsp/autoimport.go
+++ b/internal/lsp/autoimport.go
@@ -1,0 +1,337 @@
+package lsp
+
+import (
+	"go/token"
+	"strings"
+
+	gsxast "github.com/gsxhq/gsx/ast"
+	"github.com/gsxhq/gsx/internal/gsxfmt"
+	gsxparser "github.com/gsxhq/gsx/parser"
+)
+
+// SymbolKind is the LSP mirror of codegen.SymbolKind: a coarse classification of
+// an unimported package's exported symbol, carried across the Analyzer seam by
+// value so no *types.Object crosses the analysis lock. ciKind maps it to an LSP
+// CompletionItemKind for the completion item.
+type SymbolKind int
+
+const (
+	SymbolFunc SymbolKind = iota
+	SymbolVar
+	SymbolConst
+	SymbolTypeStruct
+	SymbolTypeInterface
+	SymbolTypeOther
+)
+
+// ciKind maps a SymbolKind to its LSP CompletionItemKind. It mirrors
+// goObjectPresentation's kind choices for the categories a package's top-level
+// exported scope holds.
+func (k SymbolKind) ciKind() int {
+	switch k {
+	case SymbolFunc:
+		return ciKindFunction
+	case SymbolVar:
+		return ciKindVariable
+	case SymbolConst:
+		return ciKindConstant
+	case SymbolTypeStruct:
+		return ciKindStruct
+	case SymbolTypeInterface:
+		return ciKindInterface
+	default:
+		return ciKindClass
+	}
+}
+
+// ImportSymbol is one exported symbol of an unimported package, offered as an
+// auto-import completion candidate. Kind/Detail feed the item's icon and
+// signature; the import path is supplied separately by the resolving caller
+// (one package's symbols share one path).
+type ImportSymbol struct {
+	Name   string
+	Kind   SymbolKind
+	Detail string
+}
+
+// ImportablePackage is one package a file could import: its declared name (the
+// qualifier the file would use) and its import path.
+type ImportablePackage struct {
+	Name string
+	Path string
+}
+
+// isIdentByte reports whether b can appear in a Go identifier. Used to walk an
+// authored-text qualifier backward from a member dot.
+func isIdentByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9', b == '_':
+		return true
+	case b >= 0x80: // any multibyte rune byte: be permissive, go/types is the arbiter
+		return true
+	default:
+		return false
+	}
+}
+
+// qualifierBeforeDot returns the bare identifier immediately before the member
+// dot at text[start-1], or ok=false when start-1 is not a dot or the receiver
+// is not a SIMPLE identifier (a complex receiver like `foo().` or a chained
+// `a.b.` is never an auto-import qualifier). nameEnd is the byte offset one past
+// the qualifier's last byte (its last identifier byte + 1), the position the
+// receiver's resolution is probed at.
+//
+// This is the text-level member-position test shared by expression and
+// statement cursors: for `fmt.Sprin▮`, start is the `Sprin` token start and
+// text[start-1] is the dot; for a trailing-dot cursor `fmt.▮`, start == the
+// cursor and text[start-1] is the dot. Both resolve the same qualifier `fmt`.
+func qualifierBeforeDot(text string, start int) (name string, nameEnd int, ok bool) {
+	if start <= 0 || start > len(text) || text[start-1] != '.' {
+		return "", 0, false
+	}
+	i := start - 2 // byte before the dot
+	for i >= 0 && isGoSpaceByte(text[i]) {
+		i--
+	}
+	end := i + 1 // one past the qualifier's last byte
+	for i >= 0 && isIdentByte(text[i]) {
+		i--
+	}
+	nameStart := i + 1
+	if nameStart >= end {
+		return "", 0, false // no identifier before the dot
+	}
+	// A leading digit means this is not an identifier (a numeric literal member
+	// access is not a package qualifier).
+	if c := text[nameStart]; c >= '0' && c <= '9' {
+		return "", 0, false
+	}
+	// The receiver must be a bare qualifier: the byte before it may not continue
+	// an expression (a dot, an identifier byte, or a closing bracket would make
+	// it a field/chain/complex receiver, not an unimported package name).
+	if nameStart > 0 {
+		switch c := text[nameStart-1]; {
+		case c == '.' || c == ')' || c == ']' || isIdentByte(c):
+			return "", 0, false
+		}
+	}
+	return text[nameStart:end], end, true
+}
+
+// undefinedQualifier reports whether the qualifier ending at byte nameEnd in
+// path resolves to nothing in eph — the precedence gate for auto-import: an
+// in-scope binding (a variable, a field) OR an imported package name both record
+// an occurrence in the source index, so a hit means the ordinary member path
+// already handles this receiver and auto-import must NOT fire. Only a total
+// resolution miss (an unimported package, or a typo) is an auto-import
+// candidate.
+func undefinedQualifier(eph *Package, path string, nameEnd int) bool {
+	if eph == nil || eph.SourceIndex == nil {
+		return false
+	}
+	// The index keys occurrences by the identifier's last byte; nameEnd is one
+	// past it.
+	_, resolved := eph.SourceIndex.At(path, nameEnd-1)
+	return !resolved
+}
+
+// importEditFor builds a NARROW TextEdit that adds importPath to text's import
+// region, in ORIGINAL-document coordinates, for a completion item's
+// AdditionalTextEdits. It reuses the gsxfmt import primitives (importTargetChunk
+// + addChunkImports) but — unlike the whole-document code-action edit, which
+// would illegally overlap the completion's own textEdit — emits only the minimal
+// changed byte range (a common-prefix/suffix diff of the target chunk), which
+// always lies at or above the import region and strictly before the cursor.
+//
+// ok=false means no edit is needed or possible: the path is already imported
+// (addChunkImports is a no-op), the buffer does not parse, there is no place to
+// put imports, or the computed edit would reach at or past cursorStart (a
+// safety net against overlapping the completion edit — never expected, since the
+// import region is above the cursor, but enforced rather than assumed).
+func importEditFor(text, importPath string, cursorStart int, enc encoding) (TextEdit, bool) {
+	fset := token.NewFileSet()
+	file, err := gsxparser.ParseFile(fset, "buffer.gsx", text, 0)
+	if file == nil || err != nil {
+		return TextEdit{}, false
+	}
+	chunkStart, oldSrc, ok := importChunkRegion(file, fset, text)
+	if !ok {
+		return TextEdit{}, false
+	}
+	newSrc, changed := gsxfmt.AddChunkImports(oldSrc, importPath)
+	if !changed {
+		return TextEdit{}, false
+	}
+	// AddChunkImports runs the chunk through gofmt, which normalizes away the
+	// leading blank-line separator the chunk's Src carries (the gsx printer
+	// re-adds it from a blank-before flag in the normal formatter flow — a step
+	// this direct call bypasses). Restore the chunk's original leading whitespace
+	// so the common-prefix diff below keeps the package-clause separator intact.
+	newSrc = restoreLeadingWhitespace(oldSrc, newSrc)
+	// Narrow to the minimal changed span: shared prefix/suffix bytes are
+	// untouched, so the edit replaces only the differing middle.
+	p := commonPrefixLen(oldSrc, newSrc)
+	s := commonSuffixLen(oldSrc[p:], newSrc[p:])
+	editStart := chunkStart + p
+	editEnd := chunkStart + len(oldSrc) - s
+	if editEnd > cursorStart {
+		return TextEdit{}, false // would overlap the completion edit; refuse
+	}
+	return TextEdit{
+		Range:   rangeForSpan(text, editStart, editEnd, enc),
+		NewText: newSrc[p : len(newSrc)-s],
+	}, true
+}
+
+// importChunkRegion locates the byte region of text that holds (or should hold)
+// the file's imports, returning its start offset and current source. It mirrors
+// gsxfmt.importTargetChunk's preference — the leading chunk that already
+// declares imports, else the first GoChunk — but for the no-GoChunk case
+// (`package x` directly followed by an element decl, no Go region at all) it
+// targets the whitespace between the package clause and the first declaration,
+// so an inserted import block lands exactly where a synthesized chunk would
+// print.
+func importChunkRegion(file *gsxast.File, fset *token.FileSet, text string) (start int, src string, ok bool) {
+	var first *gsxast.GoChunk
+	for _, d := range file.Decls {
+		gc, isChunk := d.(*gsxast.GoChunk)
+		if !isChunk {
+			continue
+		}
+		if gsxfmt.ChunkHasImports(gc.Src) {
+			s := fset.Position(gc.Pos()).Offset
+			return s, gc.Src, true
+		}
+		if first == nil {
+			first = gc
+		}
+	}
+	if first != nil {
+		return fset.Position(first.Pos()).Offset, first.Src, true
+	}
+	// No Go chunk: insert after the package clause. The whitespace between the
+	// package clause and the first decl is the region a synthesized import chunk
+	// occupies; replacing it preserves the author's blank-line spacing.
+	if len(file.Decls) == 0 {
+		return 0, "", false
+	}
+	declStart := fset.Position(file.Decls[0].Pos()).Offset
+	ws := declStart
+	for ws > 0 && isGoSpaceByte(text[ws-1]) {
+		ws--
+	}
+	if ws == 0 {
+		return 0, "", false // no package clause preceding — refuse rather than guess
+	}
+	return ws, text[ws:declStart], true
+}
+
+// restoreLeadingWhitespace re-prepends old's leading whitespace run to new when
+// gofmt stripped it (new no longer starts with old's separator). Idempotent when
+// new already carries the separator.
+func restoreLeadingWhitespace(old, new string) string {
+	lead := old[:len(old)-len(strings.TrimLeft(old, " \t\n"))]
+	if lead == "" || strings.HasPrefix(new, lead) {
+		return new
+	}
+	return lead + strings.TrimLeft(new, " \t\n")
+}
+
+func commonPrefixLen(a, b string) int {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+func commonSuffixLen(a, b string) int {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[len(a)-1-i] == b[len(b)-1-i] {
+		i++
+	}
+	return i
+}
+
+// unimportedQualifierItems is Option 1: an undefined qualifier in member
+// position (`fmt.▮`, `strings.ToUp▮`) resolves to candidate import path(s), and
+// each path's exported symbols become completion items whose accept inserts both
+// the symbol (the TextEdit over [start,end)) and the import (AdditionalTextEdits).
+//
+// The resolve is symbol-less — the qualifier alone — matching how member
+// completion offers a package's whole exported scope and lets the client filter
+// by the typed prefix. A qualifier that maps to several packages (an ambiguous
+// name) yields one item per surviving symbol per path, each labelled with its
+// own path (§5 of the design): honest, no relevance guessing. A candidate whose
+// import edit cannot be synthesized (already imported, unparseable buffer) is
+// skipped rather than offered without its import.
+func (s *Server) unimportedQualifierItems(dir, path, text, qualifier string, start, end int) []CompletionItem {
+	paths := s.analyzer.ResolveImport(dir, qualifier, "")
+	if len(paths) == 0 {
+		return nil
+	}
+	var items []CompletionItem
+	for _, importPath := range paths {
+		edit, ok := importEditFor(text, importPath, start, s.enc)
+		if !ok {
+			continue
+		}
+		for _, sym := range s.analyzer.ExportedSymbols(dir, importPath) {
+			if isReservedGsxInternal(sym.Name) {
+				continue
+			}
+			item := newCompletionItem(text, start, end, s.enc, sym.Name, sym.Name, sym.Kind.ciKind(), tierImported, sym.Detail, nil)
+			item.AdditionalTextEdits = []TextEdit{edit}
+			s.applyImportPathLabel(&item, sym.Detail, importPath)
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+// packageNameItems is Option 2: at a bare-identifier position, unimported
+// package names whose name has the typed prefix, each accepting to insert the
+// package identifier plus its import (AdditionalTextEdits). Ranked at
+// tierUnimported — strictly below every in-scope name, member, and keyword.
+//
+// A prefix is required: flooding an empty cursor with ~1000 package names is
+// pure noise, so package names appear only once the user commits at least one
+// character (the design's "cap noise" — a server-side narrowing that is safe
+// regardless of whether the client also filters). The path a candidate would
+// import is shown as its detail/labelDetails.
+func (s *Server) packageNameItems(dir, text, prefix string, start, end int) []CompletionItem {
+	if prefix == "" {
+		return nil
+	}
+	var items []CompletionItem
+	for _, pkg := range s.analyzer.ImportablePackages(dir) {
+		if !strings.HasPrefix(pkg.Name, prefix) {
+			continue
+		}
+		edit, ok := importEditFor(text, pkg.Path, start, s.enc)
+		if !ok {
+			continue
+		}
+		item := newCompletionItem(text, start, end, s.enc, pkg.Name, pkg.Name, ciKindModule, tierUnimported, pkg.Path, nil)
+		item.AdditionalTextEdits = []TextEdit{edit}
+		s.applyImportPathLabel(&item, pkg.Path, pkg.Path)
+		items = append(items, item)
+	}
+	return items
+}
+
+// applyImportPathLabel places the import path on an auto-import item. A client
+// that renders labelDetails gets the path in labelDetails.description (with the
+// type signature kept in detail); one that does not falls back to the plain
+// detail string carrying the path — the path being the disambiguator worth the
+// single slot.
+func (s *Server) applyImportPathLabel(item *CompletionItem, typeSig, importPath string) {
+	if s.labelDetailsSupport {
+		item.Detail = typeSig
+		item.LabelDetails = &CompletionItemLabelDetails{Description: importPath}
+		return
+	}
+	item.Detail = importPath
+}

--- a/internal/lsp/autoimport.go
+++ b/internal/lsp/autoimport.go
@@ -135,30 +135,53 @@ func undefinedQualifier(eph *Package, path string, nameEnd int) bool {
 	return !resolved
 }
 
-// importEditFor builds a NARROW TextEdit that adds importPath to text's import
-// region, in ORIGINAL-document coordinates, for a completion item's
+// importEditPrep is the buffer-level state a candidate import path's edit is
+// built from: the parse and the import-chunk region depend only on text, not
+// on which path is being added. prepareImportEdit computes it ONCE per
+// completion request; apply then does the cheap per-path work
+// (AddChunkImports + the prefix/suffix diff) for each candidate, so a request
+// offering N unimported packages/paths re-parses the buffer once instead of N
+// times.
+type importEditPrep struct {
+	text       string
+	chunkStart int
+	oldSrc     string
+	enc        encoding
+}
+
+// prepareImportEdit parses text and locates its import-chunk region — see
+// importEditFor's doc for the overall contract this feeds. ok=false means no
+// candidate path in the caller's loop can produce an edit (the buffer does not
+// parse, or there is no place to put imports), so the loop can be skipped
+// entirely.
+func prepareImportEdit(text string, enc encoding) (importEditPrep, bool) {
+	fset := token.NewFileSet()
+	file, err := gsxparser.ParseFile(fset, "buffer.gsx", text, 0)
+	if file == nil || err != nil {
+		return importEditPrep{}, false
+	}
+	chunkStart, oldSrc, ok := importChunkRegion(file, fset, text)
+	if !ok {
+		return importEditPrep{}, false
+	}
+	return importEditPrep{text: text, chunkStart: chunkStart, oldSrc: oldSrc, enc: enc}, true
+}
+
+// apply builds importPath's NARROW TextEdit against the state prepareImportEdit
+// already computed, in ORIGINAL-document coordinates, for a completion item's
 // AdditionalTextEdits. It reuses the gsxfmt import primitives (importTargetChunk
 // + addChunkImports) but — unlike the whole-document code-action edit, which
 // would illegally overlap the completion's own textEdit — emits only the minimal
 // changed byte range (a common-prefix/suffix diff of the target chunk), which
 // always lies at or above the import region and strictly before the cursor.
 //
-// ok=false means no edit is needed or possible: the path is already imported
-// (addChunkImports is a no-op), the buffer does not parse, there is no place to
-// put imports, or the computed edit would reach at or past cursorStart (a
-// safety net against overlapping the completion edit — never expected, since the
-// import region is above the cursor, but enforced rather than assumed).
-func importEditFor(text, importPath string, cursorStart int, enc encoding) (TextEdit, bool) {
-	fset := token.NewFileSet()
-	file, err := gsxparser.ParseFile(fset, "buffer.gsx", text, 0)
-	if file == nil || err != nil {
-		return TextEdit{}, false
-	}
-	chunkStart, oldSrc, ok := importChunkRegion(file, fset, text)
-	if !ok {
-		return TextEdit{}, false
-	}
-	newSrc, changed := gsxfmt.AddChunkImports(oldSrc, importPath)
+// ok=false means no edit is needed or possible: importPath is already imported
+// (AddChunkImports is a no-op), or the computed edit would reach at or past
+// cursorStart (a safety net against overlapping the completion edit — never
+// expected, since the import region is above the cursor, but enforced rather
+// than assumed).
+func (p importEditPrep) apply(importPath string, cursorStart int) (TextEdit, bool) {
+	newSrc, changed := gsxfmt.AddChunkImports(p.oldSrc, importPath)
 	if !changed {
 		return TextEdit{}, false
 	}
@@ -167,20 +190,32 @@ func importEditFor(text, importPath string, cursorStart int, enc encoding) (Text
 	// re-adds it from a blank-before flag in the normal formatter flow — a step
 	// this direct call bypasses). Restore the chunk's original leading whitespace
 	// so the common-prefix diff below keeps the package-clause separator intact.
-	newSrc = restoreLeadingWhitespace(oldSrc, newSrc)
+	newSrc = restoreLeadingWhitespace(p.oldSrc, newSrc)
 	// Narrow to the minimal changed span: shared prefix/suffix bytes are
 	// untouched, so the edit replaces only the differing middle.
-	p := commonPrefixLen(oldSrc, newSrc)
-	s := commonSuffixLen(oldSrc[p:], newSrc[p:])
-	editStart := chunkStart + p
-	editEnd := chunkStart + len(oldSrc) - s
+	pfx := commonPrefixLen(p.oldSrc, newSrc)
+	sfx := commonSuffixLen(p.oldSrc[pfx:], newSrc[pfx:])
+	editStart := p.chunkStart + pfx
+	editEnd := p.chunkStart + len(p.oldSrc) - sfx
 	if editEnd > cursorStart {
 		return TextEdit{}, false // would overlap the completion edit; refuse
 	}
 	return TextEdit{
-		Range:   rangeForSpan(text, editStart, editEnd, enc),
-		NewText: newSrc[p : len(newSrc)-s],
+		Range:   rangeForSpan(p.text, editStart, editEnd, p.enc),
+		NewText: newSrc[pfx : len(newSrc)-sfx],
 	}, true
+}
+
+// importEditFor is the single-path convenience wrapper over
+// prepareImportEdit+apply: parse once, apply once. Candidate LOOPS (Option
+// 1's per-path paths, Option 2's per-package paths) call prepareImportEdit
+// once and apply per candidate instead, so the parse is not repeated.
+func importEditFor(text, importPath string, cursorStart int, enc encoding) (TextEdit, bool) {
+	p, ok := prepareImportEdit(text, enc)
+	if !ok {
+		return TextEdit{}, false
+	}
+	return p.apply(importPath, cursorStart)
 }
 
 // importChunkRegion locates the byte region of text that holds (or should hold)
@@ -272,9 +307,16 @@ func (s *Server) unimportedQualifierItems(dir, path, text, qualifier string, sta
 	if len(paths) == 0 {
 		return nil
 	}
+	// Hoisted: the parse + import-chunk lookup don't depend on which path is
+	// being added, so they run ONCE for the whole candidate loop below instead
+	// of once per path.
+	prep, ok := prepareImportEdit(text, s.enc)
+	if !ok {
+		return nil
+	}
 	var items []CompletionItem
 	for _, importPath := range paths {
-		edit, ok := importEditFor(text, importPath, start, s.enc)
+		edit, ok := prep.apply(importPath, start)
 		if !ok {
 			continue
 		}
@@ -305,12 +347,20 @@ func (s *Server) packageNameItems(dir, text, prefix string, start, end int) []Co
 	if prefix == "" {
 		return nil
 	}
+	// Hoisted: the parse + import-chunk lookup don't depend on which package is
+	// being added, so they run ONCE for the whole candidate loop below instead
+	// of once per package (the loop can range over ~1000 std packages before
+	// the prefix filter narrows it).
+	prep, ok := prepareImportEdit(text, s.enc)
+	if !ok {
+		return nil
+	}
 	var items []CompletionItem
 	for _, pkg := range s.analyzer.ImportablePackages(dir) {
 		if !strings.HasPrefix(pkg.Name, prefix) {
 			continue
 		}
-		edit, ok := importEditFor(text, pkg.Path, start, s.enc)
+		edit, ok := prep.apply(pkg.Path, start)
 		if !ok {
 			continue
 		}

--- a/internal/lsp/autoimport_test.go
+++ b/internal/lsp/autoimport_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -302,5 +303,93 @@ func TestPackageNameItemsEmptyPrefixSuppressed(t *testing.T) {
 	s := &Server{analyzer: a, enc: encUTF8}
 	if items := s.packageNameItems("dir", text, "", 40, 40); len(items) != 0 {
 		t.Errorf("empty prefix offered %d package names, want 0 (noise cap)", len(items))
+	}
+}
+
+// TestMergePackageNameItemsSuppressesShadow pins completion.go's shadow-
+// suppression path (goContextCompletion, ~131-142): a package whose declared
+// name collides with an identifier already in scope must NOT be offered as an
+// import candidate, since accepting it would produce the exact identifier the
+// file already has, silently shadowing the existing binding rather than
+// introducing a new one. os/user is the paradigm case — its package name is
+// `user`, a common local/parameter identifier.
+func TestMergePackageNameItemsSuppressesShadow(t *testing.T) {
+	text := "package page\n\ncomponent Home(user User) {\n\t<div>{ us }</div>\n}\n"
+	start := strings.Index(text, "{ us }") + len("{ ")
+	end := start + len("us")
+
+	a := autoImportAnalyzer{
+		packages: []ImportablePackage{
+			{Name: "user", Path: "os/user"},    // shadows the in-scope `user` param
+			{Name: "usage", Path: "pkg/usage"}, // distinct name: not a shadow
+		},
+	}
+	s := &Server{analyzer: a, enc: encUTF8}
+
+	// Sanity: os/user surfaces as a raw candidate from packageNameItems alone —
+	// the suppression is the CALLER's job (mergePackageNameItems), not
+	// packageNameItems'.
+	pkgItems := s.packageNameItems("dir", text, "us", start, end)
+	pkgByLabel := itemsByLabel(pkgItems)
+	if _, ok := pkgByLabel["user"]; !ok {
+		t.Fatalf("packageNameItems did not offer raw os/user candidate; got %v", pkgByLabel)
+	}
+	if _, ok := pkgByLabel["usage"]; !ok {
+		t.Fatalf("packageNameItems did not offer pkg/usage candidate; got %v", pkgByLabel)
+	}
+
+	// The in-scope scope-chain already offered `user` as a plain identifier (no
+	// import edit) — this simulates goCompletionItems' output for the component
+	// parameter before the Option 2 merge runs.
+	scopeItems := []CompletionItem{{Label: "user", Kind: ciKindVariable}}
+
+	got := mergePackageNameItems(scopeItems, pkgItems)
+
+	var userCount int
+	var sawUsage bool
+	for _, it := range got {
+		if it.Label == "user" {
+			userCount++
+			if len(it.AdditionalTextEdits) != 0 {
+				t.Errorf("merged `user` item carries an import edit %v, want the scope item preserved untouched (os/user suppressed)", it.AdditionalTextEdits)
+			}
+		}
+		if it.Label == "usage" {
+			sawUsage = true
+		}
+	}
+	if userCount != 1 {
+		t.Errorf("merged items contain %d `user` labels, want 1 (os/user suppressed as a shadow)", userCount)
+	}
+	if !sawUsage {
+		t.Errorf("merged items missing `usage` (a non-colliding package must still be offered); got %v", got)
+	}
+}
+
+// BenchmarkPackageNameItems measures packageNameItems' cost with a large
+// candidate set (100 unimported packages all matching the typed prefix), the
+// hot path importEditFor's per-candidate re-parse made expensive: before the
+// prepareImportEdit hoist, each candidate re-parsed the whole buffer
+// (gsxparser.ParseFile) independently of the import path; after, the buffer is
+// parsed once per completion request and each candidate only runs
+// AddChunkImports + the prefix/suffix diff.
+func BenchmarkPackageNameItems(b *testing.B) {
+	text := "package page\n\nimport \"strings\"\n\ncomponent Home() {\n\t<div>{ fm }</div>\n}\n"
+	start := strings.Index(text, "{ fm }") + len("{ ")
+	end := start + len("fm")
+
+	pkgs := make([]ImportablePackage, 100)
+	for i := range pkgs {
+		pkgs[i] = ImportablePackage{Name: fmt.Sprintf("fmt%d", i), Path: fmt.Sprintf("pkg/fmt%d", i)}
+	}
+	a := autoImportAnalyzer{packages: pkgs}
+	s := &Server{analyzer: a, enc: encUTF8}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		items := s.packageNameItems("dir", text, "fmt", start, end)
+		if len(items) != 100 {
+			b.Fatalf("got %d items, want 100", len(items))
+		}
 	}
 }

--- a/internal/lsp/autoimport_test.go
+++ b/internal/lsp/autoimport_test.go
@@ -1,0 +1,306 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+)
+
+// applyTextEdits applies edits (assumed non-overlapping) to text, rightmost
+// first so earlier offsets stay valid. Used to prove an auto-import item's
+// TextEdit + AdditionalTextEdits compose into a well-formed document.
+func applyTextEdits(text string, edits []TextEdit, enc encoding) string {
+	type off struct {
+		start, end int
+		newText    string
+	}
+	os := make([]off, len(edits))
+	for i, e := range edits {
+		os[i] = off{
+			start:   byteOffsetForPosition(text, e.Range.Start.Line, e.Range.Start.Character, enc),
+			end:     byteOffsetForPosition(text, e.Range.End.Line, e.Range.End.Character, enc),
+			newText: e.NewText,
+		}
+	}
+	// Insertion sort by start descending.
+	for i := 1; i < len(os); i++ {
+		for j := i; j > 0 && os[j].start > os[j-1].start; j-- {
+			os[j], os[j-1] = os[j-1], os[j]
+		}
+	}
+	out := text
+	for _, o := range os {
+		out = out[:o.start] + o.newText + out[o.end:]
+	}
+	return out
+}
+
+func TestImportEditForCases(t *testing.T) {
+	tests := []struct {
+		name, text, path, want string
+	}{
+		{
+			name: "existing import block",
+			text: "package page\n\nimport \"strings\"\n\ncomponent Home() {\n\t<div>{ x }</div>\n}\n",
+			path: "fmt",
+			want: "package page\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n)\n\ncomponent Home() {\n\t<div>{ x }</div>\n}\n",
+		},
+		{
+			name: "no import block (insert after package clause)",
+			text: "package page\n\ncomponent Home() {\n\t<div>{ x }</div>\n}\n",
+			path: "strings",
+			want: "package page\n\nimport \"strings\"\n\ncomponent Home() {\n\t<div>{ x }</div>\n}\n",
+		},
+		{
+			name: "leading non-import chunk",
+			text: "package page\n\nvar y = 1\n\ncomponent Home() {\n\t<div>{ x }</div>\n}\n",
+			path: "fmt",
+			want: "package page\n\nimport \"fmt\"\n\nvar y = 1\n\ncomponent Home() {\n\t<div>{ x }</div>\n}\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// cursorStart deliberately large: the import region is always above it.
+			ed, ok := importEditFor(tt.text, tt.path, len(tt.text), encUTF8)
+			if !ok {
+				t.Fatal("importEditFor = !ok, want an edit")
+			}
+			got := applyTextEdits(tt.text, []TextEdit{ed}, encUTF8)
+			if got != tt.want {
+				t.Errorf("applied edit =\n%q\nwant\n%q", got, tt.want)
+			}
+			// The edit must lie strictly above the cursor.
+			endOff := byteOffsetForPosition(tt.text, ed.Range.End.Line, ed.Range.End.Character, encUTF8)
+			if endOff > len(tt.text) {
+				t.Errorf("edit end %d past buffer", endOff)
+			}
+		})
+	}
+}
+
+func TestImportEditForAlreadyImported(t *testing.T) {
+	text := "package page\n\nimport \"fmt\"\n\ncomponent Home() {\n\t<div>{ fmt.Sprint(1) }</div>\n}\n"
+	if _, ok := importEditFor(text, "fmt", len(text), encUTF8); ok {
+		t.Error("importEditFor for an already-imported path = ok, want no edit")
+	}
+}
+
+func TestImportEditForRefusesOverlap(t *testing.T) {
+	// A cursor at the very top (offset 0) forces the computed import edit end to
+	// exceed cursorStart; importEditFor must refuse rather than emit an
+	// overlapping edit.
+	text := "package page\n\ncomponent Home() {\n\t<div>{ x }</div>\n}\n"
+	if _, ok := importEditFor(text, "strings", 0, encUTF8); ok {
+		t.Error("importEditFor with cursorStart=0 = ok, want refusal (would overlap)")
+	}
+}
+
+func TestQualifierBeforeDot(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		start   int
+		wantOK  bool
+		wantQ   string
+		wantEnd int
+	}{
+		{"trailing dot", "{ fmt. }", 6, true, "fmt", 5},
+		{"typed prefix", "{ fmt.Spr }", 6, true, "fmt", 5},
+		{"space before dot", "{ fmt . }", 7, true, "fmt", 5},
+		{"chained receiver", "{ a.b. }", 6, false, "", 0},
+		{"complex receiver", "{ foo(). }", 8, false, "", 0},
+		{"not a member", "{ fm }", 4, false, "", 0},
+		{"numeric receiver", "{ 3.14 }", 4, false, "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Locate the dot's following position as the completion token start.
+			q, end, ok := qualifierBeforeDot(tt.text, tt.start)
+			if ok != tt.wantOK || q != tt.wantQ {
+				t.Fatalf("qualifierBeforeDot(%q, %d) = (%q, %d, %v), want (%q, _, %v)",
+					tt.text, tt.start, q, end, ok, tt.wantQ, tt.wantOK)
+			}
+			if ok && end != tt.wantEnd {
+				t.Errorf("nameEnd = %d, want %d", end, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestSymbolKindCiKind(t *testing.T) {
+	for k, want := range map[SymbolKind]int{
+		SymbolFunc:          ciKindFunction,
+		SymbolVar:           ciKindVariable,
+		SymbolConst:         ciKindConstant,
+		SymbolTypeStruct:    ciKindStruct,
+		SymbolTypeInterface: ciKindInterface,
+		SymbolTypeOther:     ciKindClass,
+	} {
+		if got := k.ciKind(); got != want {
+			t.Errorf("SymbolKind(%d).ciKind() = %d, want %d", k, got, want)
+		}
+	}
+}
+
+// autoImportAnalyzer is a fake Analyzer supplying auto-import data (paths,
+// symbols, package names) without a real module analysis. Other methods embed
+// nilAnalyzer.
+type autoImportAnalyzer struct {
+	nilAnalyzer
+	resolve  map[string][]string       // qualifier -> paths
+	symbols  map[string][]ImportSymbol // path -> exported symbols
+	packages []ImportablePackage
+}
+
+func (a autoImportAnalyzer) ResolveImport(_, name, _ string) []string { return a.resolve[name] }
+func (a autoImportAnalyzer) ExportedSymbols(_, path string) []ImportSymbol {
+	return a.symbols[path]
+}
+func (a autoImportAnalyzer) ImportablePackages(string) []ImportablePackage { return a.packages }
+
+func itemsByLabel(items []CompletionItem) map[string]CompletionItem {
+	m := map[string]CompletionItem{}
+	for _, it := range items {
+		m[it.Label] = it
+	}
+	return m
+}
+
+func TestUnimportedQualifierItems(t *testing.T) {
+	text := "package page\n\ncomponent Home() {\n\t<div>{ fmt. }</div>\n}\n"
+	// completion token span for the empty prefix after "fmt." : start==end at the
+	// byte right after the dot.
+	start := strings.Index(text, "fmt.") + len("fmt.")
+	end := start
+
+	a := autoImportAnalyzer{
+		resolve: map[string][]string{"fmt": {"fmt"}},
+		symbols: map[string][]ImportSymbol{
+			"fmt": {
+				{Name: "Sprintf", Kind: SymbolFunc, Detail: "func fmt.Sprintf(format string, a ...any) string"},
+				{Name: "Stringer", Kind: SymbolTypeInterface, Detail: "type fmt.Stringer interface{ String() string }"},
+			},
+		},
+	}
+
+	t.Run("no labelDetails support", func(t *testing.T) {
+		s := &Server{analyzer: a, enc: encUTF8}
+		items := s.unimportedQualifierItems("dir", "page.gsx", text, "fmt", start, end)
+		by := itemsByLabel(items)
+		sp, ok := by["Sprintf"]
+		if !ok {
+			t.Fatalf("missing Sprintf; labels=%v", by)
+		}
+		if sp.Kind != ciKindFunction {
+			t.Errorf("Sprintf kind = %d, want function", sp.Kind)
+		}
+		if len(sp.AdditionalTextEdits) != 1 {
+			t.Fatalf("Sprintf AdditionalTextEdits = %d, want 1", len(sp.AdditionalTextEdits))
+		}
+		// Applying both edits inserts the import and the symbol, and reparses clean.
+		all := append([]TextEdit{{Range: sp.TextEdit.Range, NewText: sp.TextEdit.NewText}}, sp.AdditionalTextEdits...)
+		got := applyTextEdits(text, all, encUTF8)
+		if !strings.Contains(got, "import \"fmt\"") || !strings.Contains(got, "fmt.Sprintf") {
+			t.Errorf("applied doc missing import or symbol:\n%s", got)
+		}
+		// Fallback: the import path lives in the detail string, no labelDetails.
+		if sp.LabelDetails != nil {
+			t.Errorf("labelDetails set without capability: %+v", sp.LabelDetails)
+		}
+		if sp.Detail != "fmt" {
+			t.Errorf("fallback detail = %q, want import path \"fmt\"", sp.Detail)
+		}
+	})
+
+	t.Run("labelDetails support", func(t *testing.T) {
+		s := &Server{analyzer: a, enc: encUTF8, labelDetailsSupport: true}
+		items := s.unimportedQualifierItems("dir", "page.gsx", text, "fmt", start, end)
+		sp := itemsByLabel(items)["Sprintf"]
+		if sp.LabelDetails == nil || sp.LabelDetails.Description != "fmt" {
+			t.Errorf("labelDetails = %+v, want description \"fmt\"", sp.LabelDetails)
+		}
+		if !strings.HasPrefix(sp.Detail, "func fmt.Sprintf(") {
+			t.Errorf("detail = %q, want the type signature kept", sp.Detail)
+		}
+	})
+}
+
+func TestUnimportedQualifierAmbiguousPerPath(t *testing.T) {
+	text := "package page\n\ncomponent Home() {\n\t<div>{ rand. }</div>\n}\n"
+	start := strings.Index(text, "rand.") + len("rand.")
+	a := autoImportAnalyzer{
+		resolve: map[string][]string{"rand": {"crypto/rand", "math/rand/v2"}},
+		symbols: map[string][]ImportSymbol{
+			"crypto/rand":  {{Name: "Read", Kind: SymbolFunc, Detail: "func crypto/rand.Read(b []byte) (n int, err error)"}},
+			"math/rand/v2": {{Name: "IntN", Kind: SymbolFunc, Detail: "func math/rand/v2.IntN(n int) int"}},
+		},
+	}
+	s := &Server{analyzer: a, enc: encUTF8, labelDetailsSupport: true}
+	items := s.unimportedQualifierItems("dir", "page.gsx", text, "rand", start, start)
+	if len(items) != 2 {
+		t.Fatalf("ambiguous rand = %d items, want 2 (one per path)", len(items))
+	}
+	// Each item's import edit adds its OWN path, and its labelDetails names it.
+	for _, it := range items {
+		var wantPath string
+		switch it.Label {
+		case "Read":
+			wantPath = "crypto/rand"
+		case "IntN":
+			wantPath = "math/rand/v2"
+		default:
+			t.Fatalf("unexpected item %q", it.Label)
+		}
+		if it.LabelDetails == nil || it.LabelDetails.Description != wantPath {
+			t.Errorf("%s labelDetails = %+v, want %q", it.Label, it.LabelDetails, wantPath)
+		}
+		got := applyTextEdits(text, append([]TextEdit{*it.TextEdit}, it.AdditionalTextEdits...), encUTF8)
+		if !strings.Contains(got, "import \""+wantPath+"\"") {
+			t.Errorf("%s applied doc missing import %q:\n%s", it.Label, wantPath, got)
+		}
+	}
+}
+
+func TestPackageNameItemsTierAndPrefix(t *testing.T) {
+	text := "package page\n\ncomponent Home() {\n\t<div>{ fm }</div>\n}\n"
+	start := strings.Index(text, "{ fm }") + len("{ ")
+	end := start + len("fm")
+	a := autoImportAnalyzer{
+		packages: []ImportablePackage{
+			{Name: "fmt", Path: "fmt"},
+			{Name: "flag", Path: "flag"},
+			{Name: "strings", Path: "strings"},
+		},
+	}
+	s := &Server{analyzer: a, enc: encUTF8}
+	items := s.packageNameItems("dir", text, "fm", start, end)
+	by := itemsByLabel(items)
+	if _, ok := by["fmt"]; !ok {
+		t.Fatalf("prefix `fm` did not offer fmt; labels=%v", by)
+	}
+	if _, ok := by["strings"]; ok {
+		t.Errorf("prefix `fm` wrongly offered strings")
+	}
+	fmtItem := by["fmt"]
+	if fmtItem.Kind != ciKindModule {
+		t.Errorf("fmt kind = %d, want Module", fmtItem.Kind)
+	}
+	if !strings.HasPrefix(fmtItem.SortText, "70") {
+		t.Errorf("fmt SortText = %q, want tierUnimported prefix \"70\"", fmtItem.SortText)
+	}
+	if len(fmtItem.AdditionalTextEdits) != 1 {
+		t.Fatalf("fmt AdditionalTextEdits = %d, want 1", len(fmtItem.AdditionalTextEdits))
+	}
+	got := applyTextEdits(text, append([]TextEdit{*fmtItem.TextEdit}, fmtItem.AdditionalTextEdits...), encUTF8)
+	if !strings.Contains(got, "import \"fmt\"") || !strings.Contains(got, "{ fmt }") {
+		t.Errorf("applied package-name item doc wrong:\n%s", got)
+	}
+}
+
+func TestPackageNameItemsEmptyPrefixSuppressed(t *testing.T) {
+	text := "package page\n\ncomponent Home() {\n\t<div>{  }</div>\n}\n"
+	a := autoImportAnalyzer{packages: []ImportablePackage{{Name: "fmt", Path: "fmt"}}}
+	s := &Server{analyzer: a, enc: encUTF8}
+	if items := s.packageNameItems("dir", text, "", 40, 40); len(items) != 0 {
+		t.Errorf("empty prefix offered %d package names, want 0 (noise cap)", len(items))
+	}
+}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -104,6 +104,43 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// tier. Fails silent (nil, no boost) outside the derivable subset.
 	expected := expectedTypeAt(eph, cc, skel, skelPos, exprStartOff, path)
 	items := goCompletionItems(eph, scope, skel, skelPos, statementCtx, expected, text, start, end, s.enc, path, src)
+
+	dir := filepath.Dir(path)
+	// Auto-import Option 1: the ordinary member dispatch found nothing for a
+	// member cursor whose qualifier resolves to no in-scope binding and no
+	// imported package — the last fallback. Offer the unimported package's
+	// symbols with an eager import edit. Gated on an EMPTY member list so a
+	// resolved-but-memberless receiver (`x.` where x is an int) or any local
+	// shadow never gets clobbered: precedence is in-scope binding > import
+	// qualifier > unimported.
+	if len(items) == 0 {
+		if name, nameEnd, ok := qualifierBeforeDot(text, start); ok && undefinedQualifier(eph, path, nameEnd) {
+			extra := s.unimportedQualifierItems(dir, path, text, name, start, end)
+			if len(extra) == 0 {
+				return emptyCompletion()
+			}
+			return CompletionList{IsIncomplete: false, Items: extra}
+		}
+	}
+	// Auto-import Option 2: at a bare-identifier position (not a member cursor),
+	// append unimported package names below every in-scope name and keyword. A
+	// package whose name already names an in-scope item (a local, a package-scope
+	// decl, an imported package) is skipped: offering an import that produces the
+	// same identifier the file already has is redundant and would shadow it (e.g.
+	// os/user's `user` over a local `user`).
+	if start == 0 || text[start-1] != '.' {
+		existing := make(map[string]bool, len(items))
+		for _, it := range items {
+			existing[it.Label] = true
+		}
+		for _, pk := range s.packageNameItems(dir, text, text[start:end], start, end) {
+			if existing[pk.Label] {
+				continue
+			}
+			items = append(items, pk)
+		}
+	}
+
 	if len(items) == 0 {
 		return emptyCompletion()
 	}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -129,22 +129,34 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// same identifier the file already has is redundant and would shadow it (e.g.
 	// os/user's `user` over a local `user`).
 	if start == 0 || text[start-1] != '.' {
-		existing := make(map[string]bool, len(items))
-		for _, it := range items {
-			existing[it.Label] = true
-		}
-		for _, pk := range s.packageNameItems(dir, text, text[start:end], start, end) {
-			if existing[pk.Label] {
-				continue
-			}
-			items = append(items, pk)
-		}
+		items = mergePackageNameItems(items, s.packageNameItems(dir, text, text[start:end], start, end))
 	}
 
 	if len(items) == 0 {
 		return emptyCompletion()
 	}
 	return CompletionList{IsIncomplete: false, Items: items}
+}
+
+// mergePackageNameItems appends pkgItems (unimported package-name candidates,
+// Option 2) to items (the in-scope names/members/keywords already offered),
+// skipping any candidate whose Label collides with one already present. A
+// package whose name already names an in-scope item (a local, a package-scope
+// decl, an imported package) is skipped: offering an import that produces the
+// same identifier the file already has is redundant and would shadow it (e.g.
+// os/user's package name `user` over a local `user`).
+func mergePackageNameItems(items, pkgItems []CompletionItem) []CompletionItem {
+	existing := make(map[string]bool, len(items))
+	for _, it := range items {
+		existing[it.Label] = true
+	}
+	for _, pk := range pkgItems {
+		if existing[pk.Label] {
+			continue
+		}
+		items = append(items, pk)
+	}
+	return items
 }
 
 func emptyCompletion() CompletionList {

--- a/internal/lsp/completion_items.go
+++ b/internal/lsp/completion_items.go
@@ -24,6 +24,10 @@ const (
 	tierKeyword   = 60
 	tierContext   = 5  // context-native items: filters, components, attrs
 	tierSecondary = 20 // e.g. HTML tags merged under a capitalized prefix
+	// tierUnimported ranks auto-import package-name items (Option 2) strictly
+	// below every in-scope name, member, and keyword: they are the last resort,
+	// offered only after the client has exhausted names the file already has.
+	tierUnimported = 70
 )
 
 // completionTokenSpan scans identifier bytes backward from off in text and

--- a/internal/lsp/documentsymbol_test.go
+++ b/internal/lsp/documentsymbol_test.go
@@ -60,6 +60,8 @@ func (symbolFileAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 	return gsxfmt.ImportsGoimports
 }
 func (symbolFileAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (symbolFileAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (symbolFileAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 func TestDocumentSymbol(t *testing.T) {
 	uri := "file:///m/page.gsx"

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -72,13 +72,19 @@ type completionClientCapabilities struct {
 	CompletionItem completionItemClientCapabilities `json:"completionItem"`
 }
 
-// completionItemClientCapabilities carries the one completion-item capability
-// gsx currently reads: whether the client can render a snippet's `$1`
-// tabstops and place the cursor accordingly. Gated on this rather than
-// assumed, per the LSP spec — a client that never sets it would otherwise see
-// a literal `$1` typed into the buffer.
+// completionItemClientCapabilities carries the completion-item capabilities gsx
+// reads:
+//   - SnippetSupport: whether the client can render a snippet's `$1` tabstops
+//     and place the cursor accordingly. Gated rather than assumed, per the LSP
+//     spec — a client that never sets it would otherwise see a literal `$1`
+//     typed into the buffer.
+//   - LabelDetailsSupport: whether the client renders CompletionItem.labelDetails
+//     (the modern label-adjacent detail/description fields). When set,
+//     auto-import items put the import path in labelDetails.description; when
+//     unset they fall back to the plain detail string.
 type completionItemClientCapabilities struct {
-	SnippetSupport bool `json:"snippetSupport"`
+	SnippetSupport      bool `json:"snippetSupport"`
+	LabelDetailsSupport bool `json:"labelDetailsSupport"`
 }
 
 type generalCapabilities struct {
@@ -375,15 +381,30 @@ type CompletionList struct {
 	Items        []CompletionItem `json:"items"`
 }
 
+// CompletionItemLabelDetails is the LSP labelDetails field: label-adjacent
+// annotations a capable client renders next to (Detail) and after (Description)
+// the label. gsx uses Description to carry an auto-import candidate's import
+// path. Emitted only when the client advertises labelDetailsSupport.
+type CompletionItemLabelDetails struct {
+	Detail      string `json:"detail,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 // CompletionItem is one completion candidate.
 type CompletionItem struct {
-	Label         string         `json:"label"`
-	Kind          int            `json:"kind,omitempty"`
-	Detail        string         `json:"detail,omitempty"`
-	Documentation *MarkupContent `json:"documentation,omitempty"`
-	SortText      string         `json:"sortText,omitempty"`
-	FilterText    string         `json:"filterText,omitempty"`
-	TextEdit      *TextEdit      `json:"textEdit,omitempty"`
+	Label         string                      `json:"label"`
+	LabelDetails  *CompletionItemLabelDetails `json:"labelDetails,omitempty"`
+	Kind          int                         `json:"kind,omitempty"`
+	Detail        string                      `json:"detail,omitempty"`
+	Documentation *MarkupContent              `json:"documentation,omitempty"`
+	SortText      string                      `json:"sortText,omitempty"`
+	FilterText    string                      `json:"filterText,omitempty"`
+	TextEdit      *TextEdit                   `json:"textEdit,omitempty"`
+	// AdditionalTextEdits are edits applied together with TextEdit on accept,
+	// used by auto-import completion to insert the package import. LSP requires
+	// they not overlap TextEdit; importEditFor enforces this (the import region
+	// is above the cursor). nil for every ordinary item.
+	AdditionalTextEdits []TextEdit `json:"additionalTextEdits,omitempty"`
 	// Data carries a lazy-doc lookup payload (see completionResolveData) that
 	// the client returns unchanged with a completionItem/resolve request. nil
 	// for every item whose Documentation (if any) was already filled in eagerly.

--- a/internal/lsp/references_cache_test.go
+++ b/internal/lsp/references_cache_test.go
@@ -66,6 +66,8 @@ func (a *moduleRefsAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 	return gsxfmt.ImportsGoimports
 }
 func (a *moduleRefsAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (a *moduleRefsAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (a *moduleRefsAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 // drive runs the given pre-framed messages through a fresh server over the
 // analyzer and returns the raw output. Helper mirrors the existing

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -88,6 +88,17 @@ type Analyzer interface {
 	// quickfix; none means we offer nothing. It may read package export data, so it
 	// is called ONLY from user-triggered code-action handlers, never during analysis.
 	ResolveImport(dir, name, symbol string) []string
+	// ExportedSymbols returns the exported top-level symbols of the package at
+	// importPath, for auto-import completion of an unimported qualifier (`fmt.▮`).
+	// dir locates the owning module. Like ResolveImport it may read export data
+	// and is called only from the (user-triggered) completion handler, never
+	// during analysis. An unknown/unloadable path yields nil.
+	ExportedSymbols(dir, importPath string) []ImportSymbol
+	// ImportablePackages returns every package dir could import (name + path),
+	// for auto-import package-name completion. Internal-visibility filtered for
+	// dir; excludes dir's own package. All in-memory lookups; the result may be
+	// large and the caller prefix-filters. User-triggered completion path only.
+	ImportablePackages(dir string) []ImportablePackage
 }
 
 // diskRefresher is the saved-source transition paired with Analyzer. Keeping it
@@ -130,7 +141,13 @@ type Server struct {
 	// taking attribute completions insert a `$1` tabstop inside the quotes
 	// (InsertTextFormat = Snippet) instead of the plain `name=""` insert — see
 	// htmlAttrItem.
-	snippetSupport        bool
+	snippetSupport bool
+	// labelDetailsSupport mirrors the client's
+	// textDocument.completion.completionItem.labelDetailsSupport capability,
+	// captured once at initialize. When true, auto-import items carry the import
+	// path in labelDetails.description; when false they fall back to the plain
+	// detail string. See ImportSymbol item building in completion_go.go.
+	labelDetailsSupport   bool
 	diskViewValid         bool
 	workspaceViewValid    bool
 	pendingClientRequests map[string]func(frame) error
@@ -371,6 +388,7 @@ func (s *Server) handleInitialize(f frame) error {
 	s.renameDynamicRegistration = p.Capabilities.TextDocument.Rename.DynamicRegistration
 	s.renamePrepareSupport = p.Capabilities.TextDocument.Rename.PrepareSupport
 	s.snippetSupport = p.Capabilities.TextDocument.Completion.CompletionItem.SnippetSupport
+	s.labelDetailsSupport = p.Capabilities.TextDocument.Completion.CompletionItem.LabelDetailsSupport
 	var folders []workspaceFolder
 	switch {
 	case p.WorkspaceFolders != nil:

--- a/internal/lsp/server_async_test.go
+++ b/internal/lsp/server_async_test.go
@@ -90,6 +90,8 @@ func (a *overrideLifetimeAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 }
 
 func (a *overrideLifetimeAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (a *overrideLifetimeAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (a *overrideLifetimeAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 func (a *overrideLifetimeAnalyzer) source(path string) ([]byte, bool) {
 	a.mu.Lock()
@@ -141,6 +143,8 @@ func (a *blockingAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 	return gsxfmt.ImportsGoimports
 }
 func (a *blockingAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (a *blockingAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (a *blockingAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 // TestAnalysisIsAsyncAndSupersededResultsDiscarded proves two Phase-2 properties
 // deterministically (no sleeps): (1) the Run loop answers requests while an

--- a/internal/lsp/server_debounce_test.go
+++ b/internal/lsp/server_debounce_test.go
@@ -75,6 +75,8 @@ func (a *countingAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 	return gsxfmt.ImportsGoimports
 }
 func (a *countingAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (a *countingAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (a *countingAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 func (a *countingAnalyzer) calls() int {
 	a.mu.Lock()

--- a/internal/lsp/server_lifecycle_test.go
+++ b/internal/lsp/server_lifecycle_test.go
@@ -41,6 +41,8 @@ func (nilAnalyzer) FormatSettings(string) gsxfmt.FormatSettings {
 }
 func (nilAnalyzer) ImportsMode(string) gsxfmt.ImportsMode         { return gsxfmt.ImportsGoimports }
 func (nilAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (nilAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (nilAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 // framed wraps a JSON-RPC body in Content-Length framing.
 func framed(t *testing.T, v any) string {

--- a/internal/lsp/server_sync_test.go
+++ b/internal/lsp/server_sync_test.go
@@ -58,6 +58,8 @@ func (a fakeAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 	return gsxfmt.ImportsGoimports
 }
 func (a fakeAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (a fakeAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (a fakeAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 func TestDidOpenPublishesDiagnostics(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "page.gsx")

--- a/internal/lsp/source_text_test.go
+++ b/internal/lsp/source_text_test.go
@@ -447,6 +447,8 @@ func (*authoritativeLocationAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 	return gsxfmt.ImportsGoimports
 }
 func (*authoritativeLocationAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (*authoritativeLocationAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (*authoritativeLocationAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 func TestDefinitionUsesUnsavedUTF16Target(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/lsp/workspacesymbol_test.go
+++ b/internal/lsp/workspacesymbol_test.go
@@ -73,6 +73,8 @@ func (a *wsSymAnalyzer) ImportsMode(string) gsxfmt.ImportsMode {
 	return gsxfmt.ImportsGoimports
 }
 func (a *wsSymAnalyzer) ResolveImport(string, string, string) []string { return nil }
+func (a *wsSymAnalyzer) ExportedSymbols(string, string) []ImportSymbol { return nil }
+func (a *wsSymAnalyzer) ImportablePackages(string) []ImportablePackage { return nil }
 
 func TestWorkspaceSymbolQueryAndCache(t *testing.T) {
 	module := writeWorkspaceSymbolModule(t, filepath.Join(t.TempDir(), "module"))


### PR DESCRIPTION
## Summary

The last big deferred completion feature (batch 3). Stacked on #139 — retarget to main after it merges.

**What ships** (user-decided scope after a measured design investigation):
- **Unimported qualifier symbols**: `strings.▮` with `strings` not imported → the package's exported symbols, each carrying an eager `AdditionalTextEdits` that inserts the import. Resolution reuses the warm module graph (~100µs; the expensive export-data read only fires for std packages absent from the dep graph, one-time ~50-80ms, cached).
- **Package-name items**: bare `str▮` offers `strings` as a Module-kind item (import added on accept), ranked below every in-scope name and keyword; names duplicating in-scope identifiers are suppressed (no shadow-inviting imports).
- **Ambiguity without heuristics**: multiple packages per name (`rand`) → one item per path, import path shown via capability-gated `labelDetails` (gopls-style) with `detail` fallback. The gopls-style bare-identifier symbol index was evaluated and declined: `New` → 125 candidate packages demands relevance guessing this project rejects.

**Mechanism:**
- Two new Module entry points (`PackageExportedSymbols`, `ImportablePackageNames`), serialized on `analysisMu` off the hot path exactly like `ResolveImportCandidates`; by-value tuples only across the lock.
- Import edits are NARROW import-region diffs built from `importTargetChunk`/`AddChunkImports` primitives (the whole-doc code-action edit would illegally overlap the completion edit), in original-doc coordinates, with an overlap-refusal guard; handles the no-import-block case (the package clause is gsx-level, not a Go chunk — insertion lands between clause and first decl).
- Precedence: in-scope binding > imported package > unimported (fires only on a total scope-resolution miss).
- Review's Important finding fixed: the per-candidate full-buffer re-parse in the package-name loop hoisted via a prepare-once/apply-per-path split (benchmarked, regression-guarded).

## Testing

`make ci` green. Unit: exact import-edit bytes (no-block/existing/leading-chunk/already-imported/overlap-refusal), precedence, ambiguity per-path, labelDetails gating, shadow suppression, statement position. E2e: 4 subtests incl. apply-both-edits-and-reparse proof. Adversarially reviewed (seam locking, edit synthesis, staleness story) + re-reviewed after the fix pass.

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa