### PR TITLE
feat(gen): live build-progress status — phase transitions, ordered delivery

### DIFF
--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -77,7 +77,7 @@ Scaffolds ship it; existing apps add one line to their Vite client entry:
 import "virtual:gsx-devpanel";
 ```
 
-(requires `@gsxhq/vite-plugin-gsx` ≥ 0.5.0). Disable it or rebind the key in
+(requires `@gsxhq/vite-plugin-gsx` ≥ 0.5.0; auto-show and the log box need ≥ 0.10.0). Disable it or rebind the key in
 `vite.config.ts`: `gsx({ devPanel: false })` or
 `gsx({ devPanel: { key: "k" } })`.
 

--- a/docs/guide/dev-loop.md
+++ b/docs/guide/dev-loop.md
@@ -81,6 +81,14 @@ import "virtual:gsx-devpanel";
 `vite.config.ts`: `gsx({ devPanel: false })` or
 `gsx({ devPanel: { key: "k" } })`.
 
+The panel also auto-appears on its own once a cycle runs past about 3
+seconds, so a slow rebuild surfaces without reaching for Cmd-D — tune the
+delay or turn it off with `gsx({ devPanel: { autoShow: 5000 } })` or
+`{ autoShow: false }`. While it's up, it shows the running phase with
+elapsed time and the last cycle's duration, and — when `[dev].log` is set —
+tails the backend log so you can watch build and server output without
+leaving the browser.
+
 If Vite crashes, `gsx dev` restarts it automatically and pairs with the new
 process before trusting it again (plugin ≥ 0.7.0 — older plugins just suspend
 reload/overlay pushes instead) — refresh any tabs that were already open.

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -348,11 +348,11 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			if out, err := srv.rebuild(ctx); err != nil {
 				post(buildErrorEvent(buildFailureMessage(out, err)))
 				overlayUp = true
-				// setPhase("idle") posts once; Server.Healthy and LastCycle
-				// (both below) change after it, so the explicit postStatus()
-				// carrying them is kept, not redundant.
-				setPhase("idle")
+				// Healthy settles BEFORE the phase post, like every other
+				// branch — postBest goroutines are unordered, so an interim
+				// post must never carry a value a later post has to correct.
 				status.Server.Healthy = false
+				setPhase("idle")
 				status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
 				postStatus()
 				return

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -136,19 +136,32 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	post := func(body []byte) { postEvent(viteURL, body, webUp) }
 	reload := func() { postReload(viteURL, webUp) }
 
+	// Status posts are the one kind of push that must never be delivered out
+	// of order: statuses are snapshots where the latest always wins, but
+	// postBest's per-post goroutine has no ordering guarantee at all (Go's
+	// scheduler runs the most-recently-spawned goroutine first), so two
+	// status posts fired back to back land inverted far more often than not
+	// — see the dev-panel-progress final review (I1). statusSender serializes
+	// them through one goroutine with a 1-slot latest-wins mailbox. Overlay
+	// (post, above) and reload keep their existing fire-and-forget path.
+	statusSend := newStatusSender(ctx)
+
 	status := devStatus{Phase: "idle", PhaseSince: time.Now(), Server: serverStat{Port: goPort, Upstream: origin}, FrontDoor: frontStat{State: "external"}}
 	if dc.web != nil {
 		status.FrontDoor.State = "up"
 	}
-	postStatus := func() { post(statusEvent(status)) }
+	// postStatus deposits the CURRENT status into statusSend's mailbox — see
+	// above. Every call site settles every field it wants delivered on
+	// status BEFORE calling postStatus/setPhase, never after: a post already
+	// in flight (or superseded in the mailbox) never gets a follow-up
+	// correction, so a terminal branch is exactly one postStatus call.
+	postStatus := func() { statusSend.deposit(viteURL+"/__gsx/event", statusEvent(status), webUp) }
 	// setPhase transitions status.Phase and stamps PhaseSince to now, then
 	// posts immediately — every transition (save → generating → building →
 	// starting → idle) is observable by an open panel, not just cycle ends.
-	// Call sites that mutate other status fields (LastCycle, Server.Healthy)
-	// AFTER the phase settles keep their own trailing postStatus() so that
-	// final data reaches the panel too; setPhase's own post is not redundant
-	// there; where nothing changes after, the trailing postStatus() is
-	// dropped as it would just repeat the same payload.
+	// Every OTHER status field (LastCycle, Server.Healthy) must already be
+	// settled before this call at every terminal branch — there is no
+	// trailing postStatus() anywhere in this file.
 	setPhase := func(phase string) {
 		status.Phase = phase
 		status.PhaseSince = time.Now()
@@ -249,13 +262,13 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			}
 		}
 	}
-	// setPhase("idle") posts once with the phase settled; Server.Healthy (set
-	// above, before this point) and LastCycle (set below, after) both change
-	// around it, so the explicit postStatus() below carrying LastCycle is
-	// kept — it is the one the panel needs, not a redundant repeat.
-	setPhase("idle")
+	// LastCycle (and Server.Healthy, set above in the branches that reach
+	// here) must be settled before the terminal setPhase("idle") — it is the
+	// one post the panel needs to see, and there is no second chance: an
+	// interim post has either already landed or been superseded in
+	// statusSend's mailbox by the time this one lands.
 	status.LastCycle = &cycleStat{OK: startOK, At: time.Now(), DurationMs: time.Since(initCycleStart).Milliseconds()}
-	postStatus()
+	setPhase("idle")
 	// overlayUp: an error overlay is currently shown in the browser. A later
 	// successful cycle must reload to clear it even when nothing was written —
 	// still needed for build-error and .env recovery paths.
@@ -307,11 +320,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			fmt.Fprintf(serverOut, "regen failed: %v\n", rerr)
 			post(buildErrorEvent("regen failed: " + rerr.Error()))
 			overlayUp = true
-			// setPhase("idle") posts once; LastCycle (below) changes after it,
-			// so the explicit postStatus() carrying it is kept, not redundant.
-			setPhase("idle")
+			// LastCycle settles before the terminal setPhase("idle") — see
+			// postStatus's declaration: exactly one post per terminal branch.
 			status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
-			postStatus()
+			setPhase("idle")
 			return // retained dirty state is retried on the next relevant event
 		}
 		// Overlay state from this cycle.
@@ -331,11 +343,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		}
 		if !ok {
 			overlayUp = true
-			// setPhase("idle") posts once; LastCycle (below) changes after it,
-			// so the explicit postStatus() carrying it is kept, not redundant.
-			setPhase("idle")
+			// LastCycle settles before the terminal setPhase("idle") — see
+			// postStatus's declaration: exactly one post per terminal branch.
 			status.LastCycle = &cycleStat{OK: false, Errors: errs, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
-			postStatus()
+			setPhase("idle")
 			return // keep last-good server up; overlay shows the error
 		}
 		// Successful cycle. Rebuild when code changed (or the panel forced it);
@@ -348,13 +359,12 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			if out, err := srv.rebuild(ctx); err != nil {
 				post(buildErrorEvent(buildFailureMessage(out, err)))
 				overlayUp = true
-				// Healthy settles BEFORE the phase post, like every other
-				// branch — postBest goroutines are unordered, so an interim
-				// post must never carry a value a later post has to correct.
+				// Healthy and LastCycle both settle BEFORE the terminal
+				// setPhase("idle") — see postStatus's declaration: exactly
+				// one post per terminal branch.
 				status.Server.Healthy = false
-				setPhase("idle")
 				status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
-				postStatus()
+				setPhase("idle")
 				return
 			}
 			setPhase("starting")
@@ -369,11 +379,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			reload()
 		}
 		overlayUp = false
-		// setPhase("idle") posts once; LastCycle (below) changes after it, so
-		// the explicit postStatus() carrying it is kept, not redundant.
-		setPhase("idle")
+		// LastCycle settles before the terminal setPhase("idle") — see
+		// postStatus's declaration: exactly one post per terminal branch.
 		status.LastCycle = &cycleStat{OK: true, Errors: 0, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
-		postStatus()
+		setPhase("idle")
 	}
 
 	for {
@@ -394,11 +403,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				cycle(true)
 			case "restart-server":
 				fmt.Fprintln(stdout, "gsx dev: panel: restart-server")
-				// setPhase posts on its own; Server.Healthy settles fully
-				// BEFORE the trailing setPhase("idle"), so that second
-				// setPhase's own post already carries it — no separate
-				// trailing postStatus() needed here, unlike cycle()'s
-				// terminal paths where LastCycle changes after the phase set.
+				// Server.Healthy settles fully BEFORE the terminal
+				// setPhase("idle") below — see postStatus's declaration:
+				// exactly one post per terminal branch (no LastCycle here,
+				// unlike cycle()'s terminal paths).
 				setPhase("starting")
 				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
 					status.Server.Healthy = true

--- a/gen/dev.go
+++ b/gen/dev.go
@@ -136,11 +136,24 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	post := func(body []byte) { postEvent(viteURL, body, webUp) }
 	reload := func() { postReload(viteURL, webUp) }
 
-	status := devStatus{Phase: "idle", Server: serverStat{Port: goPort, Upstream: origin}, FrontDoor: frontStat{State: "external"}}
+	status := devStatus{Phase: "idle", PhaseSince: time.Now(), Server: serverStat{Port: goPort, Upstream: origin}, FrontDoor: frontStat{State: "external"}}
 	if dc.web != nil {
 		status.FrontDoor.State = "up"
 	}
 	postStatus := func() { post(statusEvent(status)) }
+	// setPhase transitions status.Phase and stamps PhaseSince to now, then
+	// posts immediately — every transition (save → generating → building →
+	// starting → idle) is observable by an open panel, not just cycle ends.
+	// Call sites that mutate other status fields (LastCycle, Server.Healthy)
+	// AFTER the phase settles keep their own trailing postStatus() so that
+	// final data reaches the panel too; setPhase's own post is not redundant
+	// there; where nothing changes after, the trailing postStatus() is
+	// dropped as it would just repeat the same payload.
+	setPhase := func(phase string) {
+		status.Phase = phase
+		status.PhaseSince = time.Now()
+		postStatus()
+	}
 
 	publishedStartup := publishableStartupResults(startup)
 	post(aggregateEvent(publishedStartup))
@@ -222,16 +235,26 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 	// its buildErrorEvent would replace the rich gsx overlay already posted
 	// above. Skip the initial build; the first successful cycle rebuilds and
 	// starts the server (poison→good always changes bytes, so `wrote` fires).
+	initCycleStart := time.Now()
 	if startOK {
+		setPhase("building")
 		if out, err := srv.rebuild(ctx); err != nil {
 			post(buildErrorEvent(buildFailureMessage(out, err)))
 			startOK = false
-		} else if waitHealthy(ctx, healthURL, 10*time.Second) {
-			status.Server.Healthy = true
-			reload()
+		} else {
+			setPhase("starting")
+			if waitHealthy(ctx, healthURL, 10*time.Second) {
+				status.Server.Healthy = true
+				reload()
+			}
 		}
 	}
-	status.LastCycle = &cycleStat{OK: startOK, At: time.Now()}
+	// setPhase("idle") posts once with the phase settled; Server.Healthy (set
+	// above, before this point) and LastCycle (set below, after) both change
+	// around it, so the explicit postStatus() below carrying LastCycle is
+	// kept — it is the one the panel needs, not a redundant repeat.
+	setPhase("idle")
+	status.LastCycle = &cycleStat{OK: startOK, At: time.Now(), DurationMs: time.Since(initCycleStart).Milliseconds()}
 	postStatus()
 	// overlayUp: an error overlay is currently shown in the browser. A later
 	// successful cycle must reload to clear it even when nothing was written —
@@ -277,14 +300,17 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		if len(dirty.dirs) == 0 && !dirty.depDirty {
 			return
 		}
-		status.Phase = "generating"
+		cycleStart := time.Now()
+		setPhase("generating")
 		results, goChanged, rerr := dirty.regenerate(sess.regenPending)
 		if rerr != nil {
 			fmt.Fprintf(serverOut, "regen failed: %v\n", rerr)
 			post(buildErrorEvent("regen failed: " + rerr.Error()))
 			overlayUp = true
-			status.Phase = "idle"
-			status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now()}
+			// setPhase("idle") posts once; LastCycle (below) changes after it,
+			// so the explicit postStatus() carrying it is kept, not redundant.
+			setPhase("idle")
+			status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
 			postStatus()
 			return // retained dirty state is retried on the next relevant event
 		}
@@ -305,8 +331,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		}
 		if !ok {
 			overlayUp = true
-			status.Phase = "idle"
-			status.LastCycle = &cycleStat{OK: false, Errors: errs, At: time.Now()}
+			// setPhase("idle") posts once; LastCycle (below) changes after it,
+			// so the explicit postStatus() carrying it is kept, not redundant.
+			setPhase("idle")
+			status.LastCycle = &cycleStat{OK: false, Errors: errs, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
 			postStatus()
 			return // keep last-good server up; overlay shows the error
 		}
@@ -316,17 +344,20 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 		// (fixed .gsx → identical .x.go).
 		doReload := overlayUp || force
 		if goChanged || wrote || force {
-			status.Phase = "building"
+			setPhase("building")
 			if out, err := srv.rebuild(ctx); err != nil {
 				post(buildErrorEvent(buildFailureMessage(out, err)))
 				overlayUp = true
-				status.Phase = "idle"
+				// setPhase("idle") posts once; Server.Healthy and LastCycle
+				// (both below) change after it, so the explicit postStatus()
+				// carrying them is kept, not redundant.
+				setPhase("idle")
 				status.Server.Healthy = false
-				status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now()}
+				status.LastCycle = &cycleStat{OK: false, Errors: 1, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
 				postStatus()
 				return
 			}
-			status.Phase = "starting"
+			setPhase("starting")
 			if waitHealthy(ctx, healthURL, 10*time.Second) {
 				doReload = true
 				status.Server.Healthy = true
@@ -338,8 +369,10 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 			reload()
 		}
 		overlayUp = false
-		status.Phase = "idle"
-		status.LastCycle = &cycleStat{OK: true, Errors: 0, At: time.Now()}
+		// setPhase("idle") posts once; LastCycle (below) changes after it, so
+		// the explicit postStatus() carrying it is kept, not redundant.
+		setPhase("idle")
+		status.LastCycle = &cycleStat{OK: true, Errors: 0, At: time.Now(), DurationMs: time.Since(cycleStart).Milliseconds()}
 		postStatus()
 	}
 
@@ -361,16 +394,19 @@ func runDev(args []string, stdout, stderr io.Writer, merged config, td *tomlDev,
 				cycle(true)
 			case "restart-server":
 				fmt.Fprintln(stdout, "gsx dev: panel: restart-server")
-				status.Phase = "starting"
-				postStatus()
+				// setPhase posts on its own; Server.Healthy settles fully
+				// BEFORE the trailing setPhase("idle"), so that second
+				// setPhase's own post already carries it — no separate
+				// trailing postStatus() needed here, unlike cycle()'s
+				// terminal paths where LastCycle changes after the phase set.
+				setPhase("starting")
 				if err := srv.restartNoBuild(); err == nil && waitHealthy(ctx, healthURL, 10*time.Second) {
 					status.Server.Healthy = true
 					reload()
 				} else {
 					status.Server.Healthy = false
 				}
-				status.Phase = "idle"
-				postStatus()
+				setPhase("idle")
 			default:
 				fmt.Fprintf(stderr, "gsx dev: unknown panel command %q\n", c)
 			}

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -5,6 +5,7 @@ package gen
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -1227,6 +1228,217 @@ func TestDevRepostsStatusOnFirstFrontDoorContact(t *testing.T) {
 	}
 	if !strings.Contains(statusEvents.String(), `"healthy":true`) {
 		t.Errorf("no healthy status observed; status log:\n%s", statusEvents.String())
+	}
+}
+
+// TestDevPostsBuildingPhaseMidCycle pins the phase-transition-posts feature
+// (dev-panel build progress, gsx side): a rebuild cycle must post its
+// "building" phase to the panel WHILE the build is running, not just the
+// terminal "idle" once it's done — an open panel showing stale "idle" all the
+// way through a slow rebuild is exactly the gap this feature closes.
+//
+// The fixture's [dev].build deliberately sleeps 2s before compiling (via
+// `sh -c`), so:
+//   - a mid-cycle "building" status is wide open to observe, not a race, and
+//   - the terminal idle status's lastCycle.durationMs is provably >= 2000,
+//     pinning that cycle() timed itself rather than reporting a zero/bogus
+//     duration.
+//
+// "generating" is the discriminator that makes this test robust against the
+// cold-start cycle's OWN building/starting/idle posts (added by this same
+// feature) landing on the same recorder, possibly interleaved by network
+// retry timing: only cycle() (never the initial-build path) ever posts phase
+// "generating", so anchoring the search on the first generating event and
+// only accepting later building/idle events guarantees they belong to the
+// write-triggered cycle under test, not the cold-start one.
+func TestDevPostsBuildingPhaseMidCycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGo)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+	// [dev].build sleeps 2s before compiling — both the cold start and the
+	// write-triggered cycle under test go through this slow path, which is
+	// exactly what makes the mid-cycle "building" status observable instead
+	// of racing a near-instant `go build`. run points at the same relative
+	// path build writes to (resolved against devServer's cmd.Dir = proj).
+	writeFile(t, proj, "gsx.toml", "[dev]\nbuild = [\"sh\", \"-c\", \"sleep 2 && go build -o tmp/srv .\"]\nrun = [\"tmp/srv\"]\n")
+
+	goPort := freePort(t)
+	if portListening(goPort) {
+		t.Fatalf("port %s already in use (leaked scaffold server?)", goPort)
+	}
+
+	cmd := exec.Command(bin, "dev", "--web", "sleep 600")
+	cmd.Dir = proj
+	cmd.Env = devTestEnv(
+		"BROWSER=none",
+		"GO_PORT="+goPort,
+		"VITE_DEV_URL=http://127.0.0.1",
+		"GOFLAGS=-mod=mod",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("gsx dev start: %v", err)
+	}
+	defer stopDevGracefully(cmd)
+
+	// The cold start goes through the same slow [dev].build; allow a
+	// generous timeout.
+	if !waitHealthy(context.Background(), "http://localhost:"+goPort+"/healthz", 120*time.Second) {
+		t.Fatalf("Go server on GO_PORT=%s never came up after gsx dev start; output:\n%s", goPort, stdout.String())
+	}
+
+	// Learn the resolved front-door URL from the "watching … — open <url>" line.
+	var viteURL string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := regexp.MustCompile(`open (http://\S+)`).FindStringSubmatch(stdout.String()); m != nil {
+			viteURL = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if viteURL == "" {
+		t.Fatalf("front-door URL not printed; stdout=%q", stdout.String())
+	}
+	u, err := url.Parse(viteURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake vite plugin: records every {"event":"status"} POST body, decoded,
+	// in arrival order.
+	var mu sync.Mutex
+	var statusEvents []map[string]any
+	fake := &http.Server{
+		Addr: net.JoinHostPort(u.Hostname(), u.Port()),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-gsx", "1")
+			switch r.URL.Path {
+			case "/__gsx/cmd":
+				w.WriteHeader(204)
+			case "/__gsx/event":
+				body, _ := io.ReadAll(r.Body)
+				var ev map[string]any
+				if json.Unmarshal(body, &ev) == nil && ev["event"] == "status" {
+					mu.Lock()
+					statusEvents = append(statusEvents, ev)
+					mu.Unlock()
+				}
+				w.WriteHeader(204)
+			default:
+				w.WriteHeader(204)
+			}
+		}),
+	}
+	fl, err := net.Listen("tcp", fake.Addr)
+	if err != nil {
+		t.Fatalf("bind resolved front-door port %s: %v", fake.Addr, err)
+	}
+	go func() { _ = fake.Serve(fl) }()
+	defer fake.Close()
+
+	// Touch a .go file to trigger the dep-dirty rebuild path: generating →
+	// building (slow: sleep 2 + go build) → starting → idle.
+	trig := filepath.Join(proj, "zz_trigger.go")
+	if err := os.WriteFile(trig, []byte("package main\n\nvar _devtrigger = 1\n"), 0o644); err != nil {
+		t.Fatalf("write trigger: %v", err)
+	}
+
+	// Poll until the write-triggered cycle's full transition sequence has
+	// been recorded: a "generating" event, a later "building" event, and a
+	// later still terminal "idle" event whose lastCycle.durationMs >= 2000
+	// (the fixture's build always sleeps 2s, so this pins it to a REAL
+	// cycle() timing, not a zero/placeholder value).
+	var generatingEvent, buildingEvent, idleEvent map[string]any
+	deadline = time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		events := append([]map[string]any(nil), statusEvents...)
+		mu.Unlock()
+
+		generatingEvent, buildingEvent, idleEvent = nil, nil, nil
+		for _, ev := range events {
+			phase, _ := ev["phase"].(string)
+			switch {
+			case phase == "generating" && generatingEvent == nil:
+				generatingEvent = ev
+			case phase == "building" && generatingEvent != nil && buildingEvent == nil:
+				buildingEvent = ev
+			case phase == "idle" && buildingEvent != nil && idleEvent == nil:
+				if lc, ok := ev["lastCycle"].(map[string]any); ok {
+					if d, ok := lc["durationMs"].(float64); ok && d >= 2000 {
+						idleEvent = ev
+					}
+				}
+			}
+		}
+		if idleEvent != nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if generatingEvent == nil {
+		mu.Lock()
+		snap := statusEvents
+		mu.Unlock()
+		t.Fatalf("no %q status observed; events:\n%v\nstdout:\n%s", "generating", snap, stdout.String())
+	}
+	if buildingEvent == nil {
+		mu.Lock()
+		snap := statusEvents
+		mu.Unlock()
+		t.Fatalf("no %q status observed after %q (mid-cycle posts missing — this is the bug this test pins); events:\n%v\nstdout:\n%s", "building", "generating", snap, stdout.String())
+	}
+	if idleEvent == nil {
+		mu.Lock()
+		snap := statusEvents
+		mu.Unlock()
+		t.Fatalf("no terminal %q status (lastCycle.durationMs >= 2000) observed after %q; events:\n%v\nstdout:\n%s", "idle", "building", snap, stdout.String())
+	}
+
+	genSinceRaw, _ := generatingEvent["phaseSince"].(string)
+	buildSinceRaw, _ := buildingEvent["phaseSince"].(string)
+	genSince, err := time.Parse(time.RFC3339, genSinceRaw)
+	if err != nil {
+		t.Fatalf("generating phaseSince = %q, not RFC3339: %v", genSinceRaw, err)
+	}
+	buildSince, err := time.Parse(time.RFC3339, buildSinceRaw)
+	if err != nil {
+		t.Fatalf("building phaseSince = %q, not RFC3339: %v", buildSinceRaw, err)
+	}
+	if !buildSince.After(genSince) {
+		t.Errorf("building phaseSince (%s) is not after generating phaseSince (%s) — not monotonic", buildSince, genSince)
+	}
+
+	lc := idleEvent["lastCycle"].(map[string]any)
+	if d, _ := lc["durationMs"].(float64); d < 2000 {
+		t.Errorf("terminal idle lastCycle.durationMs = %v, want >= 2000 (fixture build sleeps 2s)", lc["durationMs"])
 	}
 }
 

--- a/gen/dev_test.go
+++ b/gen/dev_test.go
@@ -1442,6 +1442,229 @@ func TestDevPostsBuildingPhaseMidCycle(t *testing.T) {
 	}
 }
 
+// TestDevTerminalIdleStatusIsSinglePostWithSettledFields is the final-review
+// I1(b) pinning test: every terminal branch must settle every other status
+// field (here, both Server.Healthy and LastCycle — the build-failure branch
+// in cycle()) BEFORE the terminal setPhase("idle"), so there is only ever
+// ONE post carrying a given terminal outcome. Before this fix, every
+// terminal branch posted phase "idle" TWICE per cycle with TWO DIFFERENT
+// payloads: once from setPhase's own post (stale LastCycle/Healthy) and once
+// from a trailing postStatus() carrying the corrected values (see 883bb5c2,
+// which only generalized this for Server.Healthy, and the final review's
+// I1, which found the two-post design itself unordered and thus unsound).
+//
+// This test drives a real build failure and asserts every "idle" status
+// after the triggering "building" event carries the SAME, already-settled
+// values (Server.Healthy=false, LastCycle.OK=false/Errors=1) — i.e. no STALE
+// variant is ever observed. It does not assert exactly one delivery: the
+// contactCh first-contact repost (gen/dev.go) can legitimately race
+// setPhase's own post through Go's select and redeliver the identical
+// CURRENT status a moment later — a harmless, already-reviewed duplicate
+// (see the final review, "First-contact × setPhase interplay": "at most one
+// duplicate payload, which the client handles idempotently"), distinct from
+// the STALE-payload bug this test guards against.
+func TestDevTerminalIdleStatusIsSinglePostWithSettledFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: requires building gsx and a live Go server")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	gsxRoot := repoRoot(t)
+	bin := filepath.Join(t.TempDir(), "gsx")
+	buildCmd := exec.Command("go", "build", "-o", bin, "./cmd/gsx")
+	buildCmd.Dir = gsxRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gsx: %v\n%s", err, out)
+	}
+
+	proj := t.TempDir()
+	gomod := fmt.Sprintf(
+		"module devdemo\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => %s\n",
+		gsxRoot,
+	)
+	writeFile(t, proj, "go.mod", gomod)
+	writeFile(t, proj, "main.go", devTestMainGo)
+	writeFile(t, proj, "app.gsx", "package main\n\ncomponent Dummy() {\n\t<span>ok</span>\n}\n")
+	// [dev].build succeeds the first time (cold start) and fails every time
+	// after — deterministically reaching cycle()'s rebuild-failure branch on
+	// the write-triggered cycle below without relying on an incidental
+	// source error that gsx's own regen/type-check might catch first (which
+	// would take a different, earlier branch that never touches
+	// Server.Healthy).
+	writeFile(t, proj, "gsx.toml", "[dev]\nbuild = [\"sh\", \"-c\", \"c=$(cat build_count 2>/dev/null || echo 0); c=$((c+1)); echo $c > build_count; if [ $c -eq 1 ]; then go build -o tmp/srv .; else exit 1; fi\"]\nrun = [\"tmp/srv\"]\n")
+
+	goPort := freePort(t)
+	if portListening(goPort) {
+		t.Fatalf("port %s already in use (leaked scaffold server?)", goPort)
+	}
+
+	cmd := exec.Command(bin, "dev", "--web", "sleep 600")
+	cmd.Dir = proj
+	cmd.Env = devTestEnv(
+		"BROWSER=none",
+		"GO_PORT="+goPort,
+		"VITE_DEV_URL=http://127.0.0.1",
+		"GOFLAGS=-mod=mod",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout lockedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("gsx dev start: %v", err)
+	}
+	defer stopDevGracefully(cmd)
+
+	if !waitHealthy(context.Background(), "http://localhost:"+goPort+"/healthz", 120*time.Second) {
+		t.Fatalf("Go server on GO_PORT=%s never came up after gsx dev start; output:\n%s", goPort, stdout.String())
+	}
+
+	// Learn the resolved front-door URL from the "watching … — open <url>" line.
+	var viteURL string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if m := regexp.MustCompile(`open (http://\S+)`).FindStringSubmatch(stdout.String()); m != nil {
+			viteURL = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if viteURL == "" {
+		t.Fatalf("front-door URL not printed; stdout=%q", stdout.String())
+	}
+	u, err := url.Parse(viteURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake vite plugin: records every {"event":"status"} POST body, decoded,
+	// in arrival order.
+	var mu sync.Mutex
+	var statusEvents []map[string]any
+	fake := &http.Server{
+		Addr: net.JoinHostPort(u.Hostname(), u.Port()),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-gsx", "1")
+			switch r.URL.Path {
+			case "/__gsx/cmd":
+				w.WriteHeader(204)
+			case "/__gsx/event":
+				body, _ := io.ReadAll(r.Body)
+				var ev map[string]any
+				if json.Unmarshal(body, &ev) == nil && ev["event"] == "status" {
+					mu.Lock()
+					statusEvents = append(statusEvents, ev)
+					mu.Unlock()
+				}
+				w.WriteHeader(204)
+			default:
+				w.WriteHeader(204)
+			}
+		}),
+	}
+	fl, err := net.Listen("tcp", fake.Addr)
+	if err != nil {
+		t.Fatalf("bind resolved front-door port %s: %v", fake.Addr, err)
+	}
+	go func() { _ = fake.Serve(fl) }()
+	defer fake.Close()
+
+	// Touch a benign, valid .go file to trigger the dep-dirty rebuild path
+	// (regen succeeds; [dev].build above is what fails, deterministically,
+	// on this second invocation). Cold start never posts phase "generating"
+	// (only the write-triggered cycle does), so the first "generating"
+	// event unambiguously anchors this cycle among any cold-start echoes.
+	trig := filepath.Join(proj, "zz_trigger.go")
+	if err := os.WriteFile(trig, []byte("package main\n\nvar _devtrigger = 1\n"), 0o644); err != nil {
+		t.Fatalf("write trigger: %v", err)
+	}
+
+	var generatingIdx, buildingIdx int
+	deadline = time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		events := append([]map[string]any(nil), statusEvents...)
+		mu.Unlock()
+
+		generatingIdx, buildingIdx = -1, -1
+		for i, ev := range events {
+			phase, _ := ev["phase"].(string)
+			switch {
+			case phase == "generating" && generatingIdx == -1:
+				generatingIdx = i
+			case phase == "building" && generatingIdx != -1 && buildingIdx == -1 && i > generatingIdx:
+				buildingIdx = i
+			}
+		}
+		if buildingIdx != -1 {
+			// Any idle event after buildingIdx yet?
+			mu.Lock()
+			hasIdle := false
+			for i := buildingIdx + 1; i < len(statusEvents); i++ {
+				if p, _ := statusEvents[i]["phase"].(string); p == "idle" {
+					hasIdle = true
+					break
+				}
+			}
+			mu.Unlock()
+			if hasIdle {
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if generatingIdx == -1 {
+		mu.Lock()
+		snap := statusEvents
+		mu.Unlock()
+		t.Fatalf("no %q status observed; events:\n%v\nstdout:\n%s", "generating", snap, stdout.String())
+	}
+	if buildingIdx == -1 {
+		mu.Lock()
+		snap := statusEvents
+		mu.Unlock()
+		t.Fatalf("no %q status observed after %q; events:\n%v\nstdout:\n%s", "building", "generating", snap, stdout.String())
+	}
+
+	// Give the (legitimate) contactCh repost a moment to arrive before
+	// asserting — a bug REINTRODUCING the stale-then-corrected double post
+	// would show up as a second, DIFFERING "idle" here well within this
+	// margin.
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	events := append([]map[string]any(nil), statusEvents...)
+	mu.Unlock()
+	var idleEvents []map[string]any
+	for i := buildingIdx + 1; i < len(events); i++ {
+		if p, _ := events[i]["phase"].(string); p == "idle" {
+			idleEvents = append(idleEvents, events[i])
+		}
+	}
+	if len(idleEvents) == 0 {
+		t.Fatalf("no idle status posts after the triggering %q; full log:\n%v", "building", events)
+	}
+
+	for i, idleEvent := range idleEvents {
+		srv, _ := idleEvent["server"].(map[string]any)
+		if srv == nil || srv["healthy"] != false {
+			t.Errorf("idle status[%d] server.healthy = %v, want false (settled before every post — no stale variant)", i, srv)
+		}
+		lc, _ := idleEvent["lastCycle"].(map[string]any)
+		if lc == nil {
+			t.Fatalf("idle status[%d] missing lastCycle: %v", i, idleEvent)
+		}
+		if lc["ok"] != false {
+			t.Errorf("idle status[%d] lastCycle.ok = %v, want false", i, lc["ok"])
+		}
+		if errs, _ := lc["errors"].(float64); errs != 1 {
+			t.Errorf("idle status[%d] lastCycle.errors = %v, want 1", i, lc["errors"])
+		}
+	}
+}
+
 // TestDevEnvErrorPostsOverlay is the final-review fix-round-1 regression test
 // for the envErr branch of the .env-fire path (gen/dev.go): a resolveViteDevEnv
 // failure (e.g. an .env edit that sets VITE_PORT to a port already in use)

--- a/gen/devstatus.go
+++ b/gen/devstatus.go
@@ -9,10 +9,16 @@ import (
 // {"event":"status"} payload on /__gsx/event. Field names are the wire
 // contract with vite-plugin-gsx.
 type devStatus struct {
-	Phase     string     `json:"phase"` // idle | generating | building | starting
-	Server    serverStat `json:"server"`
-	LastCycle *cycleStat `json:"lastCycle,omitempty"`
-	FrontDoor frontStat  `json:"frontDoor"`
+	Phase string `json:"phase"` // idle | generating | building | starting
+	// PhaseSince is when the current Phase started (set by setPhase in
+	// runDev, alongside every Phase transition). Always present — never the
+	// zero value once runDev's initial status literal has run — so the
+	// panel can render elapsed time ("building… started 42s ago") without
+	// additional polling.
+	PhaseSince time.Time  `json:"phaseSince"`
+	Server     serverStat `json:"server"`
+	LastCycle  *cycleStat `json:"lastCycle,omitempty"`
+	FrontDoor  frontStat  `json:"frontDoor"`
 }
 
 type serverStat struct {
@@ -33,6 +39,10 @@ type cycleStat struct {
 	OK     bool      `json:"ok"`
 	Errors int       `json:"errors"`
 	At     time.Time `json:"at"`
+	// DurationMs is how long this cycle took end to end (from cycle()'s
+	// recorded start, or the initial-build path's own start, to this
+	// terminal post), for the panel's "last: 2m10s" expectation-setting.
+	DurationMs int64 `json:"durationMs"`
 }
 
 type frontStat struct {

--- a/gen/devstatus_test.go
+++ b/gen/devstatus_test.go
@@ -8,11 +8,13 @@ import (
 
 func TestStatusEventShape(t *testing.T) {
 	at := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	since := time.Date(2026, 7, 23, 9, 59, 0, 0, time.UTC)
 	s := devStatus{
-		Phase:     "idle",
-		Server:    serverStat{Healthy: true, Port: "7777", Upstream: "http://localhost:7777"},
-		LastCycle: &cycleStat{OK: true, Errors: 0, At: at},
-		FrontDoor: frontStat{State: "up", Restarts: 2},
+		Phase:      "idle",
+		PhaseSince: since,
+		Server:     serverStat{Healthy: true, Port: "7777", Upstream: "http://localhost:7777"},
+		LastCycle:  &cycleStat{OK: true, Errors: 0, At: at, DurationMs: 1234},
+		FrontDoor:  frontStat{State: "up", Restarts: 2},
 	}
 	var got map[string]any
 	if err := json.Unmarshal(statusEvent(s), &got); err != nil {
@@ -21,6 +23,9 @@ func TestStatusEventShape(t *testing.T) {
 	if got["event"] != "status" || got["phase"] != "idle" {
 		t.Errorf("event/phase = %v/%v", got["event"], got["phase"])
 	}
+	if got["phaseSince"] != "2026-07-23T09:59:00Z" {
+		t.Errorf("phaseSince = %v, want RFC3339 2026-07-23T09:59:00Z", got["phaseSince"])
+	}
 	srv := got["server"].(map[string]any)
 	if srv["healthy"] != true || srv["port"] != "7777" || srv["upstream"] != "http://localhost:7777" {
 		t.Errorf("server = %v", srv)
@@ -28,6 +33,9 @@ func TestStatusEventShape(t *testing.T) {
 	lc := got["lastCycle"].(map[string]any)
 	if lc["ok"] != true || lc["at"] != "2026-07-23T10:00:00Z" {
 		t.Errorf("lastCycle = %v", lc)
+	}
+	if durMs, ok := lc["durationMs"].(float64); !ok || durMs != 1234 {
+		t.Errorf("lastCycle.durationMs = %v (%T), want 1234", lc["durationMs"], lc["durationMs"])
 	}
 	fd := got["frontDoor"].(map[string]any)
 	if fd["state"] != "up" || fd["restarts"] != float64(2) {

--- a/gen/statussender.go
+++ b/gen/statussender.go
@@ -1,0 +1,137 @@
+package gen
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// statusSender serializes status POSTs through a single sender goroutine
+// consuming a 1-slot latest-wins mailbox. Overlay (aggregateEvent/
+// buildErrorEvent) and reload posts keep their existing fire-and-forget
+// postBest path — only status posts go through here.
+//
+// Statuses are snapshots where the latest always wins, so deposit()
+// overwrites any undelivered previous post outright rather than queuing
+// behind it: a busy backlog coalesces down to whatever was last deposited
+// before the sender gets to it, and the sender delivers every deposit when
+// it's keeping up (nothing to coalesce). This is the fix for final-review
+// finding I1: postBest's one-goroutine-per-post design has no ordering
+// guarantee at all — Go's scheduler runs the most-recently-spawned goroutine
+// first (the runnext slot), so back-to-back status posts arrived inverted far
+// more often than not (measured: 86/150 back-to-back, 12/12 under a retry
+// backlog).
+//
+// deposit is safe to call from any goroutine and never blocks. The sender
+// goroutine exits when ctx is done — no leak across shutdown.
+type statusSender struct {
+	mu      sync.Mutex
+	pending *statusPost
+	wake    chan struct{}
+	wg      sync.WaitGroup
+}
+
+// statusPost is one undelivered status post: the full target URL (base +
+// /__gsx/event, already joined at deposit time so a later base-URL change —
+// e.g. an .env-triggered Vite port change — never rewrites an
+// already-queued post), its marshaled body, and the gate to re-check before
+// every retry attempt.
+type statusPost struct {
+	url  string
+	body []byte
+	gate func() bool
+}
+
+// newStatusSender starts the sender goroutine and returns immediately.
+func newStatusSender(ctx context.Context) *statusSender {
+	s := &statusSender{wake: make(chan struct{}, 1)}
+	s.wg.Add(1)
+	go s.run(ctx)
+	return s
+}
+
+// deposit overwrites any undelivered previous status with (url, body, gate)
+// and wakes the sender. url == "" or a bare path (no scheme) no-ops,
+// matching postBest's same-origin/disabled convention.
+func (s *statusSender) deposit(url string, body []byte, gate func() bool) {
+	if strings.HasPrefix(url, "/") || url == "" {
+		return
+	}
+	s.mu.Lock()
+	s.pending = &statusPost{url: url, body: body, gate: gate}
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default: // sender already woken/busy; it'll see the new pending itself
+	}
+}
+
+func (s *statusSender) run(ctx context.Context) {
+	defer s.wg.Done()
+	client := devHTTPClient(2 * time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.wake:
+		}
+		for p := s.takePending(); p != nil; p = s.takePending() {
+			if !s.deliver(ctx, client, p) {
+				return
+			}
+		}
+	}
+}
+
+// takePending atomically removes and returns the mailbox's current content
+// (nil if empty).
+func (s *statusSender) takePending() *statusPost {
+	s.mu.Lock()
+	p := s.pending
+	s.pending = nil
+	s.mu.Unlock()
+	return p
+}
+
+// deliver mirrors postBest's retry/backoff/gate semantics (up to 10 attempts,
+// 150ms backoff, gate re-checked before every attempt) but runs
+// synchronously in the sender goroutine rather than spawning a new one for
+// every post — that's the whole point of statusSender: exactly one goroutine
+// ever sends a status, so there is nothing left to reorder.
+//
+// A fresher deposit landing during the backoff sleep pre-empts p outright:
+// the stale in-flight target is abandoned unsent and delivery continues on
+// the fresher value with its own full 10-attempt budget. This is what makes
+// the sender immune to the retry-backlog hazard (final-review I1, "12/12
+// inverted" cold-start probe) — a stale non-idle status retrying against a
+// front door that isn't up yet can never win a race against a newer one by
+// having been queued first; the newest deposit always pre-empts.
+//
+// Returns false only when ctx is done (the caller should stop entirely).
+func (s *statusSender) deliver(ctx context.Context, client *http.Client, p *statusPost) bool {
+	attempts := 0
+	for attempts < 10 {
+		if p.gate != nil && !p.gate() {
+			return true // gate closed: drop
+		}
+		resp, err := client.Post(p.url, "application/json", bytes.NewReader(p.body))
+		if err == nil {
+			resp.Body.Close()
+			return true // delivered
+		}
+		attempts++
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(150 * time.Millisecond):
+		}
+		if fresh := s.takePending(); fresh != nil {
+			p = fresh
+			attempts = 0 // the fresher target gets its own full budget
+		}
+	}
+	return true // exhausted retries; drop p
+}

--- a/gen/statussender_test.go
+++ b/gen/statussender_test.go
@@ -1,0 +1,164 @@
+package gen
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestStatusSenderDeliversDepositsInOrder is the final-review I1 ordering
+// probe (reviewer's shape: rapid-fire N deposits against a real HTTP server):
+// with the old one-goroutine-per-post postBest, Go's scheduler runs the
+// most-recently-spawned goroutine first (the runnext slot), so back-to-back
+// status posts arrived inverted far more often than not (86/150 in the
+// reviewer's probe). The ordered sender must never invert: every delivered
+// value must be strictly increasing (the 1-slot mailbox coalesces a busy
+// backlog to a suffix, never reorders it), and the very last thing delivered
+// must be the last thing deposited — nothing arrives after it.
+func TestStatusSenderDeliversDepositsInOrder(t *testing.T) {
+	var mu sync.Mutex
+	var received []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		n, _ := strconv.Atoi(string(b))
+		mu.Lock()
+		received = append(received, n)
+		mu.Unlock()
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	sender := newStatusSender(t.Context())
+
+	const n = 150
+	for i := 1; i <= n; i++ {
+		sender.deposit(srv.URL+"/__gsx/event", []byte(strconv.Itoa(i)), nil)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := len(received) > 0 && received[len(received)-1] == n
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Give any (incorrect) trailing post a moment to arrive, so a bug that
+	// delivers something after the last deposit is actually caught rather
+	// than raced past.
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) == 0 {
+		t.Fatal("no status delivered")
+	}
+	if got := received[len(received)-1]; got != n {
+		t.Fatalf("final received = %d, want %d (the last deposited); full sequence: %v", got, n, received)
+	}
+	for i := 1; i < len(received); i++ {
+		if received[i] <= received[i-1] {
+			t.Fatalf("received out of order at index %d: %v", i, received)
+		}
+	}
+}
+
+// TestStatusSenderRetryBacklogDeliversLatestAtBindTime is the final-review I1
+// retry-backlog probe: the front door (Vite) can bind well after gsx dev has
+// already deposited several statuses into a dead address. Nothing can
+// possibly be delivered before the bind (the address refuses every
+// connection), so whatever the sender is retrying at bind time is entirely
+// superseded by the rest of the rapid-fire burst (see deliver's supersede
+// check) long before the bind happens. The first thing the newly-bound
+// server ever receives must be the latest deposit, not one of the
+// intermediate stale ones — this is the fix for the reviewer's "12/12
+// inverted" cold-start probe (a stale non-idle phase landing after the
+// terminal idle repost).
+func TestStatusSenderRetryBacklogDeliversLatestAtBindTime(t *testing.T) {
+	port := freePort(t)
+	url := "http://127.0.0.1:" + port + "/__gsx/event"
+
+	sender := newStatusSender(t.Context())
+
+	// Nothing is listening yet. The first deposit is picked up immediately
+	// and the sender starts retrying it against a refused connection; the
+	// rest land within microseconds, well inside that first attempt's 150ms
+	// backoff, so the very next backoff check supersedes to "5" long before
+	// anything binds.
+	for i := 1; i <= 5; i++ {
+		sender.deposit(url, []byte(strconv.Itoa(i)), nil)
+	}
+
+	// Bind well before any retry budget could exhaust (10 attempts x 150ms
+	// ~= 1.5s from whenever "5" took over, itself within ~150ms of the
+	// burst) so the race is "does the pre-empted stale target ever reach the
+	// wire", not "did the sender give up first".
+	time.Sleep(300 * time.Millisecond)
+
+	var mu sync.Mutex
+	var received []int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gsx/event", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		n, _ := strconv.Atoi(string(b))
+		mu.Lock()
+		received = append(received, n)
+		mu.Unlock()
+		w.WriteHeader(204)
+	})
+	l, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = http.Serve(l, mux) }()
+	defer l.Close()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := len(received)
+		mu.Unlock()
+		if got > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) == 0 {
+		t.Fatal("no status delivered after bind")
+	}
+	if received[0] != 5 {
+		t.Errorf("first delivered = %d, want 5 (latest at bind time), not a stale queued one; full sequence: %v", received[0], received)
+	}
+}
+
+// TestStatusSenderExitsOnContextDone pins the sender's shutdown lifecycle: no
+// goroutine leak once ctx is cancelled (e.g. gsx dev shutting down).
+func TestStatusSenderExitsOnContextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sender := newStatusSender(ctx)
+	sender.deposit("http://127.0.0.1:1/__gsx/event", []byte("x"), nil) // unreachable; retries briefly then gives up
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		sender.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("statusSender goroutine did not exit after ctx cancellation")
+	}
+}

--- a/gen/templates/init/simple/package.json.tmpl
+++ b/gen/templates/init/simple/package.json.tmpl
@@ -7,7 +7,7 @@
     "build": "vite build"
   },
   "devDependencies": {
-    "@gsxhq/vite-plugin-gsx": "^0.9.0",
+    "@gsxhq/vite-plugin-gsx": "^0.10.0",
     "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
gsx side of the dev-panel build progress feature (spec: `docs/superpowers/specs/2026-07-24-dev-panel-progress-design.md`; companion plugin PR follows). Born from the one-learning experience: minutes-long rebuilds with zero feedback while the last-good binary serves.

- Status posts at every phase transition (save → generating → building → starting → idle), including cold builds, with `phaseSince` and `lastCycle.durationMs` — the panel ticks elapsed locally, no polling added.
- **Ordered, latest-wins status delivery** (`gen/statussender.go`): the final review measured goroutine-per-post delivery inverting the terminal status pair 86/150 times (Go runs the newest goroutine first) and 12/12 under retry backlog — a single sender goroutine over a 1-slot mailbox now delivers in order, coalesces only under backlog, and a fresher deposit pre-empts a stale in-flight retry mid-backoff (re-probed: 0/150 inversions, 8/8 backlog trials clean). Terminal fields settle before the idle post everywhere; overlay/reload posts unchanged.
- Verified across three probe-driven review rounds + live browser smoke (panel auto-appears ~3s into a slow build with ticking elapsed, last-cycle duration and a backend-log tail; no-op saves stay silent).

Full `gen` suite green (uncached, quiet machine, 246s); `-race` clean; `make lint` clean.

Filed follow-up (pre-existing, out of scope): unsynchronized `fd` read in the `webUp` gate closure.

https://claude.ai/code/session_01GiUqqvjkyy4rE6hScnC576