### PR TITLE
feat(gen): honor VITE_DEV_URL's explicit port when VITE_PORT is unset

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -88,8 +88,11 @@ argument. Keep `build` and `run` pointed at the same binary.
 | `no_web` | `false` | Disable the front-end command. |
 | `host` | from `VITE_DEV_URL`, otherwise `localhost` | Hostname used in `VITE_DEV_URL`. |
 
-An existing `VITE_DEV_URL` can supply the hostname when `host` is unset. The
-port still comes from `VITE_PORT` or automatic selection.
+An existing `VITE_DEV_URL` can supply the hostname when `host` is unset. Port
+precedence: `VITE_PORT` wins, then a port in `VITE_DEV_URL`, then automatic
+selection. Either explicit form (`VITE_PORT` or a port in `VITE_DEV_URL`)
+fails loudly if already in use; only a fully port-less config auto-picks. If
+both are set and disagree, `VITE_PORT` wins and `gsx dev` logs a warning.
 
 Command-line flags override `[dev]`; `[dev]` overrides the defaults. See
 [`gsx dev`](./cli.md#gsx-dev) for one-off overrides.

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -63,10 +63,13 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 
 	// --- env + ports ---
 	env := mergeDotEnv(os.Environ(), loadDotEnv(workDir))
-	env, viteURL, err := resolveViteDevEnv(env, dc.host)
+	env, viteURL, warning, err := resolveViteDevEnv(env, dc.host)
 	if err != nil {
 		fmt.Fprintf(stderr, "gsx dev: %v\n", err)
 		return 1
+	}
+	if warning != "" {
+		fmt.Fprintf(stderr, "gsx dev: %s\n", warning)
 	}
 	goPort := envPort(env, "GO_PORT", "7777")
 	healthURL := "http://localhost:" + goPort + "/healthz"
@@ -370,11 +373,15 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				envDirty = false
 				env = mergeDotEnv(os.Environ(), loadDotEnv(workDir))
 				var envErr error
-				env, viteURL, envErr = resolveViteDevEnv(env, dc.host)
+				var envWarning string
+				env, viteURL, envWarning, envErr = resolveViteDevEnv(env, dc.host)
 				if envErr != nil {
 					fmt.Fprintf(stderr, "gsx dev: %v\n", envErr)
 					overlayUp = true
 					continue
+				}
+				if envWarning != "" {
+					fmt.Fprintf(stderr, "gsx dev: %s\n", envWarning)
 				}
 				// Vite reads .env itself (loadEnv + native .env watch), so only the Go server is restarted here.
 				srv.env = env

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -101,7 +101,7 @@ func TestDevTeardownAndRestart(t *testing.T) {
 	cmd.Env = devTestEnv(
 		"BROWSER=none",
 		"GO_PORT=7799",
-		"VITE_DEV_URL=http://127.0.0.1:1",
+		"VITE_DEV_URL=http://127.0.0.1",
 		"GOFLAGS=-mod=mod",
 	)
 	// gsx dev must run in its own process group so the group-SIGINT below only
@@ -218,7 +218,7 @@ func TestDevEnvPrecedence(t *testing.T) {
 	cmd.Env = devTestEnv(
 		"BROWSER=none",
 		"GO_PORT="+portB,
-		"VITE_DEV_URL=http://127.0.0.1:1",
+		"VITE_DEV_URL=http://127.0.0.1",
 		"GOFLAGS=-mod=mod",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -414,7 +414,7 @@ func TestDevStopsPostingAfterWebExit(t *testing.T) {
 	cmd.Env = devTestEnv(
 		"BROWSER=none",
 		"GO_PORT=7811",
-		"VITE_DEV_URL=http://127.0.0.1:1",
+		"VITE_DEV_URL=http://127.0.0.1",
 		"GOFLAGS=-mod=mod",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -545,12 +545,13 @@ func (b *lockedBuffer) String() string {
 // posts) and asserts restart-server restarts the Go server and status events
 // arrive.
 //
-// gsx dev resolves its own front-door URL (host from VITE_DEV_URL if given,
-// but the PORT always comes from VITE_PORT or its own auto-picker — a stale
-// VITE_DEV_URL must never pin a busy port, see resolveViteDevEnv). So the fake
-// plugin can't pre-bind an arbitrary port and pass it via VITE_DEV_URL: it
-// must learn the real resolved URL from gsx dev's own "watching … — open
-// <url>" banner and bind there, exactly like TestDevStopsPostingAfterWebExit.
+// gsx dev resolves its own front-door URL (host from VITE_DEV_URL if given;
+// the port from VITE_PORT, else VITE_DEV_URL's own port, else its
+// auto-picker — see resolveViteDevEnv). The env here deliberately gives
+// VITE_DEV_URL no port, so the fake plugin still can't pre-bind an arbitrary
+// port that way: it must learn the real resolved URL from gsx dev's own
+// "watching … — open <url>" banner and bind there, exactly like
+// TestDevStopsPostingAfterWebExit.
 func TestDevPanelCommands(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration test: requires building gsx and a live Go server")
@@ -583,7 +584,7 @@ func TestDevPanelCommands(t *testing.T) {
 	cmd.Env = devTestEnv(
 		"BROWSER=none",
 		"GO_PORT=7813",
-		"VITE_DEV_URL=http://127.0.0.1:1",
+		"VITE_DEV_URL=http://127.0.0.1",
 		"GOFLAGS=-mod=mod",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -725,7 +726,7 @@ func TestDevPanelRebuildCommand(t *testing.T) {
 	cmd.Env = devTestEnv(
 		"BROWSER=none",
 		"GO_PORT=7825",
-		"VITE_DEV_URL=http://127.0.0.1:1",
+		"VITE_DEV_URL=http://127.0.0.1",
 		"GOFLAGS=-mod=mod",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -119,40 +119,63 @@ func envLookup(env []string, key string) (string, bool) {
 // envValue is envPort by another name for non-port keys (VITE_DEV_URL).
 func envValue(env []string, key, def string) string { return envPort(env, key, def) }
 
-func resolveViteDevEnv(env []string, host string) ([]string, string, error) {
-	// When [dev].host is unset, honor the hostname from an existing VITE_DEV_URL
-	// (typically a gitignored .env) so a per-machine dev hostname needs no
-	// committed config. Only the host is taken — the port still comes from
-	// VITE_PORT or the auto-picker, so a stale URL never pins a busy port.
-	if host == "" {
-		if raw := envValue(env, "VITE_DEV_URL", ""); raw != "" {
-			if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+// resolveViteDevEnv resolves the Vite dev server's host:port and folds it
+// back into env as VITE_PORT/VITE_DEV_URL for the spawned front door and Go
+// server to agree on.
+//
+// Precedence: VITE_PORT > VITE_DEV_URL's port > auto-pick from 5173. An
+// explicit port — either form — fails loudly (hard error) if it's already
+// bound; only a truly port-less configuration (no VITE_PORT, and no port on
+// VITE_DEV_URL) auto-picks. When [dev].host is unset, the hostname from an
+// existing VITE_DEV_URL (typically a gitignored .env) is honored too, so a
+// per-machine dev hostname needs no committed config; that lookup is
+// independent of the port precedence above. If VITE_PORT and VITE_DEV_URL's
+// port disagree, VITE_PORT wins and the non-empty warning return names the
+// override — the caller should print it once.
+func resolveViteDevEnv(env []string, host string) ([]string, string, string, error) {
+	var urlPort string
+	if raw := envValue(env, "VITE_DEV_URL", ""); raw != "" {
+		if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+			if host == "" {
 				host = u.Hostname()
 			}
+			urlPort = u.Port()
 		}
 	}
-	port, ok := envLookup(env, "VITE_PORT")
+
+	var warning string
+	port, hasVitePort := envLookup(env, "VITE_PORT")
 	var err error
-	if ok {
-		if _, err := strconv.Atoi(port); err != nil {
-			return nil, "", fmt.Errorf("invalid VITE_PORT %q", port)
+	switch {
+	case hasVitePort:
+		if _, convErr := strconv.Atoi(port); convErr != nil {
+			return nil, "", "", fmt.Errorf("invalid VITE_PORT %q", port)
+		}
+		if urlPort != "" && urlPort != port {
+			warning = fmt.Sprintf("VITE_PORT=%s overrides VITE_DEV_URL's :%s", port, urlPort)
 		}
 		if !portAvailable(port) {
-			return nil, "", fmt.Errorf("VITE_PORT %s is already in use", port)
+			return nil, "", "", fmt.Errorf("VITE_PORT %s is already in use", port)
 		}
-	} else {
+	case urlPort != "":
+		if !portAvailable(urlPort) {
+			return nil, "", "", fmt.Errorf("VITE_DEV_URL port %s is already in use", urlPort)
+		}
+		port = urlPort
+	default:
 		port, err = nextAvailablePort("5173")
+		if err != nil {
+			return nil, "", "", err
+		}
 	}
-	if err != nil {
-		return nil, "", err
-	}
+
 	if host == "" {
 		host = "localhost"
 	}
 	viteURL := "http://" + host + ":" + port
 	env = setEnvValue(env, "VITE_PORT", port)
 	env = setEnvValue(env, "VITE_DEV_URL", viteURL)
-	return env, viteURL, nil
+	return env, viteURL, warning, nil
 }
 
 func nextAvailablePort(start string) (string, error) {

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -124,6 +124,26 @@ func TestMergeDotEnv(t *testing.T) {
 	})
 }
 
+// freePort binds an ephemeral port, reads back the port the OS assigned, and
+// releases it immediately. The window between release and the caller's own
+// use is a theoretical race (acceptable here, same tolerance as the other
+// port-probing tests in this file) but avoids colliding on a fixed number
+// across parallel test suites.
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		l.Close()
+		t.Fatal(err)
+	}
+	l.Close()
+	return port
+}
+
 func TestResolveViteDevEnvSkipsBoundDefaultPort(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:5173")
 	if err != nil {
@@ -135,9 +155,12 @@ func TestResolveViteDevEnvSkipsBoundDefaultPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"}, "")
+	env, viteURL, warning, err := resolveViteDevEnv([]string{"PATH=/bin"}, "")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if warning != "" {
+		t.Errorf("warning = %q, want none", warning)
 	}
 	wantURL := "http://localhost:" + wantPort
 	if viteURL != wantURL {
@@ -152,10 +175,10 @@ func TestResolveViteDevEnvSkipsBoundDefaultPort(t *testing.T) {
 }
 
 func TestResolveViteDevEnvHost(t *testing.T) {
-	env, viteURL, err := resolveViteDevEnv([]string{"VITE_PORT=0", "PATH=/bin"}, "mstudio")
+	env, viteURL, _, err := resolveViteDevEnv([]string{"VITE_PORT=0", "PATH=/bin"}, "mstudio")
 	if err != nil {
 		// port 0 is "available" (ephemeral); if the platform rejects it, fall back.
-		env, viteURL, err = resolveViteDevEnv([]string{"PATH=/bin"}, "mstudio")
+		env, viteURL, _, err = resolveViteDevEnv([]string{"PATH=/bin"}, "mstudio")
 	}
 	if err != nil {
 		t.Fatal(err)
@@ -169,21 +192,104 @@ func TestResolveViteDevEnvHost(t *testing.T) {
 }
 
 func TestResolveViteDevEnvHostFromDevURL(t *testing.T) {
-	// With no [dev].host, the hostname comes from VITE_DEV_URL in the env.
-	_, viteURL, err := resolveViteDevEnv([]string{"VITE_DEV_URL=http://mstudio:4000", "PATH=/bin"}, "")
+	port := freePort(t)
+	devURL := "VITE_DEV_URL=http://mstudio:" + port
+	// With no [dev].host, the hostname comes from VITE_DEV_URL in the env, and
+	// (with VITE_PORT unset) so does the port.
+	_, viteURL, warning, err := resolveViteDevEnv([]string{devURL, "PATH=/bin"}, "")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if warning != "" {
+		t.Errorf("warning = %q, want none", warning)
+	}
+	wantURL := "http://mstudio:" + port
+	if viteURL != wantURL {
+		t.Fatalf("viteURL = %q, want %s (VITE_DEV_URL's port honored)", viteURL, wantURL)
+	}
+	// An explicit [dev].host wins over VITE_DEV_URL's hostname; the URL's port
+	// is still honored.
+	_, viteURL2, warning2, err := resolveViteDevEnv([]string{devURL, "PATH=/bin"}, "override")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if warning2 != "" {
+		t.Errorf("warning = %q, want none", warning2)
+	}
+	wantURL2 := "http://override:" + port
+	if viteURL2 != wantURL2 {
+		t.Fatalf("viteURL = %q, want %s ([dev].host override wins on host, URL port still honored)", viteURL2, wantURL2)
+	}
+}
+
+func TestResolveViteDevEnvPortlessURLAutoPicks(t *testing.T) {
+	// A VITE_DEV_URL with no port keeps today's behavior exactly: hostname
+	// hint only, port still comes from the auto-picker.
+	_, viteURL, warning, err := resolveViteDevEnv([]string{"VITE_DEV_URL=http://mstudio", "PATH=/bin"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if warning != "" {
+		t.Errorf("warning = %q, want none", warning)
 	}
 	if !strings.HasPrefix(viteURL, "http://mstudio:") {
-		t.Fatalf("viteURL = %q, want host mstudio from VITE_DEV_URL", viteURL)
+		t.Fatalf("viteURL = %q, want http://mstudio:<auto-picked port>", viteURL)
 	}
-	// An explicit [dev].host wins over VITE_DEV_URL.
-	_, viteURL2, err := resolveViteDevEnv([]string{"VITE_DEV_URL=http://mstudio:4000", "PATH=/bin"}, "override")
+}
+
+func TestResolveViteDevEnvHonorsURLPortWhenBusy(t *testing.T) {
+	port := freePort(t)
+	l, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		t.Skipf("could not hold port %s for test: %v", port, err)
+	}
+	defer l.Close()
+
+	_, _, _, err = resolveViteDevEnv([]string{"VITE_DEV_URL=http://mstudio:" + port, "PATH=/bin"}, "")
+	if err == nil {
+		t.Fatal("expected VITE_DEV_URL's busy explicit port to fail")
+	}
+	if !strings.Contains(err.Error(), port) || !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("error = %q, want a port-in-use message naming %s", err, port)
+	}
+}
+
+func TestResolveViteDevEnvVitePortAgreesWithURLNoWarning(t *testing.T) {
+	port := freePort(t)
+	env := []string{"VITE_PORT=" + port, "VITE_DEV_URL=http://mstudio:" + port, "PATH=/bin"}
+	_, viteURL, warning, err := resolveViteDevEnv(env, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(viteURL2, "http://override:") {
-		t.Fatalf("viteURL = %q, want [dev].host override to win", viteURL2)
+	if warning != "" {
+		t.Errorf("warning = %q, want none (VITE_PORT and VITE_DEV_URL agree)", warning)
+	}
+	want := "http://mstudio:" + port
+	if viteURL != want {
+		t.Fatalf("viteURL = %q, want %s", viteURL, want)
+	}
+}
+
+func TestResolveViteDevEnvVitePortOverridesDisagreeingURL(t *testing.T) {
+	vitePort := freePort(t)
+	urlPort := freePort(t)
+	env := []string{"VITE_PORT=" + vitePort, "VITE_DEV_URL=http://mstudio:" + urlPort, "PATH=/bin"}
+	_, viteURL, warning, err := resolveViteDevEnv(env, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://mstudio:" + vitePort
+	if viteURL != want {
+		t.Fatalf("viteURL = %q, want %s (VITE_PORT wins)", viteURL, want)
+	}
+	if warning == "" {
+		t.Fatal("expected a warning that VITE_PORT overrides VITE_DEV_URL's port")
+	}
+	if strings.Count(warning, "\n") != 0 {
+		t.Fatalf("warning = %q, want exactly one line (emitted once)", warning)
+	}
+	if !strings.Contains(warning, "VITE_PORT="+vitePort) || !strings.Contains(warning, ":"+urlPort) {
+		t.Fatalf("warning = %q, want it to name both the winning VITE_PORT=%s and overridden :%s", warning, vitePort, urlPort)
 	}
 }
 
@@ -198,7 +304,7 @@ func TestResolveViteDevEnvSkipsIPv6BoundDefaultPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env, viteURL, err := resolveViteDevEnv([]string{"PATH=/bin"}, "")
+	env, viteURL, _, err := resolveViteDevEnv([]string{"PATH=/bin"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +324,7 @@ func TestResolveViteDevEnvRejectsBoundExplicitVitePort(t *testing.T) {
 	}
 	defer l.Close()
 
-	_, _, err = resolveViteDevEnv([]string{"VITE_PORT=5173"}, "")
+	_, _, _, err = resolveViteDevEnv([]string{"VITE_PORT=5173"}, "")
 	if err == nil {
 		t.Fatal("expected bound explicit VITE_PORT to fail")
 	}

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -252,6 +252,11 @@ func TestResolveViteDevEnvHonorsURLPortWhenBusy(t *testing.T) {
 	if !strings.Contains(err.Error(), port) || !strings.Contains(err.Error(), "already in use") {
 		t.Fatalf("error = %q, want a port-in-use message naming %s", err, port)
 	}
+	// The message must attribute the pin to its source: a URL-derived pin
+	// reported as a VITE_PORT problem would send the user to the wrong line.
+	if !strings.Contains(err.Error(), "VITE_DEV_URL") {
+		t.Fatalf("error = %q, want the pin attributed to VITE_DEV_URL", err)
+	}
 }
 
 func TestResolveViteDevEnvVitePortAgreesWithURLNoWarning(t *testing.T) {


### PR DESCRIPTION
User-approved design tweak (from a one-learning confusion report): the URL's port half was silently ignored by design ("a stale URL never pins a busy port"), forcing projects to state the port twice.

- `VITE_PORT` unset + `VITE_DEV_URL` with an explicit port → that port is honored with the same hard-error-if-busy semantics (the error names VITE_DEV_URL as the source).
- Both set and disagreeing → `VITE_PORT` wins with one warning line.
- Port-less URLs unchanged (hostname hint + auto-pick from 5173). Precedence: `VITE_PORT` > URL port > auto-pick. `[dev].host` hostname override and URL-port honoring are deliberately decoupled.

**Behavior change note:** a project with a stale port-bearing `VITE_DEV_URL` and no `VITE_PORT` previously auto-picked; it now pins that port (or fails loudly if busy) — it does what the file says.

Unit table on ephemeral ports; task review clean. Local full suite has one environmental failure (`TestDevTeardownAndRestart` — a live one-learning `gsx dev` holds :7799 on this machine; reproduced identically on unmodified main). CI on a clean runner is the arbiter for that test.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576