### PR TITLE
fix(gen): anchor relative [dev].log to the project directory

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -84,7 +84,7 @@ argument. Keep `build` and `run` pointed at the same binary.
 | `web` | `["npx", "vite"]` | Front-end command. |
 | `build` | `go build` to a per-project binary | Backend build command. |
 | `run` | the default built binary | Backend command. |
-| `log` | off | File that also receives backend output; its absolute path is injected into the front-end process as `GSX_DEV_LOG`. |
+| `log` | off | File that also receives backend output; its absolute path is injected into the front-end process as `GSX_DEV_LOG`. A relative path resolves against `gsx.toml`'s directory, not the shell's cwd. |
 | `no_web` | `false` | Disable the front-end command. |
 | `host` | from `VITE_DEV_URL`, otherwise `localhost` | Hostname used in `VITE_DEV_URL`. |
 

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -165,8 +165,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		// never guesses paths relative to a cwd it doesn't share. Absent when
 		// logging is off — the plugin treats that as "no log to read".
 		// filepath.Abs matches os.Create's resolution of the same value at
-		// startup (both against this process's cwd), so the env always names
-		// the file actually being written.
+		// startup: a [dev].log config value already arrives workDir-anchored
+		// (see resolveDevConfig), so Abs is a no-op there; a --log-file/default
+		// value is still resolved against this process's cwd, same as os.Create
+		// — either way the env names the file actually being written.
 		childEnv := append(slices.Clone(env), "GSX_DEV_TOKEN="+devToken, "GSX_DEV_UPSTREAM="+origin)
 		if dc.logPath != "" {
 			if abs, aerr := filepath.Abs(dc.logPath); aerr == nil {

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -50,6 +50,47 @@ func TestDevExitsWhenExplicitVitePortIsInUse(t *testing.T) {
 	}
 }
 
+// TestDevWritesConfigLogUnderWorkDirNotCwd is the cheapest honest end-to-end
+// proof (no gsx binary build, no vite, no server) that a relative [dev].log
+// lands under workDir — not the gsx process's cwd — reproducing the
+// `gsx dev ./proj` shape from a different directory. proj deliberately has no
+// go.mod, so armWatchSession fails fast right after the backend-log block
+// (dev.go creates the log file before arming the watch session), giving a
+// quick, deterministic exit without needing a live project.
+//
+// Before the fix, dc.logPath ("tmp/dev.log") flowed unanchored to os.Create,
+// which resolves it against the test binary's actual cwd (this package's
+// source directory) — not proj — so the file at proj/tmp/dev.log never
+// existed.
+func TestDevWritesConfigLogUnderWorkDirNotCwd(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj := t.TempDir() // workDir: deliberately NOT cwd and has no go.mod.
+	if proj == cwd {
+		t.Fatalf("proj accidentally equals process cwd %q; test would not catch cwd-anchoring", proj)
+	}
+	td := &tomlDev{Log: "tmp/dev.log"}
+
+	var stdout, stderr bytes.Buffer
+	code := runDev(nil, &stdout, &stderr, config{}, td, proj)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (no go.mod under proj); stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no go.mod found above") {
+		t.Fatalf("stderr = %q, want the armWatchSession no-go.mod error (proves we reached the log-file block)", stderr.String())
+	}
+
+	want := filepath.Join(proj, "tmp", "dev.log")
+	if _, statErr := os.Stat(want); statErr != nil {
+		t.Errorf("log file not found at workDir-anchored path %q: %v", want, statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, "tmp", "dev.log")); statErr == nil {
+		t.Errorf("log file also (or instead) written under process cwd %q — should only exist under workDir", cwd)
+	}
+}
+
 // TestDevTeardownAndRestart is a full-stack integration test for `gsx dev`:
 //   - builds the gsx binary
 //   - scaffolds a minimal go project with a .gsx file and a /healthz endpoint

--- a/gen/devconfig.go
+++ b/gen/devconfig.go
@@ -75,6 +75,20 @@ func resolveDevConfig(workDir string, td *tomlDev, fl devFlags) devConfig {
 		}
 		if td.Log != "" {
 			dc.logPath = td.Log
+			// [dev].log is a config value: a relative path means "relative to
+			// the gsx.toml project directory" (workDir), not whatever
+			// directory the gsx process happens to be started from — running
+			// `gsx dev ./proj` from outside proj must still write under
+			// proj/tmp/dev.log. The CLI --log-file flag below keeps the
+			// opposite, cwd-anchored meaning: a path typed at a shell means
+			// the shell's cwd, matching every other path flag gsx accepts.
+			// There is no env-var INPUT for this key — GSX_DEV_LOG (set
+			// further down in dev.go) is an OUTPUT derived from dc.logPath via
+			// filepath.Abs, never a second, independently-anchored input — so
+			// no third anchoring choice applies here.
+			if !filepath.IsAbs(dc.logPath) {
+				dc.logPath = filepath.Join(workDir, dc.logPath)
+			}
 		}
 		if td.Host != "" {
 			dc.host = td.Host
@@ -99,7 +113,7 @@ func resolveDevConfig(workDir string, td *tomlDev, fl devFlags) devConfig {
 		case fl.noLog:
 			dc.logPath = ""
 		case len(fl.log) > 0:
-			dc.logPath = fl.log[0]
+			dc.logPath = fl.log[0] // --log-file: cwd-anchored, see the [dev] layer comment above.
 		default: // bare --log → cache-dir dev.log
 			dc.logPath = filepath.Join(devCacheDir(workDir), "dev.log")
 		}

--- a/gen/devconfig_test.go
+++ b/gen/devconfig_test.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -38,8 +39,10 @@ func TestResolveDevConfigTomlThenFlags(t *testing.T) {
 	if !reflect.DeepEqual(dc.web, []string{"pnpm", "vite"}) {
 		t.Errorf("web from toml = %v", dc.web)
 	}
-	if dc.logPath != "tmp/dev.log" {
-		t.Errorf("log from toml = %q", dc.logPath)
+	// A relative [dev].log anchors to workDir (the gsx.toml project
+	// directory), not the process's cwd.
+	if want := filepath.Join(wd, "tmp/dev.log"); dc.logPath != want {
+		t.Errorf("log from toml = %q, want %q", dc.logPath, want)
 	}
 	// flag overrides toml:
 	dc = resolveDevConfig(wd, td, devFlags{web: []string{"yarn", "vite"}, noLog: true, logSet: true})
@@ -92,7 +95,8 @@ func TestDevFlagsLogResolution(t *testing.T) {
 	if dc.logPath != filepath.Join(devCacheDir(wd), "dev.log") {
 		t.Errorf("--log should enable cache-dir log, got %q", dc.logPath)
 	}
-	// --log-file=PATH → that path
+	// --log-file=PATH → that path, cwd-anchored (unlike [dev].log): a path
+	// typed at a shell means the shell's cwd, not workDir.
 	dc = resolveDevConfig(wd, nil, devFlagsFromValues("", "", "", "tmp/dev.log", false, false, false))
 	if dc.logPath != "tmp/dev.log" {
 		t.Errorf("--log-file should set path, got %q", dc.logPath)
@@ -106,5 +110,65 @@ func TestDevFlagsLogResolution(t *testing.T) {
 	dc = resolveDevConfig(wd, nil, devFlagsFromValues("", "", "", "", false, false, false))
 	if dc.logPath != "" {
 		t.Errorf("no log flags should be off, got %q", dc.logPath)
+	}
+}
+
+// TestResolveDevConfigLogAnchoring pins the CONFIG-layer/FLAG-layer asymmetry:
+// a relative [dev].log anchors to workDir (the gsx.toml project directory) —
+// `gsx dev ./proj` run from elsewhere must still write proj/tmp/dev.log, not
+// $CWD/tmp/dev.log — while an already-absolute [dev].log passes through
+// untouched, and the --log-file flag keeps meaning "relative to the shell's
+// cwd" because a path typed at a shell means the shell's cwd.
+func TestResolveDevConfigLogAnchoring(t *testing.T) {
+	wd := t.TempDir() // workDir: deliberately NOT the test process's cwd.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wd == cwd {
+		t.Fatalf("test workDir accidentally equals process cwd %q; test would not catch cwd-anchoring", wd)
+	}
+
+	// Relative [dev].log anchors to workDir, not the process cwd.
+	dc := resolveDevConfig(wd, &tomlDev{Log: "tmp/dev.log"}, devFlags{})
+	want := filepath.Join(wd, "tmp/dev.log")
+	if dc.logPath != want {
+		t.Errorf("relative [dev].log = %q, want workDir-anchored %q", dc.logPath, want)
+	}
+	if cwdAnchored := filepath.Join(cwd, "tmp/dev.log"); dc.logPath == cwdAnchored && want != cwdAnchored {
+		t.Errorf("relative [dev].log resolved against cwd (%q) instead of workDir", cwdAnchored)
+	}
+
+	// An absolute [dev].log is untouched.
+	abs := filepath.Join(t.TempDir(), "custom", "backend.log")
+	dc = resolveDevConfig(wd, &tomlDev{Log: abs}, devFlags{})
+	if dc.logPath != abs {
+		t.Errorf("absolute [dev].log = %q, want unchanged %q", dc.logPath, abs)
+	}
+
+	// --log-file keeps cwd anchoring: resolveDevConfig must not rewrite it.
+	dc = resolveDevConfig(wd, nil, devFlagsFromValues("", "", "", "tmp/dev.log", false, false, false))
+	if dc.logPath != "tmp/dev.log" {
+		t.Errorf("--log-file should stay cwd-relative (unanchored), got %q", dc.logPath)
+	}
+}
+
+// TestResolveDevConfigLogAnchorIsAbsIdempotent pins the invariant #158's
+// GSX_DEV_LOG computation (filepath.Abs(dc.logPath), see dev.go) relies on:
+// once resolveDevConfig anchors a config-layer relative path to workDir, that
+// path is already absolute, so a subsequent filepath.Abs is a no-op — Abs
+// never reintroduces a dependency on the process's cwd. Verified, not
+// assumed: a future change to either site that broke this would still leave
+// GSX_DEV_LOG naming a real file, just not necessarily the same one gsx dev
+// writes when run from outside workDir.
+func TestResolveDevConfigLogAnchorIsAbsIdempotent(t *testing.T) {
+	wd := t.TempDir()
+	dc := resolveDevConfig(wd, &tomlDev{Log: "tmp/dev.log"}, devFlags{})
+	abs, err := filepath.Abs(dc.logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abs != dc.logPath {
+		t.Errorf("filepath.Abs(%q) = %q, want no-op (path already workDir-anchored)", dc.logPath, abs)
 	}
 }


### PR DESCRIPTION
User-decided semantics: a relative `[dev].log` in gsx.toml means relative to the gsx.toml's directory — not whatever cwd `gsx dev` happens to run from. Previously `gsx dev ./proj` wrote `$CWD/tmp/dev.log`; running from the project root coincidentally worked, which is why nobody noticed until review.

- Config-layer relative paths anchor to workDir; the `--log-file` flag keeps shell-cwd meaning (a path typed at a shell means the shell's cwd) — asymmetry documented at the resolution site.
- `GSX_DEV_LOG` (#158) still names the file actually written for both shapes — `Abs` of a pre-anchored path proven idempotent by test, not assumed.
- Review clean with independent RED reproduction (the reverted code genuinely leaked the log under the test binary's cwd).

Full `gen` suite green (240s), `-race` clean on touched tests, `make lint` clean.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576