### PR TITLE
feat(dev): inject GSX_DEV_LOG into the front-end env

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -84,7 +84,7 @@ argument. Keep `build` and `run` pointed at the same binary.
 | `web` | `["npx", "vite"]` | Front-end command. |
 | `build` | `go build` to a per-project binary | Backend build command. |
 | `run` | the default built binary | Backend command. |
-| `log` | off | File that also receives backend output. |
+| `log` | off | File that also receives backend output; its absolute path is injected into the front-end process as `GSX_DEV_LOG`. |
 | `no_web` | `false` | Disable the front-end command. |
 | `host` | from `VITE_DEV_URL`, otherwise `localhost` | Hostname used in `VITE_DEV_URL`. |
 
@@ -113,7 +113,10 @@ health = "/healthz"
 to `7777`. `health` is the path probed on `upstream` and defaults to
 `/healthz`. `upstream` is observational only — it retargets the health probe
 and dev panel, and is injected into the front-end process as
-`GSX_DEV_UPSTREAM`; it never changes where the backend listens.
+`GSX_DEV_UPSTREAM`; it never changes where the backend listens. When
+`[dev].log` is set, its resolved absolute path is likewise injected as
+`GSX_DEV_LOG`, so the Vite plugin can read the backend log without
+guessing paths; the variable is absent when logging is off.
 
 ## Pipeline filters
 

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -160,10 +160,23 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	}
 	fdCh := make(chan frontStat, 8)
 	if dc.web != nil {
+		// The backend log's location rides the same env bus as the upstream
+		// origin (GSX_DEV_UPSTREAM): resolved once, absolute, so the plugin
+		// never guesses paths relative to a cwd it doesn't share. Absent when
+		// logging is off — the plugin treats that as "no log to read".
+		// filepath.Abs matches os.Create's resolution of the same value at
+		// startup (both against this process's cwd), so the env always names
+		// the file actually being written.
+		childEnv := append(slices.Clone(env), "GSX_DEV_TOKEN="+devToken, "GSX_DEV_UPSTREAM="+origin)
+		if dc.logPath != "" {
+			if abs, aerr := filepath.Abs(dc.logPath); aerr == nil {
+				childEnv = append(childEnv, "GSX_DEV_LOG="+abs)
+			}
+		}
 		spawn := func() (*exec.Cmd, error) {
 			c := exec.Command(dc.web[0], dc.web[1:]...)
 			c.Dir, c.Stdout, c.Stderr = workDir, mkWriter("vite"), mkWriter("vite")
-			c.Env = append(slices.Clone(env), "GSX_DEV_TOKEN="+devToken, "GSX_DEV_UPSTREAM="+origin)
+			c.Env = slices.Clone(childEnv)
 			setProcGroup(c)
 			return c, c.Start()
 		}

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -362,7 +362,8 @@ func main() {
 //     GO_PORT default it would otherwise fall back to);
 //   - a status event carries that same origin/port (the panel wire shape);
 //   - the front door's spawned env carries GSX_DEV_UPSTREAM=<resolved origin>
-//     (the vite-plugin cross-repo contract line).
+//     and GSX_DEV_LOG=<absolute [dev].log path> (the vite-plugin cross-repo
+//     contract lines).
 func TestDevUpstreamSingleSource(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration test: requires building gsx and a live Go server")
@@ -390,12 +391,13 @@ func TestDevUpstreamSingleSource(t *testing.T) {
 	port := freePort(t)
 	addr := ":" + port
 	writeFile(t, proj, ".env", "ADDR="+addr+"\n")
-	writeFile(t, proj, "gsx.toml", "[dev]\nupstream = \"http://localhost${ADDR}\"\n")
-	// The front door's actual job here is just to prove GSX_DEV_UPSTREAM
-	// reaches its env — it writes the var to a marker file rather than
-	// serving Vite. Two whitespace-separated argv (no embedded quoting), so
-	// the --web flag's splitArgv (strings.Fields) parses it correctly.
-	writeFile(t, proj, "webstub.sh", "#!/bin/sh\necho \"$GSX_DEV_UPSTREAM\" > marker.txt\nsleep 600\n")
+	writeFile(t, proj, "gsx.toml", "[dev]\nupstream = \"http://localhost${ADDR}\"\nlog = \"tmp/dev.log\"\n")
+	// The front door's actual job here is just to prove GSX_DEV_UPSTREAM and
+	// GSX_DEV_LOG reach its env — it writes both (one per line) to a marker
+	// file rather than serving Vite. Two whitespace-separated argv (no
+	// embedded quoting), so the --web flag's splitArgv (strings.Fields)
+	// parses it correctly.
+	writeFile(t, proj, "webstub.sh", "#!/bin/sh\n{ echo \"$GSX_DEV_UPSTREAM\"; echo \"$GSX_DEV_LOG\"; } > marker.txt\nsleep 600\n")
 
 	if portListening(port) {
 		t.Fatalf("port %s already in use (leaked scaffold server?)", port)
@@ -500,7 +502,8 @@ func TestDevUpstreamSingleSource(t *testing.T) {
 		t.Errorf("no healthy status observed; status log:\n%s", statusEvents.String())
 	}
 
-	// Assert the front door's spawned env carried GSX_DEV_UPSTREAM.
+	// Assert the front door's spawned env carried GSX_DEV_UPSTREAM and
+	// GSX_DEV_LOG.
 	markerPath := filepath.Join(proj, "marker.txt")
 	var markerContent string
 	markerDeadline := time.Now().Add(15 * time.Second)
@@ -511,8 +514,25 @@ func TestDevUpstreamSingleSource(t *testing.T) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if markerContent != wantOrigin {
-		t.Errorf("GSX_DEV_UPSTREAM in front-door env = %q, want %q", markerContent, wantOrigin)
+	markerLines := strings.Split(markerContent, "\n")
+	if markerLines[0] != wantOrigin {
+		t.Errorf("GSX_DEV_UPSTREAM in front-door env = %q, want %q", markerLines[0], wantOrigin)
+	}
+	// GSX_DEV_LOG must be absolute and name the file gsx dev actually
+	// writes (TempDir may be behind a symlink on macOS, so compare by
+	// stat-ing the env's own path rather than string-equality against proj).
+	if len(markerLines) < 2 || markerLines[1] == "" {
+		t.Fatalf("GSX_DEV_LOG missing from front-door env; marker=%q", markerContent)
+	}
+	gotLog := markerLines[1]
+	if !filepath.IsAbs(gotLog) {
+		t.Errorf("GSX_DEV_LOG = %q, want an absolute path", gotLog)
+	}
+	if filepath.Base(gotLog) != "dev.log" || filepath.Base(filepath.Dir(gotLog)) != "tmp" {
+		t.Errorf("GSX_DEV_LOG = %q, want .../tmp/dev.log", gotLog)
+	}
+	if _, err := os.Stat(gotLog); err != nil {
+		t.Errorf("GSX_DEV_LOG names %q but stat failed: %v (env must point at the file actually written)", gotLog, err)
 	}
 }
 


### PR DESCRIPTION
When `[dev].log` is set, `gsx dev` resolves it to an absolute path and injects it into the vite child's env as `GSX_DEV_LOG`, alongside `GSX_DEV_UPSTREAM` — same single-source rationale as #155: the vite plugin (dev panel) can read the backend log without guessing paths. Absent when logging is off.

- `gen/dev.go`: resolve once before the spawn closure (front-door restarts reuse it); `filepath.Abs` matches `os.Create`'s resolution of the same value at startup, so the env always names the file actually being written.
- `gen/dev_test.go`: `TestDevUpstreamSingleSource` now pins both contract lines (webstub echoes both vars; the log assertion stats the env's own path to dodge macOS TempDir symlinks).
- `docs/guide/config.md`: `log` row + upstream section document the new bus line.

Consumer side (vite-plugin-gsx reader) follows separately.

https://claude.ai/code/session_01XzCy6Svtqnm9P6kYCsBA9N