### PR TITLE
feat: browser dev panel (Cmd-D) + front-door auto-restart

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,7 +37,7 @@ generator/CLI may use `golang.org/x/tools`.
 | Pipeline `\|>` end-to-end | [x] seed-first forward-application lowering + `std` filters + user filter packages (`gen.WithFilters` + `gen.WithFilter` aliases, multi-pkg last-wins) + `ctx` injection + `(T,error)` implicit auto-unwrap **at any stage** (halts the chain on error). Works in interp / attr / class / style / spread / child-prop values / `{{ }}` pairs / cond-attr branches (all pipeline-legal contexts). Initialism-aware naming pending. |
 | CLI (`gsx`) / `gen.Main` | [~] `generate` (incl. `--watch`/`--format=ndjson`) · `fmt` · `info` · `init` · `lsp` · `clean --cache` · `version` · `help` ship, with `--json` + structured diagnostics. `vet`/`render`/`explain`/numeric codes pending. `WithClassMerger` + `class_merger` TOML knob shipped. |
 | Language server (`gsx lsp`) | [~] diagnostics (debounced) + authored-source go-to-definition, hover, document symbols, workspace symbols + find-references + formatting ship; completion and external/non-project references deferred. Read intelligence excludes exact paired generated `.x.go` outputs while preserving legitimate unpaired authored `.x.go`. |
-| Developer experience (Vite + `init`) | [x] `gsx init` scaffold + `@gsxhq/vite-plugin-gsx` (npm v0.4.5) + `github.com/gsxhq/vite` (v0.2.0). |
+| Developer experience (Vite + `init`) | [x] `gsx init` scaffold + `@gsxhq/vite-plugin-gsx` (npm v0.5.0) + `github.com/gsxhq/vite` (v0.2.0) + browser dev panel + front-door auto-restart. |
 
 ## Done
 
@@ -770,6 +770,18 @@ pieces. Save → warm generate → build-then-swap Go server → browser reloads
   CSS dedup), `Entry(name) Bundle`, `StaticHandler()`, `NotifyReload(devURL)`, and
   context helpers (`NewContext`/`FromContext`/`Middleware`) for request-scoped
   instance threading.
+- [x] **Dev panel + front-door resilience** (2026-07-23,
+  `2026-07-23-dev-panel-design.md`) - a Cmd-D/Ctrl-D browser overlay (served by
+  `@gsxhq/vite-plugin-gsx` v0.5.0) with **Rebuild** (forced full
+  regenerate→build→restart→reload) and **Restart server** (Go-only restart)
+  buttons, plus a live status view (phase, Go server health/port, last cycle,
+  front-door state). Commands ride a FIFO mailbox drained by `gsx dev` via
+  long-poll (`GET /__gsx/cmd`); status rides the existing `/__gsx/event` POST.
+  Works under `--no-web` (front door reports `external`). Separately, `gsx dev`
+  now auto-restarts a managed front door that exits unexpectedly (backoff
+  500ms/2s/5s; three failed attempts gives up and suspends pushes), verifying
+  a respawn is really our plugin via the `x-gsx` response header on
+  `/__gsx/cmd` before resuming pushes. Docs: `guide/dev-loop.md` §Dev panel.
 
 ## Security - safe by default
 

--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -65,32 +65,24 @@ Before the first successful build, there is no last working server. Keep
 
 ## Dev panel
 
-Press **Cmd-D** (macOS) or **Ctrl-D** to toggle a browser overlay showing live
-dev-loop status: phase, Go server health + port, last cycle result, and
-front-door state. The toggle is suppressed while focus is in an input,
-textarea, or contenteditable element.
+Press **Cmd-D** (macOS) or **Ctrl-D** to toggle a status overlay with two
+buttons:
 
-Existing apps (scaffolds already have it) add `import "virtual:gsx-devpanel";` to their Vite client entry.
+- **Rebuild** — full regenerate → build → restart → reload.
+- **Restart server** — restart the Go server only.
 
-Two buttons:
+Scaffolds ship it; existing apps add one line to their Vite client entry:
 
-- **Rebuild** - forces a full regenerate → build → restart → reload, skipping
-  the warm incremental path.
-- **Restart server** - restarts the Go server only; no rebuild.
+```js
+import "virtual:gsx-devpanel";
+```
 
-The front door (Vite) auto-restarts if it exits unexpectedly, backing off
-500ms/2s/5s; three failed attempts and `gsx dev` gives up and suspends browser
-pushes until you restart it. A respawned front door must answer with `gsx
-dev`'s own `x-gsx` header before pushes resume, so a reconnect never targets
-some other process that grabbed the port. Tabs that were already open predate
-the new Vite instance's websocket token — refresh them once after a front-door
-restart.
+(requires `@gsxhq/vite-plugin-gsx` ≥ 0.5.0). Disable it or rebind the key in
+`vite.config.ts`: `gsx({ devPanel: false })` or
+`gsx({ devPanel: { key: "k" } })`.
 
-Under `--no-web` the panel still works against an externally run Vite; the
-front-door row reads `external` since `gsx dev` isn't managing that process.
-
-The panel can be disabled or its toggle key rebound via the plugin's
-`devPanel` option (`gsx({ devPanel: false })` / `gsx({ devPanel: { key: "k" } })`).
+If Vite crashes, `gsx dev` restarts it automatically — refresh any tabs that
+were already open.
 
 ## Customize the commands
 

--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -89,6 +89,9 @@ restart.
 Under `--no-web` the panel still works against an externally run Vite; the
 front-door row reads `external` since `gsx dev` isn't managing that process.
 
+The panel can be disabled or its toggle key rebound via the plugin's
+`devPanel` option (`gsx({ devPanel: false })` / `gsx({ devPanel: { key: "k" } })`).
+
 ## Customize the commands
 
 Use the [`gsx dev` flags](./cli.md#gsx-dev) for one-off changes to the front

--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -63,6 +63,28 @@ remains active. Fix the error and save again to build and reload the new version
 Before the first successful build, there is no last working server. Keep
 `gsx dev` running, fix the startup error, and save again.
 
+## Dev panel
+
+Press **Cmd-D** (macOS) or **Ctrl-D** to toggle a browser overlay showing live
+dev-loop status: phase, Go server health + port, last cycle result, and
+front-door state. The toggle is suppressed while focus is in an input,
+textarea, or contenteditable element.
+
+Two buttons:
+
+- **Rebuild** - forces a full regenerate → build → restart → reload, skipping
+  the warm incremental path.
+- **Restart server** - restarts the Go server only; no rebuild.
+
+The front door (Vite) auto-restarts if it exits unexpectedly, backing off
+500ms/2s/5s; three failed attempts and `gsx dev` gives up and suspends browser
+pushes until you restart it. A respawned front door must answer with `gsx
+dev`'s own `x-gsx` header before pushes resume, so a reconnect never targets
+some other process that grabbed the port.
+
+Under `--no-web` the panel still works against an externally run Vite; the
+front-door row reads `external` since `gsx dev` isn't managing that process.
+
 ## Customize the commands
 
 Use the [`gsx dev` flags](./cli.md#gsx-dev) for one-off changes to the front

--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -82,7 +82,9 @@ The front door (Vite) auto-restarts if it exits unexpectedly, backing off
 500ms/2s/5s; three failed attempts and `gsx dev` gives up and suspends browser
 pushes until you restart it. A respawned front door must answer with `gsx
 dev`'s own `x-gsx` header before pushes resume, so a reconnect never targets
-some other process that grabbed the port.
+some other process that grabbed the port. Tabs that were already open predate
+the new Vite instance's websocket token — refresh them once after a front-door
+restart.
 
 Under `--no-web` the panel still works against an externally run Vite; the
 front-door row reads `external` since `gsx dev` isn't managing that process.

--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -70,6 +70,8 @@ dev-loop status: phase, Go server health + port, last cycle result, and
 front-door state. The toggle is suppressed while focus is in an input,
 textarea, or contenteditable element.
 
+Existing apps (scaffolds already have it) add `import "virtual:gsx-devpanel";` to their Vite client entry.
+
 Two buttons:
 
 - **Rebuild** - forces a full regenerate → build → restart → reload, skipping

--- a/docs/superpowers/plans/2026-07-23-dev-panel.md
+++ b/docs/superpowers/plans/2026-07-23-dev-panel.md
@@ -1309,159 +1309,228 @@ git commit -m "feat: CommandMailbox for panel→gsx-dev commands"
 
 ---
 
-### Task 6: Plugin — /__gsx/cmd endpoint, ws intake, status cache (vite-plugin-gsx)
+### Task 6: Plugin — PanelChannel: /__gsx/cmd endpoint, ws intake, status cache (vite-plugin-gsx)
 
 **Files:**
-- Modify: `src/index.ts` (inside `configureServer`, alongside the existing `/__gsx/event` middleware; and `applyEvent`)
-- Test: `test/panel-endpoint.test.ts`
+- Create: `src/panel.ts`
+- Modify: `src/index.ts` (thin wiring inside `configureServer`; and `applyEvent`)
+- Test: `test/panel.test.ts`
 
 **Interfaces:**
 - Consumes: `CommandMailbox` (Task 5).
-- Produces: HTTP contract for gsx dev (Global Constraints: `x-gsx: 1` on every `/__gsx/cmd` response, 204 idle, `{"cmds":[…]}`); ws contract for the panel client (Task 7): send `gsx:cmd` `{cmd: string}`, receive `gsx:status` with the status object; status replayed to new ws connections.
+- Produces: `class PanelChannel` (below) wired into the plugin; HTTP contract for gsx dev (Global Constraints: `x-gsx: 1` on every `/__gsx/cmd` response, 204 idle, `{"cmds":[…]}`); ws contract for the panel client (Task 7): send `gsx:cmd` `{cmd: string}`, receive `gsx:status` with the status object; status replayed to new ws connections. No test-only members anywhere — the channel class IS the unit-test surface; the vite glue stays one line per hook.
+
+```ts
+export class PanelChannel {
+  constructor(logger: { warn(msg: string, opts?: unknown): void }, broadcast: (payload: unknown) => void);
+  intake(raw: unknown): void;                 // validates {cmd}, pushes to mailbox
+  applyStatus(ev: unknown): boolean;          // true = was a status event (cached + broadcast), fully handled
+  replayPayload(): string | null;             // JSON custom-event envelope of cached status, for new ws clients
+  cmdMiddleware(req: unknown, res: unknown): void; // the /__gsx/cmd handler (bound method)
+}
+```
 
 - [ ] **Step 1: Write the failing tests**
 
-Model setup on `test/event-endpoint.test.ts` (it already boots a real vite dev server with the plugin — read it first and reuse its helper style):
+Test the channel directly — the middleware through a plain `node:http` server (the exact production handler, no vite):
 
 ```ts
-// test/panel-endpoint.test.ts
+// test/panel.test.ts
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { createServer, type ViteDevServer } from "vite";
-import { gsx } from "../src/index.js";
+import { createServer, type Server } from "node:http";
+import { PanelChannel } from "../src/panel.js";
 
-let server: ViteDevServer;
+let warns: string[];
+let sent: any[];
+let chan: PanelChannel;
+let srv: Server;
 let base: string;
 
 beforeEach(async () => {
-  server = await createServer({
-    root: process.cwd(),
-    logLevel: "silent",
-    server: { port: 0 },
-    plugins: [gsx({ generateOnStart: false })],
-  });
-  await server.listen();
-  const addr = server.httpServer!.address() as { port: number };
+  warns = [];
+  sent = [];
+  chan = new PanelChannel(
+    { warn: (m: string) => warns.push(m) },
+    (p) => sent.push(p),
+  );
+  srv = createServer((req, res) => chan.cmdMiddleware(req, res));
+  await new Promise<void>((r) => srv.listen(0, r));
+  const addr = srv.address() as { port: number };
   base = `http://localhost:${addr.port}`;
 });
 
 afterEach(async () => {
-  await server.close();
+  await new Promise((r) => srv.close(r));
 });
 
-describe("/__gsx/cmd", () => {
+describe("cmdMiddleware", () => {
   it("204 + x-gsx header when idle", async () => {
-    const resp = await fetch(`${base}/__gsx/cmd?wait=0`);
+    const resp = await fetch(`${base}/?wait=0`);
     expect(resp.status).toBe(204);
     expect(resp.headers.get("x-gsx")).toBe("1");
   });
 
-  it("returns queued ws commands as JSON", async () => {
-    // Simulate the panel via the intake test hook (same validation path as ws).
-    (server as any).__gsxTestPush("rebuild");
-    const resp = await fetch(`${base}/__gsx/cmd?wait=5`);
+  it("returns intaken commands as JSON, x-gsx stamped", async () => {
+    chan.intake({ cmd: "rebuild" });
+    const resp = await fetch(`${base}/?wait=5`);
     expect(resp.status).toBe(200);
     expect(resp.headers.get("x-gsx")).toBe("1");
     expect(await resp.json()).toEqual({ cmds: ["rebuild"] });
   });
 
-  it("rejects non-GET", async () => {
-    const resp = await fetch(`${base}/__gsx/cmd`, { method: "POST" });
+  it("resolves a hanging poll when a command arrives", async () => {
+    const pending = fetch(`${base}/?wait=10`);
+    await new Promise((r) => setTimeout(r, 50));
+    chan.intake({ cmd: "restart-server" });
+    const resp = await pending;
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ cmds: ["restart-server"] });
+  });
+
+  it("rejects non-GET with 405 (still stamped)", async () => {
+    const resp = await fetch(`${base}/`, { method: "POST" });
     expect(resp.status).toBe(405);
+    expect(resp.headers.get("x-gsx")).toBe("1");
   });
 });
 
-describe("status events", () => {
-  it("caches status and stamps nothing on /__gsx/event", async () => {
-    const resp = await fetch(`${base}/__gsx/event`, {
-      method: "POST",
-      body: JSON.stringify({ event: "status", phase: "idle", server: { healthy: true, port: "7777" }, frontDoor: { state: "up", restarts: 0 } }),
-    });
-    expect(resp.status).toBe(204);
-    // Cached status is replayed to new ws connections — asserted via the test hook.
-    expect((server as any).__gsxTestStatus().phase).toBe("idle");
+describe("intake validation", () => {
+  it("drops unknown commands with a warning", async () => {
+    chan.intake({ cmd: "rm-rf" });
+    chan.intake("garbage");
+    chan.intake(null);
+    expect(warns.length).toBe(3);
+    const resp = await fetch(`${base}/?wait=0`);
+    expect(resp.status).toBe(204); // nothing queued
+  });
+});
+
+describe("status", () => {
+  const status = { event: "status", phase: "idle", server: { healthy: true, port: "7777" }, frontDoor: { state: "up", restarts: 0 } };
+
+  it("applyStatus caches, broadcasts, and claims the event", () => {
+    expect(chan.applyStatus(status)).toBe(true);
+    expect(sent).toEqual([{ type: "custom", event: "gsx:status", data: status }]);
+    const replay = JSON.parse(chan.replayPayload()!);
+    expect(replay).toEqual({ type: "custom", event: "gsx:status", data: status });
+  });
+
+  it("ignores non-status events and replays null before any status", () => {
+    expect(chan.applyStatus({ event: "generated", ok: true })).toBe(false);
+    expect(chan.applyStatus(null)).toBe(false);
+    expect(chan.replayPayload()).toBeNull();
+    expect(sent).toEqual([]);
   });
 });
 ```
-
-**Test hooks:** `server.ws.on("gsx:cmd", …)` fires only for real websocket clients, which are heavy to fake — so `configureServer` exposes two module-internal test hooks on the server object: `__gsxTestPush(cmd)` (calls the same intake function the ws handler uses — same validation path) and `__gsxTestStatus()` (returns the cached status). Assign them unconditionally; they are undocumented internals, named to make that obvious.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `npx vitest run test/panel-endpoint.test.ts`
-Expected: FAIL (404 on /__gsx/cmd; __gsxTestPush undefined)
+Run: `npx vitest run test/panel.test.ts`
+Expected: FAIL (cannot resolve ../src/panel.js)
 
-- [ ] **Step 3: Implement in src/index.ts**
-
-Add imports: `import { CommandMailbox } from "./mailbox.js";`. Inside `configureServer`, after the `/__gsx/event` middleware:
+- [ ] **Step 3: Implement src/panel.ts**
 
 ```ts
-      // 2b. Panel command channel: ws intake → mailbox → gsx dev long-poll.
-      const mailbox = new CommandMailbox();
-      const VALID_CMDS = new Set(["rebuild", "restart-server"]);
-      const intake = (raw: unknown) => {
-        const cmd = String((raw as any)?.cmd ?? "");
-        if (!VALID_CMDS.has(cmd)) {
-          logger.warn(`[gsx] ignoring unknown panel command: ${JSON.stringify(cmd)}`, { timestamp: true });
-          return;
-        }
-        mailbox.push(cmd);
-      };
-      server.ws.on("gsx:cmd", intake);
-      (server as any).__gsxTestPush = (cmd: string) => intake({ cmd });
+// PanelChannel: server side of the dev panel. Commands arrive from the panel
+// over vite's HMR ws (intake), queue in the mailbox, and leave via the
+// /__gsx/cmd long-poll (cmdMiddleware — gsx dev is the consumer). Status
+// events from gsx dev are cached for replay and broadcast as gsx:status.
+import { CommandMailbox } from "./mailbox.js";
 
-      server.middlewares.use("/__gsx/cmd", (req: any, res: any) => {
-        res.setHeader("x-gsx", "1"); // respawn-verification handshake for gsx dev
-        if (req.method !== "GET") {
-          res.statusCode = 405;
-          res.end();
-          return;
-        }
-        const url = new URL(req.url ?? "/", "http://internal");
-        const waitSec = Math.min(30, Math.max(0, parseFloat(url.searchParams.get("wait") ?? "25") || 0));
-        void mailbox.waitTake(waitSec * 1000).then((cmds) => {
-          if (cmds.length === 0) {
-            res.statusCode = 204;
-            res.end();
-            return;
-          }
-          res.setHeader("content-type", "application/json");
-          res.end(JSON.stringify({ cmds }));
-        });
-      });
-```
+const VALID_CMDS = new Set(["rebuild", "restart-server"]);
+const MAX_WAIT_SEC = 30;
 
-In `applyEvent`, handle status FIRST (before the `ev.event !== "generated"` branch):
+export class PanelChannel {
+  private mailbox = new CommandMailbox();
+  private currentStatus: unknown = null;
 
-```ts
-      let currentStatus: any = null;
-      (server as any).__gsxTestStatus = () => currentStatus;
-```
+  constructor(
+    private logger: { warn(msg: string, opts?: unknown): void },
+    private broadcast: (payload: unknown) => void,
+  ) {
+    this.cmdMiddleware = this.cmdMiddleware.bind(this);
+  }
 
-(declare next to `currentErrorPayload`), and at the top of `applyEvent`:
+  intake(raw: unknown): void {
+    const cmd = String((raw as { cmd?: unknown } | null)?.cmd ?? "");
+    if (!VALID_CMDS.has(cmd)) {
+      this.logger.warn(`[gsx] ignoring unknown panel command: ${JSON.stringify(cmd)}`, { timestamp: true });
+      return;
+    }
+    this.mailbox.push(cmd);
+  }
 
-```ts
-        if (ev.event === "status") {
-          currentStatus = ev;
-          server.ws.send({ type: "custom", event: "gsx:status", data: ev });
-          return;
-        }
-```
+  applyStatus(ev: unknown): boolean {
+    if ((ev as { event?: unknown } | null)?.event !== "status") return false;
+    this.currentStatus = ev;
+    this.broadcast({ type: "custom", event: "gsx:status", data: ev });
+    return true;
+  }
 
-In the existing `server.ws.on("connection", …)` handler, after the error replay line, add:
+  replayPayload(): string | null {
+    if (this.currentStatus === null) return null;
+    return JSON.stringify({ type: "custom", event: "gsx:status", data: this.currentStatus });
+  }
 
-```ts
-        if (currentStatus) client.send(JSON.stringify({ type: "custom", event: "gsx:status", data: currentStatus }));
+  cmdMiddleware(req: any, res: any): void {
+    res.setHeader("x-gsx", "1"); // respawn-verification handshake for gsx dev
+    if (req.method !== "GET") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+    const url = new URL(req.url ?? "/", "http://internal");
+    const waitSec = Math.min(MAX_WAIT_SEC, Math.max(0, parseFloat(url.searchParams.get("wait") ?? "25") || 0));
+    void this.mailbox.waitTake(waitSec * 1000).then((cmds) => {
+      if (cmds.length === 0) {
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ cmds }));
+    });
+  }
+}
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `npx vitest run test/panel-endpoint.test.ts` → PASS. Then the whole suite: `npx vitest run` → no regressions.
+Run: `npx vitest run test/panel.test.ts` → all PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Wire into src/index.ts (thin glue only)**
+
+Add import `import { PanelChannel } from "./panel.js";`. Inside `configureServer` (after `const logger = …`):
+
+```ts
+      const panel = new PanelChannel(logger, (p) => server.ws.send(p as any));
+      server.ws.on("gsx:cmd", (d: unknown) => panel.intake(d));
+      server.middlewares.use("/__gsx/cmd", panel.cmdMiddleware);
+```
+
+At the top of `applyEvent`:
+
+```ts
+        if (panel.applyStatus(ev)) return;
+```
+
+In the existing `server.ws.on("connection", …)` handler, after the error replay line:
+
+```ts
+        const replay = panel.replayPayload();
+        if (replay) client.send(replay);
+```
+
+- [ ] **Step 6: Run the whole suite**
+
+Run: `npx vitest run` → no regressions (the event-endpoint tests exercise `applyEvent` through a real vite server and must still pass with the status short-circuit in place).
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add src/index.ts test/panel-endpoint.test.ts
-git commit -m "feat: /__gsx/cmd long-poll endpoint, gsx:cmd ws intake, status cache + replay"
+git add src/panel.ts src/index.ts test/panel.test.ts
+git commit -m "feat: PanelChannel — /__gsx/cmd long-poll, gsx:cmd intake, status cache + replay"
 ```
 
 ---
@@ -1471,7 +1540,7 @@ git commit -m "feat: /__gsx/cmd long-poll endpoint, gsx:cmd ws intake, status ca
 **Files:**
 - Create: `src/client-logic.ts` (pure helpers — unit-tested), `src/client.ts` (DOM/custom element — logic-lean, not unit-tested)
 - Modify: `src/index.ts` (inject script + serve it), `tsup.config.ts` (second entry)
-- Test: `test/client-logic.test.ts`, plus an injection assertion in `test/panel-endpoint.test.ts`
+- Test: `test/client-logic.test.ts`, plus an injection test `test/panel-inject.test.ts`
 
 **Interfaces:**
 - Consumes: ws contract from Task 6 (`import.meta.hot.send("gsx:cmd", {cmd})`, `import.meta.hot.on("gsx:status", …)`).
@@ -1683,13 +1752,28 @@ and inside `configureServer`, a middleware serving the built client (with import
       });
 ```
 
-Add to `test/panel-endpoint.test.ts`:
+Create `test/panel-inject.test.ts` (real vite server, model the boot on `test/event-endpoint.test.ts`):
 
 ```ts
+import { describe, it, expect } from "vitest";
+import { createServer } from "vite";
+import { gsx } from "../src/index.js";
+
 describe("panel injection", () => {
   it("injects the panel script into index.html", async () => {
-    const html = await server.transformIndexHtml("/", "<html><head></head><body></body></html>");
-    expect(html).toContain("/__gsx/panel.js");
+    const server = await createServer({
+      root: process.cwd(),
+      logLevel: "silent",
+      server: { port: 0 },
+      plugins: [gsx({ generateOnStart: false })],
+    });
+    await server.listen();
+    try {
+      const html = await server.transformIndexHtml("/", "<html><head></head><body></body></html>");
+      expect(html).toContain("/__gsx/panel.js");
+    } finally {
+      await server.close();
+    }
   });
 });
 ```
@@ -1701,7 +1785,7 @@ Run: `npx vitest run` → all PASS. Then `npm run build` → succeeds and `ls di
 - [ ] **Step 8: Commit**
 
 ```bash
-git add src/client.ts src/client-logic.ts src/index.ts tsup.config.ts test/client-logic.test.ts test/panel-endpoint.test.ts
+git add src/client.ts src/client-logic.ts src/index.ts tsup.config.ts test/client-logic.test.ts test/panel-inject.test.ts
 git commit -m "feat: dev panel client — Cmd-D toggle, rebuild/restart buttons, live status"
 ```
 

--- a/docs/superpowers/plans/2026-07-23-dev-panel.md
+++ b/docs/superpowers/plans/2026-07-23-dev-panel.md
@@ -1,0 +1,1742 @@
+# Dev Panel + Front-Door Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Browser dev panel (Cmd-D/Ctrl-D) with Rebuild / Restart-server buttons and live status, plus auto-restart of the managed vite front door.
+
+**Architecture:** Commands flow browser → vite HMR ws → plugin mailbox → `gsx dev` long-poll (`GET /__gsx/cmd`). Status flows the existing direction: `gsx dev` POSTs a new `{"event":"status"}` to `/__gsx/event`; the plugin caches + broadcasts `gsx:status`. A `frontDoor` manager in `gen/` owns the vite child: per-instance exit gate, respawn with backoff, `x-gsx: 1` verification handshake before reopening pushes, crash-loop give-up.
+
+**Tech Stack:** Go stdlib (`gen/` may use x/tools but doesn't need it here), TypeScript + vitest + tsup in `vite-plugin-gsx`.
+
+**Spec:** `docs/superpowers/specs/2026-07-23-dev-panel-design.md` — read it first.
+
+## Global Constraints
+
+- gsx repo work happens in worktree `.worktrees/dev-panel` (branch `dev-panel`, based on `dev-event-fixes`). Plugin work happens in `~/personal/gsxhq/vite-plugin-gsx` on a new branch `dev-panel`. **Verify `git branch --show-current` prints `dev-panel` before every commit, in both repos.**
+- gsx runtime (root package) is stdlib-only; all Go changes here live in `gen/` (tooling).
+- Commands: exactly `rebuild` and `restart-server`. Unknown → log + drop.
+- Command response JSON: `{"cmds":["rebuild"]}`. Empty mailbox after wait → HTTP 204. Every `/__gsx/cmd` response carries header `x-gsx: 1`.
+- Status JSON (field names are the cross-repo contract):
+  `{"event":"status","phase":"idle|generating|building|starting","server":{"healthy":true,"port":"7777"},"lastCycle":{"ok":true,"errors":0,"at":"<RFC3339>"},"frontDoor":{"state":"up|restarting|given-up|external","restarts":0}}`
+- Restart backoff: 500ms → 2s → 5s; the 4th consecutive rapid exit (lived < 30s — i.e. three failed restart attempts) → give up. Respawn verification window: 5s.
+- Go tests: `go test ./gen -run <Name> -count=1` from the worktree root; integration tests skip with `testing.Short()`. Plugin tests: `npx vitest run <file>` from the plugin repo root.
+- gsx gate before finishing: `make check` (worktree), `gofmt -l gen/` empty. Plugin gate: `npm run build && npx vitest run`.
+
+---
+
+### Task 1: Status types + statusEvent (gen)
+
+**Files:**
+- Create: `gen/devstatus.go`
+- Test: `gen/devstatus_test.go`
+
+**Interfaces:**
+- Produces: `type devStatus struct` (fields below), `func statusEvent(s devStatus) []byte`. Task 4 mutates a `devStatus` and posts `statusEvent(...)` via the existing `post()`; Task 5's recorder and the plugin (Task 7) parse the JSON contract above.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// gen/devstatus_test.go
+package gen
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestStatusEventShape(t *testing.T) {
+	at := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	s := devStatus{
+		Phase:     "idle",
+		Server:    serverStat{Healthy: true, Port: "7777"},
+		LastCycle: &cycleStat{OK: true, Errors: 0, At: at},
+		FrontDoor: frontStat{State: "up", Restarts: 2},
+	}
+	var got map[string]any
+	if err := json.Unmarshal(statusEvent(s), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["event"] != "status" || got["phase"] != "idle" {
+		t.Errorf("event/phase = %v/%v", got["event"], got["phase"])
+	}
+	srv := got["server"].(map[string]any)
+	if srv["healthy"] != true || srv["port"] != "7777" {
+		t.Errorf("server = %v", srv)
+	}
+	lc := got["lastCycle"].(map[string]any)
+	if lc["ok"] != true || lc["at"] != "2026-07-23T10:00:00Z" {
+		t.Errorf("lastCycle = %v", lc)
+	}
+	fd := got["frontDoor"].(map[string]any)
+	if fd["state"] != "up" || fd["restarts"] != float64(2) {
+		t.Errorf("frontDoor = %v", fd)
+	}
+}
+
+func TestStatusEventOmitsNilLastCycle(t *testing.T) {
+	var got map[string]any
+	_ = json.Unmarshal(statusEvent(devStatus{Phase: "generating"}), &got)
+	if _, present := got["lastCycle"]; present {
+		t.Error("nil lastCycle must be omitted")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./gen -run TestStatusEvent -count=1`
+Expected: FAIL (compile error: undefined devStatus/statusEvent)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// gen/devstatus.go
+package gen
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// devStatus is the dev-loop state pushed to the browser panel as an
+// {"event":"status"} payload on /__gsx/event. Field names are the wire
+// contract with vite-plugin-gsx.
+type devStatus struct {
+	Phase     string     `json:"phase"` // idle | generating | building | starting
+	Server    serverStat `json:"server"`
+	LastCycle *cycleStat `json:"lastCycle,omitempty"`
+	FrontDoor frontStat  `json:"frontDoor"`
+}
+
+type serverStat struct {
+	Healthy bool   `json:"healthy"`
+	Port    string `json:"port"`
+}
+
+type cycleStat struct {
+	OK     bool      `json:"ok"`
+	Errors int       `json:"errors"`
+	At     time.Time `json:"at"`
+}
+
+type frontStat struct {
+	State    string `json:"state"` // up | restarting | given-up | external
+	Restarts int    `json:"restarts"`
+}
+
+func statusEvent(s devStatus) []byte {
+	b, _ := json.Marshal(struct {
+		Event string `json:"event"`
+		devStatus
+	}{"status", s})
+	return b
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./gen -run TestStatusEvent -count=1 -v` → both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gen/devstatus.go gen/devstatus_test.go
+git commit -m "feat(gen): devStatus wire type for panel status events"
+```
+
+---
+
+### Task 2: pollCommands long-poll client (gen)
+
+**Files:**
+- Create: `gen/devcmd.go`
+- Test: `gen/devcmd_test.go`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `func pollCommands(ctx context.Context, base string, up func() bool, out chan<- string)` — blocks until ctx done; delivers each command string on `out`. Task 4 runs it in a goroutine with the front-door gate as `up`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// gen/devcmd_test.go
+package gen
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// cmdServer serves /__gsx/cmd from a queue of canned responses.
+func cmdServer(t *testing.T, responses ...func(w http.ResponseWriter)) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/__gsx/cmd" {
+			w.WriteHeader(404)
+			return
+		}
+		n := int(calls.Add(1)) - 1
+		if n < len(responses) {
+			responses[n](w)
+			return
+		}
+		w.WriteHeader(204) // idle long-poll afterwards
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func respondCmds(cmds ...string) func(http.ResponseWriter) {
+	return func(w http.ResponseWriter) {
+		b, _ := json.Marshal(map[string]any{"cmds": cmds})
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	}
+}
+
+func TestPollCommandsDeliversAndRepolls(t *testing.T) {
+	srv, calls := cmdServer(t,
+		respondCmds("rebuild"),
+		func(w http.ResponseWriter) { w.WriteHeader(204) },
+		respondCmds("restart-server", "rebuild"),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan string, 8)
+	go pollCommands(ctx, srv.URL, func() bool { return true }, out)
+
+	want := []string{"rebuild", "restart-server", "rebuild"}
+	for i, w := range want {
+		select {
+		case got := <-out:
+			if got != w {
+				t.Fatalf("cmd[%d] = %q, want %q", i, got, w)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for cmd[%d] (calls=%d)", i, calls.Load())
+		}
+	}
+}
+
+func TestPollCommandsSuspendedWhileGateDown(t *testing.T) {
+	srv, calls := cmdServer(t, respondCmds("rebuild"))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan string, 1)
+	go pollCommands(ctx, srv.URL, func() bool { return false }, out)
+	time.Sleep(600 * time.Millisecond)
+	if calls.Load() != 0 {
+		t.Errorf("polled %d times while gate down; want 0", calls.Load())
+	}
+}
+
+func TestPollCommandsSurvivesServerDown(t *testing.T) {
+	// Nothing listens at base: pollCommands must keep retrying with backoff,
+	// not exit; and honor ctx cancellation promptly.
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan string, 1)
+	done := make(chan struct{})
+	go func() { pollCommands(ctx, "http://127.0.0.1:1", func() bool { return true }, out); close(done) }()
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("pollCommands did not return after ctx cancel")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./gen -run TestPollCommands -count=1`
+Expected: FAIL (undefined pollCommands)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// gen/devcmd.go
+package gen
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// pollCommands long-polls base+/__gsx/cmd?wait=25 and delivers each command on
+// out. up gates polling exactly like browser pushes: while the front door is
+// down/unverified, no requests are made. Transport errors back off 1s→2s→5s
+// (reset on success). Returns when ctx is done.
+func pollCommands(ctx context.Context, base string, up func() bool, out chan<- string) {
+	if strings.HasPrefix(base, "/") || base == "" {
+		return
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	backoff := time.Second
+	sleep := func(d time.Duration) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(d):
+			return true
+		}
+	}
+	for ctx.Err() == nil {
+		if !up() {
+			if !sleep(time.Second) {
+				return
+			}
+			continue
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/__gsx/cmd?wait=25", nil)
+		if err != nil {
+			return
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			if !sleep(backoff) {
+				return
+			}
+			backoff = min(backoff*2, 5*time.Second)
+			continue
+		}
+		backoff = time.Second
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			continue // 204 idle poll (or transient non-200): immediately re-poll
+		}
+		var payload struct {
+			Cmds []string `json:"cmds"`
+		}
+		if json.Unmarshal(body, &payload) != nil {
+			continue
+		}
+		for _, c := range payload.Cmds {
+			select {
+			case out <- c:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./gen -run TestPollCommands -count=1 -v` → all three PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gen/devcmd.go gen/devcmd_test.go
+git commit -m "feat(gen): pollCommands long-poll client for panel commands"
+```
+
+---
+
+### Task 3: frontDoor manager with restart + verification (gen)
+
+The big one: extract vite ownership from `runDev` into a `frontDoor` type, add auto-restart with backoff, respawn verification, crash-loop give-up.
+
+**Files:**
+- Create: `gen/frontdoor.go`
+- Test: `gen/frontdoor_test.go`
+- Modify: `gen/dev.go` (replace the inline vite start + monitor + `webExited` gate — the block from `webExited := make(chan struct{})` through the monitor goroutine, and `shutdownProcesses`)
+
+**Interfaces:**
+- Consumes: `killProcGroupOwned(c *exec.Cmd, done <-chan struct{}, timeout time.Duration)`, `setProcGroup(c *exec.Cmd)` (existing, `gen/devproc_*.go`).
+- Produces (used by Task 4):
+  - `func newFrontDoor(spawn func() (*exec.Cmd, error), verifyURL string, onState func(frontStat), logw io.Writer) *frontDoor`
+  - `func (f *frontDoor) start() error` — spawns first instance (gate opens immediately: first-instance semantics)
+  - `func (f *frontDoor) up() bool` — the push/poll gate
+  - `func (f *frontDoor) shutdown(timeout time.Duration)` — suppresses restart + notice, kills current instance
+  - `func restartPolicy(rapidExits int) (delay time.Duration, giveUp bool)` — 500ms/2s/5s then give up
+  - `func verifyFrontDoor(ctx context.Context, url string) bool` — probes `GET url+"/__gsx/cmd?wait=0"`, true iff header `x-gsx: 1`
+  - `onState` receives `frontStat{State: "up"|"restarting"|"given-up", Restarts: n}` on every transition (never called for shutdown). It may be called from the monitor goroutine — Task 4 forwards it through a channel into the select loop.
+
+- [ ] **Step 1: Write the failing tests (policy + verify + lifecycle)**
+
+```go
+// gen/frontdoor_test.go
+package gen
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRestartPolicy(t *testing.T) {
+	cases := []struct {
+		rapid  int
+		delay  time.Duration
+		giveUp bool
+	}{{0, 500 * time.Millisecond, false}, {1, 2 * time.Second, false}, {2, 5 * time.Second, false}, {3, 0, true}, {7, 0, true}}
+	for _, c := range cases {
+		d, g := restartPolicy(c.rapid)
+		if d != c.delay || g != c.giveUp {
+			t.Errorf("restartPolicy(%d) = %v,%v want %v,%v", c.rapid, d, g, c.delay, c.giveUp)
+		}
+	}
+}
+
+func TestVerifyFrontDoor(t *testing.T) {
+	ours := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-gsx", "1")
+		w.WriteHeader(204)
+	}))
+	defer ours.Close()
+	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200) // SPA fallback: 200 without the header
+	}))
+	defer foreign.Close()
+	if !verifyFrontDoor(context.Background(), ours.URL) {
+		t.Error("our plugin endpoint must verify")
+	}
+	if verifyFrontDoor(context.Background(), foreign.URL) {
+		t.Error("foreign 200 without x-gsx must NOT verify")
+	}
+	if verifyFrontDoor(context.Background(), "http://127.0.0.1:1") {
+		t.Error("connection refused must NOT verify")
+	}
+}
+
+// stateRecorder collects onState transitions.
+type stateRecorder struct {
+	mu     sync.Mutex
+	states []frontStat
+}
+
+func (r *stateRecorder) record(s frontStat) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states = append(r.states, s)
+}
+func (r *stateRecorder) list() []frontStat {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]frontStat(nil), r.states...)
+}
+func (r *stateRecorder) waitFor(t *testing.T, state string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, s := range r.list() {
+			if s.State == state {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("state %q never reached; got %+v", state, r.list())
+}
+
+// TestFrontDoorRestartsAndVerifies: the child exits once, the respawn stays up
+// and the verify URL answers with x-gsx — the gate must reopen.
+func TestFrontDoorRestartsAndVerifies(t *testing.T) {
+	verify := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-gsx", "1")
+		w.WriteHeader(204)
+	}))
+	defer verify.Close()
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "runs")
+	// First run appends a line and exits; later runs append and sleep.
+	script := "echo run >> " + marker + "; n=$(wc -l < " + marker + "); [ $n -ge 2 ] && sleep 60; exit 0"
+	rec := &stateRecorder{}
+	fd := newFrontDoor(func() (*exec.Cmd, error) {
+		c := exec.Command("sh", "-c", script)
+		setProcGroup(c)
+		return c, c.Start()
+	}, verify.URL, rec.record, os.Stderr)
+	if err := fd.start(); err != nil {
+		t.Fatal(err)
+	}
+	defer fd.shutdown(5 * time.Second)
+
+	if !fd.up() {
+		t.Fatal("gate must be open for the first instance")
+	}
+	rec.waitFor(t, "restarting", 10*time.Second)
+	rec.waitFor(t, "up", 10*time.Second) // respawn verified against verify.URL
+	if !fd.up() {
+		t.Error("gate must reopen after a verified respawn")
+	}
+	b, _ := os.ReadFile(marker)
+	if got := len(splitLines(string(b))); got < 2 {
+		t.Errorf("child ran %d times; want >= 2 (respawn)", got)
+	}
+}
+
+// TestFrontDoorGivesUpOnCrashLoop: child always exits immediately and nothing
+// verifies — after 3 rapid exits the manager gives up and the gate stays shut.
+func TestFrontDoorGivesUpOnCrashLoop(t *testing.T) {
+	rec := &stateRecorder{}
+	fd := newFrontDoor(func() (*exec.Cmd, error) {
+		c := exec.Command("sh", "-c", "exit 0")
+		setProcGroup(c)
+		return c, c.Start()
+	}, "http://127.0.0.1:1", rec.record, os.Stderr)
+	if err := fd.start(); err != nil {
+		t.Fatal(err)
+	}
+	defer fd.shutdown(time.Second)
+	rec.waitFor(t, "given-up", 30*time.Second)
+	if fd.up() {
+		t.Error("gate must stay shut after give-up")
+	}
+}
+
+// TestFrontDoorShutdownSilent: intentional shutdown must produce no
+// restarting/given-up transitions.
+func TestFrontDoorShutdownSilent(t *testing.T) {
+	rec := &stateRecorder{}
+	fd := newFrontDoor(func() (*exec.Cmd, error) {
+		c := exec.Command("sleep", "60")
+		setProcGroup(c)
+		return c, c.Start()
+	}, "http://127.0.0.1:1", rec.record, os.Stderr)
+	if err := fd.start(); err != nil {
+		t.Fatal(err)
+	}
+	fd.shutdown(5 * time.Second)
+	time.Sleep(200 * time.Millisecond)
+	for _, s := range rec.list() {
+		if s.State == "restarting" || s.State == "given-up" {
+			t.Errorf("shutdown produced transition %+v", s)
+		}
+	}
+	if fd.up() {
+		t.Error("gate must be shut after shutdown")
+	}
+}
+
+func splitLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+```
+
+(Add `"strings"` to the imports.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./gen -run 'TestRestartPolicy|TestVerifyFrontDoor|TestFrontDoor' -count=1`
+Expected: FAIL (undefined newFrontDoor/restartPolicy/verifyFrontDoor/frontStat is defined but the rest missing)
+
+- [ ] **Step 3: Implement gen/frontdoor.go**
+
+```go
+// gen/frontdoor.go
+package gen
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// frontDoor owns the managed vite child: it monitors exits, respawns with
+// backoff, verifies a respawn is really our plugin (x-gsx header) before
+// reopening the push/poll gate, and gives up on a crash loop. The first
+// instance opens the gate immediately (its port was vetted by portAvailable;
+// postBest retries cover the cold start).
+type frontDoor struct {
+	spawn     func() (*exec.Cmd, error)
+	verifyURL string
+	onState   func(frontStat)
+	logw      io.Writer
+
+	mu       sync.Mutex
+	cmd      *exec.Cmd
+	exited   chan struct{} // current instance; closed once its Wait returns
+	open     bool          // push/poll gate
+	restarts int
+	done     bool          // given up or shut down
+	shutdownC chan struct{} // closed by shutdown(); aborts backoff sleeps
+}
+
+// restartTimeout: an instance that lived at least this long resets the
+// rapid-exit counter. Also the boundary for "rapid".
+const frontDoorRapidWindow = 30 * time.Second
+
+// frontDoorVerifyWindow bounds how long a respawn may take to verify before it
+// is killed and counted as a rapid exit.
+const frontDoorVerifyWindow = 5 * time.Second
+
+// restartPolicy maps consecutive rapid exits to the backoff before the next
+// attempt, or giveUp.
+func restartPolicy(rapidExits int) (time.Duration, bool) {
+	switch rapidExits {
+	case 0:
+		return 500 * time.Millisecond, false
+	case 1:
+		return 2 * time.Second, false
+	case 2:
+		return 5 * time.Second, false
+	}
+	return 0, true
+}
+
+// verifyFrontDoor reports whether url is served by OUR vite plugin: the
+// /__gsx/cmd endpoint stamps x-gsx: 1 on every response. A foreign listener
+// (or vite's SPA fallback answering 200 for unknown paths) lacks it.
+func verifyFrontDoor(ctx context.Context, url string) bool {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/__gsx/cmd?wait=0", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.Header.Get("x-gsx") == "1"
+}
+
+func newFrontDoor(spawn func() (*exec.Cmd, error), verifyURL string, onState func(frontStat), logw io.Writer) *frontDoor {
+	return &frontDoor{spawn: spawn, verifyURL: verifyURL, onState: onState, logw: logw, shutdownC: make(chan struct{})}
+}
+
+// start launches the first instance and its supervisor. The gate opens
+// immediately (first-instance semantics).
+func (f *frontDoor) start() error {
+	cmd, err := f.spawn()
+	if err != nil {
+		return err
+	}
+	exited := make(chan struct{})
+	f.mu.Lock()
+	f.cmd, f.exited, f.open = cmd, exited, true
+	f.mu.Unlock()
+	go func() { _ = cmd.Wait(); close(exited) }()
+	go f.run(exited, time.Now())
+	return nil
+}
+
+func (f *frontDoor) up() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.open
+}
+
+// shutdown suppresses restarts and kills the current instance. Safe to call
+// once; runDev calls it from shutdownProcesses.
+func (f *frontDoor) shutdown(timeout time.Duration) {
+	f.mu.Lock()
+	if f.done {
+		f.mu.Unlock()
+		return
+	}
+	f.done = true
+	f.open = false
+	cmd, exited := f.cmd, f.exited
+	close(f.shutdownC)
+	f.mu.Unlock()
+	if cmd != nil {
+		killProcGroupOwned(cmd, exited, timeout)
+	}
+}
+
+// run supervises instances for the frontDoor's lifetime: wait for the current
+// instance to exit, apply the restart policy, respawn, verify, repeat — until
+// verified instances keep living, give-up, or shutdown. Every path out of an
+// iteration leaves open == false except verified-up. Each instance's Wait is
+// owned by the small goroutine that closes its exited channel.
+func (f *frontDoor) run(exited chan struct{}, started time.Time) {
+	rapid := 0 // consecutive exits where the instance lived < frontDoorRapidWindow
+	for {
+		<-exited
+		f.mu.Lock()
+		if f.done {
+			f.mu.Unlock()
+			return
+		}
+		f.open = false
+		f.mu.Unlock()
+		if time.Since(started) < frontDoorRapidWindow {
+			rapid++
+		} else {
+			rapid = 1
+		}
+		delay, giveUp := restartPolicy(rapid - 1)
+		if giveUp {
+			f.giveUp()
+			return
+		}
+		f.transition(frontStat{State: "restarting", Restarts: f.restartCount()})
+		fmt.Fprintf(f.logw, "gsx dev: front door exited — restarting in %s\n", delay)
+		select {
+		case <-f.shutdownC:
+			return
+		case <-time.After(delay):
+		}
+		next, err := f.spawn()
+		if err != nil {
+			fmt.Fprintf(f.logw, "gsx dev: front door restart failed: %v\n", err)
+			// No instance to wait on: synthesize an immediate rapid exit.
+			exited = closedChan()
+			started = time.Now()
+			continue
+		}
+		nextExited := make(chan struct{})
+		go func(c *exec.Cmd, ch chan struct{}) { _ = c.Wait(); close(ch) }(next, nextExited)
+		f.mu.Lock()
+		if f.done {
+			f.mu.Unlock()
+			killProcGroupOwned(next, nextExited, 2*time.Second)
+			return
+		}
+		f.cmd, f.exited = next, nextExited
+		f.restarts++
+		f.mu.Unlock()
+		exited, started = nextExited, time.Now()
+		if f.verifyRespawn(nextExited) {
+			f.mu.Lock()
+			ok := !f.done
+			f.open = ok
+			f.mu.Unlock()
+			if ok {
+				f.transition(frontStat{State: "up", Restarts: f.restartCount()})
+			}
+		} else {
+			// Never verified (foreign port owner, drifted port, or died during
+			// the window): kill it; the loop's <-exited counts it as rapid.
+			fmt.Fprintln(f.logw, "gsx dev: restarted front door did not verify (no x-gsx endpoint at its URL) — killing it")
+			f.mu.Lock()
+			cur, curExited := f.cmd, f.exited
+			f.mu.Unlock()
+			killProcGroupOwned(cur, curExited, 2*time.Second)
+		}
+	}
+}
+
+func closedChan() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func (f *frontDoor) restartCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.restarts
+}
+
+func (f *frontDoor) giveUp() {
+	f.mu.Lock()
+	f.done = true
+	f.open = false
+	f.mu.Unlock()
+	fmt.Fprintln(f.logw, "gsx dev: front door exited — giving up after repeated failures; suspending browser reload/overlay pushes")
+	f.transition(frontStat{State: "given-up", Restarts: f.restartCount()})
+}
+
+// verifyRespawn polls verifyFrontDoor until success, instance exit, shutdown,
+// or the verify window elapses.
+func (f *frontDoor) verifyRespawn(exited <-chan struct{}) bool {
+	deadline := time.Now().Add(frontDoorVerifyWindow)
+	for time.Now().Before(deadline) {
+		select {
+		case <-f.shutdownC:
+			return false
+		case <-exited:
+			return false
+		default:
+		}
+		if verifyFrontDoor(context.Background(), f.verifyURL) {
+			return true
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return false
+}
+
+func (f *frontDoor) transition(s frontStat) {
+	if f.onState != nil {
+		f.onState(s)
+	}
+}
+```
+
+**Policy indexing note:** `restartPolicy(rapid - 1)` — the Nth consecutive rapid exit (rapid=N) yields the Nth backoff; the 4th rapid exit hits `restartPolicy(3)` = give up. That is: three failed restart attempts, then give up (matches the Step 1 policy table).
+
+- [ ] **Step 4: Run tests until they pass**
+
+Run: `go test ./gen -run 'TestRestartPolicy|TestVerifyFrontDoor|TestFrontDoor' -count=1 -v`
+Expected: all PASS. Also run with `-race`.
+
+- [ ] **Step 5: Rewire dev.go onto frontDoor**
+
+In `gen/dev.go`, delete the `webExited` channel, `shuttingDown` atomic, `webUp` closure, the inline vite spawn block and its monitor goroutine, and change `shutdownProcesses`. Replace with:
+
+```go
+	// post/reload gate every browser push on the managed front door being up
+	// (see frontDoor). With --no-web the front door is externally managed and
+	// pushes always go out.
+	var fd *frontDoor
+	webUp := func() bool { return fd == nil || fd.up() }
+	post := func(body []byte) { postEvent(viteURL, body, webUp) }
+	reload := func() { postReload(viteURL, webUp) }
+```
+
+and (in place of the old vite block; `fdCh` is consumed in Task 4 — for THIS task, create it and drain it so nothing blocks):
+
+```go
+	// --- Vite (front door), unless --no-web ---
+	fdCh := make(chan frontStat, 8)
+	if dc.web != nil {
+		spawn := func() (*exec.Cmd, error) {
+			c := exec.Command(dc.web[0], dc.web[1:]...)
+			c.Dir, c.Env, c.Stdout, c.Stderr = workDir, env, mkWriter("vite"), mkWriter("vite")
+			setProcGroup(c)
+			return c, c.Start()
+		}
+		fd = newFrontDoor(spawn, viteURL, func(s frontStat) {
+			select {
+			case fdCh <- s:
+			default: // never block the monitor on a full channel
+			}
+		}, stdout)
+		if err := fd.start(); err != nil {
+			fmt.Fprintf(stderr, "gsx dev: starting front door: %v\n", err)
+			return 1
+		}
+	}
+```
+
+and:
+
+```go
+	shutdownProcesses := func() {
+		srv.stop()
+		if fd != nil {
+			fd.shutdown(5 * time.Second)
+		}
+	}
+```
+
+Until Task 4 wires `fdCh` into the select loop, add a temporary case that keeps the channel drained:
+
+```go
+		case <-fdCh: // consumed for real in the status task
+```
+
+- [ ] **Step 6: Update the two existing integration tests' expectations**
+
+`TestDevStopsPostingAfterWebExit` (gen/dev_test.go): the `sleep 1` front door now triggers restart attempts (each respawned `sleep 1` never verifies — `VITE_DEV_URL=http://127.0.0.1:1`... note the test's real resolved URL is the printed one; respawns get killed after the 5s verify window and it gives up after 3). Update the wait: instead of `"front door exited"` alone, wait for the give-up line (`"giving up after repeated failures"`) with a 60s deadline, THEN the 4s drain, then bind the recorder. The zero-posts assertion is unchanged — respawned instances never verify, so the gate never reopens.
+
+`TestDevTeardownAndRestart`: the no-notice-on-shutdown assertion now checks for `"front door exited"` absence — still valid (shutdown path produces no transitions and no notice). No change needed; run it to confirm.
+
+- [ ] **Step 7: Run the full gen suite**
+
+Run: `go test ./gen -count=1 -timeout 900s` and `go test ./gen -race -run 'TestFrontDoor|TestDev' -count=1 -timeout 900s`
+Expected: PASS. Fix regressions before committing (likely suspects: log wording asserted in dev tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add gen/frontdoor.go gen/frontdoor_test.go gen/dev.go gen/dev_test.go
+git commit -m "feat(gen): frontDoor manager — auto-restart with backoff, x-gsx respawn verification, crash-loop give-up"
+```
+
+---
+
+### Task 4: Wire commands + status into the runDev loop (gen)
+
+**Files:**
+- Modify: `gen/dev.go` (the select loop and the `<-fire` case; see anchors below)
+- Test: `gen/dev_test.go` (integration, extends the recorder pattern)
+
+**Interfaces:**
+- Consumes: `pollCommands` (Task 2), `devStatus`/`statusEvent` (Task 1), `fd`/`fdCh`/`webUp` (Task 3), existing `dirty`, `srv`, `post`, `reload`, `waitHealthy`.
+- Produces: `gsx dev` behavior — `rebuild` forces a full cycle, `restart-server` restarts the Go server; status posted on startup, cycle end, and front-door transitions. The wire shapes are pinned by Task 1's tests and Global Constraints.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `gen/dev_test.go`. Reuses `repoRoot`, `writeFile`, `devTestEnv`, `stopDevGracefully`, `lockedBuffer`, `waitHealthy`, `portListening` (all already in this file). First add a `/pid` route to the scaffold server constant `devTestMainGo` so restarts are observable — in the string constant, above the `/healthz` handler, add:
+
+```go
+	mux.HandleFunc("/pid", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "%d", os.Getpid())
+	})
+```
+
+(and add `"fmt"` + `"os"` to devTestMainGo's import block if not present — read the constant first). Then:
+
+```go
+// TestDevPanelCommands drives gsx dev through the command channel: the test
+// plays the vite plugin (serves /__gsx/cmd from a queue, records /__gsx/event
+// posts) and asserts restart-server restarts the Go server and status events
+// arrive.
+func TestDevPanelCommands(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	// Fake vite plugin: long-poll queue + event recorder, x-gsx stamped.
+	cmdQ := make(chan string, 4)
+	var statusEvents lockedBuffer
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-gsx", "1")
+		switch r.URL.Path {
+		case "/__gsx/cmd":
+			select {
+			case c := <-cmdQ:
+				fmt.Fprintf(w, `{"cmds":[%q]}`, c)
+			case <-time.After(2 * time.Second):
+				w.WriteHeader(204)
+			}
+		case "/__gsx/event":
+			body, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(body), `"event":"status"`) {
+				statusEvents.Write(append(body, '\n'))
+			}
+			w.WriteHeader(204)
+		default:
+			w.WriteHeader(204)
+		}
+	}))
+	defer fake.Close()
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGo)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+	if portListening("7813") {
+		t.Fatal("port 7813 already in use (leaked scaffold server?)")
+	}
+
+	cmd := exec.Command(bin, "dev", "--web", "sleep 600")
+	cmd.Dir = proj
+	cmd.Env = devTestEnv(
+		"BROWSER=none",
+		"GO_PORT=7813",
+		"VITE_DEV_URL="+fake.URL,
+		"GOFLAGS=-mod=mod",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer stopDevGracefully(cmd)
+
+	if !waitHealthy(context.Background(), "http://localhost:7813/healthz", 120*time.Second) {
+		t.Fatalf("server never came up; output:\n%s", stdout.String())
+	}
+	pidOf := func() string {
+		resp, err := http.Get("http://localhost:7813/pid")
+		if err != nil {
+			return ""
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return string(b)
+	}
+	before := pidOf()
+	if before == "" {
+		t.Fatal("could not read /pid")
+	}
+
+	cmdQ <- "restart-server"
+	deadline := time.Now().Add(60 * time.Second)
+	restarted := false
+	for time.Now().Before(deadline) {
+		if p := pidOf(); p != "" && p != before {
+			restarted = true
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !restarted {
+		t.Errorf("restart-server did not restart the Go server (pid stayed %s)\noutput:\n%s", before, stdout.String())
+	}
+
+	// Status events observed (startup + restart transitions at minimum).
+	if !strings.Contains(statusEvents.String(), `"event":"status"`) {
+		t.Errorf("no status events posted; output:\n%s", stdout.String())
+	}
+	if !strings.Contains(statusEvents.String(), `"healthy":true`) {
+		t.Errorf("no healthy status observed; status log:\n%s", statusEvents.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./gen -run TestDevPanelCommands -count=1 -v -timeout 600s`
+Expected: FAIL — `restart-server did not restart` and `no status events posted` (gsx dev neither polls commands nor posts status yet). The server-up part must PASS; if it doesn't, fix the test before proceeding.
+
+- [ ] **Step 3: Implement loop wiring in gen/dev.go**
+
+(a) After the `post`/`reload` closures, add status state + poster (uses `goPort` which is already resolved above this point — verify by reading the surrounding code):
+
+```go
+	status := devStatus{Phase: "idle", Server: serverStat{Port: goPort}, FrontDoor: frontStat{State: "external"}}
+	if dc.web != nil {
+		status.FrontDoor.State = "up"
+	}
+	postStatus := func() { post(statusEvent(status)) }
+```
+
+(b) After the front-door block (Task 3's), start the command intake:
+
+```go
+	cmds := make(chan string, 8)
+	go pollCommands(ctx, viteURL, webUp, cmds)
+```
+
+(c) In the initial-build section, record the outcome and post the first status. The existing code:
+
+```go
+	if startOK {
+		if out, err := srv.rebuild(ctx); err != nil {
+			post(buildErrorEvent(buildFailureMessage(out, err)))
+			startOK = false
+		} else if waitHealthy(ctx, healthURL, 10*time.Second) {
+			reload()
+		}
+	}
+```
+
+becomes:
+
+```go
+	if startOK {
+		if out, err := srv.rebuild(ctx); err != nil {
+			post(buildErrorEvent(buildFailureMessage(out, err)))
+			startOK = false
+		} else if waitHealthy(ctx, healthURL, 10*time.Second) {
+			status.Server.Healthy = true
+			reload()
+		}
+	}
+	now := time.Now()
+	status.LastCycle = &cycleStat{OK: startOK, At: now}
+	postStatus()
+```
+
+(d) Extract the source-cycle body of the `<-fire` case (everything from `if len(dirty.dirs) == 0 && !dirty.depDirty` to `overlayUp = false`) into a closure defined just above the `for {` loop, with a `force` flag and status threading:
+
+```go
+	cycle := func(force bool) {
+		if len(dirty.dirs) == 0 && !dirty.depDirty {
+			return
+		}
+		status.Phase = "generating"
+		results, goChanged, rerr := dirty.regenerate(sess.regenPending)
+		if rerr != nil {
+			fmt.Fprintf(serverOut, "regen failed: %v\n", rerr)
+			post(buildErrorEvent("regen failed: " + rerr.Error()))
+			overlayUp = true
+			status.Phase = "idle"
+			status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now()}
+			postStatus()
+			return // retained dirty state is retried on the next relevant event
+		}
+		post(aggregateEvent(results))
+		reportHardErrors(gsxOut, results)
+		ok := true
+		wrote := false
+		errs := 0
+		for _, r := range results {
+			ok = ok && r.OK
+			wrote = wrote || len(r.Written) > 0 || len(r.Removed) > 0
+			errs += len(r.Diags)
+		}
+		if !ok {
+			overlayUp = true
+			status.Phase = "idle"
+			status.LastCycle = &cycleStat{OK: false, Errors: errs, At: time.Now()}
+			postStatus()
+			return // keep last-good server up; overlay shows the error
+		}
+		doReload := overlayUp || force
+		if goChanged || wrote || force {
+			status.Phase = "building"
+			if out, err := srv.rebuild(ctx); err != nil {
+				post(buildErrorEvent(buildFailureMessage(out, err)))
+				overlayUp = true
+				status.Phase = "idle"
+				status.Server.Healthy = false
+				status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now()}
+				postStatus()
+				return
+			}
+			status.Phase = "starting"
+			if waitHealthy(ctx, healthURL, 10*time.Second) {
+				doReload = true
+				status.Server.Healthy = true
+			} else {
+				status.Server.Healthy = false
+			}
+		}
+		if doReload {
+			reload()
+		}
+		overlayUp = false
+		status.Phase = "idle"
+		status.LastCycle = &cycleStat{OK: true, Errors: 0, At: time.Now()}
+		postStatus()
+	}
+```
+
+The `<-fire` case keeps its `.env` block verbatim — except add `status.Server.Port = goPort` right after the existing `goPort = envPort(env, "GO_PORT", "7777")` line so a `.env` port change doesn't leave the panel showing the old port — then ends with `cycle(false)`. **`r.Diags` above is a guess — read `cycleResult` in gen/ and use its actual diagnostics field; if counting is awkward, count `!r.OK` results instead. This is the one place the plan defers to the code.**
+
+(e) Add two new select cases (replacing Task 3's temporary `case <-fdCh:` drain):
+
+```go
+		case c := <-cmds:
+			switch c {
+			case "rebuild":
+				fmt.Fprintln(stdout, "gsx dev: panel: rebuild")
+				dirty.depDirty = true
+				cycle(true)
+			case "restart-server":
+				fmt.Fprintln(stdout, "gsx dev: panel: restart-server")
+				status.Phase = "starting"
+				postStatus()
+				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
+					status.Server.Healthy = true
+					reload()
+				} else {
+					status.Server.Healthy = false
+				}
+				status.Phase = "idle"
+				postStatus()
+			default:
+				fmt.Fprintf(stderr, "gsx dev: unknown panel command %q\n", c)
+			}
+
+		case fs := <-fdCh:
+			status.FrontDoor = fs
+			postStatus()
+```
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `go test ./gen -run TestDevPanelCommands -count=1 -v -timeout 600s`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full gen suite + race**
+
+Run: `go test ./gen -count=1 -timeout 900s` and `go test ./gen -race -run TestDev -count=1 -timeout 900s`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gen/dev.go gen/dev_test.go
+git commit -m "feat(gen): panel commands (rebuild, restart-server) + status events in the dev loop"
+```
+
+---
+
+### Task 5: Plugin — CommandMailbox (vite-plugin-gsx)
+
+From here on, work in `~/personal/gsxhq/vite-plugin-gsx`. First: `git checkout -b dev-panel` (from its default branch, clean tree).
+
+**Files:**
+- Create: `src/mailbox.ts`
+- Test: `test/mailbox.test.ts`
+
+**Interfaces:**
+- Produces: `class CommandMailbox { push(cmd: string): void; waitTake(timeoutMs: number): Promise<string[]> }` — cap 16, consecutive duplicates collapsed, a waiting `waitTake` resolves immediately on push, a second concurrent `waitTake` resolves the first with `[]`. Task 6 wires it to the ws intake and `/__gsx/cmd`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// test/mailbox.test.ts
+import { describe, it, expect } from "vitest";
+import { CommandMailbox } from "../src/mailbox.js";
+
+describe("CommandMailbox", () => {
+  it("delivers queued commands in order and drains", async () => {
+    const m = new CommandMailbox();
+    m.push("rebuild");
+    m.push("restart-server");
+    expect(await m.waitTake(10)).toEqual(["rebuild", "restart-server"]);
+    expect(await m.waitTake(10)).toEqual([]); // drained → timeout
+  });
+
+  it("collapses consecutive duplicates", async () => {
+    const m = new CommandMailbox();
+    m.push("rebuild");
+    m.push("rebuild");
+    m.push("restart-server");
+    m.push("rebuild");
+    expect(await m.waitTake(10)).toEqual(["rebuild", "restart-server", "rebuild"]);
+  });
+
+  it("caps the queue at 16", async () => {
+    const m = new CommandMailbox();
+    for (let i = 0; i < 40; i++) m.push(`c${i}`); // distinct → no dedupe
+    expect((await m.waitTake(10)).length).toBe(16);
+  });
+
+  it("resolves a pending waiter immediately on push", async () => {
+    const m = new CommandMailbox();
+    const p = m.waitTake(5000);
+    m.push("rebuild");
+    const t0 = Date.now();
+    expect(await p).toEqual(["rebuild"]);
+    expect(Date.now() - t0).toBeLessThan(1000); // did not wait out the timeout
+  });
+
+  it("a second waiter displaces the first (resolved empty)", async () => {
+    const m = new CommandMailbox();
+    const first = m.waitTake(5000);
+    const second = m.waitTake(5000);
+    expect(await first).toEqual([]);
+    m.push("rebuild");
+    expect(await second).toEqual(["rebuild"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run test/mailbox.test.ts`
+Expected: FAIL (cannot resolve ../src/mailbox.js)
+
+- [ ] **Step 3: Implement src/mailbox.ts**
+
+```ts
+// One in-memory command queue between the panel (ws) and gsx dev (long-poll).
+// Cap + consecutive-dupe collapse keep a stuck consumer from accumulating junk.
+const CAP = 16;
+
+export class CommandMailbox {
+  private queue: string[] = [];
+  private waiter: { resolve: (cmds: string[]) => void; timer: ReturnType<typeof setTimeout> } | null = null;
+
+  push(cmd: string): void {
+    if (this.waiter) {
+      const w = this.waiter;
+      this.waiter = null;
+      clearTimeout(w.timer);
+      w.resolve([cmd]);
+      return;
+    }
+    if (this.queue.length >= CAP) return;
+    if (this.queue[this.queue.length - 1] === cmd) return;
+    this.queue.push(cmd);
+  }
+
+  /** Resolve with all queued commands, waiting up to timeoutMs if empty. */
+  waitTake(timeoutMs: number): Promise<string[]> {
+    if (this.queue.length > 0) {
+      const q = this.queue;
+      this.queue = [];
+      return Promise.resolve(q);
+    }
+    if (this.waiter) {
+      // Single consumer (one gsx dev): a newer poll displaces the older one.
+      const w = this.waiter;
+      this.waiter = null;
+      clearTimeout(w.timer);
+      w.resolve([]);
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.waiter = null;
+        resolve([]);
+      }, timeoutMs);
+      this.waiter = { resolve, timer };
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run test/mailbox.test.ts` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mailbox.ts test/mailbox.test.ts
+git commit -m "feat: CommandMailbox for panel→gsx-dev commands"
+```
+
+---
+
+### Task 6: Plugin — /__gsx/cmd endpoint, ws intake, status cache (vite-plugin-gsx)
+
+**Files:**
+- Modify: `src/index.ts` (inside `configureServer`, alongside the existing `/__gsx/event` middleware; and `applyEvent`)
+- Test: `test/panel-endpoint.test.ts`
+
+**Interfaces:**
+- Consumes: `CommandMailbox` (Task 5).
+- Produces: HTTP contract for gsx dev (Global Constraints: `x-gsx: 1` on every `/__gsx/cmd` response, 204 idle, `{"cmds":[…]}`); ws contract for the panel client (Task 7): send `gsx:cmd` `{cmd: string}`, receive `gsx:status` with the status object; status replayed to new ws connections.
+
+- [ ] **Step 1: Write the failing tests**
+
+Model setup on `test/event-endpoint.test.ts` (it already boots a real vite dev server with the plugin — read it first and reuse its helper style):
+
+```ts
+// test/panel-endpoint.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createServer, type ViteDevServer } from "vite";
+import { gsx } from "../src/index.js";
+
+let server: ViteDevServer;
+let base: string;
+
+beforeEach(async () => {
+  server = await createServer({
+    root: process.cwd(),
+    logLevel: "silent",
+    server: { port: 0 },
+    plugins: [gsx({ generateOnStart: false })],
+  });
+  await server.listen();
+  const addr = server.httpServer!.address() as { port: number };
+  base = `http://localhost:${addr.port}`;
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+describe("/__gsx/cmd", () => {
+  it("204 + x-gsx header when idle", async () => {
+    const resp = await fetch(`${base}/__gsx/cmd?wait=0`);
+    expect(resp.status).toBe(204);
+    expect(resp.headers.get("x-gsx")).toBe("1");
+  });
+
+  it("returns queued ws commands as JSON", async () => {
+    // Simulate the panel via the intake test hook (same validation path as ws).
+    (server as any).__gsxTestPush("rebuild");
+    const resp = await fetch(`${base}/__gsx/cmd?wait=5`);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("x-gsx")).toBe("1");
+    expect(await resp.json()).toEqual({ cmds: ["rebuild"] });
+  });
+
+  it("rejects non-GET", async () => {
+    const resp = await fetch(`${base}/__gsx/cmd`, { method: "POST" });
+    expect(resp.status).toBe(405);
+  });
+});
+
+describe("status events", () => {
+  it("caches status and stamps nothing on /__gsx/event", async () => {
+    const resp = await fetch(`${base}/__gsx/event`, {
+      method: "POST",
+      body: JSON.stringify({ event: "status", phase: "idle", server: { healthy: true, port: "7777" }, frontDoor: { state: "up", restarts: 0 } }),
+    });
+    expect(resp.status).toBe(204);
+    // Cached status is replayed to new ws connections — asserted via the test hook.
+    expect((server as any).__gsxTestStatus().phase).toBe("idle");
+  });
+});
+```
+
+**Test hooks:** `server.ws.on("gsx:cmd", …)` fires only for real websocket clients, which are heavy to fake — so `configureServer` exposes two module-internal test hooks on the server object: `__gsxTestPush(cmd)` (calls the same intake function the ws handler uses — same validation path) and `__gsxTestStatus()` (returns the cached status). Assign them unconditionally; they are undocumented internals, named to make that obvious.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run test/panel-endpoint.test.ts`
+Expected: FAIL (404 on /__gsx/cmd; __gsxTestPush undefined)
+
+- [ ] **Step 3: Implement in src/index.ts**
+
+Add imports: `import { CommandMailbox } from "./mailbox.js";`. Inside `configureServer`, after the `/__gsx/event` middleware:
+
+```ts
+      // 2b. Panel command channel: ws intake → mailbox → gsx dev long-poll.
+      const mailbox = new CommandMailbox();
+      const VALID_CMDS = new Set(["rebuild", "restart-server"]);
+      const intake = (raw: unknown) => {
+        const cmd = String((raw as any)?.cmd ?? "");
+        if (!VALID_CMDS.has(cmd)) {
+          logger.warn(`[gsx] ignoring unknown panel command: ${JSON.stringify(cmd)}`, { timestamp: true });
+          return;
+        }
+        mailbox.push(cmd);
+      };
+      server.ws.on("gsx:cmd", intake);
+      (server as any).__gsxTestPush = (cmd: string) => intake({ cmd });
+
+      server.middlewares.use("/__gsx/cmd", (req: any, res: any) => {
+        res.setHeader("x-gsx", "1"); // respawn-verification handshake for gsx dev
+        if (req.method !== "GET") {
+          res.statusCode = 405;
+          res.end();
+          return;
+        }
+        const url = new URL(req.url ?? "/", "http://internal");
+        const waitSec = Math.min(30, Math.max(0, parseFloat(url.searchParams.get("wait") ?? "25") || 0));
+        void mailbox.waitTake(waitSec * 1000).then((cmds) => {
+          if (cmds.length === 0) {
+            res.statusCode = 204;
+            res.end();
+            return;
+          }
+          res.setHeader("content-type", "application/json");
+          res.end(JSON.stringify({ cmds }));
+        });
+      });
+```
+
+In `applyEvent`, handle status FIRST (before the `ev.event !== "generated"` branch):
+
+```ts
+      let currentStatus: any = null;
+      (server as any).__gsxTestStatus = () => currentStatus;
+```
+
+(declare next to `currentErrorPayload`), and at the top of `applyEvent`:
+
+```ts
+        if (ev.event === "status") {
+          currentStatus = ev;
+          server.ws.send({ type: "custom", event: "gsx:status", data: ev });
+          return;
+        }
+```
+
+In the existing `server.ws.on("connection", …)` handler, after the error replay line, add:
+
+```ts
+        if (currentStatus) client.send(JSON.stringify({ type: "custom", event: "gsx:status", data: currentStatus }));
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run test/panel-endpoint.test.ts` → PASS. Then the whole suite: `npx vitest run` → no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts test/panel-endpoint.test.ts
+git commit -m "feat: /__gsx/cmd long-poll endpoint, gsx:cmd ws intake, status cache + replay"
+```
+
+---
+
+### Task 7: Plugin — panel client (vite-plugin-gsx)
+
+**Files:**
+- Create: `src/client-logic.ts` (pure helpers — unit-tested), `src/client.ts` (DOM/custom element — logic-lean, not unit-tested)
+- Modify: `src/index.ts` (inject script + serve it), `tsup.config.ts` (second entry)
+- Test: `test/client-logic.test.ts`, plus an injection assertion in `test/panel-endpoint.test.ts`
+
+**Interfaces:**
+- Consumes: ws contract from Task 6 (`import.meta.hot.send("gsx:cmd", {cmd})`, `import.meta.hot.on("gsx:status", …)`).
+- Produces: `isToggleKey(e, editing)`, `isEditable(target)`, `renderStatus(status): string` in client-logic; `/__gsx/panel.js` served by the plugin; `<gsx-devpanel>` custom element toggled by Cmd-D/Ctrl-D.
+
+- [ ] **Step 1: Write the failing logic tests**
+
+```ts
+// test/client-logic.test.ts
+import { describe, it, expect } from "vitest";
+import { isToggleKey, isEditable, renderStatus } from "../src/client-logic.js";
+
+const key = (over: Partial<{ key: string; metaKey: boolean; ctrlKey: boolean; altKey: boolean }> = {}) => ({
+  key: "d", metaKey: false, ctrlKey: false, altKey: false, ...over,
+});
+
+describe("isToggleKey", () => {
+  it("cmd-d and ctrl-d toggle", () => {
+    expect(isToggleKey(key({ metaKey: true }), false)).toBe(true);
+    expect(isToggleKey(key({ ctrlKey: true }), false)).toBe(true);
+    expect(isToggleKey(key({ key: "D", ctrlKey: true }), false)).toBe(true);
+  });
+  it("plain d, alt-d, other keys don't", () => {
+    expect(isToggleKey(key(), false)).toBe(false);
+    expect(isToggleKey(key({ metaKey: true, altKey: true }), false)).toBe(false);
+    expect(isToggleKey(key({ key: "e", metaKey: true }), false)).toBe(false);
+  });
+  it("suppressed while editing", () => {
+    expect(isToggleKey(key({ metaKey: true }), true)).toBe(false);
+  });
+});
+
+describe("isEditable", () => {
+  it("input/textarea/select and contenteditable are editable", () => {
+    expect(isEditable({ tagName: "INPUT" })).toBe(true);
+    expect(isEditable({ tagName: "TEXTAREA" })).toBe(true);
+    expect(isEditable({ tagName: "SELECT" })).toBe(true);
+    expect(isEditable({ tagName: "DIV", isContentEditable: true })).toBe(true);
+  });
+  it("plain elements and null are not", () => {
+    expect(isEditable({ tagName: "DIV" })).toBe(false);
+    expect(isEditable(null)).toBe(false);
+  });
+});
+
+describe("renderStatus", () => {
+  const status = {
+    phase: "idle",
+    server: { healthy: true, port: "7777" },
+    lastCycle: { ok: true, errors: 0, at: "2026-07-23T10:00:00Z" },
+    frontDoor: { state: "up", restarts: 1 },
+  };
+  it("renders the key facts", () => {
+    const html = renderStatus(status);
+    for (const frag of ["idle", "7777", "healthy", "up"]) {
+      expect(html).toContain(frag);
+    }
+  });
+  it("handles missing status", () => {
+    expect(renderStatus(null)).toContain("waiting for status");
+  });
+  it("escapes injected strings", () => {
+    const html = renderStatus({ ...status, phase: "<img src=x onerror=alert(1)>" });
+    expect(html).not.toContain("<img");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run test/client-logic.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement src/client-logic.ts**
+
+```ts
+// Pure helpers for the dev panel client. No DOM APIs — unit-testable.
+
+export interface KeyLike {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+}
+
+export function isToggleKey(e: KeyLike, editing: boolean): boolean {
+  return !editing && !e.altKey && (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "d";
+}
+
+export function isEditable(target: unknown): boolean {
+  const t = target as { tagName?: string; isContentEditable?: boolean } | null;
+  if (!t) return false;
+  if (t.isContentEditable) return true;
+  return t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT";
+}
+
+function esc(v: unknown): string {
+  return String(v).replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+}
+
+export function renderStatus(status: any): string {
+  if (!status) return `<p class="muted">waiting for status…</p>`;
+  const server = status.server ?? {};
+  const fd = status.frontDoor ?? {};
+  const lc = status.lastCycle;
+  const rows = [
+    ["phase", esc(status.phase ?? "?")],
+    ["server", `${server.healthy ? "healthy" : "down"} :${esc(server.port ?? "?")}`],
+    ["front door", `${esc(fd.state ?? "?")}${fd.restarts ? ` (${esc(fd.restarts)} restarts)` : ""}`],
+  ];
+  if (lc) rows.push(["last cycle", `${lc.ok ? "ok" : `${esc(lc.errors)} error(s)`} at ${esc(lc.at ?? "")}`]);
+  return `<dl>${rows.map(([k, v]) => `<dt>${k}</dt><dd>${v}</dd>`).join("")}</dl>`;
+}
+```
+
+- [ ] **Step 4: Run logic tests to verify they pass**
+
+Run: `npx vitest run test/client-logic.test.ts` → PASS.
+
+- [ ] **Step 5: Implement src/client.ts (no unit test — keep every branch trivial)**
+
+```ts
+// Dev panel: <gsx-devpanel> in shadow DOM, toggled by Cmd-D/Ctrl-D.
+// Served by the plugin at /__gsx/panel.js; talks over vite's HMR websocket.
+import { isToggleKey, isEditable, renderStatus } from "./client-logic.js";
+
+const hot = (import.meta as any).hot;
+if (hot) {
+  let status: any = null;
+  let inflight = false;
+
+  const host = document.createElement("gsx-devpanel");
+  const root = host.attachShadow({ mode: "open" });
+  host.style.display = "none";
+  document.body.appendChild(host);
+
+  const render = () => {
+    root.innerHTML = `
+      <style>
+        .panel { position: fixed; right: 16px; bottom: 16px; z-index: 99998;
+          background: #1b1b1f; color: #e8e8ea; font: 13px/1.5 ui-monospace, monospace;
+          border: 1px solid #3c3c44; border-radius: 8px; padding: 12px 16px; min-width: 260px;
+          box-shadow: 0 4px 24px rgba(0,0,0,.4); }
+        h1 { font-size: 13px; margin: 0 0 8px; font-weight: 600; }
+        dl { display: grid; grid-template-columns: auto 1fr; gap: 2px 12px; margin: 0 0 10px; }
+        dt { opacity: .6 } dd { margin: 0 }
+        button { margin-right: 8px; background: #2b2b31; color: inherit; border: 1px solid #3c3c44;
+          border-radius: 6px; padding: 4px 10px; cursor: pointer; font: inherit; }
+        button:disabled { opacity: .4; cursor: default; }
+        .muted { opacity: .6; margin: 0 0 10px }
+      </style>
+      <div class="panel">
+        <h1>gsx dev</h1>
+        ${renderStatus(status)}
+        <button id="rebuild" ${inflight ? "disabled" : ""}>Rebuild</button>
+        <button id="restart" ${inflight ? "disabled" : ""}>Restart server</button>
+      </div>`;
+    root.getElementById("rebuild")?.addEventListener("click", () => send("rebuild"));
+    root.getElementById("restart")?.addEventListener("click", () => send("restart-server"));
+  };
+
+  const send = (cmd: string) => {
+    inflight = true;
+    hot.send("gsx:cmd", { cmd });
+    render();
+  };
+
+  hot.on("gsx:status", (s: any) => {
+    status = s;
+    inflight = false;
+    if (host.style.display !== "none") render();
+  });
+
+  window.addEventListener("keydown", (e) => {
+    if (!isToggleKey(e, isEditable(e.target))) return;
+    e.preventDefault();
+    const show = host.style.display === "none";
+    host.style.display = show ? "" : "none";
+    if (show) render();
+  });
+}
+```
+
+- [ ] **Step 6: Build entry + injection + serving**
+
+In `tsup.config.ts`, make the entry a list including the client (read the file; it currently builds `src/index.ts`): `entry: ["src/index.ts", "src/client.ts"]`. The client entry must stay dependency-free ESM.
+
+In `src/index.ts` add to the plugin object (sibling of `configureServer`):
+
+```ts
+    transformIndexHtml() {
+      return [{ tag: "script", attrs: { type: "module", src: "/__gsx/panel.js" }, injectTo: "head" as const }];
+    },
+```
+
+and inside `configureServer`, a middleware serving the built client (with imports `import { fileURLToPath } from "node:url";` at top):
+
+```ts
+      // 2c. Panel client script. Built as dist/client.js next to this module.
+      server.middlewares.use("/__gsx/panel.js", (_req: any, res: any) => {
+        try {
+          const js = readFileSync(fileURLToPath(new URL("./client.js", import.meta.url)));
+          res.setHeader("content-type", "text/javascript");
+          res.end(js);
+        } catch {
+          // Running from src (tests): panel absent, not fatal.
+          res.statusCode = 404;
+          res.end("// gsx panel client not built");
+        }
+      });
+```
+
+Add to `test/panel-endpoint.test.ts`:
+
+```ts
+describe("panel injection", () => {
+  it("injects the panel script into index.html", async () => {
+    const html = await server.transformIndexHtml("/", "<html><head></head><body></body></html>");
+    expect(html).toContain("/__gsx/panel.js");
+  });
+});
+```
+
+- [ ] **Step 7: Verify**
+
+Run: `npx vitest run` → all PASS. Then `npm run build` → succeeds and `ls dist/client.js` exists. Then a REAL smoke test: `cd examples`' smallest example (read `examples/` for the runnable one), start its dev setup, open the page, press Cmd-D, click Restart server, confirm the panel renders and the command reaches gsx dev (its stdout logs `gsx dev: panel: restart-server`). This is the only end-to-end browser check in the plan — do not skip it; record what you saw in the commit message body.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/client.ts src/client-logic.ts src/index.ts tsup.config.ts test/client-logic.test.ts test/panel-endpoint.test.ts
+git commit -m "feat: dev panel client — Cmd-D toggle, rebuild/restart buttons, live status"
+```
+
+---
+
+### Task 8: Docs + versioning (both repos)
+
+**Files:**
+- Modify (gsx worktree): `docs/guide/dev-loop.md`, `docs/ROADMAP.md`
+- Modify (plugin): `README.md`, `package.json` (version → 0.5.0)
+
+**Interfaces:** none — documentation of the shipped contract only.
+
+- [ ] **Step 1: gsx dev-loop guide**
+
+Read `docs/guide/dev-loop.md` first and match its voice (concise — behavior plainly; rationale lives in the spec). Add a "Dev panel" section covering: Cmd-D/Ctrl-D toggle, the two buttons, the status view, front-door auto-restart + give-up, `--no-web` (panel works, front door shown as `external`). A handful of sentences, not paragraphs. If any code fence needs literal `{{ }}`, wrap the block in `::: v-pre`.
+
+- [ ] **Step 2: ROADMAP**
+
+Read `docs/ROADMAP.md`; move/mark the dev-panel line appropriately (add under shipped/in-progress per its existing structure).
+
+- [ ] **Step 3: Plugin README + version**
+
+Add a short "Dev panel" section to `README.md` (what it is, the keybinding, that it needs `gsx dev`). Bump `package.json` version to `0.5.0` (minor: new feature).
+
+- [ ] **Step 4: Verify + commit (both repos)**
+
+gsx worktree: `make check` passes; commit `docs: dev panel + front-door resilience guide/ROADMAP`.
+Plugin: `npm run build && npx vitest run` passes; commit `docs: dev panel README; v0.5.0`.
+
+---
+
+## Final gate (before review handoff)
+
+- [ ] gsx worktree: `make ci` (authoritative, uncached) — green.
+- [ ] Plugin: `npm run build && npx vitest run` — green.
+- [ ] The Task 7 Step 7 browser smoke test was actually performed.
+- [ ] Independent adversarial review (per CLAUDE.md): fresh reviewer builds throwaway probes — at minimum: (1) foreign-listener probe: bind the vite port with a non-gsx server, kill vite, confirm gsx dev never POSTs there and gives up; (2) command-flood probe: hammer `gsx:cmd` and confirm the loop stays responsive and the mailbox caps.

--- a/docs/superpowers/specs/2026-07-23-dev-panel-design.md
+++ b/docs/superpowers/specs/2026-07-23-dev-panel-design.md
@@ -97,10 +97,13 @@ the error-overlay replay), broadcasts `gsx:status` on change.
 
 ## Security
 
-Dev-only, localhost. Foreign origins can POST but cannot read cross-origin
-responses, so the mailbox cannot be drained by a hostile page; vite's ws has
-token protection; both commands are non-destructive. No own token in v1 —
-revisit if commands grow teeth (e.g. anything that writes files).
+Dev-only, localhost. Foreign origins cannot read cross-origin responses, but a
+hostile local page CAN fire no-cors GETs at `/__gsx/cmd`, displacing gsx dev's
+long-poll and eating queued commands — a dev-only denial-of-service nuisance,
+no data exposure; both commands are non-destructive. Accepted for v1. The
+planned follow-up (per-session token in the front door's child env, echoed as
+the `x-gsx` header value) closes both this and the gsx-vs-gsx respawn
+verification gap.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-23-dev-panel-design.md
+++ b/docs/superpowers/specs/2026-07-23-dev-panel-design.md
@@ -68,11 +68,26 @@ the error-overlay replay), broadcasts `gsx:status` on change.
 
 ## vite-plugin-gsx
 
-- `src/client.ts`: custom element, shadow DOM (vite's overlay technique),
-  injected in serve mode via virtual module + `transformIndexHtml`.
+- `src/client.ts`: custom element, shadow DOM (vite's overlay technique).
   Cmd-D/Ctrl-D toggles (`preventDefault`; ignored when focus is in
   input/textarea/contenteditable). Buttons disable while a command is in
-  flight, re-arm on the next status event.
+  flight, re-arm on the next status event — and stay disabled until the FIRST
+  status event arrives ("waiting for gsx dev…"), so the panel degrades
+  honestly in daemon/standalone-vite mode where nothing consumes commands.
+- **Delivery — explicit entry import** (gsx apps have no vite `index.html`;
+  their HTML streams from the Go server, so `transformIndexHtml` can never
+  fire; and a raw-served script would lack vite's HMR transform). The app's
+  client entry imports `virtual:gsx-devpanel`; the `gsx init` template ships
+  the line, existing apps add it (documented in the dev-loop guide). `gsx()`
+  returns a plugin array: the serve-only main plugin, plus a tiny
+  always-applied resolver that maps the virtual id to the built panel client
+  in dev (transformed by vite → real `import.meta.hot`) and to an empty
+  module in prod builds (the main plugin is `apply: "serve"`, so without the
+  resolver a `vite build` of the entry import would fail). The
+  `github.com/gsxhq/vite` Go helper is deliberately untouched — no coupling
+  from the URL-resolver lib to this plugin. (Monkey-patching the served
+  `@vite/client` was considered and rejected: vite-internal seam, also loads
+  in web workers; see vitejs/vite#17644.)
 - Server side: `/__gsx/cmd` long-poll middleware + mailbox,
   `server.ws.on('gsx:cmd')` intake, status cache + broadcast. All `/__gsx/cmd`
   responses (200 and 204) carry the `x-gsx: 1` header — the respawn

--- a/docs/superpowers/specs/2026-07-23-dev-panel-design.md
+++ b/docs/superpowers/specs/2026-07-23-dev-panel-design.md
@@ -1,0 +1,95 @@
+# Dev panel + front-door resilience
+
+Browser dev panel (vite-overlay-style) toggled by Cmd-D/Ctrl-D with Rebuild /
+Restart-server buttons and a live status view, plus auto-restart of the managed
+front door. Spans `gsx` (`gen/`) and `vite-plugin-gsx`. Builds on branch
+`dev-event-fixes` (the `webExited` push gate).
+
+## Problem
+
+The dev loop is opaque and uncontrollable from the browser: no way to force a
+rebuild or restart the Go server without touching the terminal, and no
+visibility into dev-loop state (the front-door incident surfaced as "tabs
+reload at random" instead of "front door exited 20 minutes ago"). When the
+managed front door dies, the session stays half-alive with pushes suspended.
+
+The panel is served *by* the front door, so it cannot fix front-door death —
+auto-restart in `gsx dev` covers that; the panel covers control + visibility.
+
+## Protocol
+
+Three parties: panel (browser) ↔ vite plugin ↔ `gsx dev`. `gsx dev` keeps a
+single outbound relationship with vite — no new listeners or ports; restarts on
+either side heal by reconnection.
+
+**Commands (browser → gsx dev).** Panel sends
+`import.meta.hot.send('gsx:cmd', {cmd})`. Plugin appends to a FIFO mailbox
+(cap 16, consecutive duplicates collapsed). `gsx dev` long-polls
+`GET {viteURL}/__gsx/cmd?wait=25s`: immediate `200 {"cmds":[…]}` when the
+mailbox is non-empty, `204` on timeout. Commands: `rebuild`, `restart-server`.
+Unknown commands are logged and dropped.
+
+**Status (gsx dev → browser).** New `{"event":"status"}` payload on the
+existing `/__gsx/event` POST:
+
+- `phase`: `idle` | `generating` | `building` | `starting`
+- Go server: healthy/unhealthy + port
+- last cycle: ok, error count, timestamp
+- front door: `up` | `restarting` | `given-up` | `external`, restart count
+
+Posted on startup, after every cycle, and on server/front-door transitions.
+Plugin caches the latest, replays it to each new ws client (same pattern as
+the error-overlay replay), broadcasts `gsx:status` on change.
+
+## gsx dev (`gen/`)
+
+- **Command intake goroutine**: long-poll loop (stdlib HTTP), gated by `webUp`
+  like pushes, backoff while the front door is down. Feeds `cmds chan
+  devCommand`, consumed by the existing select loop like watcher events:
+  - `rebuild`: force full dirty-all regenerate → build → restart → reload.
+  - `restart-server`: stop + restart current binary (no rebuild), then reload.
+- **Status struct** maintained in the loop, posted via the existing `post()`.
+- **Front-door auto-restart**: on unexpected exit (not `shuttingDown`) the
+  monitor respawns vite with backoff 500ms → 2s → 5s. Three exits within ~30s
+  = crash-looping: give up, log, fall back to suspend-pushes.
+  - Refactor: `webExited` becomes per-instance; push/poll gate reads an atomic
+    pointer to the current instance's channel; shutdown kills the current
+    instance.
+
+## vite-plugin-gsx
+
+- `src/client.ts`: custom element, shadow DOM (vite's overlay technique),
+  injected in serve mode via virtual module + `transformIndexHtml`.
+  Cmd-D/Ctrl-D toggles (`preventDefault`; ignored when focus is in
+  input/textarea/contenteditable). Buttons disable while a command is in
+  flight, re-arm on the next status event.
+- Server side: `/__gsx/cmd` long-poll middleware + mailbox,
+  `server.ws.on('gsx:cmd')` intake, status cache + broadcast.
+- `--no-web`: an externally-run vite loads the plugin, so panel and mailbox
+  work identically; auto-restart is N/A (front door reported `external`).
+
+## Security
+
+Dev-only, localhost. Foreign origins can POST but cannot read cross-origin
+responses, so the mailbox cannot be drained by a hostile page; vite's ws has
+token protection; both commands are non-destructive. No own token in v1 —
+revisit if commands grow teeth (e.g. anything that writes files).
+
+## Testing
+
+- gsx unit: long-poll client against a fake vite (immediate, delayed, 204,
+  down/backoff, gate-suspended cases).
+- gsx integration (`gen/dev_test.go`, recorder pattern from
+  `TestDevStopsPostingAfterWebExit`): mailbox command → observable cycle
+  (`/gen2` trick); front door killed → respawned stub observed; crash-loop →
+  give-up; status events observed at the recorder.
+- plugin (vitest): mailbox semantics (cap, dedupe, drain), long-poll endpoint,
+  ws intake, status cache/replay. Panel client stays logic-lean.
+- No corpus changes (no syntax change). Docs: dev-loop guide section.
+
+## Out of scope
+
+- Panel actions beyond `rebuild` / `restart-server` (e.g. reload-browser
+  button, log tail).
+- Any production-build presence of the panel.
+- Authenticating the command channel (see Security).

--- a/docs/superpowers/specs/2026-07-23-dev-panel-design.md
+++ b/docs/superpowers/specs/2026-07-23-dev-panel-design.md
@@ -50,11 +50,21 @@ the error-overlay replay), broadcasts `gsx:status` on change.
   - `restart-server`: stop + restart current binary (no rebuild), then reload.
 - **Status struct** maintained in the loop, posted via the existing `post()`.
 - **Front-door auto-restart**: on unexpected exit (not `shuttingDown`) the
-  monitor respawns vite with backoff 500ms → 2s → 5s. Three exits within ~30s
-  = crash-looping: give up, log, fall back to suspend-pushes.
-  - Refactor: `webExited` becomes per-instance; push/poll gate reads an atomic
-    pointer to the current instance's channel; shutdown kills the current
-    instance.
+  monitor respawns vite with backoff 500ms → 2s → 5s. Three failed restart
+  attempts (every instance lived < 30s) = crash-looping: give up, log, fall
+  back to suspend-pushes.
+  - Refactor: `webExited` becomes per-instance; push/poll gate reads the
+    current instance's state; shutdown kills the current instance.
+  - **Respawn verification**: a respawned vite can fail to bind (port taken by
+    a foreign process → posting would recreate the original incident) or
+    drift to port+1 (vite auto-increments without `strictPort`, making the
+    startup-resolved URL stale). After a respawn the push/poll gate therefore
+    stays shut until a probe of `GET {viteURL}/__gsx/cmd?wait=0` returns the
+    `x-gsx: 1` response header (stamped by our plugin; a foreign listener or
+    SPA fallback lacks it). An instance that never verifies within ~5s is
+    killed and counted as a rapid exit. The first instance keeps today's
+    gate-open-from-start semantics (`portAvailable` vetted its port;
+    `postBest` retries cover the cold start).
 
 ## vite-plugin-gsx
 
@@ -64,7 +74,9 @@ the error-overlay replay), broadcasts `gsx:status` on change.
   input/textarea/contenteditable). Buttons disable while a command is in
   flight, re-arm on the next status event.
 - Server side: `/__gsx/cmd` long-poll middleware + mailbox,
-  `server.ws.on('gsx:cmd')` intake, status cache + broadcast.
+  `server.ws.on('gsx:cmd')` intake, status cache + broadcast. All `/__gsx/cmd`
+  responses (200 and 204) carry the `x-gsx: 1` header — the respawn
+  verification handshake.
 - `--no-web`: an externally-run vite loads the plugin, so panel and mailbox
   work identically; auto-restart is N/A (front door reported `external`).
 

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -100,22 +99,11 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	// Drive the overlay from the cold generate (e.g. a pre-existing codegen
 	// error). A mixed operational failure has not committed its filesystem
 	// transaction, so only its errors/diagnostics are publishable at this point.
-	// post/reload gate every browser push on the managed front door still
-	// running: once it exits, its resolved port may be re-bound by any other
-	// process (typically another project's vite dev server), and posting there
-	// would drive a stranger's browser session. webExited is closed by the
-	// front door's Wait monitor; with --no-web the front door is externally
-	// managed, the channel never closes, and pushes always go out.
-	webExited := make(chan struct{})
-	var shuttingDown atomic.Bool // set before shutdown kills the front door
-	webUp := func() bool {
-		select {
-		case <-webExited:
-			return false
-		default:
-			return true
-		}
-	}
+	// post/reload gate every browser push on the managed front door being up
+	// (see frontDoor). With --no-web the front door is externally managed and
+	// pushes always go out.
+	var fd *frontDoor
+	webUp := func() bool { return fd == nil || fd.up() }
 	post := func(body []byte) { postEvent(viteURL, body, webUp) }
 	reload := func() { postReload(viteURL, webUp) }
 
@@ -124,25 +112,24 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	reportHardErrors(gsxOut, publishedStartup)
 
 	// --- Vite (front door), unless --no-web ---
-	var vite *exec.Cmd
+	fdCh := make(chan frontStat, 8)
 	if dc.web != nil {
-		vite = exec.Command(dc.web[0], dc.web[1:]...)
-		vite.Dir, vite.Env, vite.Stdout, vite.Stderr = workDir, env, mkWriter("vite"), mkWriter("vite")
-		setProcGroup(vite)
-		if err := vite.Start(); err != nil {
+		spawn := func() (*exec.Cmd, error) {
+			c := exec.Command(dc.web[0], dc.web[1:]...)
+			c.Dir, c.Env, c.Stdout, c.Stderr = workDir, env, mkWriter("vite"), mkWriter("vite")
+			setProcGroup(c)
+			return c, c.Start()
+		}
+		fd = newFrontDoor(spawn, viteURL, func(s frontStat) {
+			select {
+			case fdCh <- s:
+			default: // never block the monitor on a full channel
+			}
+		}, stdout)
+		if err := fd.start(); err != nil {
 			fmt.Fprintf(stderr, "gsx dev: starting front door: %v\n", err)
 			return 1
 		}
-		// Sole owner of vite.Wait (shutdown uses killProcGroupOwned). Close the
-		// gate first so pushes stop the instant the exit is observed; the
-		// notice is for an unexpected exit only, not shutdown killing vite.
-		go func() {
-			_ = vite.Wait()
-			close(webExited)
-			if !shuttingDown.Load() {
-				fmt.Fprintln(stdout, "gsx dev: front door exited — suspending browser reload/overlay pushes")
-			}
-		}()
 	}
 
 	// --- Go server: initial build + run ---
@@ -176,10 +163,9 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		fmt.Fprintf(stdout, "gsx dev: managing Go side only (no front door) — watching %s\n", workDir)
 	}
 	shutdownProcesses := func() {
-		shuttingDown.Store(true)
 		srv.stop()
-		if vite != nil {
-			killProcGroupOwned(vite, webExited, 5*time.Second)
+		if fd != nil {
+			fd.shutdown(5 * time.Second)
 		}
 	}
 
@@ -209,6 +195,8 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			}
 			shutdownProcesses()
 			return 0
+
+		case <-fdCh: // consumed for real in the status task
 
 		case ev, ok := <-w.Events:
 			if !ok {

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/gsxhq/gsx/internal/diag"
 )
 
 // runDev owns the dev loop: it generates (warm Module), builds+runs the Go
@@ -107,6 +109,12 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	post := func(body []byte) { postEvent(viteURL, body, webUp) }
 	reload := func() { postReload(viteURL, webUp) }
 
+	status := devStatus{Phase: "idle", Server: serverStat{Port: goPort}, FrontDoor: frontStat{State: "external"}}
+	if dc.web != nil {
+		status.FrontDoor.State = "up"
+	}
+	postStatus := func() { post(statusEvent(status)) }
+
 	publishedStartup := publishableStartupResults(startup)
 	post(aggregateEvent(publishedStartup))
 	reportHardErrors(gsxOut, publishedStartup)
@@ -132,6 +140,9 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		}
 	}
 
+	cmds := make(chan string, 8)
+	go pollCommands(ctx, viteURL, webUp, cmds)
+
 	// --- Go server: initial build + run ---
 	srv := &devServer{dir: workDir, build: dc.build, run: dc.run, env: env, out: serverOut, buildOut: gsxOut, healthURL: healthURL}
 	startOK := true
@@ -147,9 +158,12 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			post(buildErrorEvent(buildFailureMessage(out, err)))
 			startOK = false
 		} else if waitHealthy(ctx, healthURL, 10*time.Second) {
+			status.Server.Healthy = true
 			reload()
 		}
 	}
+	status.LastCycle = &cycleStat{OK: startOK, At: time.Now()}
+	postStatus()
 	// overlayUp: an error overlay is currently shown in the browser. A later
 	// successful cycle must reload to clear it even when nothing was written —
 	// still needed for build-error and .env recovery paths.
@@ -186,6 +200,80 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		})
 	}
 
+	// cycle runs one generate→build→reload pass over the current dirty set.
+	// force (set by the panel's "rebuild" command) rebuilds+reloads even when
+	// nothing is dirty on disk. Every exit path threads status/postStatus so
+	// the panel always reflects the outcome of the cycle it triggered.
+	cycle := func(force bool) {
+		if len(dirty.dirs) == 0 && !dirty.depDirty {
+			return
+		}
+		status.Phase = "generating"
+		results, goChanged, rerr := dirty.regenerate(sess.regenPending)
+		if rerr != nil {
+			fmt.Fprintf(serverOut, "regen failed: %v\n", rerr)
+			post(buildErrorEvent("regen failed: " + rerr.Error()))
+			overlayUp = true
+			status.Phase = "idle"
+			status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now()}
+			postStatus()
+			return // retained dirty state is retried on the next relevant event
+		}
+		// Overlay state from this cycle.
+		post(aggregateEvent(results))
+		reportHardErrors(gsxOut, results)
+		ok := true
+		wrote := false
+		errs := 0
+		for _, r := range results {
+			ok = ok && r.OK
+			wrote = wrote || len(r.Written) > 0 || len(r.Removed) > 0
+			for _, d := range r.Diags {
+				if d.Severity == diag.Error {
+					errs++
+				}
+			}
+		}
+		if !ok {
+			overlayUp = true
+			status.Phase = "idle"
+			status.LastCycle = &cycleStat{OK: false, Errors: errs, At: time.Now()}
+			postStatus()
+			return // keep last-good server up; overlay shows the error
+		}
+		// Successful cycle. Rebuild when code changed (or the panel forced it);
+		// reload the browser if we rebuilt OR we're recovering from a shown
+		// error overlay — the latter must clear even when nothing was written
+		// (fixed .gsx → identical .x.go).
+		doReload := overlayUp || force
+		if goChanged || wrote || force {
+			status.Phase = "building"
+			if out, err := srv.rebuild(ctx); err != nil {
+				post(buildErrorEvent(buildFailureMessage(out, err)))
+				overlayUp = true
+				status.Phase = "idle"
+				status.Server.Healthy = false
+				status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now()}
+				postStatus()
+				return
+			}
+			status.Phase = "starting"
+			if waitHealthy(ctx, healthURL, 10*time.Second) {
+				doReload = true
+				status.Server.Healthy = true
+			} else {
+				status.Server.Healthy = false
+			}
+		}
+		if doReload {
+			reload()
+		}
+		overlayUp = false
+		status.Phase = "idle"
+		status.LastCycle = &cycleStat{OK: true, Errors: 0, At: time.Now()}
+		postStatus()
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -196,7 +284,31 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			shutdownProcesses()
 			return 0
 
-		case <-fdCh: // consumed for real in the status task
+		case c := <-cmds:
+			switch c {
+			case "rebuild":
+				fmt.Fprintln(stdout, "gsx dev: panel: rebuild")
+				dirty.depDirty = true
+				cycle(true)
+			case "restart-server":
+				fmt.Fprintln(stdout, "gsx dev: panel: restart-server")
+				status.Phase = "starting"
+				postStatus()
+				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
+					status.Server.Healthy = true
+					reload()
+				} else {
+					status.Server.Healthy = false
+				}
+				status.Phase = "idle"
+				postStatus()
+			default:
+				fmt.Fprintf(stderr, "gsx dev: unknown panel command %q\n", c)
+			}
+
+		case fs := <-fdCh:
+			status.FrontDoor = fs
+			postStatus()
 
 		case ev, ok := <-w.Events:
 			if !ok {
@@ -239,6 +351,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				// Vite reads .env itself (loadEnv + native .env watch), so only the Go server is restarted here.
 				srv.env = env
 				goPort = envPort(env, "GO_PORT", "7777")
+				status.Server.Port = goPort
 				healthURL = "http://localhost:" + goPort + "/healthz"
 				srv.healthURL = healthURL
 				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
@@ -247,46 +360,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				}
 				// fall through: an .env-only fire has no source dirtiness.
 			}
-			if len(dirty.dirs) == 0 && !dirty.depDirty {
-				continue
-			}
-			results, goChanged, rerr := dirty.regenerate(sess.regenPending)
-			if rerr != nil {
-				fmt.Fprintf(serverOut, "regen failed: %v\n", rerr)
-				post(buildErrorEvent("regen failed: " + rerr.Error()))
-				overlayUp = true
-				continue // retained dirty state is retried on the next relevant event
-			}
-			// Overlay state from this cycle.
-			post(aggregateEvent(results))
-			reportHardErrors(gsxOut, results)
-			ok := true
-			wrote := false
-			for _, r := range results {
-				ok = ok && r.OK
-				wrote = wrote || len(r.Written) > 0 || len(r.Removed) > 0
-			}
-			if !ok {
-				overlayUp = true
-				continue // keep last-good server up; overlay shows the error
-			}
-			// Successful cycle. Rebuild when code changed; reload the browser if we
-			// rebuilt OR we're recovering from a shown error overlay — the latter
-			// must clear even when nothing was written (fixed .gsx → identical .x.go).
-			doReload := overlayUp
-			if goChanged || wrote {
-				if out, err := srv.rebuild(ctx); err != nil {
-					post(buildErrorEvent(buildFailureMessage(out, err)))
-					overlayUp = true
-					continue
-				} else if waitHealthy(ctx, healthURL, 10*time.Second) {
-					doReload = true
-				}
-			}
-			if doReload {
-				reload()
-			}
-			overlayUp = false
+			cycle(false)
 
 		case werr, ok := <-w.Errors:
 			if !ok || errors.Is(werr, fsnotify.ErrClosed) {

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -372,16 +372,20 @@ func TestDevStopsPostingAfterWebExit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait until gsx dev itself has observed the front-door exit, then let the
-	// startup posts' retry window drain: a push issued while the front door was
-	// still alive may legitimately be delivered a few seconds later (postBest
-	// retries + client timeout), and must not be counted against the gate.
-	deadline = time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) && !strings.Contains(stdout.String(), "front door exited") {
+	// Wait until gsx dev's front door has given up: the "sleep 1" front door
+	// exits every ~1s, so each respawn (an equally short-lived "sleep 1" that
+	// never answers /__gsx/cmd) fails to verify, and after 3 rapid restart
+	// attempts the frontDoor manager gives up for good — the gate then stays
+	// permanently shut. Then let the startup posts' retry window drain: a push
+	// issued while the front door was still alive may legitimately be delivered
+	// a few seconds later (postBest retries + client timeout), and must not be
+	// counted against the gate.
+	deadline = time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(stdout.String(), "giving up after repeated failures") {
 		time.Sleep(100 * time.Millisecond)
 	}
-	if !strings.Contains(stdout.String(), "front door exited") {
-		t.Fatalf("gsx dev never logged the front-door exit; stdout=%q", stdout.String())
+	if !strings.Contains(stdout.String(), "giving up after repeated failures") {
+		t.Fatalf("gsx dev's front door never gave up; stdout=%q", stdout.String())
 	}
 	time.Sleep(4 * time.Second)
 

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -206,6 +206,7 @@ const devTestMainGo = `package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -219,6 +220,9 @@ func main() {
 		port = "7777"
 	}
 	mux := http.NewServeMux()
+	mux.HandleFunc("/pid", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "%d", os.Getpid())
+	})
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -462,4 +466,152 @@ func (b *lockedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// TestDevPanelCommands drives gsx dev through the command channel: the test
+// plays the vite plugin (serves /__gsx/cmd from a queue, records /__gsx/event
+// posts) and asserts restart-server restarts the Go server and status events
+// arrive.
+//
+// gsx dev resolves its own front-door URL (host from VITE_DEV_URL if given,
+// but the PORT always comes from VITE_PORT or its own auto-picker — a stale
+// VITE_DEV_URL must never pin a busy port, see resolveViteDevEnv). So the fake
+// plugin can't pre-bind an arbitrary port and pass it via VITE_DEV_URL: it
+// must learn the real resolved URL from gsx dev's own "watching … — open
+// <url>" banner and bind there, exactly like TestDevStopsPostingAfterWebExit.
+func TestDevPanelCommands(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGo)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+	if portListening("7813") {
+		t.Fatal("port 7813 already in use (leaked scaffold server?)")
+	}
+
+	cmd := exec.Command(bin, "dev", "--web", "sleep 600")
+	cmd.Dir = proj
+	cmd.Env = devTestEnv(
+		"BROWSER=none",
+		"GO_PORT=7813",
+		"VITE_DEV_URL=http://127.0.0.1:1",
+		"GOFLAGS=-mod=mod",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer stopDevGracefully(cmd)
+
+	if !waitHealthy(context.Background(), "http://localhost:7813/healthz", 120*time.Second) {
+		t.Fatalf("server never came up; output:\n%s", stdout.String())
+	}
+
+	// Learn the resolved front-door URL from the "watching … — open <url>" line.
+	var viteURL string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := regexp.MustCompile(`open (http://\S+)`).FindStringSubmatch(stdout.String()); m != nil {
+			viteURL = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if viteURL == "" {
+		t.Fatalf("front-door URL not printed; stdout=%q", stdout.String())
+	}
+	u, err := url.Parse(viteURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake vite plugin bound at the resolved front-door address: long-poll
+	// queue + event recorder, x-gsx stamped.
+	cmdQ := make(chan string, 4)
+	var statusEvents lockedBuffer
+	fake := &http.Server{
+		Addr: net.JoinHostPort(u.Hostname(), u.Port()),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-gsx", "1")
+			switch r.URL.Path {
+			case "/__gsx/cmd":
+				select {
+				case c := <-cmdQ:
+					fmt.Fprintf(w, `{"cmds":[%q]}`, c)
+				case <-time.After(2 * time.Second):
+					w.WriteHeader(204)
+				}
+			case "/__gsx/event":
+				body, _ := io.ReadAll(r.Body)
+				if strings.Contains(string(body), `"event":"status"`) {
+					statusEvents.Write(append(body, '\n'))
+				}
+				w.WriteHeader(204)
+			default:
+				w.WriteHeader(204)
+			}
+		}),
+	}
+	fl, err := net.Listen("tcp", fake.Addr)
+	if err != nil {
+		t.Fatalf("bind resolved front-door port %s: %v", fake.Addr, err)
+	}
+	go func() { _ = fake.Serve(fl) }()
+	defer fake.Close()
+
+	pidOf := func() string {
+		resp, err := http.Get("http://localhost:7813/pid")
+		if err != nil {
+			return ""
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return string(b)
+	}
+	before := pidOf()
+	if before == "" {
+		t.Fatal("could not read /pid")
+	}
+
+	cmdQ <- "restart-server"
+	restartDeadline := time.Now().Add(60 * time.Second)
+	restarted := false
+	for time.Now().Before(restartDeadline) {
+		if p := pidOf(); p != "" && p != before {
+			restarted = true
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !restarted {
+		t.Errorf("restart-server did not restart the Go server (pid stayed %s)\noutput:\n%s", before, stdout.String())
+	}
+
+	// Status events observed (startup + restart transitions at minimum).
+	if !strings.Contains(statusEvents.String(), `"event":"status"`) {
+		t.Errorf("no status events posted; output:\n%s", stdout.String())
+	}
+	if !strings.Contains(statusEvents.String(), `"healthy":true`) {
+		t.Errorf("no healthy status observed; status log:\n%s", statusEvents.String())
+	}
 }

--- a/gen/devcmd.go
+++ b/gen/devcmd.go
@@ -46,18 +46,34 @@ func pollCommands(ctx context.Context, base string, up func() bool, out chan<- s
 			backoff = min(backoff*2, 5*time.Second)
 			continue
 		}
-		backoff = time.Second
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
 		resp.Body.Close()
+		if resp.StatusCode == http.StatusNoContent {
+			backoff = time.Second
+			continue // idle long-poll: immediately re-poll
+		}
 		if resp.StatusCode != http.StatusOK {
-			continue // 204 idle poll (or transient non-200): immediately re-poll
+			// Any other non-200 (500, 404, ...) is a failure, not an idle
+			// poll: back off exactly like a transport error so an erroring
+			// server can't be busy-spun against.
+			if !sleep(backoff) {
+				return
+			}
+			backoff = min(backoff*2, 5*time.Second)
+			continue
 		}
 		var payload struct {
 			Cmds []string `json:"cmds"`
 		}
 		if json.Unmarshal(body, &payload) != nil {
+			// Malformed body on a 200: same backoff treatment as a failure.
+			if !sleep(backoff) {
+				return
+			}
+			backoff = min(backoff*2, 5*time.Second)
 			continue
 		}
+		backoff = time.Second
 		for _, c := range payload.Cmds {
 			select {
 			case out <- c:

--- a/gen/devcmd.go
+++ b/gen/devcmd.go
@@ -1,0 +1,69 @@
+package gen
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// pollCommands long-polls base+/__gsx/cmd?wait=25 and delivers each command on
+// out. up gates polling exactly like browser pushes: while the front door is
+// down/unverified, no requests are made. Transport errors back off 1s→2s→5s
+// (reset on success). Returns when ctx is done.
+func pollCommands(ctx context.Context, base string, up func() bool, out chan<- string) {
+	if strings.HasPrefix(base, "/") || base == "" {
+		return
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	backoff := time.Second
+	sleep := func(d time.Duration) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(d):
+			return true
+		}
+	}
+	for ctx.Err() == nil {
+		if !up() {
+			if !sleep(time.Second) {
+				return
+			}
+			continue
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/__gsx/cmd?wait=25", nil)
+		if err != nil {
+			return
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			if !sleep(backoff) {
+				return
+			}
+			backoff = min(backoff*2, 5*time.Second)
+			continue
+		}
+		backoff = time.Second
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			continue // 204 idle poll (or transient non-200): immediately re-poll
+		}
+		var payload struct {
+			Cmds []string `json:"cmds"`
+		}
+		if json.Unmarshal(body, &payload) != nil {
+			continue
+		}
+		for _, c := range payload.Cmds {
+			select {
+			case out <- c:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}

--- a/gen/devcmd_test.go
+++ b/gen/devcmd_test.go
@@ -44,8 +44,7 @@ func TestPollCommandsDeliversAndRepolls(t *testing.T) {
 		func(w http.ResponseWriter) { w.WriteHeader(204) },
 		respondCmds("restart-server", "rebuild"),
 	)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	out := make(chan string, 8)
 	go pollCommands(ctx, srv.URL, func() bool { return true }, out)
 
@@ -64,8 +63,7 @@ func TestPollCommandsDeliversAndRepolls(t *testing.T) {
 
 func TestPollCommandsSuspendedWhileGateDown(t *testing.T) {
 	srv, calls := cmdServer(t, respondCmds("rebuild"))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	out := make(chan string, 1)
 	go pollCommands(ctx, srv.URL, func() bool { return false }, out)
 	time.Sleep(600 * time.Millisecond)

--- a/gen/devcmd_test.go
+++ b/gen/devcmd_test.go
@@ -76,16 +76,77 @@ func TestPollCommandsSuspendedWhileGateDown(t *testing.T) {
 
 func TestPollCommandsSurvivesServerDown(t *testing.T) {
 	// Nothing listens at base: pollCommands must keep retrying with backoff,
-	// not exit; and honor ctx cancellation promptly.
+	// not exit, and must return promptly on ctx cancellation even while
+	// blocked inside a backoff sleep. Sleeping 2.5s lets the backoff climb
+	// past the 1s tier into the 2s tier (1s -> 2s escalation) before we
+	// cancel, so this pins ctx-aware sleeping: a naive time.Sleep(backoff)
+	// implementation (ignoring ctx) would still be blocked well past the
+	// 500ms deadline below.
 	ctx, cancel := context.WithCancel(context.Background())
 	out := make(chan string, 1)
 	done := make(chan struct{})
 	go func() { pollCommands(ctx, "http://127.0.0.1:1", func() bool { return true }, out); close(done) }()
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(2500 * time.Millisecond)
 	cancel()
 	select {
 	case <-done:
-	case <-time.After(3 * time.Second):
-		t.Fatal("pollCommands did not return after ctx cancel")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pollCommands did not return within 500ms of ctx cancel (stuck in a non-ctx-aware backoff sleep?)")
+	}
+}
+
+// TestPollCommandsBackoffOnErrorResponses proves pollCommands throttles on
+// every kind of non-204 failure: HTTP error statuses (e.g. 500) and a 200
+// whose body isn't valid JSON. Neither must busy-spin; both must escalate
+// backoff exactly like a transport error.
+func TestPollCommandsBackoffOnErrorResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "500 status",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "200 with malformed JSON body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("not json"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				tc.handler(w, r)
+			}))
+			defer srv.Close()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			out := make(chan string, 1)
+			done := make(chan struct{})
+			go func() { pollCommands(ctx, srv.URL, func() bool { return true }, out); close(done) }()
+
+			time.Sleep(1200 * time.Millisecond)
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatal("pollCommands did not return after ctx cancel")
+			}
+
+			// Correct backoff (1s, then 2s, ...) yields roughly 2-3 requests
+			// in 1.2s: one immediately, one after the first 1s sleep. A
+			// busy-spinning implementation makes thousands.
+			if n := calls.Load(); n > 4 {
+				t.Errorf("polled %d times in 1.2s against a %s server; want <= 4 (busy-spin, no backoff applied)", n, tc.name)
+			}
+		})
 	}
 }

--- a/gen/devcmd_test.go
+++ b/gen/devcmd_test.go
@@ -1,0 +1,91 @@
+package gen
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// cmdServer serves /__gsx/cmd from a queue of canned responses.
+func cmdServer(t *testing.T, responses ...func(w http.ResponseWriter)) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/__gsx/cmd" {
+			w.WriteHeader(404)
+			return
+		}
+		n := int(calls.Add(1)) - 1
+		if n < len(responses) {
+			responses[n](w)
+			return
+		}
+		w.WriteHeader(204) // idle long-poll afterwards
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func respondCmds(cmds ...string) func(http.ResponseWriter) {
+	return func(w http.ResponseWriter) {
+		b, _ := json.Marshal(map[string]any{"cmds": cmds})
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	}
+}
+
+func TestPollCommandsDeliversAndRepolls(t *testing.T) {
+	srv, calls := cmdServer(t,
+		respondCmds("rebuild"),
+		func(w http.ResponseWriter) { w.WriteHeader(204) },
+		respondCmds("restart-server", "rebuild"),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan string, 8)
+	go pollCommands(ctx, srv.URL, func() bool { return true }, out)
+
+	want := []string{"rebuild", "restart-server", "rebuild"}
+	for i, w := range want {
+		select {
+		case got := <-out:
+			if got != w {
+				t.Fatalf("cmd[%d] = %q, want %q", i, got, w)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for cmd[%d] (calls=%d)", i, calls.Load())
+		}
+	}
+}
+
+func TestPollCommandsSuspendedWhileGateDown(t *testing.T) {
+	srv, calls := cmdServer(t, respondCmds("rebuild"))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan string, 1)
+	go pollCommands(ctx, srv.URL, func() bool { return false }, out)
+	time.Sleep(600 * time.Millisecond)
+	if calls.Load() != 0 {
+		t.Errorf("polled %d times while gate down; want 0", calls.Load())
+	}
+}
+
+func TestPollCommandsSurvivesServerDown(t *testing.T) {
+	// Nothing listens at base: pollCommands must keep retrying with backoff,
+	// not exit; and honor ctx cancellation promptly.
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan string, 1)
+	done := make(chan struct{})
+	go func() { pollCommands(ctx, "http://127.0.0.1:1", func() bool { return true }, out); close(done) }()
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("pollCommands did not return after ctx cancel")
+	}
+}

--- a/gen/devstatus.go
+++ b/gen/devstatus.go
@@ -1,0 +1,41 @@
+// gen/devstatus.go
+package gen
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// devStatus is the dev-loop state pushed to the browser panel as an
+// {"event":"status"} payload on /__gsx/event. Field names are the wire
+// contract with vite-plugin-gsx.
+type devStatus struct {
+	Phase     string     `json:"phase"` // idle | generating | building | starting
+	Server    serverStat `json:"server"`
+	LastCycle *cycleStat `json:"lastCycle,omitempty"`
+	FrontDoor frontStat  `json:"frontDoor"`
+}
+
+type serverStat struct {
+	Healthy bool   `json:"healthy"`
+	Port    string `json:"port"`
+}
+
+type cycleStat struct {
+	OK     bool      `json:"ok"`
+	Errors int       `json:"errors"`
+	At     time.Time `json:"at"`
+}
+
+type frontStat struct {
+	State    string `json:"state"` // up | restarting | given-up | external
+	Restarts int    `json:"restarts"`
+}
+
+func statusEvent(s devStatus) []byte {
+	b, _ := json.Marshal(struct {
+		Event string `json:"event"`
+		devStatus
+	}{"status", s})
+	return b
+}

--- a/gen/devstatus.go
+++ b/gen/devstatus.go
@@ -1,4 +1,3 @@
-// gen/devstatus.go
 package gen
 
 import (

--- a/gen/devstatus_test.go
+++ b/gen/devstatus_test.go
@@ -1,4 +1,3 @@
-// gen/devstatus_test.go
 package gen
 
 import (

--- a/gen/devstatus_test.go
+++ b/gen/devstatus_test.go
@@ -1,0 +1,45 @@
+// gen/devstatus_test.go
+package gen
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestStatusEventShape(t *testing.T) {
+	at := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	s := devStatus{
+		Phase:     "idle",
+		Server:    serverStat{Healthy: true, Port: "7777"},
+		LastCycle: &cycleStat{OK: true, Errors: 0, At: at},
+		FrontDoor: frontStat{State: "up", Restarts: 2},
+	}
+	var got map[string]any
+	if err := json.Unmarshal(statusEvent(s), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["event"] != "status" || got["phase"] != "idle" {
+		t.Errorf("event/phase = %v/%v", got["event"], got["phase"])
+	}
+	srv := got["server"].(map[string]any)
+	if srv["healthy"] != true || srv["port"] != "7777" {
+		t.Errorf("server = %v", srv)
+	}
+	lc := got["lastCycle"].(map[string]any)
+	if lc["ok"] != true || lc["at"] != "2026-07-23T10:00:00Z" {
+		t.Errorf("lastCycle = %v", lc)
+	}
+	fd := got["frontDoor"].(map[string]any)
+	if fd["state"] != "up" || fd["restarts"] != float64(2) {
+		t.Errorf("frontDoor = %v", fd)
+	}
+}
+
+func TestStatusEventOmitsNilLastCycle(t *testing.T) {
+	var got map[string]any
+	_ = json.Unmarshal(statusEvent(devStatus{Phase: "generating"}), &got)
+	if _, present := got["lastCycle"]; present {
+		t.Error("nil lastCycle must be omitted")
+	}
+}

--- a/gen/frontdoor.go
+++ b/gen/frontdoor.go
@@ -1,4 +1,3 @@
-// gen/frontdoor.go
 package gen
 
 import (

--- a/gen/frontdoor.go
+++ b/gen/frontdoor.go
@@ -1,0 +1,244 @@
+// gen/frontdoor.go
+package gen
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// frontDoor owns the managed vite child: it monitors exits, respawns with
+// backoff, verifies a respawn is really our plugin (x-gsx header) before
+// reopening the push/poll gate, and gives up on a crash loop. The first
+// instance opens the gate immediately (its port was vetted by portAvailable;
+// postBest retries cover the cold start).
+type frontDoor struct {
+	spawn     func() (*exec.Cmd, error)
+	verifyURL string
+	onState   func(frontStat)
+	logw      io.Writer
+
+	mu        sync.Mutex
+	cmd       *exec.Cmd
+	exited    chan struct{} // current instance; closed once its Wait returns
+	open      bool          // push/poll gate
+	restarts  int
+	done      bool          // given up or shut down
+	shutdownC chan struct{} // closed by shutdown(); aborts backoff sleeps
+}
+
+// frontDoorRapidWindow: an instance that lived at least this long resets the
+// rapid-exit counter. Also the boundary for "rapid".
+const frontDoorRapidWindow = 30 * time.Second
+
+// frontDoorVerifyWindow bounds how long a respawn may take to verify before it
+// is killed and counted as a rapid exit.
+const frontDoorVerifyWindow = 5 * time.Second
+
+// restartPolicy maps consecutive rapid exits to the backoff before the next
+// attempt, or giveUp.
+func restartPolicy(rapidExits int) (time.Duration, bool) {
+	switch rapidExits {
+	case 0:
+		return 500 * time.Millisecond, false
+	case 1:
+		return 2 * time.Second, false
+	case 2:
+		return 5 * time.Second, false
+	}
+	return 0, true
+}
+
+// verifyFrontDoor reports whether url is served by OUR vite plugin: the
+// /__gsx/cmd endpoint stamps x-gsx: 1 on every response. A foreign listener
+// (or vite's SPA fallback answering 200 for unknown paths) lacks it.
+func verifyFrontDoor(ctx context.Context, url string) bool {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/__gsx/cmd?wait=0", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.Header.Get("x-gsx") == "1"
+}
+
+func newFrontDoor(spawn func() (*exec.Cmd, error), verifyURL string, onState func(frontStat), logw io.Writer) *frontDoor {
+	return &frontDoor{spawn: spawn, verifyURL: verifyURL, onState: onState, logw: logw, shutdownC: make(chan struct{})}
+}
+
+// start launches the first instance and its supervisor. The gate opens
+// immediately (first-instance semantics).
+func (f *frontDoor) start() error {
+	cmd, err := f.spawn()
+	if err != nil {
+		return err
+	}
+	exited := make(chan struct{})
+	f.mu.Lock()
+	f.cmd, f.exited, f.open = cmd, exited, true
+	f.mu.Unlock()
+	go func() { _ = cmd.Wait(); close(exited) }()
+	go f.run(exited, time.Now())
+	return nil
+}
+
+func (f *frontDoor) up() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.open
+}
+
+// shutdown suppresses restarts and kills the current instance. Safe to call
+// once; runDev calls it from shutdownProcesses.
+func (f *frontDoor) shutdown(timeout time.Duration) {
+	f.mu.Lock()
+	if f.done {
+		f.mu.Unlock()
+		return
+	}
+	f.done = true
+	f.open = false
+	cmd, exited := f.cmd, f.exited
+	close(f.shutdownC)
+	f.mu.Unlock()
+	if cmd != nil {
+		killProcGroupOwned(cmd, exited, timeout)
+	}
+}
+
+// run supervises instances for the frontDoor's lifetime: wait for the current
+// instance to exit, apply the restart policy, respawn, verify, repeat — until
+// verified instances keep living, give-up, or shutdown. Every path out of an
+// iteration leaves open == false except verified-up. Each instance's Wait is
+// owned by the small goroutine that closes its exited channel.
+func (f *frontDoor) run(exited chan struct{}, started time.Time) {
+	rapid := 0 // consecutive exits where the instance lived < frontDoorRapidWindow
+	for {
+		<-exited
+		f.mu.Lock()
+		if f.done {
+			f.mu.Unlock()
+			return
+		}
+		f.open = false
+		f.mu.Unlock()
+		if time.Since(started) < frontDoorRapidWindow {
+			rapid++
+		} else {
+			rapid = 1
+		}
+		delay, giveUp := restartPolicy(rapid - 1)
+		if giveUp {
+			f.giveUp()
+			return
+		}
+		f.transition(frontStat{State: "restarting", Restarts: f.restartCount()})
+		fmt.Fprintf(f.logw, "gsx dev: front door exited — restarting in %s\n", delay)
+		select {
+		case <-f.shutdownC:
+			return
+		case <-time.After(delay):
+		}
+		next, err := f.spawn()
+		if err != nil {
+			fmt.Fprintf(f.logw, "gsx dev: front door restart failed: %v\n", err)
+			// No instance to wait on: synthesize an immediate rapid exit.
+			exited = closedChan()
+			started = time.Now()
+			continue
+		}
+		nextExited := make(chan struct{})
+		go func(c *exec.Cmd, ch chan struct{}) { _ = c.Wait(); close(ch) }(next, nextExited)
+		f.mu.Lock()
+		if f.done {
+			f.mu.Unlock()
+			killProcGroupOwned(next, nextExited, 2*time.Second)
+			return
+		}
+		f.cmd, f.exited = next, nextExited
+		f.restarts++
+		f.mu.Unlock()
+		exited, started = nextExited, time.Now()
+		if f.verifyRespawn(nextExited) {
+			f.mu.Lock()
+			ok := !f.done
+			f.open = ok
+			f.mu.Unlock()
+			if ok {
+				f.transition(frontStat{State: "up", Restarts: f.restartCount()})
+			}
+		} else {
+			// Never verified (foreign port owner, drifted port, or died during
+			// the window): kill it; the loop's <-exited counts it as rapid.
+			fmt.Fprintln(f.logw, "gsx dev: restarted front door did not verify (no x-gsx endpoint at its URL) — killing it")
+			f.mu.Lock()
+			cur, curExited := f.cmd, f.exited
+			f.mu.Unlock()
+			killProcGroupOwned(cur, curExited, 2*time.Second)
+		}
+	}
+}
+
+func closedChan() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func (f *frontDoor) restartCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.restarts
+}
+
+// giveUp declares the crash loop lost and suppresses further restarts. It
+// checks-and-sets f.done under the lock so a concurrent shutdown() that wins
+// the race is authoritative: shutdown must never be followed by a spurious
+// given-up notice (onState is documented to never fire for shutdown).
+func (f *frontDoor) giveUp() {
+	f.mu.Lock()
+	if f.done {
+		f.mu.Unlock()
+		return
+	}
+	f.done = true
+	f.open = false
+	f.mu.Unlock()
+	fmt.Fprintln(f.logw, "gsx dev: front door exited — giving up after repeated failures; suspending browser reload/overlay pushes")
+	f.transition(frontStat{State: "given-up", Restarts: f.restartCount()})
+}
+
+// verifyRespawn polls verifyFrontDoor until success, instance exit, shutdown,
+// or the verify window elapses.
+func (f *frontDoor) verifyRespawn(exited <-chan struct{}) bool {
+	deadline := time.Now().Add(frontDoorVerifyWindow)
+	for time.Now().Before(deadline) {
+		select {
+		case <-f.shutdownC:
+			return false
+		case <-exited:
+			return false
+		default:
+		}
+		if verifyFrontDoor(context.Background(), f.verifyURL) {
+			return true
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return false
+}
+
+func (f *frontDoor) transition(s frontStat) {
+	if f.onState != nil {
+		f.onState(s)
+	}
+}

--- a/gen/frontdoor_test.go
+++ b/gen/frontdoor_test.go
@@ -1,0 +1,186 @@
+// gen/frontdoor_test.go
+package gen
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRestartPolicy(t *testing.T) {
+	cases := []struct {
+		rapid  int
+		delay  time.Duration
+		giveUp bool
+	}{{0, 500 * time.Millisecond, false}, {1, 2 * time.Second, false}, {2, 5 * time.Second, false}, {3, 0, true}, {7, 0, true}}
+	for _, c := range cases {
+		d, g := restartPolicy(c.rapid)
+		if d != c.delay || g != c.giveUp {
+			t.Errorf("restartPolicy(%d) = %v,%v want %v,%v", c.rapid, d, g, c.delay, c.giveUp)
+		}
+	}
+}
+
+func TestVerifyFrontDoor(t *testing.T) {
+	ours := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-gsx", "1")
+		w.WriteHeader(204)
+	}))
+	defer ours.Close()
+	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200) // SPA fallback: 200 without the header
+	}))
+	defer foreign.Close()
+	if !verifyFrontDoor(context.Background(), ours.URL) {
+		t.Error("our plugin endpoint must verify")
+	}
+	if verifyFrontDoor(context.Background(), foreign.URL) {
+		t.Error("foreign 200 without x-gsx must NOT verify")
+	}
+	if verifyFrontDoor(context.Background(), "http://127.0.0.1:1") {
+		t.Error("connection refused must NOT verify")
+	}
+}
+
+// stateRecorder collects onState transitions.
+type stateRecorder struct {
+	mu     sync.Mutex
+	states []frontStat
+}
+
+func (r *stateRecorder) record(s frontStat) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states = append(r.states, s)
+}
+func (r *stateRecorder) list() []frontStat {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]frontStat(nil), r.states...)
+}
+func (r *stateRecorder) waitFor(t *testing.T, state string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, s := range r.list() {
+			if s.State == state {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("state %q never reached; got %+v", state, r.list())
+}
+
+// TestFrontDoorRestartsAndVerifies: the child exits once, the respawn stays up
+// and the verify URL answers with x-gsx — the gate must reopen.
+func TestFrontDoorRestartsAndVerifies(t *testing.T) {
+	verify := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-gsx", "1")
+		w.WriteHeader(204)
+	}))
+	defer verify.Close()
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "runs")
+	// First run appends a line and exits; later runs append and sleep.
+	script := "echo run >> " + marker + "; n=$(wc -l < " + marker + "); [ $n -ge 2 ] && sleep 60; exit 0"
+	rec := &stateRecorder{}
+	fd := newFrontDoor(func() (*exec.Cmd, error) {
+		c := exec.Command("sh", "-c", script)
+		setProcGroup(c)
+		return c, c.Start()
+	}, verify.URL, rec.record, os.Stderr)
+	if err := fd.start(); err != nil {
+		t.Fatal(err)
+	}
+	defer fd.shutdown(5 * time.Second)
+
+	if !fd.up() {
+		t.Fatal("gate must be open for the first instance")
+	}
+	rec.waitFor(t, "restarting", 10*time.Second)
+	rec.waitFor(t, "up", 10*time.Second) // respawn verified against verify.URL
+	if !fd.up() {
+		t.Error("gate must reopen after a verified respawn")
+	}
+	// The respawn's "echo run >> marker" is a freshly forked shell process
+	// racing an in-process HTTP round trip to the (already-listening) verify
+	// server: "up" can legitimately fire a beat before the fork is scheduled
+	// to run its first line. Poll instead of a single read — this is eventual
+	// consistency in the test's own side channel, not something frontDoor
+	// promises to order against onState.
+	deadline := time.Now().Add(5 * time.Second)
+	var lines []string
+	for time.Now().Before(deadline) {
+		b, _ := os.ReadFile(marker)
+		lines = splitLines(string(b))
+		if len(lines) >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if len(lines) < 2 {
+		t.Errorf("child ran %d times; want >= 2 (respawn)", len(lines))
+	}
+}
+
+// TestFrontDoorGivesUpOnCrashLoop: child always exits immediately and nothing
+// verifies — after 3 rapid exits the manager gives up and the gate stays shut.
+func TestFrontDoorGivesUpOnCrashLoop(t *testing.T) {
+	rec := &stateRecorder{}
+	fd := newFrontDoor(func() (*exec.Cmd, error) {
+		c := exec.Command("sh", "-c", "exit 0")
+		setProcGroup(c)
+		return c, c.Start()
+	}, "http://127.0.0.1:1", rec.record, os.Stderr)
+	if err := fd.start(); err != nil {
+		t.Fatal(err)
+	}
+	defer fd.shutdown(time.Second)
+	rec.waitFor(t, "given-up", 30*time.Second)
+	if fd.up() {
+		t.Error("gate must stay shut after give-up")
+	}
+}
+
+// TestFrontDoorShutdownSilent: intentional shutdown must produce no
+// restarting/given-up transitions.
+func TestFrontDoorShutdownSilent(t *testing.T) {
+	rec := &stateRecorder{}
+	fd := newFrontDoor(func() (*exec.Cmd, error) {
+		c := exec.Command("sleep", "60")
+		setProcGroup(c)
+		return c, c.Start()
+	}, "http://127.0.0.1:1", rec.record, os.Stderr)
+	if err := fd.start(); err != nil {
+		t.Fatal(err)
+	}
+	fd.shutdown(5 * time.Second)
+	time.Sleep(200 * time.Millisecond)
+	for _, s := range rec.list() {
+		if s.State == "restarting" || s.State == "given-up" {
+			t.Errorf("shutdown produced transition %+v", s)
+		}
+	}
+	if fd.up() {
+		t.Error("gate must be shut after shutdown")
+	}
+}
+
+func splitLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/gen/frontdoor_test.go
+++ b/gen/frontdoor_test.go
@@ -177,7 +177,7 @@ func TestFrontDoorShutdownSilent(t *testing.T) {
 
 func splitLines(s string) []string {
 	var out []string
-	for _, l := range strings.Split(s, "\n") {
+	for l := range strings.SplitSeq(s, "\n") {
 		if l != "" {
 			out = append(out, l)
 		}

--- a/gen/frontdoor_test.go
+++ b/gen/frontdoor_test.go
@@ -1,4 +1,3 @@
-// gen/frontdoor_test.go
 package gen
 
 import (

--- a/gen/init_test.go
+++ b/gen/init_test.go
@@ -340,6 +340,21 @@ func TestInitScaffoldHasDevCommand(t *testing.T) {
 	}
 }
 
+func TestInitScaffoldImportsDevPanel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if code, _, errb := initNI(t, "--module", "devpaneldemo", dir); code != 0 {
+		t.Fatalf("init failed: %d %s", code, errb)
+	}
+	mainJS, err := os.ReadFile(filepath.Join(dir, "web", "main.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(mainJS), `import "virtual:gsx-devpanel";`) {
+		t.Errorf("web/main.js should import the gsx dev panel: %s", mainJS)
+	}
+}
+
 func TestInitScaffoldCompiles(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {

--- a/gen/templates/init/simple/package.json.tmpl
+++ b/gen/templates/init/simple/package.json.tmpl
@@ -7,7 +7,7 @@
     "build": "vite build"
   },
   "devDependencies": {
-    "@gsxhq/vite-plugin-gsx": "^0.4.6",
+    "@gsxhq/vite-plugin-gsx": "^0.5.0",
     "vite": "^6.0.0"
   }
 }

--- a/gen/templates/init/simple/web/main.js
+++ b/gen/templates/init/simple/web/main.js
@@ -1,3 +1,5 @@
+// gsx dev panel: Cmd-D / Ctrl-D
+import "virtual:gsx-devpanel";
 import "./style.css";
 import { setupCounter } from "./counter.js";
 


### PR DESCRIPTION
#146 merged; this now targets `main` directly (recreated as #148 after GitHub closed the stacked PR when its base branch was deleted).

Browser dev panel toggled by Cmd-D/Ctrl-D with Rebuild / Restart-server buttons and a live status view, plus auto-restart of the managed front door. Spec: `docs/superpowers/specs/2026-07-23-dev-panel-design.md`.

**gsx side (this PR):**
- `devStatus` wire types + `statusEvent` — `{"event":"status"}` posted to `/__gsx/event` on startup, every cycle, and front-door transitions.
- `pollCommands` — long-polls the plugin's `/__gsx/cmd` (stdlib, gated like pushes, backoff on errors, never busy-spins).
- `frontDoor` manager — unexpected exit → respawn with 500ms/2s/5s backoff; a respawn must answer with the plugin's `x-gsx` header before pushes resume (a foreign port-grabber or drifted port never gets pushes); three failed attempts → give up and suspend, as before.
- Loop wiring: `rebuild` forces a full regen→build→restart→reload cycle; `restart-server` restarts without rebuilding.
- Scaffold: `web/main.js` imports `virtual:gsx-devpanel` (delivery is an explicit entry import — gsx apps have no vite `index.html`, so `transformIndexHtml` can never fire); plugin pin bumped to `^0.5.0`.

**Companion PR:** gsxhq/vite-plugin-gsx#1 — plugin v0.5.0 must publish to npm **before** this merges (fresh scaffolds resolve the virtual module from the released plugin).

**Verification beyond unit tests:** `make ci` green; live browser smoke test (panel, live status, both commands round-tripped); live probes — killed vite → verified respawn healed the session; 350-message command flood → bounded by mailbox cap, validation dropped all bogus commands, loop stayed responsive. Independent adversarial whole-branch review: no Criticals; fast-follows filed (per-session x-gsx token, rebuild e2e test).

**Known limitation (documented):** tabs already open across a front-door respawn need one manual refresh (vite 6 rotates its ws token; the old client doesn't fall back to reload).

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576

