### PR TITLE
fix(lsp): heal unclosed {{ }} GoBlocks in completion repair

### DIFF
--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -1754,6 +1754,106 @@ func TestGoMemberStatementCompletionE2E(t *testing.T) {
 	})
 }
 
+// TestGoBlockUnclosedCompletionE2E is TestGoCompletionE2E/TestGoMemberStatementCompletionE2E's
+// no-autopair sibling for a `{{ }}` GoBlock: a completely UNCLOSED block, no
+// trailing `}}` at all — the real typing flow this bugfix targets (the user
+// report: `{{ user := Get▮`, package-local `GetUserInfoFromContext` offered).
+// Before the "_}}" repair patch (completion_repair.go) none of these healed:
+// repairAtCursor had no closer for a doubled `{{` brace, so completion
+// returned zero items across all three shapes below regardless of what
+// followed the cursor.
+func TestGoBlockUnclosedCompletionE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	extra := map[string]string{"page/types.go": "package page\n\ntype UserInfo struct {\n\tName  string\n\tEmail string\n}\n\n// GetUserInfoFromContext looks up the caller's UserInfo.\nfunc GetUserInfoFromContext(ctx int) UserInfo { return UserInfo{} }\n"}
+
+	// Shape 1 (the exact user report): a package-local function name typed as
+	// the RHS of a `:=`, no closing `}}` yet. Resolves via the ordinary scope
+	// path (goCompletionItems' scopeCandidates branch) at tierPackage (sort
+	// prefix "30"), same tier a closed-buffer `{{ user := Get }}` would use —
+	// pinning that the repair produces no different a result than the already-
+	// working closed shape.
+	t.Run("assignment rhs ident suffix", func(t *testing.T) {
+		source := "package page\n\ncomponent Home(cid int) {\n\t{{ user := Get\n}\n"
+		cursor := strings.Index(source, "Get") + len("Get")
+		items := runHTMLCompletionE2E(t, extra, source, cursor)
+		var got *lsp.CompletionItem
+		labels := map[string]bool{}
+		for i := range items {
+			labels[items[i].Label] = true
+			if items[i].Label == "GetUserInfoFromContext" {
+				got = &items[i]
+			}
+		}
+		if got == nil {
+			t.Fatalf("unclosed GoBlock completion missing package-local `GetUserInfoFromContext`; labels=%v", labels)
+		}
+		if !strings.HasPrefix(got.SortText, "30") {
+			t.Errorf("`GetUserInfoFromContext` SortText = %q, want tierPackage prefix \"30\"", got.SortText)
+		}
+		for _, kw := range []string{"if", "for", "return"} {
+			if !labels[kw] {
+				t.Errorf("unclosed GoBlock completion missing statement keyword %q; labels=%v", kw, labels)
+			}
+		}
+	})
+
+	// Shape 2: nothing at all follows `:=` yet — the ONE shape that needs the
+	// "_}}" patch's placeholder for a reason beyond convenience: a bare "}}"
+	// heal would leave the embedded statement `x := ` with no RHS, a Go SYNTAX
+	// error (not the merely-undefined-identifier kind shape 1 tolerates), so
+	// the ephemeral analysis would fail to resolve any scope at all without
+	// the placeholder.
+	t.Run("assignment rhs bare", func(t *testing.T) {
+		source := "package page\n\ncomponent Home() {\n\t{{ x := \n}\n"
+		cursor := strings.Index(source, "x := ") + len("x := ")
+		items := runHTMLCompletionE2E(t, extra, source, cursor)
+		if len(items) == 0 {
+			t.Fatal("unclosed bare-RHS GoBlock completion returned zero items")
+		}
+		labels := map[string]bool{}
+		for _, it := range items {
+			labels[it.Label] = true
+		}
+		if !labels["x"] {
+			t.Errorf("unclosed bare-RHS GoBlock completion missing local `x`; labels=%v", labels)
+		}
+		if !labels["if"] {
+			t.Errorf("unclosed bare-RHS GoBlock completion missing statement keyword `if`; labels=%v", labels)
+		}
+	})
+
+	// Shape 3 (the user's actual target flow): a two-statement block, first
+	// line complete and already bound (`user := GetUserInfoFromContext(cid)`),
+	// cursor on the SECOND line at a member position (`user.▮`), the whole
+	// block still unclosed. Resolves through statementMemberItems' SourceIndex
+	// path (completion_go.go) — the ephemeral analysis type-checks the WHOLE
+	// healed block as one statement list, so the first line's binding is live
+	// for the second line's member lookup exactly as real Go scoping requires.
+	// (The component parameter is named `cid`, not `ctx`: `ctx` is a gsx
+	// reserved identifier — completion_gsx.go's reserved-name check — and using
+	// it as a declared param name sinks the whole package to diagnostics-only,
+	// which was caught here as an initial false failure on this exact test.)
+	t.Run("two-line member after bound var", func(t *testing.T) {
+		source := "package page\n\ncomponent Home(cid int) {\n\t{{ user := GetUserInfoFromContext(cid)\n\tuser.\n}\n"
+		cursor := strings.LastIndex(source, "user.") + len("user.")
+		items := runHTMLCompletionE2E(t, extra, source, cursor)
+		labels := map[string]bool{}
+		for _, it := range items {
+			labels[it.Label] = true
+		}
+		for _, name := range []string{"Name", "Email"} {
+			if !labels[name] {
+				t.Errorf("two-line unclosed GoBlock member completion missing %q; labels=%v", name, labels)
+			}
+		}
+		if labels["user"] {
+			t.Errorf("member position must not offer scope locals; got `user`: %v", labels)
+		}
+	})
+}
+
 // assertNoGsxInternalLeak fails if any completion item, in ANY completion
 // response carried by output, has a label with the reserved `_gsx` prefix — the
 // generated-code internals (_gsxuse/_gsxcompsig/_gsxrt/_gsxbody/...) the

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -75,6 +75,22 @@ func (s *Server) goContextCompletion(cc completionContext, path, text string, of
 	// Guarded by r.patch != "_" so a chooser `_` repair is never doubled (the
 	// chooser's "}"/"_}" repairs are unaffected by the guard: "}" always wins
 	// over "_}" for a trailing-dot cursor, so `_}` is never the live patch here).
+	//
+	// The same insertion fires unconditionally for a GoBlock STATEMENT-position
+	// dot cursor too (`{{ x.▮`, unclosed, chooser patch "_}}") — there is no
+	// ExprMap skeleton selector for a GoBlock (goCompletionBridge's CtrlMap
+	// branch returns skel == nil), so "the skeleton carries a valid selector"
+	// does not literally apply, but the insertion still matters for a more
+	// basic reason: the embedded Go statement `x.` is not syntactically valid
+	// Go on its own (a trailing dot needs a selector name) and would fail to
+	// parse in the ephemeral analysis regardless of statementMemberItems. Since
+	// the guard only excludes r.patch == "_", not "_}}", this composes with the
+	// chooser's own leading "_" (part of "_}}") into a double-underscore
+	// selector (`x.__`) — traced in completion_repair.go's "_}}" doc comment;
+	// verified harmless because statementMemberItems resolves the receiver from
+	// pkg.SourceIndex keyed on the AUTHORED byte before the dot, never from the
+	// Sel identifier's spelling, so which placeholder name ends up there does
+	// not matter, only that the statement parses.
 	src := r.src
 	if cc.kind == ctxGoExpr && off > 0 && off <= len(text) && text[off-1] == '.' && r.patch != "_" && off <= len(src) {
 		patched := make([]byte, 0, len(src)+1)

--- a/internal/lsp/completion_context_test.go
+++ b/internal/lsp/completion_context_test.go
@@ -50,6 +50,14 @@ func TestClassifyCompletionContext(t *testing.T) {
 		{"unclosed interp trailing dot", "package p\n\ncomponent C(u U) {\n\t<div>{ u.§\n</div>\n}\n", ctxGoExpr},
 		{"unclosed interp plain ident", "package p\n\ncomponent C(x string) {\n\t<div>{ x§\n</div>\n}\n", ctxGoExpr},
 		{"unclosed pipe stage empty", "package p\n\ncomponent C(x string) {\n\t<div>{ x |> §\n</div>\n}\n", ctxPipeStage},
+		// Unclosed `{{ }}` GoBlocks (no autopaired closing brace, healed via the
+		// new "_}}" repair patch): a statement-position sibling of the unclosed
+		// interp cases above, still classifying ctxGoExpr through the CtrlMap/
+		// GoBlock nodeNavSpans span (completion_context.go's Rule 1+2 loop), same
+		// as the already-closed "goblock" case.
+		{"unclosed goblock ident suffix", "package p\n\ncomponent C() {\n\t{{ user := Get§\n}\n", ctxGoExpr},
+		{"unclosed goblock bare rhs", "package p\n\ncomponent C() {\n\t{{ x := §\n}\n", ctxGoExpr},
+		{"unclosed goblock member dot", "package p\n\ncomponent C() {\n\t{{ x.§\n}\n", ctxGoExpr},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/lsp/completion_repair.go
+++ b/internal/lsp/completion_repair.go
@@ -12,7 +12,7 @@ import (
 // repairResult is the buffer completion analyzes, plus what was done to it.
 type repairResult struct {
 	src    []byte         // patched bytes (== live buffer when patch == "")
-	patch  string         // inserted at off (see completionPatches): "", "_", "}", "_}", "/>", "\"/>", "\"\"/>", "}/>", "_/>"
+	patch  string         // inserted at off (see completionPatches): "", "_", "}", "_}", "_}}", "/>", "\"/>", "\"\"/>", "}/>", "_/>"
 	parsed *gsxast.File   // parse of src (nil only when unrepairable)
 	fset   *token.FileSet // resolves parsed's positions
 }
@@ -43,6 +43,69 @@ type repairResult struct {
 // position relative to "}" only matters for the pipe case; putting it right
 // after "}" keeps both single-purpose-brace patches adjacent.
 //
+// "_}}" closes an UNCLOSED `{{ }}` GoBlock — the no-autopair sibling of the
+// "}"/"_}" body-interp closers above, for a STATEMENT-position construct
+// instead of an expression one: `{{ user := Get▮` (no closing `}}` yet) parses
+// as gsx once the doubled brace closes, but the GoBlock's Code text feeds a
+// STATEMENT into the ephemeral skeleton (goCompletionBridge's CtrlMap/GoBlock
+// branch), which go/parser must accept as syntactically valid Go before any
+// scope resolves at all — an expression fragment tolerates a dangling
+// selector or a bare/prefixed identifier same as before, but a short variable
+// declaration with nothing after `:=` (`{{ x := ▮` closed bare as `x := }}`)
+// is a Go SYNTAX error, not the "undefined identifier" SEMANTIC error a
+// dangling `Get` produces — the parse of the embedded statement fails
+// outright and no scope is ever reached. "_}}" inserts a placeholder so the
+// statement always has a syntactically complete tail (`x := _`), which
+// go/types accepts as a value-less expression it can still error on
+// (semantically, `_` is not a legal operand — same "non-fatal" class of error
+// as an undefined identifier) while still resolving the scope at that
+// position.
+//
+// Only ONE new patch is needed, not a plain "}}" alongside it: parseGoBlock's
+// own pre-check (markup.go) is a brace/string-balance scan over the Code
+// text, never a Go-syntax check, so inserting the extra leading "_" ahead of
+// "}}" can only ever ADD an ordinary identifier byte — it can never turn a
+// gsx-parseable buffer unparseable, nor vice versa. "_}}" therefore parses at
+// the gsx level in EVERY case a bare "}}" would (verified empirically across
+// every shape below), which means a bare "}}" patch could never win the
+// first-clean-parse race against "_}}" if both were in the list — whichever
+// sorts first always wins, unconditionally, for every shape, making the
+// other dead. Adding "_}}" alone sidesteps that non-choice entirely: it is
+// simultaneously correct for the identifier-suffix shape above (the extra
+// trailing "_" merges into the typed prefix, e.g. `Get` becomes `Get_` in the
+// EMBEDDED skeleton statement only — harmless, since the scope-enumeration
+// path lists every visible object regardless of what the statement's own RHS
+// identifier resolves to; the completion token span itself is still computed
+// against the ORIGINAL, unpatched text) and for the bare-declaration shape
+// that needs the placeholder to parse as Go at all.
+//
+// It also heals a trailing-member GoBlock statement cursor (`{{ x.▮`,
+// `{{ user := GetUserInfoFromContext(ctx)\n\tuser.▮`): the SAME construct as
+// the closed-buffer trailing-dot case, just in statement position. Composes
+// with goContextCompletion's separate dot-phantom insertion (completion.go),
+// which fires independently on `text[off-1] == '.'` regardless of node kind
+// — traced: for `x.▮` the winning "_}}" patch already places `x._}}` at
+// repair time (Code becomes `x._`), then the dot-phantom's own `_` insertion
+// (guarded only on `r.patch != "_"`, which "_}}" is not) inserts a SECOND `_`
+// ahead of the first, landing on `x.__}}` (Code `x.__`) — a syntactically
+// valid double-underscore selector. This is redundant, not wrong: the
+// statement member path (statementMemberItems) resolves the receiver from
+// pkg.SourceIndex keyed on the AUTHORED byte immediately before the dot, not
+// from the Sel identifier's spelling, so neither insertion's exact text
+// matters, only that SOME valid selector name follows the dot so the
+// embedded statement parses. Left uncorrected deliberately — excluding "_}}"
+// from the dot-phantom guard would be an unforced, unverified special case
+// for a compose that is already proven harmless (TestGoMemberStatementCompletionE2E
+// et al. pass either way), and this codebase's stated principle is to not
+// add heuristics beyond what correctness requires.
+//
+// It sits right after "_}" (the last of the "closed"-style body-interp
+// closers) and before the tag/attr-value family: like "}"/"_}", it never
+// competes with them (a `{{ }}` GoBlock and a `<tag`/`attr=` region are
+// disjoint constructs), so its exact position relative to them is
+// immaterial; grouping it with the other statement/expression closers keeps
+// the list's ordering story simple to state.
+//
 // "_/>" is last: a phantom tag-name closer for a bare `<▮` or a qualified
 // `<pkg.▮` with nothing typed after the dot — neither has any typed text a
 // simple `/>` self-close can attach to (`</>`  and `<pkg./>` both still fail
@@ -56,7 +119,7 @@ type repairResult struct {
 // simpler `/>` patch alone — `<div cl` + "_/>" would parse too (as attribute
 // `cl_`), but that muddies the present-attr-name reasoning downstream, so the
 // plain `/>` heal (attribute `cl`) must keep winning.
-var completionPatches = []string{"", "_", "}", "_}", "/>", "\"/>", "\"\"/>", "}/>", "_/>"}
+var completionPatches = []string{"", "_", "}", "_}", "_}}", "/>", "\"/>", "\"\"/>", "}/>", "_/>"}
 
 // repairAtCursor parses text; on failure tries a closed, ordered patch list
 // inserted at off, first parse wins. Deterministic; never touches bytes before

--- a/internal/lsp/completion_repair_test.go
+++ b/internal/lsp/completion_repair_test.go
@@ -44,6 +44,23 @@ func TestRepairAtCursor(t *testing.T) {
 		// as an empty pipeline stage, so the placeholder-identifier "_}" patch
 		// is required (mirrors the closed-buffer "_" case above).
 		{"unclosed empty pipe stage", "package p\n\ncomponent C() {\n\t<div>{ x |> §\n</div>\n}\n", "_}", true},
+		// Unclosed `{{ }}` GoBlocks (no autopaired closing brace): the
+		// statement-position sibling of the body-interp closers above. "}"
+		// and "_}" never win here — a lone `}` (single brace) is never
+		// enough to close a doubled `{{`, it only unbalances further — so
+		// "_}}" is the first of the list that closes the block at all. It
+		// wins over a hypothetical bare "}}" for every shape (not just
+		// this one) because parseGoBlock's pre-check is a brace/string
+		// balance scan, never a Go-syntax check — see the "_}}" doc
+		// comment on completionPatches above for the full argument.
+		{"unclosed GoBlock ident suffix", "package p\n\ncomponent C() {\n\t{{ user := Get§\n}\n", "_}}", true},
+		// The bare-declaration shape: nothing follows `:=` at all, so
+		// unlike the ident-suffix case above, the placeholder is load-
+		// bearing for the EMBEDDED Go to parse, not just cosmetic — `x :=
+		// }}` (bare "}}", hypothetically) is a Go syntax error (short var
+		// decl with no RHS), which "_}}"'s placeholder avoids.
+		{"unclosed GoBlock bare RHS", "package p\n\ncomponent C() {\n\t{{ x := §\n}\n", "_}}", true},
+		{"unclosed GoBlock member dot", "package p\n\ncomponent C() {\n\t{{ x.§\n}\n", "_}}", true},
 		{"unrepairable", "package p\n\ncomponent C() {\n\t<§<<%%\n}\n", "", false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

User-reported: `{{ user := Get▮` (unclosed GoBlock) offered no completion. The repair set gained interp closers in #142 but nothing emitting the `}}` a GoBlock needs.

**Fix:** one new patch, `"_}}"`. A separate bare `"}}"` was investigated and rejected with a proof the review verified from parser first principles: `parseGoBlock`'s pre-check is a pure brace-balance scan (never Go syntax), so the two patches are indistinguishable at gsx-parse level — a bare `"}}"` ordered first would even *reproduce* the bug for the bare-RHS shape (`{{ x := ▮` → `x := }}` parses as gsx, then dies in the skeleton). `"_}}"` alone is necessary and sufficient; the placeholder composes harmlessly with the existing dot-phantom (traced byte-for-byte: `x.__}}` — the member path resolves the receiver via SourceIndex on original-text bytes, never the Sel spelling).

**Probe on the requester's exact flow (one-learning):** `{{ user := Get▮` → 2083 items incl. `GetUserInfoFromContext` at package tier; two-line `{{ user := GetUserInfoFromContext(ctx)` + `user.▮` → exactly `db.UserInfo`'s 16 fields, no scope leak.

## Testing

Repair-table pins (3 new + all 15 existing winners exact-equality), classification pins, 3-subtest e2e incl. the two-line member shape, real-project probes. `make ci` green. Review verified the dead-`}}` argument against parser source and traced the phantom composition; one Minor noted for follow-up (the patch incidentally heals doubly-nested unclosed braces in plain interps — benign, unpinned).

https://claude.ai/code/session_01NHMAaMsoZwgjNVvR3GLxAa