### PR TITLE
fix(gen): re-post dev status on first front-door contact

### DIFF
--- a/gen/dev.go
+++ b/gen/dev.go
@@ -193,7 +193,22 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	}
 
 	cmds := make(chan string, 8)
-	go pollCommands(ctx, viteURL, devToken, webUp, cmds)
+	// contactCh fires exactly once, the moment pollCommands' first successful
+	// response proves the front door is actually serving our plugin (its gate
+	// opens optimistically on process start — see frontDoor — well before
+	// vite/npm has finished booting on a warm start). The status-cache-driven
+	// dev panel would otherwise wait forever for a cycle that may never come
+	// on an idle project; this re-posts the CURRENT status once contact is
+	// made, deliberately fresh rather than a longer retry of the possibly-stale
+	// startup post.
+	contactCh := make(chan struct{}, 1)
+	onContact := func() {
+		select {
+		case contactCh <- struct{}{}:
+		default: // already signaled; onContact only ever fires once anyway
+		}
+	}
+	go pollCommands(ctx, viteURL, devToken, webUp, cmds, onContact)
 
 	// --- Go server: initial build + run ---
 	srv := &devServer{dir: workDir, build: dc.build, run: dc.run, env: env, out: serverOut, buildOut: gsxOut, healthURL: healthURL}
@@ -360,6 +375,13 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 
 		case fs := <-fdCh:
 			status.FrontDoor = fs
+			postStatus()
+
+		case <-contactCh:
+			// First proof the front door is actually serving our plugin
+			// (see contactCh's declaration above): re-post the current
+			// status so a panel that opened before any cycle ran no longer
+			// waits forever on an idle project.
 			postStatus()
 
 		case ev, ok := <-w.Events:

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -1047,6 +1047,148 @@ func TestDevPanelRebuildCommand(t *testing.T) {
 	}
 }
 
+// TestDevRepostsStatusOnFirstFrontDoorContact reproduces the warm-start bug:
+// npm/vite can take longer to bind the front-door port than postBest's
+// ~1.6s retry window on the startup status post, so a freshly opened dev
+// panel's status cache stays empty forever on an idle project (no later
+// cycle ever re-posts to fill it in). It proves the fix: pollCommands'
+// long-poll against the front door succeeding for the FIRST time — proof
+// vite is actually up — makes gsx dev re-post the current status, with no
+// panel command sent and no source change.
+//
+// The managed front door here is "sleep 600": it never listens on the
+// resolved URL at all. frontDoor's gate opens immediately on process start
+// regardless (first-instance semantics — see frontdoor.go), so pollCommands
+// starts polling that URL right away and hits connection-refused, backing
+// off, exactly like a real vite that hasn't finished booting yet. Only
+// after gsx dev is confirmed healthy AND a few seconds have passed (long
+// past the historical startup-post retry window, and enough for pollCommands
+// to have backed off at least once) does the test bind the resolved
+// front-door port — standing in for vite finally coming up. From that point
+// on nothing else happens: no /__gsx/cmd command is queued, nothing on disk
+// changes. A status event must still arrive promptly, sourced purely from
+// pollCommands' first successful long-poll.
+func TestDevRepostsStatusOnFirstFrontDoorContact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGo)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+	if portListening("7829") {
+		t.Fatal("port 7829 already in use (leaked scaffold server?)")
+	}
+
+	cmd := exec.Command(bin, "dev", "--web", "sleep 600")
+	cmd.Dir = proj
+	cmd.Env = devTestEnv(
+		"BROWSER=none",
+		"GO_PORT=7829",
+		"VITE_DEV_URL=http://127.0.0.1",
+		"GOFLAGS=-mod=mod",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer stopDevGracefully(cmd)
+
+	if !waitHealthy(context.Background(), "http://localhost:7829/healthz", 120*time.Second) {
+		t.Fatalf("server never came up; output:\n%s", stdout.String())
+	}
+
+	// Learn the resolved front-door URL from the "watching … — open <url>" line
+	// (VITE_DEV_URL above deliberately carries no port, so nothing but gsx
+	// dev's own auto-picker determines it — the test cannot pre-bind it).
+	var viteURL string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := regexp.MustCompile(`open (http://\S+)`).FindStringSubmatch(stdout.String()); m != nil {
+			viteURL = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if viteURL == "" {
+		t.Fatalf("front-door URL not printed; stdout=%q", stdout.String())
+	}
+	u, err := url.Parse(viteURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the warm-start delay: gsx dev and its Go server are fully up
+	// and healthy, yet nothing is listening at the resolved front-door port
+	// for a few more seconds — long past postBest's ~1.6s retry window on the
+	// startup status post, and long enough for pollCommands to have hit
+	// connection-refused and backed off at least once.
+	time.Sleep(3 * time.Second)
+
+	// NOW bind "vite". No /__gsx/cmd command is ever queued and nothing on
+	// disk changes from here on — the only thing that can make a status
+	// event arrive is pollCommands' long-poll finally succeeding.
+	var statusEvents lockedBuffer
+	fake := &http.Server{
+		Addr: net.JoinHostPort(u.Hostname(), u.Port()),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-gsx", "1")
+			switch r.URL.Path {
+			case "/__gsx/cmd":
+				w.WriteHeader(204) // idle long-poll: no commands queued, ever
+			case "/__gsx/event":
+				body, _ := io.ReadAll(r.Body)
+				if strings.Contains(string(body), `"event":"status"`) {
+					statusEvents.Write(append(body, '\n'))
+				}
+				w.WriteHeader(204)
+			default:
+				w.WriteHeader(204)
+			}
+		}),
+	}
+	fl, err := net.Listen("tcp", fake.Addr)
+	if err != nil {
+		t.Fatalf("bind resolved front-door port %s: %v", fake.Addr, err)
+	}
+	go func() { _ = fake.Serve(fl) }()
+	defer fake.Close()
+
+	// pollCommands' connection-refused backoff caps at 5s; give it a generous
+	// margin above that on top of the actual poll/round-trip for CI headroom.
+	deadline = time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(statusEvents.String(), `"event":"status"`) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !strings.Contains(statusEvents.String(), `"event":"status"`) {
+		t.Fatalf("no status event posted within 20s of the front door binding (first-contact repost missing); gsx dev stdout:\n%s", stdout.String())
+	}
+	if !strings.Contains(statusEvents.String(), `"healthy":true`) {
+		t.Errorf("no healthy status observed; status log:\n%s", statusEvents.String())
+	}
+}
+
 // TestDevEnvErrorPostsOverlay is the final-review fix-round-1 regression test
 // for the envErr branch of the .env-fire path (gen/dev.go): a resolveViteDevEnv
 // failure (e.g. an .env edit that sets VITE_PORT to a port already in use)

--- a/gen/devcmd.go
+++ b/gen/devcmd.go
@@ -19,7 +19,17 @@ import (
 // to match before releasing anything from the mailbox (else 403, without
 // draining it); when unconfigured (externally-run vite, --no-web) the plugin
 // ignores the header entirely, so sending it is always safe.
-func pollCommands(ctx context.Context, base, token string, up func() bool, out chan<- string) {
+//
+// onContact, when non-nil, is invoked exactly once — on the first successful
+// response (200 or 204, the same paths that already reset backoff) seen
+// across this call's lifetime. It never fires for transport errors, non-2xx
+// statuses, or malformed bodies, and never fires again afterward. This is the
+// earliest proof that the front door is actually serving our plugin (a
+// managed vite's gate opens optimistically on process start, well before it
+// necessarily answers requests — see frontDoor), used by runDev to re-post
+// the current status once instead of leaving a warm-started panel waiting
+// forever for a cycle that may never come.
+func pollCommands(ctx context.Context, base, token string, up func() bool, out chan<- string, onContact func()) {
 	if strings.HasPrefix(base, "/") || base == "" {
 		return
 	}
@@ -31,6 +41,15 @@ func pollCommands(ctx context.Context, base, token string, up func() bool, out c
 			return false
 		case <-time.After(d):
 			return true
+		}
+	}
+	contacted := false
+	signalContact := func() {
+		if !contacted {
+			contacted = true
+			if onContact != nil {
+				onContact()
+			}
 		}
 	}
 	for ctx.Err() == nil {
@@ -57,6 +76,7 @@ func pollCommands(ctx context.Context, base, token string, up func() bool, out c
 		resp.Body.Close()
 		if resp.StatusCode == http.StatusNoContent {
 			backoff = time.Second
+			signalContact()
 			continue // idle long-poll: immediately re-poll
 		}
 		if resp.StatusCode != http.StatusOK {
@@ -81,6 +101,7 @@ func pollCommands(ctx context.Context, base, token string, up func() bool, out c
 			continue
 		}
 		backoff = time.Second
+		signalContact()
 		for _, c := range payload.Cmds {
 			select {
 			case out <- c:

--- a/gen/devcmd_test.go
+++ b/gen/devcmd_test.go
@@ -46,7 +46,7 @@ func TestPollCommandsDeliversAndRepolls(t *testing.T) {
 	)
 	ctx := t.Context()
 	out := make(chan string, 8)
-	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out)
+	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out, nil)
 
 	want := []string{"rebuild", "restart-server", "rebuild"}
 	for i, w := range want {
@@ -65,7 +65,7 @@ func TestPollCommandsSuspendedWhileGateDown(t *testing.T) {
 	srv, calls := cmdServer(t, respondCmds("rebuild"))
 	ctx := t.Context()
 	out := make(chan string, 1)
-	go pollCommands(ctx, srv.URL, "tok", func() bool { return false }, out)
+	go pollCommands(ctx, srv.URL, "tok", func() bool { return false }, out, nil)
 	time.Sleep(600 * time.Millisecond)
 	if calls.Load() != 0 {
 		t.Errorf("polled %d times while gate down; want 0", calls.Load())
@@ -83,7 +83,10 @@ func TestPollCommandsSurvivesServerDown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	out := make(chan string, 1)
 	done := make(chan struct{})
-	go func() { pollCommands(ctx, "http://127.0.0.1:1", "tok", func() bool { return true }, out); close(done) }()
+	go func() {
+		pollCommands(ctx, "http://127.0.0.1:1", "tok", func() bool { return true }, out, nil)
+		close(done)
+	}()
 	time.Sleep(2500 * time.Millisecond)
 	cancel()
 	select {
@@ -111,7 +114,7 @@ func TestPollCommandsSendsTokenHeader(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	out := make(chan string, 1)
 	done := make(chan struct{})
-	go func() { pollCommands(ctx, srv.URL, "secret-token", func() bool { return true }, out); close(done) }()
+	go func() { pollCommands(ctx, srv.URL, "secret-token", func() bool { return true }, out, nil); close(done) }()
 	time.Sleep(400 * time.Millisecond)
 	cancel()
 	select {
@@ -164,7 +167,7 @@ func TestPollCommandsBackoffOnErrorResponses(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			out := make(chan string, 1)
 			done := make(chan struct{})
-			go func() { pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out); close(done) }()
+			go func() { pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out, nil); close(done) }()
 
 			time.Sleep(1200 * time.Millisecond)
 			cancel()
@@ -181,5 +184,99 @@ func TestPollCommandsBackoffOnErrorResponses(t *testing.T) {
 				t.Errorf("polled %d times in 1.2s against a %s server; want <= 4 (busy-spin, no backoff applied)", n, tc.name)
 			}
 		})
+	}
+}
+
+// TestPollCommandsOnContactFiresOnceOnFirstSuccess proves onContact fires
+// exactly once, on the first successful response (200 or 204 — the same
+// paths that already reset backoff), and is NOT invoked for the failing
+// attempts (500, malformed-JSON 200) that precede it, nor again on any
+// later success.
+func TestPollCommandsOnContactFiresOnceOnFirstSuccess(t *testing.T) {
+	srv, calls := cmdServer(t,
+		func(w http.ResponseWriter) { w.WriteHeader(http.StatusInternalServerError) },
+		// A token-mismatch 403 (foreign tokened plugin) must not count as contact.
+		func(w http.ResponseWriter) { w.WriteHeader(http.StatusForbidden) },
+		func(w http.ResponseWriter) { w.WriteHeader(http.StatusOK); _, _ = w.Write([]byte("not json")) },
+		func(w http.ResponseWriter) { w.WriteHeader(204) }, // first success
+		respondCmds("rebuild"), // later success
+		func(w http.ResponseWriter) { w.WriteHeader(204) },
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan string, 4)
+	var contacted atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out, func() { contacted.Add(1) })
+		close(done)
+	}()
+
+	select {
+	case got := <-out:
+		if got != "rebuild" {
+			t.Fatalf("cmd = %q, want %q", got, "rebuild")
+		}
+	case <-time.After(15 * time.Second):
+		// Three failing attempts back off 1s+2s+4s before the first success.
+		t.Fatalf("timed out waiting for the rebuild cmd (calls=%d)", calls.Load())
+	}
+	// Give the loop a moment to also process the trailing 204 so a
+	// double-fire on a later success would have had its chance to happen.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("pollCommands did not return after ctx cancel")
+	}
+
+	if n := contacted.Load(); n != 1 {
+		t.Errorf("onContact called %d times, want exactly 1", n)
+	}
+}
+
+// TestPollCommandsOnContactNotCalledOnTransportError proves onContact never
+// fires while every attempt is a connection-refused transport error (no
+// success has ever occurred).
+func TestPollCommandsOnContactNotCalledOnTransportError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan string, 1)
+	var contacted atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		pollCommands(ctx, "http://127.0.0.1:1", "tok", func() bool { return true }, out, func() { contacted.Add(1) })
+		close(done)
+	}()
+	time.Sleep(2500 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pollCommands did not return within 500ms of ctx cancel")
+	}
+
+	if n := contacted.Load(); n != 0 {
+		t.Errorf("onContact called %d times against an always-refused server, want 0", n)
+	}
+}
+
+// TestPollCommandsOnContactNilSafe proves a nil onContact is safe: pollCommands
+// must keep delivering commands normally without panicking.
+func TestPollCommandsOnContactNilSafe(t *testing.T) {
+	srv, calls := cmdServer(t,
+		respondCmds("rebuild"),
+		func(w http.ResponseWriter) { w.WriteHeader(204) },
+	)
+	ctx := t.Context()
+	out := make(chan string, 8)
+	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out, nil)
+
+	select {
+	case got := <-out:
+		if got != "rebuild" {
+			t.Fatalf("cmd = %q, want %q", got, "rebuild")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for cmd (calls=%d)", calls.Load())
 	}
 }


### PR DESCRIPTION
Fixes the user-reproduced "waiting for status… (is gsx dev running?)" panel state (gsxui, `make site-dev`): on warm starts every startup status post fires before the vite front door finishes booting, expires unheard, and nothing re-posts on an idle project.

`pollCommands` gains a fire-once `onContact` callback on its first successful poll response (200/204 only — errors, 403s from foreign tokened plugins, and malformed bodies never count), wired through a buffered channel into the select loop to re-post the CURRENT status — fresh values, not a longer retry of a stale post.

Review clean (including a revert-probe proving the integration test bites, and a trace confirming the repost rides the existing cold-start trust boundary, unwidened). Full `gen` suite green locally (240s — thanks #157), `-race` clean, `make lint` clean.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576