### PR TITLE
feat(gen): single source of truth for the dev backend upstream

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -108,7 +108,7 @@ health = "/healthz"
 ```
 
 `${VAR}` in `upstream` expands against the merged shell + `.env` environment
-(shell wins); an unset variable is a startup error. The default, when
+(shell wins); an unset or empty variable is a startup error. The default, when
 `upstream` is unset, is `http://localhost:${GO_PORT}` with `GO_PORT` defaulting
 to `7777`. `health` is the path probed on `upstream` and defaults to
 `/healthz`. `upstream` is observational only — it retargets the health probe

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -97,6 +97,24 @@ both are set and disagree, `VITE_PORT` wins and `gsx dev` logs a warning.
 Command-line flags override `[dev]`; `[dev]` overrides the defaults. See
 [`gsx dev`](./cli.md#gsx-dev) for one-off overrides.
 
+### Dev backend upstream `upstream`/`health`
+
+Use `upstream` when the backend's listen address is not the default port:
+
+```toml
+[dev]
+upstream = "http://localhost${ADDR}"   # ADDR=:8890 -> http://localhost:8890
+health = "/healthz"
+```
+
+`${VAR}` in `upstream` expands against the merged shell + `.env` environment
+(shell wins); an unset variable is a startup error. The default, when
+`upstream` is unset, is `http://localhost:${GO_PORT}` with `GO_PORT` defaulting
+to `7777`. `health` is the path probed on `upstream` and defaults to
+`/healthz`. `upstream` is observational only — it retargets the health probe
+and dev panel, and is injected into the front-end process as
+`GSX_DEV_UPSTREAM`; it never changes where the backend listens.
+
 ## Pipeline filters
 
 Filters are exported Go functions that receive the piped value as their first

--- a/gen/configfile.go
+++ b/gen/configfile.go
@@ -68,6 +68,14 @@ type tomlDev struct {
 	// it when the dev server must be reachable under a specific hostname —
 	// e.g. host = "mstudio" yields VITE_DEV_URL=http://mstudio:<port>.
 	Host string `toml:"host"`
+	// Upstream is the dev backend's origin, ${VAR}-expanded against the merged
+	// shell+.env (e.g. "http://localhost${ADDR}"). It is observational only —
+	// gsx dev never sets the app's listen address — and feeds both the health
+	// probe and the GSX_DEV_UPSTREAM env injected into the vite child. Empty
+	// defaults to http://localhost:${GO_PORT|7777} (today's behavior).
+	Upstream string `toml:"upstream"`
+	// Health is the path probed on Upstream (default "/healthz").
+	Health string `toml:"health"`
 }
 
 // tomlMinify is the [minify] table: per-asset level spellings. A nil pointer

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -71,8 +71,15 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	if warning != "" {
 		fmt.Fprintf(stderr, "gsx dev: %s\n", warning)
 	}
-	goPort := envPort(env, "GO_PORT", "7777")
-	healthURL := "http://localhost:" + goPort + "/healthz"
+	var tdUpstream, tdHealth string
+	if td != nil {
+		tdUpstream, tdHealth = td.Upstream, td.Health
+	}
+	origin, healthURL, goPort, err := resolveUpstream(tdUpstream, tdHealth, env)
+	if err != nil {
+		fmt.Fprintf(stderr, "gsx dev: %v\n", err)
+		return 1
+	}
 
 	var termMu sync.Mutex
 	mkWriter := func(name string) io.Writer { return &prefixWriter{name: name, w: stdout, mu: &termMu} }
@@ -128,7 +135,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	post := func(body []byte) { postEvent(viteURL, body, webUp) }
 	reload := func() { postReload(viteURL, webUp) }
 
-	status := devStatus{Phase: "idle", Server: serverStat{Port: goPort}, FrontDoor: frontStat{State: "external"}}
+	status := devStatus{Phase: "idle", Server: serverStat{Port: goPort, Upstream: origin}, FrontDoor: frontStat{State: "external"}}
 	if dc.web != nil {
 		status.FrontDoor.State = "up"
 	}
@@ -155,7 +162,7 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		spawn := func() (*exec.Cmd, error) {
 			c := exec.Command(dc.web[0], dc.web[1:]...)
 			c.Dir, c.Stdout, c.Stderr = workDir, mkWriter("vite"), mkWriter("vite")
-			c.Env = append(slices.Clone(env), "GSX_DEV_TOKEN="+devToken)
+			c.Env = append(slices.Clone(env), "GSX_DEV_TOKEN="+devToken, "GSX_DEV_UPSTREAM="+origin)
 			setProcGroup(c)
 			return c, c.Start()
 		}
@@ -383,11 +390,24 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				if envWarning != "" {
 					fmt.Fprintf(stderr, "gsx dev: %s\n", envWarning)
 				}
+				newOrigin, newHealthURL, newPort, upErr := resolveUpstream(tdUpstream, tdHealth, env)
+				if upErr != nil {
+					// A broken [dev].upstream (e.g. a now-unset ${VAR}, or an
+					// env edit that produces a bare trailing ":") must not crash
+					// a running dev loop or corrupt the last-known-good probe
+					// target: log + overlay it and keep everything (server env,
+					// healthURL, status) exactly as it was — mirrors the
+					// envErr handling just above.
+					fmt.Fprintf(stderr, "gsx dev: %v\n", upErr)
+					post(buildErrorEvent(upErr.Error()))
+					overlayUp = true
+					continue
+				}
+				origin, healthURL, goPort = newOrigin, newHealthURL, newPort
 				// Vite reads .env itself (loadEnv + native .env watch), so only the Go server is restarted here.
 				srv.env = env
-				goPort = envPort(env, "GO_PORT", "7777")
 				status.Server.Port = goPort
-				healthURL = "http://localhost:" + goPort + "/healthz"
+				status.Server.Upstream = origin
 				srv.healthURL = healthURL
 				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
 					reload()

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -378,15 +378,28 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			// .env change → restart server with fresh env (no rebuild) + reload.
 			if envDirty {
 				envDirty = false
-				env = mergeDotEnv(os.Environ(), loadDotEnv(workDir))
-				var envErr error
-				var envWarning string
-				env, viteURL, envWarning, envErr = resolveViteDevEnv(env, dc.host)
+				newEnv := mergeDotEnv(os.Environ(), loadDotEnv(workDir))
+				resolvedEnv, newViteURL, envWarning, envErr := resolveViteDevEnv(newEnv, dc.host)
 				if envErr != nil {
+					// A broken .env edit (e.g. an explicit VITE_PORT that's now
+					// in use) must not crash a running dev loop OR corrupt
+					// env/viteURL: resolveViteDevEnv's failure return is the
+					// zero value for both, and env/viteURL are read by every
+					// later post()/reload()/pollCommands call in this
+					// function — assigning them here would silently and
+					// permanently break every future post (postBest treats an
+					// empty base URL as a same-origin path and no-ops). Keep
+					// both exactly as they were, log + overlay the error
+					// (mirrors the upErr handling just below: both are
+					// resolution failures from the same .env-fire path, and
+					// the browser should learn of either from the overlay,
+					// not just the terminal), and let the developer retry.
 					fmt.Fprintf(stderr, "gsx dev: %v\n", envErr)
+					post(buildErrorEvent(envErr.Error()))
 					overlayUp = true
 					continue
 				}
+				env, viteURL = resolvedEnv, newViteURL
 				if envWarning != "" {
 					fmt.Fprintf(stderr, "gsx dev: %s\n", envWarning)
 				}

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -1021,3 +1021,155 @@ func TestDevPanelRebuildCommand(t *testing.T) {
 		t.Errorf("log missing %q; output:\n%s", "gsx dev: panel: rebuild", stdout.String())
 	}
 }
+
+// TestDevEnvErrorPostsOverlay is the final-review fix-round-1 regression test
+// for the envErr branch of the .env-fire path (gen/dev.go): a resolveViteDevEnv
+// failure (e.g. an .env edit that sets VITE_PORT to a port already in use)
+// must post an error event to the browser overlay, exactly like the sibling
+// resolveUpstream (upErr) branch just below it — before this fix, envErr only
+// logged to the terminal.
+//
+// It also guards a bug the naive fix would otherwise reintroduce: the .env-fire
+// code assigns resolveViteDevEnv's four return values directly into the
+// function-scoped env/viteURL variables (`env, viteURL, envWarning, envErr =
+// resolveViteDevEnv(...)`); on error those returns are the zero values, so a
+// naive "just add post()" would clobber viteURL to "" first — and post()'s
+// underlying postBest() treats an empty base URL as a same-origin path and
+// no-ops, silently defeating the fix it was meant to implement. This test
+// pins that the overlay post actually reaches the front door AND that a
+// subsequent, successful .env edit still reaches it too (proving env/viteURL
+// survive an intervening error untouched).
+func TestDevEnvErrorPostsOverlay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGo)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+
+	goPort := freePort(t)
+	vitePort := freePort(t)
+	// Held for the whole test so VITE_PORT=blockedPort deterministically fails
+	// resolveViteDevEnv's portAvailable check — this is the "already in use"
+	// .env edit under test, not a transient race.
+	blockedPort := freePort(t)
+	bl, err := net.Listen("tcp", "127.0.0.1:"+blockedPort)
+	if err != nil {
+		t.Fatalf("hold blocked port %s: %v", blockedPort, err)
+	}
+	defer bl.Close()
+
+	goodEnv := "GO_PORT=" + goPort + "\nVITE_PORT=" + vitePort + "\n"
+	writeFile(t, proj, ".env", goodEnv)
+
+	if portListening(goPort) {
+		t.Fatalf("port %s already in use (leaked scaffold server?)", goPort)
+	}
+
+	cmd := exec.Command(bin, "dev", "--web", "sleep 600")
+	cmd.Dir = proj
+	// No VITE_DEV_URL/VITE_PORT in the shell env: VITE_PORT is pinned via .env
+	// alone so every env recompute (startup and every later .env fire) resolves
+	// to the SAME port deterministically — no auto-pick variance to guard against.
+	cmd.Env = devTestEnv("BROWSER=none", "GOFLAGS=-mod=mod")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer stopDevGracefully(cmd)
+
+	if !waitHealthy(context.Background(), "http://localhost:"+goPort+"/healthz", 120*time.Second) {
+		t.Fatalf("server never came up; output:\n%s", stdout.String())
+	}
+
+	wantViteURL := "http://localhost:" + vitePort
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(stdout.String(), "open "+wantViteURL) {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !strings.Contains(stdout.String(), "open "+wantViteURL) {
+		t.Fatalf("front-door URL %q not printed (VITE_PORT pinning failed?); output:\n%s", wantViteURL, stdout.String())
+	}
+
+	// Fake vite plugin bound at the pinned front-door address: records every
+	// /__gsx/event POST body and every /__reload hit.
+	var events lockedBuffer
+	var reloads atomic.Int32
+	fake := &http.Server{
+		Addr: net.JoinHostPort("localhost", vitePort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-gsx", "1")
+			switch r.URL.Path {
+			case "/__gsx/event":
+				body, _ := io.ReadAll(r.Body)
+				events.Write(append(body, '\n'))
+			case "/__reload":
+				reloads.Add(1)
+			case "/__gsx/cmd":
+				time.Sleep(50 * time.Millisecond)
+			}
+			w.WriteHeader(204)
+		}),
+	}
+	fl, err := net.Listen("tcp", fake.Addr)
+	if err != nil {
+		t.Fatalf("bind resolved front-door port %s: %v", fake.Addr, err)
+	}
+	go func() { _ = fake.Serve(fl) }()
+	defer fake.Close()
+
+	// The .env edit under test: VITE_PORT now points at the held blockedPort —
+	// resolveViteDevEnv must fail with "already in use", and the failure must
+	// be posted to the browser overlay (not just logged).
+	writeFile(t, proj, ".env", "GO_PORT="+goPort+"\nVITE_PORT="+blockedPort+"\n")
+
+	wantErrFrag := "VITE_PORT " + blockedPort + " is already in use"
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(events.String(), wantErrFrag) {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !strings.Contains(events.String(), wantErrFrag) {
+		t.Fatalf("no error event posted for the broken VITE_PORT edit (want %q); events:\n%s\nstdout:\n%s",
+			wantErrFrag, events.String(), stdout.String())
+	}
+	if !strings.Contains(events.String(), `"ok":false`) {
+		t.Errorf("posted error event should be ok:false (buildErrorEvent shape); events:\n%s", events.String())
+	}
+
+	// Recovery: revert .env to the original, valid VITE_PORT. If envErr's
+	// failed resolveViteDevEnv had clobbered the shared env/viteURL variables,
+	// this cycle's reload() would silently target an empty/wrong base URL and
+	// the fake listener (still bound at the ORIGINAL vitePort) would never see
+	// it — proving env/viteURL survived the intervening error untouched.
+	writeFile(t, proj, ".env", goodEnv)
+
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) && reloads.Load() == 0 {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if reloads.Load() == 0 {
+		t.Fatalf("no /__reload after reverting .env to a valid VITE_PORT — env/viteURL likely corrupted by the prior error; stdout:\n%s", stdout.String())
+	}
+	if !waitHealthy(context.Background(), "http://localhost:"+goPort+"/healthz", 30*time.Second) {
+		t.Fatalf("server not healthy after recovery; output:\n%s", stdout.String())
+	}
+}

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -311,6 +311,211 @@ func main() {
 }
 `
 
+// devTestMainGoADDR is a sibling of devTestMainGo that listens on ADDR (e.g.
+// ":8890") instead of GO_PORT — used by TestDevUpstreamSingleSource to prove
+// gsx dev's health probe/status follow a resolved [dev].upstream ${ADDR}
+// reference rather than the GO_PORT default (ADDR is already ":port"-shaped,
+// so unlike devTestMainGo it is used as Addr directly, no ":" + port).
+const devTestMainGoADDR = `package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	addr := os.Getenv("ADDR")
+	if addr == "" {
+		addr = ":7777"
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/pid", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "%d", os.Getpid())
+	})
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() { _ = srv.ListenAndServe() }()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	<-ctx.Done()
+
+	shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutCtx)
+}
+`
+
+// TestDevUpstreamSingleSource pins the top-down [dev].upstream design end to
+// end: gsx.toml carries "upstream = \"http://localhost${ADDR}\"" and the
+// project's .env sets ADDR — GO_PORT appears NOWHERE in this test's env or
+// config. It asserts:
+//   - the scaffold server (listening on ADDR) is probed healthy at the
+//     RESOLVED origin (proving the probe followed [dev].upstream, not the
+//     GO_PORT default it would otherwise fall back to);
+//   - a status event carries that same origin/port (the panel wire shape);
+//   - the front door's spawned env carries GSX_DEV_UPSTREAM=<resolved origin>
+//     (the vite-plugin cross-repo contract line).
+func TestDevUpstreamSingleSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGoADDR)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+
+	port := freePort(t)
+	addr := ":" + port
+	writeFile(t, proj, ".env", "ADDR="+addr+"\n")
+	writeFile(t, proj, "gsx.toml", "[dev]\nupstream = \"http://localhost${ADDR}\"\n")
+	// The front door's actual job here is just to prove GSX_DEV_UPSTREAM
+	// reaches its env — it writes the var to a marker file rather than
+	// serving Vite. Two whitespace-separated argv (no embedded quoting), so
+	// the --web flag's splitArgv (strings.Fields) parses it correctly.
+	writeFile(t, proj, "webstub.sh", "#!/bin/sh\necho \"$GSX_DEV_UPSTREAM\" > marker.txt\nsleep 600\n")
+
+	if portListening(port) {
+		t.Fatalf("port %s already in use (leaked scaffold server?)", port)
+	}
+
+	cmd := exec.Command(bin, "dev", "--web", "sh webstub.sh")
+	cmd.Dir = proj
+	// Deliberately NO GO_PORT anywhere in the child env: proves the probe
+	// follows the resolved [dev].upstream, not the GO_PORT default.
+	cmd.Env = devTestEnv(
+		"BROWSER=none",
+		"VITE_DEV_URL=http://127.0.0.1",
+		"GOFLAGS=-mod=mod",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer stopDevGracefully(cmd)
+
+	wantOrigin := "http://localhost:" + port
+	if !waitHealthy(context.Background(), wantOrigin+"/healthz", 120*time.Second) {
+		t.Fatalf("Go server on ADDR=%s (resolved upstream %s) never came up; output:\n%s", addr, wantOrigin, stdout.String())
+	}
+
+	// Learn the resolved front-door URL from the "watching … — open <url>" line.
+	var viteURL string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := regexp.MustCompile(`open (http://\S+)`).FindStringSubmatch(stdout.String()); m != nil {
+			viteURL = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if viteURL == "" {
+		t.Fatalf("front-door URL not printed; stdout=%q", stdout.String())
+	}
+	u, err := url.Parse(viteURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake vite plugin bound at the resolved front-door address: long-poll
+	// queue (to force a fresh status push once we're listening) + event
+	// recorder, same pattern as TestDevPanelCommands.
+	cmdQ := make(chan string, 4)
+	var statusEvents lockedBuffer
+	fake := &http.Server{
+		Addr: net.JoinHostPort(u.Hostname(), u.Port()),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-gsx", "1")
+			switch r.URL.Path {
+			case "/__gsx/cmd":
+				select {
+				case c := <-cmdQ:
+					fmt.Fprintf(w, `{"cmds":[%q]}`, c)
+				case <-time.After(2 * time.Second):
+					w.WriteHeader(204)
+				}
+			case "/__gsx/event":
+				body, _ := io.ReadAll(r.Body)
+				if strings.Contains(string(body), `"event":"status"`) {
+					statusEvents.Write(append(body, '\n'))
+				}
+				w.WriteHeader(204)
+			default:
+				w.WriteHeader(204)
+			}
+		}),
+	}
+	fl, err := net.Listen("tcp", fake.Addr)
+	if err != nil {
+		t.Fatalf("bind resolved front-door port %s: %v", fake.Addr, err)
+	}
+	go func() { _ = fake.Serve(fl) }()
+	defer fake.Close()
+
+	// Force a fresh status push now that the fake recorder is listening
+	// (the cold startup post race-started before we could bind here).
+	cmdQ <- "restart-server"
+
+	wantUpstreamFrag := fmt.Sprintf(`"upstream":"%s"`, wantOrigin)
+	wantPortFrag := fmt.Sprintf(`"port":"%s"`, port)
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(statusEvents.String(), wantUpstreamFrag) && strings.Contains(statusEvents.String(), wantPortFrag) {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !strings.Contains(statusEvents.String(), wantUpstreamFrag) {
+		t.Errorf("no status event carried %q; events:\n%s\nstdout:\n%s", wantUpstreamFrag, statusEvents.String(), stdout.String())
+	}
+	if !strings.Contains(statusEvents.String(), wantPortFrag) {
+		t.Errorf("no status event carried %q; events:\n%s", wantPortFrag, statusEvents.String())
+	}
+	if !strings.Contains(statusEvents.String(), `"healthy":true`) {
+		t.Errorf("no healthy status observed; status log:\n%s", statusEvents.String())
+	}
+
+	// Assert the front door's spawned env carried GSX_DEV_UPSTREAM.
+	markerPath := filepath.Join(proj, "marker.txt")
+	var markerContent string
+	markerDeadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(markerDeadline) {
+		if b, err := os.ReadFile(markerPath); err == nil {
+			markerContent = strings.TrimSpace(string(b))
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if markerContent != wantOrigin {
+		t.Errorf("GSX_DEV_UPSTREAM in front-door env = %q, want %q", markerContent, wantOrigin)
+	}
+}
+
 func TestKillProcGroupOwnedReapsViaExternalWaiter(t *testing.T) {
 	cmd := exec.Command("sleep", "60")
 	setProcGroup(cmd)

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -126,10 +126,14 @@ func envValue(env []string, key, def string) string { return envPort(env, key, d
 // or $VAR with no braces is left untouched — only ${...} is special, and
 // there is no escape mechanism.
 //
-// An unset variable, an empty name (${}), or an unterminated ${ (no closing
-// }) is a startup error rather than a silent empty string; the error names
-// the offending reference/variable so a bad gsx.toml [dev].upstream fails
-// loudly.
+// An unset variable, a variable that is SET BUT EMPTY, an empty name (${}),
+// or an unterminated ${ (no closing }) is a startup error rather than a
+// silent empty string; the error names the offending reference/variable so a
+// bad gsx.toml [dev].upstream fails loudly. Set-but-empty gets the same
+// treatment as unset: e.g. ADDR="" in .env would otherwise silently collapse
+// "http://localhost${ADDR}" to "http://localhost" — a valid origin (port 80)
+// with no diagnostic, exactly the undiagnosable "server down" this function
+// exists to prevent.
 func expandEnvRefs(s string, env []string) (string, error) {
 	var b strings.Builder
 	rest := s
@@ -152,6 +156,9 @@ func expandEnvRefs(s string, env []string) (string, error) {
 		v, ok := envLookup(env, name)
 		if !ok {
 			return "", fmt.Errorf("unset env var %q referenced in %q", name, s)
+		}
+		if v == "" {
+			return "", fmt.Errorf("env var %q referenced in %q is set but empty", name, s)
 		}
 		b.WriteString(v)
 		rest = after[j+1:]
@@ -212,12 +219,15 @@ func resolveUpstream(upstream, health string, env []string) (origin, healthURL, 
 		return "", "", "", fmt.Errorf("[dev].upstream %q: must be an origin only (no path/query/fragment)", expanded)
 	}
 	if strings.HasSuffix(u.Host, ":") && u.Port() == "" {
-		// A present-but-empty env var expanding into a literal ":" in the
-		// template (e.g. "http://localhost:${ADDR}" with ADDR="") round-trips
-		// through url.Parse unnoticed (Host "localhost:", Port() ""), and Go's
-		// http client then silently dials port 80 — an undiagnosable "server
-		// down". Reject it, naming the template and its expansion so the
-		// empty env var is obvious.
+		// A literal trailing ":" already in [dev].upstream itself (no ${...}
+		// reference at all, e.g. a hardcoded "http://localhost:" in gsx.toml)
+		// round-trips through url.Parse unnoticed (Host "localhost:", Port()
+		// ""), and Go's http client then silently dials port 80 — an
+		// undiagnosable "server down". Reject it, naming the template and its
+		// expansion. Set-but-empty ${VAR} references (e.g.
+		// "http://localhost:${ADDR}" with ADDR="") are now caught earlier, by
+		// expandEnvRefs itself, naming the variable — this guard only remains
+		// reachable for a literal, var-free trailing colon.
 		return "", "", "", fmt.Errorf("[dev].upstream %q expands to %q: host %q has an empty port (bare trailing \":\") — check the referenced env var(s) aren't empty", upstream, expanded, u.Host)
 	}
 

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -145,23 +145,22 @@ func expandEnvRefs(s string, env []string) (string, error) {
 		}
 		b.WriteString(rest[:i])
 		after := rest[i+2:]
-		j := strings.IndexByte(after, '}')
-		if j < 0 {
+		name, tail, ok := strings.Cut(after, "}")
+		if !ok {
 			return "", fmt.Errorf("unterminated %q in %q", rest[i:], s)
 		}
-		name := after[:j]
 		if name == "" {
 			return "", fmt.Errorf("empty %q reference in %q", "${}", s)
 		}
-		v, ok := envLookup(env, name)
-		if !ok {
+		v, set := envLookup(env, name)
+		if !set {
 			return "", fmt.Errorf("unset env var %q referenced in %q", name, s)
 		}
 		if v == "" {
 			return "", fmt.Errorf("env var %q referenced in %q is set but empty", name, s)
 		}
 		b.WriteString(v)
-		rest = after[j+1:]
+		rest = tail
 	}
 	return b.String(), nil
 }

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -182,6 +182,13 @@ func resolveUpstream(upstream, health string, env []string) (origin, healthURL, 
 
 	if upstream == "" {
 		port = envPort(env, "GO_PORT", "7777")
+		if port == "" {
+			// GO_PORT is SET but empty (distinct from absent, which envPort
+			// would have defaulted to "7777"): "http://localhost:" + "" round-trips
+			// verbatim past url.Parse (Host "localhost:", Port() "") and Go's http
+			// client then silently dials port 80 — an undiagnosable "server down".
+			return "", "", "", fmt.Errorf("GO_PORT is set but empty — unset it or give it a port number")
+		}
 		origin = "http://localhost:" + port
 		return origin, origin + health, port, nil
 	}
@@ -203,6 +210,15 @@ func resolveUpstream(upstream, health string, env []string) (origin, healthURL, 
 	}
 	if u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
 		return "", "", "", fmt.Errorf("[dev].upstream %q: must be an origin only (no path/query/fragment)", expanded)
+	}
+	if strings.HasSuffix(u.Host, ":") && u.Port() == "" {
+		// A present-but-empty env var expanding into a literal ":" in the
+		// template (e.g. "http://localhost:${ADDR}" with ADDR="") round-trips
+		// through url.Parse unnoticed (Host "localhost:", Port() ""), and Go's
+		// http client then silently dials port 80 — an undiagnosable "server
+		// down". Reject it, naming the template and its expansion so the
+		// empty env var is obvious.
+		return "", "", "", fmt.Errorf("[dev].upstream %q expands to %q: host %q has an empty port (bare trailing \":\") — check the referenced env var(s) aren't empty", upstream, expanded, u.Host)
 	}
 
 	origin = u.Scheme + "://" + u.Host

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -159,6 +159,56 @@ func expandEnvRefs(s string, env []string) (string, error) {
 	return b.String(), nil
 }
 
+// resolveUpstream resolves [dev].upstream/health into the origin gsx dev
+// probes and reports, and the healthURL it probes — the single source of
+// truth also injected into the vite child as GSX_DEV_UPSTREAM (origin only,
+// no path) so the plugin's devFallback() and gsx dev's panel/probe never
+// drift from independently-guessed env vars.
+//
+// upstream is observational only: it never changes where the app listens.
+// Empty upstream defaults to http://localhost:${GO_PORT|7777} — exactly
+// today's behavior, zero migration. A non-empty upstream is ${VAR}-expanded
+// (expandEnvRefs) against env, then parsed as an absolute http/https URL; a
+// non-empty path/query/fragment is rejected since upstream must be an origin.
+// health defaults to "/healthz" and must be an absolute path; healthURL is
+// origin+health. port is u.Port() (may be empty when the URL carries none).
+func resolveUpstream(upstream, health string, env []string) (origin, healthURL, port string, err error) {
+	if health == "" {
+		health = "/healthz"
+	}
+	if !strings.HasPrefix(health, "/") {
+		return "", "", "", fmt.Errorf("[dev].health %q must start with \"/\"", health)
+	}
+
+	if upstream == "" {
+		port = envPort(env, "GO_PORT", "7777")
+		origin = "http://localhost:" + port
+		return origin, origin + health, port, nil
+	}
+
+	expanded, err := expandEnvRefs(upstream, env)
+	if err != nil {
+		return "", "", "", fmt.Errorf("[dev].upstream: %w", err)
+	}
+
+	u, err := url.Parse(expanded)
+	if err != nil {
+		return "", "", "", fmt.Errorf("[dev].upstream %q: invalid URL: %w", expanded, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", "", "", fmt.Errorf("[dev].upstream %q: scheme must be http or https", expanded)
+	}
+	if u.Host == "" {
+		return "", "", "", fmt.Errorf("[dev].upstream %q: missing host", expanded)
+	}
+	if u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return "", "", "", fmt.Errorf("[dev].upstream %q: must be an origin only (no path/query/fragment)", expanded)
+	}
+
+	origin = u.Scheme + "://" + u.Host
+	return origin, origin + health, u.Port(), nil
+}
+
 // resolveViteDevEnv resolves the Vite dev server's host:port and folds it
 // back into env as VITE_PORT/VITE_DEV_URL for the spawned front door and Go
 // server to agree on.

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -119,6 +119,46 @@ func envLookup(env []string, key string) (string, bool) {
 // envValue is envPort by another name for non-port keys (VITE_DEV_URL).
 func envValue(env []string, key, def string) string { return envPort(env, key, def) }
 
+// expandEnvRefs replaces every ${NAME} reference in s with NAME's value
+// looked up in env (a KEY=VALUE slice, e.g. the merged shell+.env env
+// resolveViteDevEnv works from). Expansion is a single pass: an expanded
+// value is never itself re-scanned for further ${...} references. A bare $
+// or $VAR with no braces is left untouched — only ${...} is special, and
+// there is no escape mechanism.
+//
+// An unset variable, an empty name (${}), or an unterminated ${ (no closing
+// }) is a startup error rather than a silent empty string; the error names
+// the offending reference/variable so a bad gsx.toml [dev].upstream fails
+// loudly.
+func expandEnvRefs(s string, env []string) (string, error) {
+	var b strings.Builder
+	rest := s
+	for {
+		i := strings.Index(rest, "${")
+		if i < 0 {
+			b.WriteString(rest)
+			break
+		}
+		b.WriteString(rest[:i])
+		after := rest[i+2:]
+		j := strings.IndexByte(after, '}')
+		if j < 0 {
+			return "", fmt.Errorf("unterminated %q in %q", rest[i:], s)
+		}
+		name := after[:j]
+		if name == "" {
+			return "", fmt.Errorf("empty %q reference in %q", "${}", s)
+		}
+		v, ok := envLookup(env, name)
+		if !ok {
+			return "", fmt.Errorf("unset env var %q referenced in %q", name, s)
+		}
+		b.WriteString(v)
+		rest = after[j+1:]
+	}
+	return b.String(), nil
+}
+
 // resolveViteDevEnv resolves the Vite dev server's host:port and folds it
 // back into env as VITE_PORT/VITE_DEV_URL for the spawned front door and Go
 // server to agree on.

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -126,9 +126,14 @@ func TestMergeDotEnv(t *testing.T) {
 
 // TestExpandEnvRefs pins ${VAR} expansion semantics for [dev].upstream: single
 // pass (no re-expansion of expanded values), bare $/$VAR left untouched, and
-// unset/malformed references are startup errors naming the offending var.
+// unset/malformed/set-but-empty references are startup errors naming the
+// offending var. Set-but-empty is an error (not a silent ""): the guard exists
+// so e.g. ADDR="" doesn't quietly collapse "http://localhost${ADDR}" to
+// "http://localhost" (port 80, no diagnostic) — see TestResolveUpstream's
+// "set-but-empty var referenced with no literal colon" case for the
+// end-to-end shape this was found in.
 func TestExpandEnvRefs(t *testing.T) {
-	env := []string{"ADDR=:8890", "SCHEME=http", "P=9000"}
+	env := []string{"ADDR=:8890", "SCHEME=http", "P=9000", "EMPTY="}
 
 	cases := []struct {
 		name    string
@@ -139,6 +144,7 @@ func TestExpandEnvRefs(t *testing.T) {
 		{name: "single var concatenation", in: "http://localhost${ADDR}", want: "http://localhost:8890"},
 		{name: "multi var", in: "${SCHEME}://x:${P}", want: "http://x:9000"},
 		{name: "unset var errors naming it", in: "${NOPE}", wantErr: "NOPE"},
+		{name: "set-but-empty var errors naming it", in: "http://localhost${EMPTY}", wantErr: "EMPTY"},
 		{name: "bare dollar sign untouched", in: "$ADDR literal", want: "$ADDR literal"},
 		{name: "empty braces error", in: "${}", wantErr: "${}"},
 		{name: "unterminated brace errors", in: "${X", wantErr: "${X"},
@@ -237,14 +243,36 @@ func TestResolveUpstream(t *testing.T) {
 			wantPort:      "8890",
 		},
 		{
-			// A present-but-empty env var expanding into a literal ":" in the
-			// template produces "http://localhost:" — url.Parse accepts it
-			// silently (Host "localhost:", Port ""), and Go's http client would
-			// then dial port 80 without complaint, giving an undiagnosable
-			// "server down". This must be a resolution error naming the value.
-			name:          "explicit upstream with present-but-empty var yields bare trailing colon errors",
+			// A present-but-empty env var referenced in the template is now
+			// rejected by expandEnvRefs itself (I1 fix), naming the var, before
+			// resolveUpstream's own bare-trailing-colon guard would ever see the
+			// expansion. Was "empty port" (the bare-colon guard's message) before
+			// this fix; now the earlier, more general expandEnvRefs error fires
+			// for every shape that references the empty var, not just this one.
+			name:          "explicit upstream with present-but-empty var errors naming it",
 			upstream:      "http://localhost:${ADDR}",
 			env:           []string{"ADDR="},
+			wantErrSubstr: "ADDR",
+		},
+		{
+			// The documented canonical shape (docs/guide/config.md's
+			// upstream = "http://localhost${ADDR}") with ADDR set but empty: no
+			// literal colon is left behind by the template itself, so the
+			// bare-trailing-colon guard alone would never catch this — before the
+			// I1 fix this resolved silently to "http://localhost" (port 80, no
+			// diagnostic). Now caught at expandEnvRefs.
+			name:          "documented ADDR shape with present-but-empty var errors naming it",
+			upstream:      "http://localhost${ADDR}",
+			env:           []string{"ADDR="},
+			wantErrSubstr: "ADDR",
+		},
+		{
+			// No ${} reference at all — a hardcoded literal trailing colon in
+			// [dev].upstream. expandEnvRefs has nothing to expand (no set-but-empty
+			// var to name), so this exercises the bare-trailing-colon guard that
+			// I1 explicitly keeps for literal-":"-concat shapes.
+			name:          "literal trailing colon with no var reference still errors via bare-colon guard",
+			upstream:      "http://localhost:",
 			wantErrSubstr: "empty port",
 		},
 		{

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -236,6 +236,23 @@ func TestResolveUpstream(t *testing.T) {
 			wantHealthURL: "http://localhost:8890/live",
 			wantPort:      "8890",
 		},
+		{
+			// A present-but-empty env var expanding into a literal ":" in the
+			// template produces "http://localhost:" — url.Parse accepts it
+			// silently (Host "localhost:", Port ""), and Go's http client would
+			// then dial port 80 without complaint, giving an undiagnosable
+			// "server down". This must be a resolution error naming the value.
+			name:          "explicit upstream with present-but-empty var yields bare trailing colon errors",
+			upstream:      "http://localhost:${ADDR}",
+			env:           []string{"ADDR="},
+			wantErrSubstr: "empty port",
+		},
+		{
+			name:          "default upstream with GO_PORT present but empty errors",
+			upstream:      "",
+			env:           []string{"GO_PORT="},
+			wantErrSubstr: "GO_PORT",
+		},
 	}
 
 	for _, tc := range cases {

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -124,6 +124,49 @@ func TestMergeDotEnv(t *testing.T) {
 	})
 }
 
+// TestExpandEnvRefs pins ${VAR} expansion semantics for [dev].upstream: single
+// pass (no re-expansion of expanded values), bare $/$VAR left untouched, and
+// unset/malformed references are startup errors naming the offending var.
+func TestExpandEnvRefs(t *testing.T) {
+	env := []string{"ADDR=:8890", "SCHEME=http", "P=9000"}
+
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr string // substring expected in error, "" means no error
+	}{
+		{name: "single var concatenation", in: "http://localhost${ADDR}", want: "http://localhost:8890"},
+		{name: "multi var", in: "${SCHEME}://x:${P}", want: "http://x:9000"},
+		{name: "unset var errors naming it", in: "${NOPE}", wantErr: "NOPE"},
+		{name: "bare dollar sign untouched", in: "$ADDR literal", want: "$ADDR literal"},
+		{name: "empty braces error", in: "${}", wantErr: "${}"},
+		{name: "unterminated brace errors", in: "${X", wantErr: "${X"},
+		{name: "no refs unchanged", in: "http://localhost:7777", want: "http://localhost:7777"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandEnvRefs(tc.in, env)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expandEnvRefs(%q) = %q, nil; want error containing %q", tc.in, got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expandEnvRefs(%q) error = %q, want substring %q", tc.in, err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expandEnvRefs(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("expandEnvRefs(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // freePort binds an ephemeral port, reads back the port the OS assigned, and
 // releases it immediately. The window between release and the caller's own
 // use is a theoretical race (acceptable here, same tolerance as the other

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -167,6 +167,107 @@ func TestExpandEnvRefs(t *testing.T) {
 	}
 }
 
+// TestResolveUpstream pins [dev].upstream/health resolution: empty upstream
+// falls back to today's http://localhost:${GO_PORT|7777} behavior; a
+// non-empty upstream is ${VAR}-expanded, parsed, and must be an origin only
+// (http/https, host, no path/query/fragment).
+func TestResolveUpstream(t *testing.T) {
+	cases := []struct {
+		name          string
+		upstream      string
+		health        string
+		env           []string
+		wantOrigin    string
+		wantHealthURL string
+		wantPort      string
+		wantErrSubstr string
+	}{
+		{
+			name:          "absent upstream no GO_PORT defaults to 7777",
+			upstream:      "",
+			env:           nil,
+			wantOrigin:    "http://localhost:7777",
+			wantHealthURL: "http://localhost:7777/healthz",
+			wantPort:      "7777",
+		},
+		{
+			name:          "absent upstream honors GO_PORT",
+			upstream:      "",
+			env:           []string{"GO_PORT=8081"},
+			wantOrigin:    "http://localhost:8081",
+			wantHealthURL: "http://localhost:8081/healthz",
+			wantPort:      "8081",
+		},
+		{
+			name:          "upstream expands ADDR",
+			upstream:      "http://localhost${ADDR}",
+			env:           []string{"ADDR=:8890"},
+			wantOrigin:    "http://localhost:8890",
+			wantHealthURL: "http://localhost:8890/healthz",
+			wantPort:      "8890",
+		},
+		{
+			name:          "explicit upstream with no port",
+			upstream:      "http://mstudio",
+			wantOrigin:    "http://mstudio",
+			wantHealthURL: "http://mstudio/healthz",
+			wantPort:      "",
+		},
+		{
+			name:          "path in upstream errors",
+			upstream:      "http://localhost:8890/foo",
+			wantErrSubstr: "path",
+		},
+		{
+			name:          "non-http scheme errors",
+			upstream:      "ftp://localhost:8890",
+			wantErrSubstr: "scheme",
+		},
+		{
+			name:          "unset var in upstream errors",
+			upstream:      "http://localhost${NOPE}",
+			wantErrSubstr: "NOPE",
+		},
+		{
+			name:          "custom health path suffixes healthURL",
+			upstream:      "http://localhost:8890",
+			health:        "/live",
+			wantOrigin:    "http://localhost:8890",
+			wantHealthURL: "http://localhost:8890/live",
+			wantPort:      "8890",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origin, healthURL, port, err := resolveUpstream(tc.upstream, tc.health, tc.env)
+			if tc.wantErrSubstr != "" {
+				if err == nil {
+					t.Fatalf("resolveUpstream(%q, %q) = (%q, %q, %q), nil; want error containing %q",
+						tc.upstream, tc.health, origin, healthURL, port, tc.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Errorf("resolveUpstream(%q, %q) error = %q, want substring %q",
+						tc.upstream, tc.health, err.Error(), tc.wantErrSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveUpstream(%q, %q) unexpected error: %v", tc.upstream, tc.health, err)
+			}
+			if origin != tc.wantOrigin {
+				t.Errorf("origin = %q, want %q", origin, tc.wantOrigin)
+			}
+			if healthURL != tc.wantHealthURL {
+				t.Errorf("healthURL = %q, want %q", healthURL, tc.wantHealthURL)
+			}
+			if port != tc.wantPort {
+				t.Errorf("port = %q, want %q", port, tc.wantPort)
+			}
+		})
+	}
+}
+
 // freePort binds an ephemeral port, reads back the port the OS assigned, and
 // releases it immediately. The window between release and the caller's own
 // use is a theoretical race (acceptable here, same tolerance as the other

--- a/gen/devstatus.go
+++ b/gen/devstatus.go
@@ -16,8 +16,17 @@ type devStatus struct {
 }
 
 type serverStat struct {
-	Healthy bool   `json:"healthy"`
-	Port    string `json:"port"`
+	Healthy bool `json:"healthy"`
+	// Port is derived from the resolved upstream's URL port (empty when the
+	// upstream carries none), never from GO_PORT directly — kept for one
+	// release so an older plugin's panel (rendering ":" + server.port) still
+	// renders. See Upstream for the single source of truth.
+	Port string `json:"port"`
+	// Upstream is the resolved [dev].upstream origin (see resolveUpstream) —
+	// the single source of truth for the dev backend the health probe hits
+	// and the panel should display. The plugin renders
+	// server.upstream ?? ":" + server.port.
+	Upstream string `json:"upstream"`
 }
 
 type cycleStat struct {

--- a/gen/devstatus_test.go
+++ b/gen/devstatus_test.go
@@ -10,7 +10,7 @@ func TestStatusEventShape(t *testing.T) {
 	at := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
 	s := devStatus{
 		Phase:     "idle",
-		Server:    serverStat{Healthy: true, Port: "7777"},
+		Server:    serverStat{Healthy: true, Port: "7777", Upstream: "http://localhost:7777"},
 		LastCycle: &cycleStat{OK: true, Errors: 0, At: at},
 		FrontDoor: frontStat{State: "up", Restarts: 2},
 	}
@@ -22,7 +22,7 @@ func TestStatusEventShape(t *testing.T) {
 		t.Errorf("event/phase = %v/%v", got["event"], got["phase"])
 	}
 	srv := got["server"].(map[string]any)
-	if srv["healthy"] != true || srv["port"] != "7777" {
+	if srv["healthy"] != true || srv["port"] != "7777" || srv["upstream"] != "http://localhost:7777" {
 		t.Errorf("server = %v", srv)
 	}
 	lc := got["lastCycle"].(map[string]any)

--- a/gen/init_test.go
+++ b/gen/init_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -352,6 +353,44 @@ func TestInitScaffoldImportsDevPanel(t *testing.T) {
 	}
 	if !strings.Contains(string(mainJS), `import "virtual:gsx-devpanel";`) {
 		t.Errorf("web/main.js should import the gsx dev panel: %s", mainJS)
+	}
+}
+
+// TestInitScaffoldViteConfigHasExplicitUpstreamTarget guards against C1 from
+// the dev-upstream final review: a zero-arg devFallback() throws whenever
+// neither opts.target nor GSX_DEV_UPSTREAM is set — which happens for
+// `vite build` (the scaffold's own documented production flow) and standalone
+// `vite` (no `gsx dev`), per the spec's "fallback keeps standalone vite
+// working" pin. The template must compute the upstream once and pass it
+// explicitly to devFallback AND the proxy target so evaluation never depends
+// on GSX_DEV_UPSTREAM being present.
+//
+// This is a byte-level guard; the actual evaluation-order fix was verified by
+// running the real template through vite's loadConfigFromFile — see
+// .superpowers/sdd/final-review.md's "Fix round 1" section for the probe
+// transcript (build/no-env, serve/no-env, serve/env-injected — all resolve;
+// none throw).
+func TestInitScaffoldViteConfigHasExplicitUpstreamTarget(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if code, _, errb := initNI(t, "--module", "upstreamdemo", dir); code != 0 {
+		t.Fatalf("init failed: %d %s", code, errb)
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "vite.config.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(cfg)
+
+	zeroArg := regexp.MustCompile(`devFallback\(\s*\)`)
+	if zeroArg.MatchString(s) {
+		t.Errorf("vite.config.ts calls devFallback() with no args — throws under `vite build`/standalone vite when GSX_DEV_UPSTREAM is unset:\n%s", s)
+	}
+	if !strings.Contains(s, "devFallback({ target: upstream })") {
+		t.Errorf("vite.config.ts should pass an explicit computed target to devFallback: %s", s)
+	}
+	if !strings.Contains(s, "target: upstream,") {
+		t.Errorf("vite.config.ts proxy should use the same computed upstream as devFallback's target: %s", s)
 	}
 }
 

--- a/gen/templates/init/simple/package.json.tmpl
+++ b/gen/templates/init/simple/package.json.tmpl
@@ -7,7 +7,7 @@
     "build": "vite build"
   },
   "devDependencies": {
-    "@gsxhq/vite-plugin-gsx": "^0.7.0",
+    "@gsxhq/vite-plugin-gsx": "^0.8.0",
     "vite": "^6.0.0"
   }
 }

--- a/gen/templates/init/simple/vite.config.ts
+++ b/gen/templates/init/simple/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig(({ command, mode }) => {
   const vitePort = parseInt(env.VITE_PORT || "5173", 10);
   // Serve a self-recovering interstitial while the Go server is down/restarting
   // (instead of a raw proxy error).
-  const fallback = devFallback({ target: `http://localhost:${goPort}` });
+  const fallback = devFallback();
 
   // While the Go server is down/restarting, the dev-fallback interstitial already
   // shows it — so drop Vite's redundant "http proxy error … ECONNREFUSED" spam.
@@ -53,7 +53,7 @@ export default defineConfig(({ command, mode }) => {
         // No `ws: true` — the Go server has no WebSocket; proxying ws would
         // capture Vite's HMR socket.
         "^(?!/__vite/|/__dev).*": {
-          target: `http://localhost:${goPort}`,
+          target: process.env.GSX_DEV_UPSTREAM ?? `http://localhost:${goPort}`,
           changeOrigin: true,
           configure: fallback.configureProxy,
         },

--- a/gen/templates/init/simple/vite.config.ts
+++ b/gen/templates/init/simple/vite.config.ts
@@ -5,9 +5,17 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const goPort = env.GO_PORT || "7777";
   const vitePort = parseInt(env.VITE_PORT || "5173", 10);
+  // Single-computed upstream: `gsx dev` injects GSX_DEV_UPSTREAM into the real
+  // process env (not .env, so loadEnv above won't see it); everything else
+  // (standalone `vite`, `vite build`) falls back to GO_PORT. Passed explicitly
+  // to devFallback AND the proxy below so evaluation order can't matter — a
+  // no-args devFallback call throws when neither is set, which would break
+  // `vite build` (devFallback is inert there, but the zero-arg constructor
+  // still throws) and standalone `vite serve`.
+  const upstream = process.env.GSX_DEV_UPSTREAM ?? `http://localhost:${goPort}`;
   // Serve a self-recovering interstitial while the Go server is down/restarting
   // (instead of a raw proxy error).
-  const fallback = devFallback();
+  const fallback = devFallback({ target: upstream });
 
   // While the Go server is down/restarting, the dev-fallback interstitial already
   // shows it — so drop Vite's redundant "http proxy error … ECONNREFUSED" spam.
@@ -53,7 +61,7 @@ export default defineConfig(({ command, mode }) => {
         // No `ws: true` — the Go server has no WebSocket; proxying ws would
         // capture Vite's HMR socket.
         "^(?!/__vite/|/__dev).*": {
-          target: process.env.GSX_DEV_UPSTREAM ?? `http://localhost:${goPort}`,
+          target: upstream,
           changeOrigin: true,
           configure: fallback.configureProxy,
         },

--- a/gen/templates/init/simple/vite.config.ts
+++ b/gen/templates/init/simple/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig(({ command, mode }) => {
   const goPort = env.GO_PORT || "7777";
   const vitePort = parseInt(env.VITE_PORT || "5173", 10);
   // Single-computed upstream: `gsx dev` injects GSX_DEV_UPSTREAM into the real
-  // process env (not .env, so loadEnv above won't see it); everything else
+  // process env, injected by gsx dev at spawn; everything else
   // (standalone `vite`, `vite build`) falls back to GO_PORT. Passed explicitly
   // to devFallback AND the proxy below so evaluation order can't matter — a
   // no-args devFallback call throws when neither is set, which would break


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-23-dev-upstream-single-source-design.md` — born from a real one-learning incident (`.env ADDR=:8890`, panel forever "server down :7777").

- `gsx.toml [dev].upstream` (`${VAR}`-expanded against the merged env, shell wins) + `[dev].health`; default reproduces today's `GO_PORT`/7777 behavior exactly. Unset **or empty** referenced vars error loudly, as do path-bearing or trailing-colon origins — never a silent port-80 probe.
- `gsx dev` derives its health probe and the panel's server row from the resolved upstream, and injects `GSX_DEV_UPSTREAM` into the front-door env (the token-injection direction; observational only — the app still owns where it listens).
- Scaffold's `vite.config.ts` computes the upstream once (`GSX_DEV_UPSTREAM ?? localhost:GO_PORT`) and passes it explicitly, so env-injected serve, standalone `vite`, and `vite build` all work.
- Bonus fix caught in review: a bad `.env` edit previously zero-valued the resolution locals, permanently silencing all pushes; errors now keep last-good values and post an overlay (the pre-existing `envErr` path harmonized too).

**Merge order:** gsxhq/vite-plugin-gsx#3 must merge + release first; the scaffold pin (`^0.7.0`) then gets bumped here to the npm-verified released version before this merges.

Verification: full `gen` suite green (minus the `:7799`-hardcoded teardown test blocked by a live local process — CI arbitrates); live two-phase browser smoke (default config, then the one-learning `ADDR` shape — panel showed `healthy http://localhost:7919` from `upstream = "http://localhost${ADDR}"`); adversarial final review with real-bytes cross-repo probes, two rounds.

**Known follow-up (filed):** with fast warm startups, all startup status posts can precede vite's boot, leaving a fresh panel at "waiting for status" until the first cycle; candidate fix is re-posting status on `pollCommands`' first contact.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576