### PR TITLE
chore(gen): scaffold pins vite-plugin-gsx ^0.9.0

### DIFF
--- a/gen/templates/init/simple/package.json.tmpl
+++ b/gen/templates/init/simple/package.json.tmpl
@@ -7,7 +7,7 @@
     "build": "vite build"
   },
   "devDependencies": {
-    "@gsxhq/vite-plugin-gsx": "^0.8.0",
+    "@gsxhq/vite-plugin-gsx": "^0.9.0",
     "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
0.9.0 is live on npm (`npm view @gsxhq/vite-plugin-gsx@'^0.9.0'` resolves). Brings the /__gsx/log endpoint to fresh scaffolds. `TestInit` green.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576