### PR TITLE
fix(dev): disable HTTP keep-alives in the dev loop's helper clients

### DIFF
--- a/gen/devcmd.go
+++ b/gen/devcmd.go
@@ -33,7 +33,7 @@ func pollCommands(ctx context.Context, base, token string, up func() bool, out c
 	if strings.HasPrefix(base, "/") || base == "" {
 		return
 	}
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := devHTTPClient(30 * time.Second)
 	backoff := time.Second
 	sleep := func(d time.Duration) bool {
 		select {

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -338,7 +338,8 @@ func setEnvValue(env []string, key, value string) []string {
 }
 
 // devHTTPClient returns a client for the dev loop's chatter with the Vite dev
-// server and the backend (health polls, overlay pushes, command polls), with
+// server and the backend (health polls, overlay pushes, command polls, front
+// door verification), with
 // keep-alives disabled. An idle pooled connection to Vite (Node) is torn down
 // by Node's keepAliveTimeout, and the teardown can emit an unsolicited
 // "HTTP/1.1 400 Bad Request" that Go's transport logs to the terminal as

--- a/gen/devserver.go
+++ b/gen/devserver.go
@@ -337,11 +337,25 @@ func setEnvValue(env []string, key, value string) []string {
 	return append(env, pre+value)
 }
 
+// devHTTPClient returns a client for the dev loop's chatter with the Vite dev
+// server and the backend (health polls, overlay pushes, command polls), with
+// keep-alives disabled. An idle pooled connection to Vite (Node) is torn down
+// by Node's keepAliveTimeout, and the teardown can emit an unsolicited
+// "HTTP/1.1 400 Bad Request" that Go's transport logs to the terminal as
+// "Unsolicited response received on idle HTTP channel" — alarming noise in
+// every gsx dev session. These clients make at most one localhost request
+// every few seconds, so per-request connections cost nothing.
+func devHTTPClient(timeout time.Duration) *http.Client {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DisableKeepAlives = true
+	return &http.Client{Timeout: timeout, Transport: t}
+}
+
 // waitHealthy polls url until it returns any HTTP status (2xx–5xx ⇒ the server
 // is accepting connections) or timeout elapses. A refused connection retries.
 func waitHealthy(ctx context.Context, url string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
-	client := &http.Client{Timeout: 500 * time.Millisecond}
+	client := devHTTPClient(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		select {
 		case <-ctx.Done():
@@ -432,7 +446,7 @@ func postBest(url string, body []byte, gate func() bool) {
 		return
 	}
 	go func() {
-		client := &http.Client{Timeout: 2 * time.Second}
+		client := devHTTPClient(2 * time.Second)
 		for range 10 {
 			if gate != nil && !gate() {
 				return

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -540,6 +540,53 @@ func TestWaitHealthy(t *testing.T) {
 	}
 }
 
+// The dev loop's HTTP helpers chatter with the Vite dev server (Node). A
+// pooled keep-alive connection left idle there is torn down by Node's
+// keepAliveTimeout, and the teardown can emit an unsolicited
+// "HTTP/1.1 400 Bad Request" that Go's transport logs to the terminal
+// ("Unsolicited response received on idle HTTP channel ...") — alarming noise
+// in every gsx dev session. Each helper must therefore close its connection
+// per request (Connection: close) so no idle socket is ever parked in a pool.
+func TestDevHTTPHelpersCloseConnections(t *testing.T) {
+	got := make(chan bool, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case got <- r.Close:
+		default: // pollCommands re-polls in a loop; drop extras
+		}
+		if r.URL.Path == "/__gsx/cmd" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	recv := func(name string) {
+		t.Helper()
+		select {
+		case closed := <-got:
+			if !closed {
+				t.Errorf("%s: request left connection open (want Connection: close)", name)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s: no request received", name)
+		}
+	}
+
+	waitHealthy(context.Background(), srv.URL+"/healthz", 2*time.Second)
+	recv("waitHealthy")
+
+	postEvent(srv.URL, []byte(`{}`), nil)
+	recv("postEvent")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out := make(chan string, 1)
+	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out)
+	recv("pollCommands")
+	cancel()
+}
+
 func TestAggregateEvent(t *testing.T) {
 	results := []cycleResult{
 		{Dir: "a", Written: []string{"/x/a.x.go"}, OK: true, DurMs: 2},

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -582,7 +582,7 @@ func TestDevHTTPHelpersCloseConnections(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	out := make(chan string, 1)
-	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out)
+	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out, nil)
 	recv("pollCommands")
 	cancel()
 }

--- a/gen/devserver_test.go
+++ b/gen/devserver_test.go
@@ -580,6 +580,9 @@ func TestDevHTTPHelpersCloseConnections(t *testing.T) {
 	postEvent(srv.URL, []byte(`{}`), nil)
 	recv("postEvent")
 
+	verifyFrontDoor(context.Background(), srv.URL, "tok")
+	recv("verifyFrontDoor")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	out := make(chan string, 1)
 	go pollCommands(ctx, srv.URL, "tok", func() bool { return true }, out, nil)

--- a/gen/frontdoor.go
+++ b/gen/frontdoor.go
@@ -80,7 +80,7 @@ func verifyFrontDoor(ctx context.Context, url, token string) bool {
 		return false
 	}
 	req.Header.Set("x-gsx-token", token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := devHTTPClient(2 * time.Second).Do(req)
 	if err != nil {
 		return false
 	}

--- a/gen/templates/init/simple/go.mod.tmpl
+++ b/gen/templates/init/simple/go.mod.tmpl
@@ -2,4 +2,4 @@ module «.Module»
 
 go 1.24
 
-require github.com/gsxhq/vite v0.2.0
+require github.com/gsxhq/vite v0.3.2


### PR DESCRIPTION
Every `gsx dev` session eventually prints

    Unsolicited response received on idle HTTP channel starting with "HTTP/1.1 400 Bad Request\r\n\r\n"; err=<nil>

which looks like something is broken. Nothing is: Go's transport logs this when a server writes on a connection the client parked idle in its keep-alive pool. The bare status line with no headers is Node's stock `clientError` reply — Node (Vite) tears down idle keep-alive sockets after ~5s (`keepAliveTimeout`), and the teardown race can fire that 400 down the wire.

The pooled connections belong to `waitHealthy`, `postBest`, and `pollCommands`, which all shared `http.DefaultTransport`. None of them benefit from pooling (at most one localhost request every few seconds), so this gives them a shared `devHTTPClient` with `DisableKeepAlives: true` — every request sends `Connection: close`, and no idle socket ever exists for Node to write to.

Pinned by `TestDevHTTPHelpersCloseConnections` (server-side `r.Close` assertion for all three helpers), watched RED before the fix.

Sibling fix for the app-side helper: gsxhq/vite#1 (`NotifyReload` had the same latent issue via `http.DefaultClient`).

https://claude.ai/code/session_01QA44dyPcgxnjeJJDhcEKak
