### PR TITLE
fix(lsp): heal unclosed body interpolations in completion repair

### DIFF
--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -615,6 +615,104 @@ func TestPipeStageEmptyCompletionE2E(t *testing.T) {
 	}
 }
 
+// TestPipeStageUnclosedCompletionE2E is TestPipeStageEmptyCompletionE2E's
+// no-autopair sibling: `{ user.Name |> ▮` with NO closing `}` at all (the
+// real editing flow when the client does not autopair braces — see the probe
+// that found this gap on the real one-learning project). Before the "_}"
+// repair patch this returned zero items outright (repairAtCursor found
+// nothing in its patch list that could close a bare body interpolation);
+// with it, the same filter table as the closed-buffer case is offered.
+func TestPipeStageUnclosedCompletionE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	extra := map[string]string{"page/types.go": "package page\n\ntype User struct{ Name string }\n"}
+	source := "package page\n\ncomponent Home(user User) {\n\t<div>{ user.Name |> \n</div>\n}\n"
+	cursor := strings.Index(source, "|> ") + len("|> ")
+	items := runHTMLCompletionE2E(t, extra, source, cursor)
+	if len(items) == 0 {
+		t.Fatal("unclosed empty pipe-stage completion returned zero items")
+	}
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	for _, name := range []string{"upper", "urlquery"} {
+		if !labels[name] {
+			t.Errorf("unclosed pipe-stage completion missing filter %q; labels=%v", name, labels)
+		}
+	}
+}
+
+// TestGoMemberCompletionUnclosedE2E is TestGoMemberCompletionE2E's
+// no-autopair sibling: `{ user.▮` with NO closing `}` — the real typing flow
+// this bugfix targets. Before the "}" repair patch, repairAtCursor's patch
+// list had no closer for a bare body interpolation, so repair failed
+// outright and completion returned zero items regardless of what followed
+// the dot. With the patch, the buffer heals exactly like the already-closed
+// `{ user.▮ }` case (TestGoMemberCompletionE2E's "trailing-dot" scenario).
+func TestGoMemberCompletionUnclosedE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	extra := map[string]string{"page/types.go": "package page\n\ntype User struct {\n\tName string\n\tAge  int\n}\n"}
+	source := "package page\n\ncomponent Home(user User) {\n\t<div>{ user.\n</div>\n}\n"
+	cursor := strings.Index(source, "user.") + len("user.")
+	items := runHTMLCompletionE2E(t, extra, source, cursor)
+	labels := map[string]bool{}
+	for _, it := range items {
+		labels[it.Label] = true
+	}
+	for _, name := range []string{"Name", "Age"} {
+		if !labels[name] {
+			t.Errorf("unclosed trailing-dot member %q missing; labels=%v", name, labels)
+		}
+	}
+	if labels["user"] {
+		t.Errorf("member position must not offer scope locals; got `user`: %v", labels)
+	}
+}
+
+// TestAutoImportCompletionUnclosedE2E is TestAutoImportCompletionE2E's
+// no-autopair sibling: `{ strconv.▮` with NO closing `}`, strconv unimported.
+// This is the exact probe-confirmed scenario from the real one-learning
+// project (badge.gsx) that motivated this fix. Before the "}" repair patch
+// this returned zero items; with it, the unimported-qualifier auto-import
+// path fires exactly as it does for the closed-buffer case, offering
+// strconv's exported symbols with an import edit.
+func TestAutoImportCompletionUnclosedE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	source := "package page\n\ncomponent Home() {\n\t<div>{ strconv.\n</div>\n}\n"
+	cursor := strings.Index(source, "strconv.") + len("strconv.")
+	items := runHTMLCompletionE2E(t, nil, source, cursor)
+	var itoa *lsp.CompletionItem
+	for i := range items {
+		if items[i].Label == "Itoa" {
+			itoa = &items[i]
+		}
+	}
+	if itoa == nil {
+		labels := map[string]bool{}
+		for _, it := range items {
+			labels[it.Label] = true
+		}
+		t.Fatalf("unclosed unimported `strconv.` did not offer Itoa; labels=%v (%d items)", labels, len(items))
+	}
+	if len(itoa.AdditionalTextEdits) != 1 {
+		t.Fatalf("Itoa AdditionalTextEdits = %d, want 1 (the import)", len(itoa.AdditionalTextEdits))
+	}
+	all := append([]lsp.TextEdit{*itoa.TextEdit}, itoa.AdditionalTextEdits...)
+	got := applyLSPEdits(source, all)
+	if !strings.Contains(got, "import \"strconv\"") {
+		t.Errorf("applied doc missing import \"strconv\":\n%s", got)
+	}
+	if !strings.Contains(got, "strconv.Itoa") {
+		t.Errorf("applied doc missing strconv.Itoa:\n%s", got)
+	}
+}
+
 // TestPipeStageTypedNarrowingE2E drives the typed pipe-filter compatibility
 // filtering end to end: at `{ user.Age |> ▮ }` the incoming type is int, so
 // string-subject filters (upper) are withheld while the any-subject printf and

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -64,13 +64,17 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// PHANTOM SKELETON REPAIR — the SECOND completion patch site, distinct from
 	// Task 6's gsx-parse chooser in repairAtCursor (completion_repair.go). A
 	// trailing-dot member cursor like `{ user.▮ }` PARSES cleanly as gsx (the
-	// chooser picks the empty patch), but the generated SKELETON carries a broken
+	// chooser picks the empty patch); an UNCLOSED one like `{ user.▮` (no
+	// autopaired brace) parses clean too, once the chooser's "}" patch closes
+	// the body interp. Either way the generated SKELETON carries a broken
 	// selector `user.` that yields no member type info. Insert `_` at the cursor so
 	// the skeleton carries a valid `user._` selector whose `_` Sel is an
 	// empty-prefix member cursor. CROSS-TASK INVARIANT: this patches AT the cursor
 	// only — bytes before off (all import lines included) never move — so the
 	// bridge offsets computed against cc (over the original buffer) stay valid.
-	// Guarded by r.patch != "_" so a chooser `_` repair is never doubled.
+	// Guarded by r.patch != "_" so a chooser `_` repair is never doubled (the
+	// chooser's "}"/"_}" repairs are unaffected by the guard: "}" always wins
+	// over "_}" for a trailing-dot cursor, so `_}` is never the live patch here).
 	src := r.src
 	if cc.kind == ctxGoExpr && off > 0 && off <= len(text) && text[off-1] == '.' && r.patch != "_" && off <= len(src) {
 		patched := make([]byte, 0, len(src)+1)
@@ -113,9 +117,23 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// resolved-but-memberless receiver (`x.` where x is an int) or any local
 	// shadow never gets clobbered: precedence is in-scope binding > import
 	// qualifier > unimported.
+	//
+	// unimportedQualifierItems/packageNameItems parse their `text` argument to
+	// locate the import-chunk region (prepareImportEdit). A mid-edit buffer
+	// that only parses THANKS TO a repair patch (e.g. an unclosed `{ strconv.▮`
+	// body interp, healed by the "}" patch) still fails to parse in its
+	// ORIGINAL, unrepaired form — so `text` itself must not be passed here.
+	// `src` is repair-patched into a parseable buffer, and every edit these two
+	// calls compute (the import-chunk region, and the item's own [start,end)
+	// edit, since end == off always) lies strictly before `off` — the single
+	// point where src and text diverge (repair patches only ever insert AT/
+	// after the cursor) — so parsing src instead of text is both necessary and
+	// safe: every byte offset the resulting edits reference is identical in
+	// both buffers.
+	srcText := string(src)
 	if len(items) == 0 {
 		if name, nameEnd, ok := qualifierBeforeDot(text, start); ok && undefinedQualifier(eph, path, nameEnd) {
-			extra := s.unimportedQualifierItems(dir, path, text, name, start, end)
+			extra := s.unimportedQualifierItems(dir, path, srcText, name, start, end)
 			if len(extra) == 0 {
 				return emptyCompletion()
 			}
@@ -129,7 +147,7 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// same identifier the file already has is redundant and would shadow it (e.g.
 	// os/user's `user` over a local `user`).
 	if start == 0 || text[start-1] != '.' {
-		items = mergePackageNameItems(items, s.packageNameItems(dir, text, text[start:end], start, end))
+		items = mergePackageNameItems(items, s.packageNameItems(dir, srcText, text[start:end], start, end))
 	}
 
 	if len(items) == 0 {

--- a/internal/lsp/completion_context.go
+++ b/internal/lsp/completion_context.go
@@ -60,13 +60,15 @@ func classifyCompletionContext(r repairResult, path string, off int) completionC
 	fset := r.fset
 	posOff := func(p token.Pos) int { return fset.Position(p).Offset }
 
-	// phantomStage: the `_` patch healed an empty `|> ` stage — the `_` at the
-	// cursor is a repair token, not authored. phantomValue: the `""/>` patch
-	// healed a dangling `attr=` — the empty string value is injected, not
-	// typed. phantomTag: the `_/>` patch healed a bare `<▮` or a qualified
-	// `<pkg.▮` with nothing after the dot — the `_` standing in for the
-	// tag/member name is injected, not typed.
-	phantomStage := r.patch == "_"
+	// phantomStage: the `_` patch healed an empty `|> ` stage (closed buffer)
+	// or the `_}` patch healed an UNCLOSED empty stage (`{ x |> ▮`, no
+	// autopaired brace) — either way the `_` at the cursor is a repair token,
+	// not authored. phantomValue: the `""/>` patch healed a dangling `attr=`
+	// — the empty string value is injected, not typed. phantomTag: the `_/>`
+	// patch healed a bare `<▮` or a qualified `<pkg.▮` with nothing after the
+	// dot — the `_` standing in for the tag/member name is injected, not
+	// typed.
+	phantomStage := r.patch == "_" || r.patch == "_}"
 	phantomValue := r.patch == "\"\"/>"
 	phantomTag := r.patch == "_/>"
 

--- a/internal/lsp/completion_context_test.go
+++ b/internal/lsp/completion_context_test.go
@@ -44,6 +44,12 @@ func TestClassifyCompletionContext(t *testing.T) {
 		// A `>` inside a quoted attribute value does not end the tag, so a cursor
 		// past it is still an attribute-name position.
 		{"attr name after quoted gt", "package p\n\ncomponent C() {\n\t<div title=\"a>b\" §/>\n}\n", ctxAttrName},
+		// Unclosed body interpolations (no autopaired closing `}`): healed via
+		// the new "}"/"_}" repair patches, these classify exactly like their
+		// already-closed counterparts above.
+		{"unclosed interp trailing dot", "package p\n\ncomponent C(u U) {\n\t<div>{ u.§\n</div>\n}\n", ctxGoExpr},
+		{"unclosed interp plain ident", "package p\n\ncomponent C(x string) {\n\t<div>{ x§\n</div>\n}\n", ctxGoExpr},
+		{"unclosed pipe stage empty", "package p\n\ncomponent C(x string) {\n\t<div>{ x |> §\n</div>\n}\n", ctxPipeStage},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -129,6 +135,19 @@ func TestClassifyCompletionContextFields(t *testing.T) {
 		}
 		if !got.phantom {
 			t.Fatal("phantom = false, want true (injected _ stage)")
+		}
+	})
+
+	t.Run("unclosed pipe stage phantom flag set", func(t *testing.T) {
+		// No autopaired closing `}` — healed via the "_}" repair patch, not
+		// the closed-buffer "_" patch, but the injected `_` is just as much a
+		// repair token as the closed case above.
+		got, _ := classify("package p\n\ncomponent C(x string) {\n\t<div>{ x |> §\n</div>\n}\n")
+		if got.kind != ctxPipeStage {
+			t.Fatalf("kind = %v, want ctxPipeStage", got.kind)
+		}
+		if !got.phantom {
+			t.Fatal("phantom = false, want true (injected _ stage via \"_}\" patch)")
 		}
 	})
 

--- a/internal/lsp/completion_repair.go
+++ b/internal/lsp/completion_repair.go
@@ -12,7 +12,7 @@ import (
 // repairResult is the buffer completion analyzes, plus what was done to it.
 type repairResult struct {
 	src    []byte         // patched bytes (== live buffer when patch == "")
-	patch  string         // inserted at off (see completionPatches): "", "_", "/>", "\"/>", "\"\"/>", "}/>", "_/>"
+	patch  string         // inserted at off (see completionPatches): "", "_", "}", "_}", "/>", "\"/>", "\"\"/>", "}/>", "_/>"
 	parsed *gsxast.File   // parse of src (nil only when unrepairable)
 	fset   *token.FileSet // resolves parsed's positions
 }
@@ -20,6 +20,28 @@ type repairResult struct {
 // completionPatches is the closed, ordered repair set. Each is tried by
 // inserting at the cursor and reparsing; the first parse wins. Bytes before
 // the cursor are never modified, so every client-visible offset survives.
+//
+// "}" closes an UNCLOSED body interpolation with no autopaired brace — a
+// trailing-member cursor (`{ strconv.▮`, `{ user.▮`) or a bare/prefixed ident
+// (`{ us▮`) with nothing after it. Both shapes parse as gsx once the brace
+// closes (a trailing-dot selector is itself a valid, if incomplete, Go
+// expression to the gsx grammar; completion.go's separate trailing-dot
+// phantom then heals the resulting skeleton's broken selector, same as the
+// already-closed case). It sits right after "_" — before any of the
+// tag/attr-value closers — because it is purely a body-interp heal: inside an
+// open tag (an ExprAttr value, `class={x▮`) a lone `}` still leaves the tag
+// itself unclosed and fails to parse (verified), so it never preempts the
+// "}/>" case below regardless of order; ordering it early just keeps the
+// common body-interp path short.
+//
+// "_}" closes an UNCLOSED empty pipe stage (`{ x |> ▮`, no autopaired brace):
+// a bare `}` right after `|> ` is rejected as an empty pipeline stage, so a
+// placeholder identifier is required, exactly as the tag-closer reasoning
+// below. It must come after "}" (a plain `}` never falsely wins here — the
+// empty-stage error keeps it from parsing at all) and it also independently
+// heals the same trailing-member/bare-ident shapes "}" already heals, so its
+// position relative to "}" only matters for the pipe case; putting it right
+// after "}" keeps both single-purpose-brace patches adjacent.
 //
 // "_/>" is last: a phantom tag-name closer for a bare `<▮` or a qualified
 // `<pkg.▮` with nothing typed after the dot — neither has any typed text a
@@ -34,7 +56,7 @@ type repairResult struct {
 // simpler `/>` patch alone — `<div cl` + "_/>" would parse too (as attribute
 // `cl_`), but that muddies the present-attr-name reasoning downstream, so the
 // plain `/>` heal (attribute `cl`) must keep winning.
-var completionPatches = []string{"", "_", "/>", "\"/>", "\"\"/>", "}/>", "_/>"}
+var completionPatches = []string{"", "_", "}", "_}", "/>", "\"/>", "\"\"/>", "}/>", "_/>"}
 
 // repairAtCursor parses text; on failure tries a closed, ordered patch list
 // inserted at off, first parse wins. Deterministic; never touches bytes before

--- a/internal/lsp/completion_repair_test.go
+++ b/internal/lsp/completion_repair_test.go
@@ -31,6 +31,19 @@ func TestRepairAtCursor(t *testing.T) {
 		// value (`x/>`) is also rejected by gsx.
 		{"dangling equals", "package p\n\ncomponent C() {\n\t<div class=§\n}\n", "\"\"/>", true},
 		{"unclosed expr attr", "package p\n\ncomponent C() {\n\t<div class={x§\n}\n", "}/>", true},
+		// Unclosed body interpolations: the no-autopair typing flow (no
+		// closing `}` at all yet). "}" closes the brace; the trailing-dot
+		// selector (an incomplete but valid Go expression to the gsx grammar)
+		// and the bare/prefixed identifier both parse clean once the brace
+		// closes — same shape as the already-closed cases above, just without
+		// their trailing " }".
+		{"unclosed member trailing dot", "package p\n\ncomponent C() {\n\t<div>{ strconv.§\n</div>\n}\n", "}", true},
+		{"unclosed member trailing dot (local)", "package p\n\ncomponent C() {\n\t<div>{ user.§\n</div>\n}\n", "}", true},
+		{"unclosed plain ident prefix", "package p\n\ncomponent C() {\n\t<div>{ us§\n</div>\n}\n", "}", true},
+		// Unclosed empty pipe stage: a lone "}" right after `|> ` is rejected
+		// as an empty pipeline stage, so the placeholder-identifier "_}" patch
+		// is required (mirrors the closed-buffer "_" case above).
+		{"unclosed empty pipe stage", "package p\n\ncomponent C() {\n\t<div>{ x |> §\n</div>\n}\n", "_}", true},
 		{"unrepairable", "package p\n\ncomponent C() {\n\t<§<<%%\n}\n", "", false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

First real-editor test of the auto-import feature caught this: an **unclosed** body interpolation — `{ strconv.▮` typed without autopair's closing brace — returned 0 completion items. The repair patch list had closers for tags and attribute values but none for a bare body interp (every original repair fixture happened to include the closing brace — the same fixture blind spot as the historical bare-`<` bug). With the brace present the feature worked all along.

**Fixes:**
1. Patch list gains `"}"` (heals `{ user.▮`, `{ strconv.▮`, `{ us▮`) and `"_}"` (heals the unclosed empty pipe `{ x |> ▮`), ordered so every pre-existing case keeps its current winning patch (pinned by exact-equality tests).
2. **Second pre-existing bug found by the new e2e**: the auto-import fallback parsed the raw *unrepaired* buffer to compute import edits — silently yielding 0 items whenever ANY repair patch was active (all closer-healed shapes, not just the new ones). Now parses the repaired src; sound because every import edit lies strictly before the cursor where the two buffers are byte-identical, with a runtime overlap-refusal net.

Probe on the exact user scenario (one-learning `ds/badge/badge.gsx`, unclosed `{ strconv.`): 0 → **38 items with import edits**.

## Testing

Repair-table pins (new cases + every existing winning patch), classification, 3 new e2e (unclosed member / auto-import incl. applying both edits to the ORIGINAL unclosed buffer and reparsing / pipe), real-project probe. `make ci` green. Adversarially reviewed: patch-ordering non-interference verified empirically, phantom composition traced, src-coordinate safety both reasoned and runtime-enforced.

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa