### PR TITLE
fix(gen): dev-loop push gating, pid-reuse guard, build-overlay err fallback, portAvailable wildcard probe

### DIFF
--- a/gen/dev.go
+++ b/gen/dev.go
@@ -99,8 +99,26 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	// Drive the overlay from the cold generate (e.g. a pre-existing codegen
 	// error). A mixed operational failure has not committed its filesystem
 	// transaction, so only its errors/diagnostics are publishable at this point.
+	// post/reload gate every browser push on the managed front door still
+	// running: once it exits, its resolved port may be re-bound by any other
+	// process (typically another project's vite dev server), and posting there
+	// would drive a stranger's browser session. webExited is closed by the
+	// front door's Wait monitor; with --no-web the front door is externally
+	// managed, the channel never closes, and pushes always go out.
+	webExited := make(chan struct{})
+	webUp := func() bool {
+		select {
+		case <-webExited:
+			return false
+		default:
+			return true
+		}
+	}
+	post := func(body []byte) { postEvent(viteURL, body, webUp) }
+	reload := func() { postReload(viteURL, webUp) }
+
 	publishedStartup := publishableStartupResults(startup)
-	postEvent(viteURL, aggregateEvent(publishedStartup))
+	post(aggregateEvent(publishedStartup))
 	reportHardErrors(gsxOut, publishedStartup)
 
 	// --- Vite (front door), unless --no-web ---
@@ -113,6 +131,12 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			fmt.Fprintf(stderr, "gsx dev: starting front door: %v\n", err)
 			return 1
 		}
+		// Sole owner of vite.Wait (shutdown uses killProcGroupOwned).
+		go func() {
+			_ = vite.Wait()
+			fmt.Fprintln(stdout, "gsx dev: front door exited — suspending browser reload/overlay pushes")
+			close(webExited)
+		}()
 	}
 
 	// --- Go server: initial build + run ---
@@ -127,10 +151,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	// starts the server (poison→good always changes bytes, so `wrote` fires).
 	if startOK {
 		if out, err := srv.rebuild(ctx); err != nil {
-			postEvent(viteURL, buildErrorEvent(out))
+			post(buildErrorEvent(buildFailureMessage(out, err)))
 			startOK = false
 		} else if waitHealthy(ctx, healthURL, 10*time.Second) {
-			postReload(viteURL)
+			reload()
 		}
 	}
 	// overlayUp: an error overlay is currently shown in the browser. A later
@@ -148,7 +172,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	shutdownProcesses := func() {
 		srv.stop()
 		if vite != nil {
-			killProcGroup(vite, 5*time.Second)
+			killProcGroupOwned(vite, webExited, 5*time.Second)
 		}
 	}
 
@@ -223,7 +247,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				healthURL = "http://localhost:" + goPort + "/healthz"
 				srv.healthURL = healthURL
 				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
-					postReload(viteURL)
+					reload()
 					overlayUp = false
 				}
 				// fall through: an .env-only fire has no source dirtiness.
@@ -234,12 +258,12 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			results, goChanged, rerr := dirty.regenerate(sess.regenPending)
 			if rerr != nil {
 				fmt.Fprintf(serverOut, "regen failed: %v\n", rerr)
-				postEvent(viteURL, buildErrorEvent("regen failed: "+rerr.Error()))
+				post(buildErrorEvent("regen failed: " + rerr.Error()))
 				overlayUp = true
 				continue // retained dirty state is retried on the next relevant event
 			}
 			// Overlay state from this cycle.
-			postEvent(viteURL, aggregateEvent(results))
+			post(aggregateEvent(results))
 			reportHardErrors(gsxOut, results)
 			ok := true
 			wrote := false
@@ -254,18 +278,18 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			// Successful cycle. Rebuild when code changed; reload the browser if we
 			// rebuilt OR we're recovering from a shown error overlay — the latter
 			// must clear even when nothing was written (fixed .gsx → identical .x.go).
-			reload := overlayUp
+			doReload := overlayUp
 			if goChanged || wrote {
 				if out, err := srv.rebuild(ctx); err != nil {
-					postEvent(viteURL, buildErrorEvent(out))
+					post(buildErrorEvent(buildFailureMessage(out, err)))
 					overlayUp = true
 					continue
 				} else if waitHealthy(ctx, healthURL, 10*time.Second) {
-					reload = true
+					doReload = true
 				}
 			}
-			if reload {
-				postReload(viteURL)
+			if doReload {
+				reload()
 			}
 			overlayUp = false
 

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -106,6 +107,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	// front door's Wait monitor; with --no-web the front door is externally
 	// managed, the channel never closes, and pushes always go out.
 	webExited := make(chan struct{})
+	var shuttingDown atomic.Bool // set before shutdown kills the front door
 	webUp := func() bool {
 		select {
 		case <-webExited:
@@ -131,11 +133,15 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			fmt.Fprintf(stderr, "gsx dev: starting front door: %v\n", err)
 			return 1
 		}
-		// Sole owner of vite.Wait (shutdown uses killProcGroupOwned).
+		// Sole owner of vite.Wait (shutdown uses killProcGroupOwned). Close the
+		// gate first so pushes stop the instant the exit is observed; the
+		// notice is for an unexpected exit only, not shutdown killing vite.
 		go func() {
 			_ = vite.Wait()
-			fmt.Fprintln(stdout, "gsx dev: front door exited — suspending browser reload/overlay pushes")
 			close(webExited)
+			if !shuttingDown.Load() {
+				fmt.Fprintln(stdout, "gsx dev: front door exited — suspending browser reload/overlay pushes")
+			}
 		}()
 	}
 
@@ -170,6 +176,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		fmt.Fprintf(stdout, "gsx dev: managing Go side only (no front door) — watching %s\n", workDir)
 	}
 	shutdownProcesses := func() {
+		shuttingDown.Store(true)
 		srv.stop()
 		if vite != nil {
 			killProcGroupOwned(vite, webExited, 5*time.Second)

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -6,11 +6,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -92,7 +98,7 @@ func TestDevTeardownAndRestart(t *testing.T) {
 	//    `go build` update go.sum for the replaced local gsx module as needed.
 	cmd := exec.Command(bin, "dev", "--web", "sleep 60")
 	cmd.Dir = proj
-	cmd.Env = append(os.Environ(),
+	cmd.Env = devTestEnv(
 		"BROWSER=none",
 		"GO_PORT=7799",
 		"VITE_DEV_URL=http://127.0.0.1:1",
@@ -107,11 +113,7 @@ func TestDevTeardownAndRestart(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("gsx dev start: %v", err)
 	}
-	defer func() {
-		// Safety: if the test panics or returns early, kill gsx dev.
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		_ = cmd.Wait()
-	}()
+	defer stopDevGracefully(cmd)
 
 	// 4. Wait for the Go server to bind GO_PORT. The initial cycle is slow
 	//    (cold go/packages.Load + go build), so allow a generous timeout.
@@ -155,6 +157,22 @@ func TestDevTeardownAndRestart(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 	}
 	t.Error("GO_PORT=7799 still held 15s after group-SIGINT (teardown leaked; server not killed)")
+}
+
+// stopDevGracefully tears down a gsx dev child: SIGINT first so gsx dev kills
+// its OWN children (they live in separate process groups — a bare SIGKILL to
+// gsx dev's group would leak the scaffold Go server, which then shadows the
+// next run's server on GO_PORT), SIGKILL as a backstop.
+func stopDevGracefully(cmd *exec.Cmd) {
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		<-done
+	}
 }
 
 // portListening reports whether anything is accepting TCP connections on
@@ -209,3 +227,199 @@ func main() {
 	_ = srv.Shutdown(shutCtx)
 }
 `
+
+func TestKillProcGroupOwnedReapsViaExternalWaiter(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	setProcGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// The monitor goroutine owns Wait, mirroring runDev's front-door monitor.
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+	killProcGroupOwned(cmd, done, 5*time.Second)
+	select {
+	case <-done:
+	default:
+		t.Fatal("child not reaped after killProcGroupOwned returned")
+	}
+}
+
+// devTestEnv returns os.Environ() with VITE_PORT / VITE_DEV_URL scrubbed
+// (an ambient value from the developer's shell must not leak into the gsx dev
+// under test) plus the given overrides.
+func devTestEnv(extra ...string) []string {
+	var env []string
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "VITE_PORT=") || strings.HasPrefix(e, "VITE_DEV_URL=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	return append(env, extra...)
+}
+
+// TestDevStopsPostingAfterWebExit reproduces cross-project overlay pollution:
+// gsx dev resolves its front-door port once at startup; when the managed front
+// door later exits, any other process (typically another project's vite dev
+// server) can bind that port, and gsx dev's overlay/reload posts would land in
+// a stranger's browser session. After the managed front door exits, gsx dev
+// must stop posting.
+func TestDevStopsPostingAfterWebExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGo)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+
+	// A leaked scaffold server from an earlier run would answer /healthz and
+	// shadow this run's server (its ListenAndServe error is silent).
+	if portListening("7811") {
+		t.Fatal("port 7811 already in use (leaked scaffold server from an earlier run?)")
+	}
+
+	// The front door exits after 1s — long before the cold first cycle ends.
+	cmd := exec.Command(bin, "dev", "--web", "sleep 1")
+	cmd.Dir = proj
+	cmd.Env = devTestEnv(
+		"BROWSER=none",
+		"GO_PORT=7811",
+		"VITE_DEV_URL=http://127.0.0.1:1",
+		"GOFLAGS=-mod=mod",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout, stderrBuf lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("gsx dev start: %v", err)
+	}
+	defer stopDevGracefully(cmd)
+
+	if !waitHealthy(context.Background(), "http://localhost:7811/healthz", 120*time.Second) {
+		t.Fatal("Go server on GO_PORT=7811 never came up after gsx dev start")
+	}
+
+	// Learn the resolved front-door URL from the "watching … — open <url>" line.
+	var viteURL string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := regexp.MustCompile(`open (http://\S+)`).FindStringSubmatch(stdout.String()); m != nil {
+			viteURL = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if viteURL == "" {
+		t.Fatalf("front-door URL not printed; stdout=%q", stdout.String())
+	}
+	u, err := url.Parse(viteURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until gsx dev itself has observed the front-door exit, then let the
+	// startup posts' retry window drain: a push issued while the front door was
+	// still alive may legitimately be delivered a few seconds later (postBest
+	// retries + client timeout), and must not be counted against the gate.
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(stdout.String(), "front door exited") {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !strings.Contains(stdout.String(), "front door exited") {
+		t.Fatalf("gsx dev never logged the front-door exit; stdout=%q", stdout.String())
+	}
+	time.Sleep(4 * time.Second)
+
+	// The front door is dead; bind its port as "another project's vite" and
+	// record anything gsx dev still posts there.
+	var posts atomic.Int32
+	var postLog lockedBuffer
+	recorder := &http.Server{
+		Addr: net.JoinHostPort("127.0.0.1", u.Port()),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				posts.Add(1)
+				body, _ := io.ReadAll(r.Body)
+				fmt.Fprintf(&postLog, "%s %s %s\n", time.Now().Format("15:04:05.000"), r.URL.Path, body)
+			}
+			w.WriteHeader(204)
+		}),
+	}
+	rl, err := net.Listen("tcp", recorder.Addr)
+	if err != nil {
+		t.Fatalf("bind resolved front-door port %s: %v", recorder.Addr, err)
+	}
+	go func() { _ = recorder.Serve(rl) }()
+	defer recorder.Close()
+
+	// Change the server source so the completed cycle is observable: the
+	// rebuilt+restarted server answers /gen2.
+	writeFile(t, proj, "main.go", strings.Replace(devTestMainGo,
+		"mux.HandleFunc(\"/healthz\"",
+		"mux.HandleFunc(\"/gen2\", func(w http.ResponseWriter, _ *http.Request) {\n\t\tw.WriteHeader(http.StatusOK)\n\t})\n\tmux.HandleFunc(\"/healthz\"", 1))
+	// The pre-rebuild server answers /gen2 with 404 (waitHealthy accepts any
+	// response, so it cannot detect the swap); only an explicit 200 proves the
+	// rebuilt+restarted server is up and the cycle completed.
+	gen2OK := false
+	cli := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline = time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		if resp, err := cli.Get("http://localhost:7811/gen2"); err == nil {
+			code := resp.StatusCode
+			resp.Body.Close()
+			if code == http.StatusOK {
+				gen2OK = true
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !gen2OK {
+		onDisk, _ := os.ReadFile(filepath.Join(proj, "main.go"))
+		t.Fatalf("rebuilt server never served /gen2 (rebuild cycle did not complete)\nposts=%d rewriteApplied=%v healthz=%v\nposts received:\n%s\ngsx dev stdout:\n%s\nstderr:\n%s",
+			posts.Load(), strings.Contains(string(onDisk), "/gen2"),
+			waitHealthy(context.Background(), "http://localhost:7811/healthz", time.Second),
+			postLog.String(), stdout.String(), stderrBuf.String())
+	}
+
+	if n := posts.Load(); n != 0 {
+		t.Errorf("gsx dev posted %d event(s) to the re-bound front-door port after its web process exited; want 0\nposts received:\n%s\ngsx dev stdout:\n%s", n, postLog.String(), stdout.String())
+	}
+}
+
+// lockedBuffer is a mutex-guarded bytes.Buffer usable as an exec.Cmd output.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -24,7 +24,12 @@ func TestDevExitsWhenExplicitVitePortIsInUse(t *testing.T) {
 	defer l.Close()
 
 	proj := t.TempDir()
+	writeFile(t, proj, "go.mod", "module devdemo\n\ngo 1.24\n")
 	writeFile(t, proj, ".env", "VITE_PORT=5173\n")
+	// runDev resolves env from os.Environ() before the project .env, so an
+	// ambient VITE_PORT (e.g. exported by the developer's shell for another
+	// project) would silently override the pinned port under test.
+	t.Setenv("VITE_PORT", "5173")
 
 	var stdout, stderr bytes.Buffer
 	code := runDev(nil, &stdout, &stderr, config{}, nil, proj)

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -107,8 +107,9 @@ func TestDevTeardownAndRestart(t *testing.T) {
 	// gsx dev must run in its own process group so the group-SIGINT below only
 	// reaches gsx dev itself — not the test harness.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	// Drain gsx dev output so its pipe never blocks.
-	cmd.Stdout = devNullWriter{}
+	// Capture stdout (asserted on below); drain stderr so its pipe never blocks.
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = devNullWriter{}
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("gsx dev start: %v", err)
@@ -152,6 +153,12 @@ func TestDevTeardownAndRestart(t *testing.T) {
 		if !portListening("7799") {
 			// Port is free; reap gsx dev to avoid a zombie.
 			_ = cmd.Wait()
+			// The front-door-exit notice is for an UNEXPECTED exit (pushes get
+			// suspended); vite exiting because shutdown killed it is expected
+			// and must not print it.
+			if strings.Contains(stdout.String(), "front door exited") {
+				t.Errorf("intentional shutdown printed the front-door-exit notice\nstdout:\n%s", stdout.String())
+			}
 			return // clean teardown ✓
 		}
 		time.Sleep(200 * time.Millisecond)
@@ -242,6 +249,35 @@ func TestKillProcGroupOwnedReapsViaExternalWaiter(t *testing.T) {
 	case <-done:
 	default:
 		t.Fatal("child not reaped after killProcGroupOwned returned")
+	}
+}
+
+// Once the owning monitor has reaped the child (done closed), its pid may have
+// been recycled by the OS to an unrelated process — killProcGroupOwned must not
+// signal it. The victim process group stands in for whoever received the
+// recycled pid: a Cmd whose recorded Process.Pid now belongs to the victim.
+func TestKillProcGroupOwnedSkipsReapedChild(t *testing.T) {
+	victim := exec.Command("sleep", "60")
+	setProcGroup(victim)
+	if err := victim.Start(); err != nil {
+		t.Fatal(err)
+	}
+	victimExited := make(chan struct{})
+	go func() { _ = victim.Wait(); close(victimExited) }()
+	defer func() {
+		_ = syscall.Kill(-victim.Process.Pid, syscall.SIGKILL)
+		<-victimExited
+	}()
+
+	reaped := &exec.Cmd{Process: &os.Process{Pid: victim.Process.Pid}}
+	done := make(chan struct{})
+	close(done)
+	killProcGroupOwned(reaped, done, 5*time.Second)
+
+	select {
+	case <-victimExited:
+		t.Fatal("killProcGroupOwned signaled a reaped child's pid: the unrelated process group holding the recycled pid was killed")
+	case <-time.After(500 * time.Millisecond):
 	}
 }
 

--- a/gen/devproc_js.go
+++ b/gen/devproc_js.go
@@ -24,6 +24,13 @@ func killProcGroupOwned(c *exec.Cmd, done <-chan struct{}, _ time.Duration) {
 	if c == nil || c.Process == nil {
 		return
 	}
+	select {
+	case <-done:
+		// Already exited and reaped by the owning monitor: the pid may have
+		// been recycled to an unrelated process — do not signal it.
+		return
+	default:
+	}
 	_ = c.Process.Kill()
 	<-done
 }

--- a/gen/devproc_js.go
+++ b/gen/devproc_js.go
@@ -19,3 +19,11 @@ func killProcGroup(c *exec.Cmd, _ time.Duration) {
 	_ = c.Process.Kill()
 	_ = c.Wait()
 }
+
+func killProcGroupOwned(c *exec.Cmd, done <-chan struct{}, _ time.Duration) {
+	if c == nil || c.Process == nil {
+		return
+	}
+	_ = c.Process.Kill()
+	<-done
+}

--- a/gen/devproc_unix.go
+++ b/gen/devproc_unix.go
@@ -21,10 +21,20 @@ func killProcGroup(c *exec.Cmd, timeout time.Duration) {
 	if c == nil || c.Process == nil {
 		return
 	}
-	pgid := c.Process.Pid // Setpgid made the child the group leader (pgid == pid)
-	_ = syscall.Kill(-pgid, syscall.SIGTERM)
 	done := make(chan struct{})
 	go func() { _ = c.Wait(); close(done) }()
+	killProcGroupOwned(c, done, timeout)
+}
+
+// killProcGroupOwned is killProcGroup for a child whose Wait is owned by an
+// external monitor goroutine: done must be closed once that Wait has returned.
+// It never calls c.Wait itself.
+func killProcGroupOwned(c *exec.Cmd, done <-chan struct{}, timeout time.Duration) {
+	if c == nil || c.Process == nil {
+		return
+	}
+	pgid := c.Process.Pid // Setpgid made the child the group leader (pgid == pid)
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
 	t := time.NewTimer(timeout)
 	defer t.Stop()
 	select {

--- a/gen/devproc_unix.go
+++ b/gen/devproc_unix.go
@@ -33,6 +33,13 @@ func killProcGroupOwned(c *exec.Cmd, done <-chan struct{}, timeout time.Duration
 	if c == nil || c.Process == nil {
 		return
 	}
+	select {
+	case <-done:
+		// Already exited and reaped by the owning monitor: the pid may have
+		// been recycled to an unrelated process — do not signal it.
+		return
+	default:
+	}
 	pgid := c.Process.Pid // Setpgid made the child the group leader (pgid == pid)
 	_ = syscall.Kill(-pgid, syscall.SIGTERM)
 	t := time.NewTimer(timeout)

--- a/gen/devproc_windows.go
+++ b/gen/devproc_windows.go
@@ -35,6 +35,13 @@ func killProcGroupOwned(c *exec.Cmd, done <-chan struct{}, timeout time.Duration
 	if c == nil || c.Process == nil {
 		return
 	}
+	select {
+	case <-done:
+		// Already exited and reaped by the owning monitor: the pid may have
+		// been recycled to an unrelated process — do not signal it.
+		return
+	default:
+	}
 	pid := strconv.Itoa(c.Process.Pid)
 	_ = exec.Command("taskkill", "/T", "/PID", pid).Run()
 	t := time.NewTimer(timeout)

--- a/gen/devproc_windows.go
+++ b/gen/devproc_windows.go
@@ -23,10 +23,20 @@ func killProcGroup(c *exec.Cmd, timeout time.Duration) {
 	if c == nil || c.Process == nil {
 		return
 	}
-	pid := strconv.Itoa(c.Process.Pid)
-	_ = exec.Command("taskkill", "/T", "/PID", pid).Run()
 	done := make(chan struct{})
 	go func() { _ = c.Wait(); close(done) }()
+	killProcGroupOwned(c, done, timeout)
+}
+
+// killProcGroupOwned is killProcGroup for a child whose Wait is owned by an
+// external monitor goroutine: done must be closed once that Wait has returned.
+// It never calls c.Wait itself.
+func killProcGroupOwned(c *exec.Cmd, done <-chan struct{}, timeout time.Duration) {
+	if c == nil || c.Process == nil {
+		return
+	}
+	pid := strconv.Itoa(c.Process.Pid)
+	_ = exec.Command("taskkill", "/T", "/PID", pid).Run()
 	t := time.NewTimer(timeout)
 	defer t.Stop()
 	select {

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -146,7 +146,11 @@ func nextAvailablePort(start string) (string, error) {
 }
 
 func portAvailable(port string) bool {
-	for _, addr := range []string{"127.0.0.1:" + port, "[::1]:" + port} {
+	// The wildcard probe catches listeners bound to *:port (e.g. a running
+	// vite): with SO_REUSEADDR (set by net.Listen) the specific-address probes
+	// can succeed alongside a wildcard listener on at least macOS. The specific
+	// probes in turn catch listeners the wildcard probe may coexist with.
+	for _, addr := range []string{":" + port, "127.0.0.1:" + port, "[::1]:" + port} {
 		l, err := net.Listen("tcp", addr)
 		if err == nil {
 			l.Close()
@@ -249,20 +253,28 @@ func reportHardErrors(w io.Writer, results []cycleResult) {
 }
 
 // postEvent best-effort POSTs body to base+/__gsx/event (overlay state).
-func postEvent(base string, body []byte) { postBest(base+"/__gsx/event", body) }
+func postEvent(base string, body []byte, gate func() bool) {
+	postBest(base+"/__gsx/event", body, gate)
+}
 
 // postReload best-effort POSTs to base+/__reload (browser full-reload).
-func postReload(base string) { postBest(base+"/__reload", nil) }
+func postReload(base string, gate func() bool) { postBest(base+"/__reload", nil, gate) }
 
 // postBest POSTs with a few short retries so a not-yet-up Vite isn't fatal
 // (mirrors vite.NotifyReload's cold-start handling). dev-only; base "" no-ops.
-func postBest(url string, body []byte) {
+// gate, when non-nil, is re-checked before every attempt: the retry window can
+// straddle the managed front door's exit, after which the port may belong to a
+// stranger and the push must not be delivered.
+func postBest(url string, body []byte, gate func() bool) {
 	if strings.HasPrefix(url, "/") || url == "" {
 		return
 	}
 	go func() {
 		client := &http.Client{Timeout: 2 * time.Second}
 		for range 10 {
+			if gate != nil && !gate() {
+				return
+			}
 			resp, err := client.Post(url, "application/json", bytes.NewReader(body))
 			if err == nil {
 				resp.Body.Close()
@@ -308,6 +320,20 @@ func (d *devServer) effectiveBuildOut() io.Writer {
 		return d.buildOut
 	}
 	return d.out
+}
+
+// buildFailureMessage is the overlay counterpart of writeBuildFailure: the
+// compiler output when there is any, otherwise the error itself. Operational
+// failures (exec errors, a failed server start) produce no compiler output,
+// and posting buildErrorEvent(output) alone would show an empty overlay.
+func buildFailureMessage(output string, err error) string {
+	if strings.TrimSpace(output) != "" {
+		return output
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 
 func writeBuildFailure(w io.Writer, output string, err error) {

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -307,7 +307,7 @@ func TestPostEventReachesServer(t *testing.T) {
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-	postEvent(srv.URL, []byte(`{"event":"generated","ok":true}`))
+	postEvent(srv.URL, []byte(`{"event":"generated","ok":true}`), nil)
 	select {
 	case b := <-got:
 		if !strings.Contains(b, "generated") {
@@ -315,5 +315,38 @@ func TestPostEventReachesServer(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("postEvent did not reach server")
+	}
+}
+
+func TestPortAvailableDetectsWildcardListener(t *testing.T) {
+	// A dev server (vite binds *:PORT) must make the port unavailable. The
+	// specific-address probes alone miss this on macOS: SO_REUSEADDR (set by
+	// net.Listen) permits binding 127.0.0.1:PORT / [::1]:PORT alongside an
+	// existing wildcard listener.
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if portAvailable(port) {
+		t.Errorf("portAvailable(%s) = true while a wildcard listener holds the port", port)
+	}
+}
+
+func TestBuildFailureMessagePrefersCompilerOutput(t *testing.T) {
+	out := "# devdemo\nmain.go:3:1: undefined: x\n"
+	if got := buildFailureMessage(out, errors.New("exit status 1")); got != out {
+		t.Errorf("buildFailureMessage = %q, want compiler output %q", got, out)
+	}
+}
+
+func TestBuildFailureMessageFallsBackToError(t *testing.T) {
+	err := errors.New("fork/exec tmp/server: no such file or directory")
+	if got := buildFailureMessage("  \n", err); got != err.Error() {
+		t.Errorf("buildFailureMessage = %q, want %q", got, err.Error())
 	}
 }


### PR DESCRIPTION
Fixes from a real cross-project incident: a `gsx dev` whose vite had exited kept POSTing overlay/reload events to its startup-resolved port after another project's vite re-bound it — foreign empty overlays and random tab reloads.

- **Gate every browser push on the managed front door still running.** A monitor goroutine solely owns `vite.Wait` and closes `webExited`; `postBest` re-checks the gate before every retry attempt. `--no-web` keeps posting (externally-managed front door).
- **`killProcGroupOwned` won't signal a reaped child's recycled pid** — eager reaping by the monitor freed the pid for OS reuse; shutdown could SIGTERM an unrelated process group. Early-return when the child is already reaped (found in review, fixed test-first: `TestKillProcGroupOwnedSkipsReapedChild`).
- **Build overlay falls back to the error text** when compiler output is empty (operational failures previously rendered an empty overlay).
- **`portAvailable` probes the wildcard address** — on macOS, SO_REUSEADDR let the specific-address probes succeed alongside a `*:port` listener, so a busy port could be handed out as free (probe-verified).
- Shutdown notice quieted on intentional teardown; test hardening: `TestDevStopsPostingAfterWebExit` reproduces the incident end-to-end, SIGINT-first teardown, ambient `VITE_PORT` scrubbing.

Tests: full `gen` suite green (`-count=1`), `-race` clean on touched tests, `make ci` green (as part of the stacked dev-panel branch).

Note: PR #147 stacks on this branch.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576
