### PR TITLE
feat(gen): pair the front door via GSX_DEV_TOKEN

### DIFF
--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -81,8 +81,10 @@ import "virtual:gsx-devpanel";
 `vite.config.ts`: `gsx({ devPanel: false })` or
 `gsx({ devPanel: { key: "k" } })`.
 
-If Vite crashes, `gsx dev` restarts it automatically — refresh any tabs that
-were already open.
+If Vite crashes, `gsx dev` restarts it automatically and pairs with the new
+process before trusting it again (needs a plugin new enough to echo that
+pairing back — older plugins just suspend reload/overlay pushes instead) —
+refresh any tabs that were already open.
 
 ## Customize the commands
 

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -2,6 +2,8 @@ package gen
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -20,6 +23,19 @@ import (
 
 	"github.com/gsxhq/gsx/internal/diag"
 )
+
+// genDevToken returns a random 16-byte value hex-encoded (32 chars). runDev
+// generates one per process and passes it to its managed vite child via
+// GSX_DEV_TOKEN so front-door respawn verification (see verifyFrontDoor) can
+// tell "our vite" apart from another gsx project's vite racing onto the same
+// freed port during backoff.
+func genDevToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating dev token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
 
 // runDev owns the dev loop: it generates (warm Module), builds+runs the Go
 // server, supervises Vite, watches sources + .env, and drives the browser. It
@@ -120,15 +136,27 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	reportHardErrors(gsxOut, publishedStartup)
 
 	// --- Vite (front door), unless --no-web ---
+	// devToken pairs gsx dev with the vite it spawns: only the vite child's
+	// env carries it (the Go server's env/srv.env is untouched — it has no
+	// use for it, keeping the separation tidy). --no-web / externally-run
+	// vite never receives it, so pollCommands sending the header below is
+	// harmless there too (an untokened plugin ignores the request header and
+	// keeps stamping "1").
+	devToken, err := genDevToken()
+	if err != nil {
+		fmt.Fprintf(stderr, "gsx dev: %v\n", err)
+		return 1
+	}
 	fdCh := make(chan frontStat, 8)
 	if dc.web != nil {
 		spawn := func() (*exec.Cmd, error) {
 			c := exec.Command(dc.web[0], dc.web[1:]...)
-			c.Dir, c.Env, c.Stdout, c.Stderr = workDir, env, mkWriter("vite"), mkWriter("vite")
+			c.Dir, c.Stdout, c.Stderr = workDir, mkWriter("vite"), mkWriter("vite")
+			c.Env = append(slices.Clone(env), "GSX_DEV_TOKEN="+devToken)
 			setProcGroup(c)
 			return c, c.Start()
 		}
-		fd = newFrontDoor(spawn, viteURL, func(s frontStat) {
+		fd = newFrontDoor(spawn, viteURL, devToken, func(s frontStat) {
 			select {
 			case fdCh <- s:
 			default: // never block the monitor on a full channel
@@ -141,7 +169,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	}
 
 	cmds := make(chan string, 8)
-	go pollCommands(ctx, viteURL, webUp, cmds)
+	go pollCommands(ctx, viteURL, devToken, webUp, cmds)
 
 	// --- Go server: initial build + run ---
 	srv := &devServer{dir: workDir, build: dc.build, run: dc.run, env: env, out: serverOut, buildOut: gsxOut, healthURL: healthURL}

--- a/gen/devcmd.go
+++ b/gen/devcmd.go
@@ -13,7 +13,13 @@ import (
 // out. up gates polling exactly like browser pushes: while the front door is
 // down/unverified, no requests are made. Transport errors back off 1s→2s→5s
 // (reset on success). Returns when ctx is done.
-func pollCommands(ctx context.Context, base string, up func() bool, out chan<- string) {
+//
+// token is sent as the x-gsx-token request header on every attempt. When the
+// front door's plugin has a GSX_DEV_TOKEN configured it requires this header
+// to match before releasing anything from the mailbox (else 403, without
+// draining it); when unconfigured (externally-run vite, --no-web) the plugin
+// ignores the header entirely, so sending it is always safe.
+func pollCommands(ctx context.Context, base, token string, up func() bool, out chan<- string) {
 	if strings.HasPrefix(base, "/") || base == "" {
 		return
 	}
@@ -38,6 +44,7 @@ func pollCommands(ctx context.Context, base string, up func() bool, out chan<- s
 		if err != nil {
 			return
 		}
+		req.Header.Set("x-gsx-token", token)
 		resp, err := client.Do(req)
 		if err != nil {
 			if !sleep(backoff) {

--- a/gen/devcmd_test.go
+++ b/gen/devcmd_test.go
@@ -46,7 +46,7 @@ func TestPollCommandsDeliversAndRepolls(t *testing.T) {
 	)
 	ctx := t.Context()
 	out := make(chan string, 8)
-	go pollCommands(ctx, srv.URL, func() bool { return true }, out)
+	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out)
 
 	want := []string{"rebuild", "restart-server", "rebuild"}
 	for i, w := range want {
@@ -65,7 +65,7 @@ func TestPollCommandsSuspendedWhileGateDown(t *testing.T) {
 	srv, calls := cmdServer(t, respondCmds("rebuild"))
 	ctx := t.Context()
 	out := make(chan string, 1)
-	go pollCommands(ctx, srv.URL, func() bool { return false }, out)
+	go pollCommands(ctx, srv.URL, "tok", func() bool { return false }, out)
 	time.Sleep(600 * time.Millisecond)
 	if calls.Load() != 0 {
 		t.Errorf("polled %d times while gate down; want 0", calls.Load())
@@ -83,13 +83,48 @@ func TestPollCommandsSurvivesServerDown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	out := make(chan string, 1)
 	done := make(chan struct{})
-	go func() { pollCommands(ctx, "http://127.0.0.1:1", func() bool { return true }, out); close(done) }()
+	go func() { pollCommands(ctx, "http://127.0.0.1:1", "tok", func() bool { return true }, out); close(done) }()
 	time.Sleep(2500 * time.Millisecond)
 	cancel()
 	select {
 	case <-done:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("pollCommands did not return within 500ms of ctx cancel (stuck in a non-ctx-aware backoff sleep?)")
+	}
+}
+
+// TestPollCommandsSendsTokenHeader proves every request — the initial poll
+// and subsequent re-polls — carries x-gsx-token: <token>, so a tokened
+// front-door plugin can authenticate the mailbox drain.
+func TestPollCommandsSendsTokenHeader(t *testing.T) {
+	var seen atomic.Int32
+	var mismatched atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen.Add(1)
+		if r.Header.Get("x-gsx-token") != "secret-token" {
+			mismatched.Store(true)
+		}
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan string, 1)
+	done := make(chan struct{})
+	go func() { pollCommands(ctx, srv.URL, "secret-token", func() bool { return true }, out); close(done) }()
+	time.Sleep(400 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pollCommands did not return after ctx cancel")
+	}
+
+	if seen.Load() == 0 {
+		t.Fatal("server never received a request")
+	}
+	if mismatched.Load() {
+		t.Error("at least one request was missing x-gsx-token or had the wrong value")
 	}
 }
 
@@ -129,7 +164,7 @@ func TestPollCommandsBackoffOnErrorResponses(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			out := make(chan string, 1)
 			done := make(chan struct{})
-			go func() { pollCommands(ctx, srv.URL, func() bool { return true }, out); close(done) }()
+			go func() { pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out); close(done) }()
 
 			time.Sleep(1200 * time.Millisecond)
 			cancel()

--- a/gen/frontdoor.go
+++ b/gen/frontdoor.go
@@ -11,13 +11,15 @@ import (
 )
 
 // frontDoor owns the managed vite child: it monitors exits, respawns with
-// backoff, verifies a respawn is really our plugin (x-gsx header) before
-// reopening the push/poll gate, and gives up on a crash loop. The first
-// instance opens the gate immediately (its port was vetted by portAvailable;
-// postBest retries cover the cold start).
+// backoff, verifies a respawn is really OUR vite (x-gsx echoes our token)
+// before reopening the push/poll gate, and gives up on a crash loop. The
+// first instance opens the gate immediately (its port was vetted by
+// portAvailable; postBest retries cover the cold start) — only respawns onto
+// a possibly-stolen port are re-verified.
 type frontDoor struct {
 	spawn     func() (*exec.Cmd, error)
 	verifyURL string
+	token     string // GSX_DEV_TOKEN passed to the spawned vite child; see verifyFrontDoor
 	onState   func(frontStat)
 	logw      io.Writer
 
@@ -52,26 +54,37 @@ func restartPolicy(rapidExits int) (time.Duration, bool) {
 	return 0, true
 }
 
-// verifyFrontDoor reports whether url is served by OUR vite plugin: the
-// /__gsx/cmd endpoint stamps x-gsx: 1 on every response. A foreign listener
-// (or vite's SPA fallback answering 200 for unknown paths) lacks it.
-func verifyFrontDoor(ctx context.Context, url string) bool {
+// verifyFrontDoor reports whether url is served by the vite THIS gsx dev
+// spawned. gsx dev passes a random per-process token to its vite child via
+// GSX_DEV_TOKEN; the plugin's /__gsx/cmd endpoint then stamps x-gsx with that
+// token instead of the plain "1" it uses when no token is configured (see
+// panel.ts). A respawn only verifies when the response's x-gsx header EQUALS
+// our token — merely being present isn't enough, since another gsx project's
+// vite could have raced onto the just-freed port during our backoff window
+// and would answer with ITS OWN token (or the untokened "1"), never ours.
+//
+// Compat: a managed front door running a plugin predating GSX_DEV_TOKEN
+// always echoes "1" and so never verifies here; gsx dev then degrades to the
+// pre-auto-restart suspend behavior for that respawn (see frontDoor's
+// give-up path) until the plugin is upgraded.
+func verifyFrontDoor(ctx context.Context, url, token string) bool {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/__gsx/cmd?wait=0", nil)
 	if err != nil {
 		return false
 	}
+	req.Header.Set("x-gsx-token", token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false
 	}
 	resp.Body.Close()
-	return resp.Header.Get("x-gsx") == "1"
+	return resp.Header.Get("x-gsx") == token
 }
 
-func newFrontDoor(spawn func() (*exec.Cmd, error), verifyURL string, onState func(frontStat), logw io.Writer) *frontDoor {
-	return &frontDoor{spawn: spawn, verifyURL: verifyURL, onState: onState, logw: logw, shutdownC: make(chan struct{})}
+func newFrontDoor(spawn func() (*exec.Cmd, error), verifyURL, token string, onState func(frontStat), logw io.Writer) *frontDoor {
+	return &frontDoor{spawn: spawn, verifyURL: verifyURL, token: token, onState: onState, logw: logw, shutdownC: make(chan struct{})}
 }
 
 // start launches the first instance and its supervisor. The gate opens
@@ -178,7 +191,7 @@ func (f *frontDoor) run(exited chan struct{}, started time.Time) {
 		} else {
 			// Never verified (foreign port owner, drifted port, or died during
 			// the window): kill it; the loop's <-exited counts it as rapid.
-			fmt.Fprintln(f.logw, "gsx dev: restarted front door did not verify (no x-gsx endpoint at its URL) — killing it")
+			fmt.Fprintln(f.logw, "gsx dev: restarted front door did not verify (no x-gsx echo of our token at its URL) — killing it")
 			f.mu.Lock()
 			cur, curExited := f.cmd, f.exited
 			f.mu.Unlock()
@@ -228,7 +241,7 @@ func (f *frontDoor) verifyRespawn(exited <-chan struct{}) bool {
 			return false
 		default:
 		}
-		if verifyFrontDoor(context.Background(), f.verifyURL) {
+		if verifyFrontDoor(context.Background(), f.verifyURL, f.token) {
 			return true
 		}
 		time.Sleep(250 * time.Millisecond)

--- a/gen/frontdoor.go
+++ b/gen/frontdoor.go
@@ -68,6 +68,11 @@ func restartPolicy(rapidExits int) (time.Duration, bool) {
 // pre-auto-restart suspend behavior for that respawn (see frontDoor's
 // give-up path) until the plugin is upgraded.
 func verifyFrontDoor(ctx context.Context, url, token string) bool {
+	if token == "" {
+		// A header-less response echoes "" via Header.Get and would match.
+		// runDev never passes an empty token; defend the callee anyway.
+		return false
+	}
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/__gsx/cmd?wait=0", nil)

--- a/gen/frontdoor_test.go
+++ b/gen/frontdoor_test.go
@@ -89,6 +89,9 @@ func TestVerifyFrontDoor(t *testing.T) {
 	if !verifyFrontDoor(context.Background(), tokened.URL, token) {
 		t.Error("plugin echoing our exact token must verify")
 	}
+	if verifyFrontDoor(context.Background(), foreign.URL, "") {
+		t.Error("an empty token must never verify — a header-less response echoes \"\" and would match")
+	}
 	if verifyFrontDoor(context.Background(), oldPlugin.URL, token) {
 		t.Error("older plugin always echoing \"1\" must NOT verify against a real token")
 	}

--- a/gen/frontdoor_test.go
+++ b/gen/frontdoor_test.go
@@ -13,6 +13,30 @@ import (
 	"time"
 )
 
+// TestGenDevTokenFormatAndUniqueness pins the shape runDev relies on: a
+// 16-byte value hex-encoded (32 lowercase hex chars), fresh each call.
+func TestGenDevTokenFormatAndUniqueness(t *testing.T) {
+	a, err := genDevToken()
+	if err != nil {
+		t.Fatalf("genDevToken: %v", err)
+	}
+	if len(a) != 32 {
+		t.Errorf("len(token) = %d, want 32 (16 bytes hex-encoded)", len(a))
+	}
+	for _, r := range a {
+		if !strings.Contains("0123456789abcdef", string(r)) {
+			t.Fatalf("token %q has non-hex-lowercase rune %q", a, r)
+		}
+	}
+	b, err := genDevToken()
+	if err != nil {
+		t.Fatalf("genDevToken: %v", err)
+	}
+	if a == b {
+		t.Error("two calls to genDevToken produced the same token")
+	}
+}
+
 func TestRestartPolicy(t *testing.T) {
 	cases := []struct {
 		rapid  int
@@ -27,23 +51,54 @@ func TestRestartPolicy(t *testing.T) {
 	}
 }
 
+// TestVerifyFrontDoor pins the x-gsx-token pairing contract: verifyFrontDoor
+// sends the request header x-gsx-token and requires the response's x-gsx
+// header to EQUAL the token — not just be present. A tokened plugin echoes
+// the token only when it saw the matching request header; an older plugin
+// (predating GSX_DEV_TOKEN) always echoes the literal "1" and must therefore
+// fail verification against any real token (that mismatch is exactly how a
+// foreign gsx dev's respawn verification correctly fails against our front
+// door, and vice versa — see the compat note in frontdoor.go).
 func TestVerifyFrontDoor(t *testing.T) {
-	ours := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-gsx", "1")
+	const token = "abc123deadbeef"
+
+	tokened := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-gsx-token") == token {
+			w.Header().Set("x-gsx", token)
+		} else {
+			w.Header().Set("x-gsx", "1") // no/wrong request token: untokened-plugin fallback
+		}
 		w.WriteHeader(204)
 	}))
-	defer ours.Close()
+	defer tokened.Close()
+	oldPlugin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-gsx", "1") // pre-token plugin: always "1", ignores request headers
+		w.WriteHeader(204)
+	}))
+	defer oldPlugin.Close()
+	wrongToken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-gsx", "some-other-processes-token")
+		w.WriteHeader(204)
+	}))
+	defer wrongToken.Close()
 	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200) // SPA fallback: 200 without the header
 	}))
 	defer foreign.Close()
-	if !verifyFrontDoor(context.Background(), ours.URL) {
-		t.Error("our plugin endpoint must verify")
+
+	if !verifyFrontDoor(context.Background(), tokened.URL, token) {
+		t.Error("plugin echoing our exact token must verify")
 	}
-	if verifyFrontDoor(context.Background(), foreign.URL) {
+	if verifyFrontDoor(context.Background(), oldPlugin.URL, token) {
+		t.Error("older plugin always echoing \"1\" must NOT verify against a real token")
+	}
+	if verifyFrontDoor(context.Background(), wrongToken.URL, token) {
+		t.Error("a different process's token must NOT verify")
+	}
+	if verifyFrontDoor(context.Background(), foreign.URL, token) {
 		t.Error("foreign 200 without x-gsx must NOT verify")
 	}
-	if verifyFrontDoor(context.Background(), "http://127.0.0.1:1") {
+	if verifyFrontDoor(context.Background(), "http://127.0.0.1:1", token) {
 		t.Error("connection refused must NOT verify")
 	}
 }
@@ -81,8 +136,13 @@ func (r *stateRecorder) waitFor(t *testing.T, state string, timeout time.Duratio
 // TestFrontDoorRestartsAndVerifies: the child exits once, the respawn stays up
 // and the verify URL answers with x-gsx — the gate must reopen.
 func TestFrontDoorRestartsAndVerifies(t *testing.T) {
+	const token = "restart-verify-token"
 	verify := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-gsx", "1")
+		if r.Header.Get("x-gsx-token") == token {
+			w.Header().Set("x-gsx", token)
+		} else {
+			w.Header().Set("x-gsx", "1")
+		}
 		w.WriteHeader(204)
 	}))
 	defer verify.Close()
@@ -96,7 +156,7 @@ func TestFrontDoorRestartsAndVerifies(t *testing.T) {
 		c := exec.Command("sh", "-c", script)
 		setProcGroup(c)
 		return c, c.Start()
-	}, verify.URL, rec.record, os.Stderr)
+	}, verify.URL, token, rec.record, os.Stderr)
 	if err := fd.start(); err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +199,7 @@ func TestFrontDoorGivesUpOnCrashLoop(t *testing.T) {
 		c := exec.Command("sh", "-c", "exit 0")
 		setProcGroup(c)
 		return c, c.Start()
-	}, "http://127.0.0.1:1", rec.record, os.Stderr)
+	}, "http://127.0.0.1:1", "crash-loop-token", rec.record, os.Stderr)
 	if err := fd.start(); err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +218,7 @@ func TestFrontDoorShutdownSilent(t *testing.T) {
 		c := exec.Command("sleep", "60")
 		setProcGroup(c)
 		return c, c.Start()
-	}, "http://127.0.0.1:1", rec.record, os.Stderr)
+	}, "http://127.0.0.1:1", "shutdown-silent-token", rec.record, os.Stderr)
 	if err := fd.start(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
gsx side of the token pairing (companion: gsxhq/vite-plugin-gsx#2 — **merge + release that first**).

- One crypto/rand token per `gsx dev` process, passed only to the vite child via `GSX_DEV_TOKEN` (the Go server env never carries it — verified no aliasing via `slices.Clone`).
- `verifyFrontDoor` sends `x-gsx-token` and requires the response `x-gsx` to equal the token — an old plugin echoing `1` no longer verifies (degrades to pre-auto-restart suspend behavior; guide notes the plugin-version requirement). Empty token never verifies (defense-in-depth guard).
- `pollCommands` sends the token header on every request.

Full `gen` suite green on a quiet machine (`-count=1`, 210s); `-race` clean on the touched tests; task review clean.

**Post-release follow-ups for this PR before merge:** fill the guide's plugin-version caveat and bump the scaffold pin to the actual released version (npm-verified — the `^0.5.0` caret trap will not be repeated).

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576