### PR TITLE
fix(gen): scaffold plugin pin ^0.6.0 (released version; ^0.5.0 matches nothing)

### DIFF
--- a/gen/templates/init/simple/package.json.tmpl
+++ b/gen/templates/init/simple/package.json.tmpl
@@ -7,7 +7,7 @@
     "build": "vite build"
   },
   "devDependencies": {
-    "@gsxhq/vite-plugin-gsx": "^0.5.0",
+    "@gsxhq/vite-plugin-gsx": "^0.6.0",
     "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
The dev-panel plugin released as **0.6.0** (minor bump via release.yml), but the scaffold pins `^0.5.0` — a 0.x caret stays within the minor, and no 0.5.x was ever published, so fresh `gsx init` + `npm install` currently fails with E404 (verified: `npm view @gsxhq/vite-plugin-gsx@'^0.5.0'` → no match). One-line template fix; `TestInit` green.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576