### PR TITLE
chore: scaffold + guide reference plugin 0.7.0

### DIFF
--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -82,9 +82,8 @@ import "virtual:gsx-devpanel";
 `gsx({ devPanel: { key: "k" } })`.
 
 If Vite crashes, `gsx dev` restarts it automatically and pairs with the new
-process before trusting it again (needs a plugin new enough to echo that
-pairing back — older plugins just suspend reload/overlay pushes instead) —
-refresh any tabs that were already open.
+process before trusting it again (plugin ≥ 0.7.0 — older plugins just suspend
+reload/overlay pushes instead) — refresh any tabs that were already open.
 
 ## Customize the commands
 

--- a/gen/templates/init/simple/package.json.tmpl
+++ b/gen/templates/init/simple/package.json.tmpl
@@ -7,7 +7,7 @@
     "build": "vite build"
   },
   "devDependencies": {
-    "@gsxhq/vite-plugin-gsx": "^0.6.0",
+    "@gsxhq/vite-plugin-gsx": "^0.7.0",
     "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
Post-release follow-up for #151: scaffold pins `^0.7.0` (npm-verified: `npm view @gsxhq/vite-plugin-gsx@'^0.7.0'` resolves to 0.7.0) and the dev-loop guide's auto-restart caveat now cites the released version. `TestInit` green.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576