### PR TITLE
feat: uniform if/switch branching in attribute and class/style positions

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -89,6 +89,10 @@ func SetSpan(n Node, start, end token.Pos) {
 		v.span = s
 	case *CondAttr:
 		v.span = s
+	case *SwitchAttr:
+		v.span = s
+	case *AttrCaseClause:
+		v.span = s
 	case *ComposedAttr:
 		v.span = s
 	case *ComposedPart:
@@ -612,6 +616,40 @@ type CondAttr struct {
 
 func (*CondAttr) attrNode() {}
 
+// SwitchAttr is an in-tag `{ switch [Tag] { case List: … default: … } }`
+// attribute group — the switch counterpart of CondAttr, mirroring SwitchMarkup
+// in attribute position. Tag is "" for a tagless `switch { case cond: … }`.
+//
+// Each case arm holds an attribute list, so the group emits a real Go `switch`
+// wrapping its arms' attribute emits, the same way CondAttr emits a real Go
+// `if`. There is deliberately no `fallthrough`: an attribute list is not a
+// statement list, so falling through would emit two arms' attributes and
+// silently duplicate names.
+type SwitchAttr struct {
+	span
+	Tag    string
+	TagPos token.Pos // first char of Tag in source (NoPos for a tagless switch)
+	Cases  []*AttrCaseClause
+}
+
+func (*SwitchAttr) attrNode() {}
+
+// AttrCaseClause is one `case List:` or `default:` arm of a SwitchAttr — the
+// attribute-position counterpart of CaseClause. It is a Node (for Inspect and
+// positions) but is neither Markup nor Attr. List is the raw Go case
+// expression(s); Default is true for the `default:` arm (List == "").
+type AttrCaseClause struct {
+	span
+	List    string
+	ListPos token.Pos // first char of List in source (NoPos for `default:`)
+	Default bool
+	Body    []Attr
+}
+
+// Deliberately no BodyMultiline counterpart to CaseClause: an attribute switch
+// always prints broken across lines, the same templ-style layout CondAttr uses,
+// so there is no inline form for the formatter to preserve.
+
 // ComposedPart is one complete contribution in a composable class/style list. Its
 // Pos and End span covers the contribution between comma delimiters, including
 // surrounding trivia and any pipeline stages or `: cond` guard.
@@ -624,8 +662,8 @@ func (*CondAttr) attrNode() {}
 //
 // ComposedPart is a Node so it can be keyed in the resolved map for renderer
 // application and (T, error) auto-unwrap on plain parts, conditional or not
-// (#88). When CSSSegments != nil, Expr/Cond/Stages/CF are unused. When CF !=
-// nil, Expr/Cond/Stages and CSSSegments are unused.
+// (#88). When LiteralSegments != nil, Expr/Cond/Stages/CF are unused. When CF !=
+// nil, Expr/Cond/Stages and LiteralSegments are unused.
 type ComposedPart struct {
 	span
 	Expr string
@@ -636,13 +674,19 @@ type ComposedPart struct {
 	Cond    string
 	// CondPos is the position of the first char of the `: cond` guard text in
 	// source (NoPos when Cond == "").
-	CondPos     token.Pos
-	Stages      []PipeStage
-	CSSSegments []Markup
-	// CSSDoubleQuoted records the delimiter of a composed CSS literal part
-	// (style={ css`…` } vs style={ css"…" }). See EmbeddedAttr.DoubleQuoted.
-	CSSDoubleQuoted bool
-	CF              *ValueCF
+	CondPos token.Pos
+	Stages  []PipeStage
+	// LiteralSegments is set for a prefixed backtick literal part: css`…` in
+	// style={…}, f`…` in class={…}. Each attribute accepts the literal whose
+	// language matches its own value context, and nothing else.
+	LiteralSegments []Markup
+	// LiteralLang is that literal's language (EmbeddedCSS for style,
+	// EmbeddedText for class); meaningful only when LiteralSegments != nil.
+	LiteralLang EmbeddedLang
+	// LiteralDoubleQuoted records the literal's delimiter (css`…` vs css"…",
+	// f`…` vs f"…"). See EmbeddedAttr.DoubleQuoted.
+	LiteralDoubleQuoted bool
+	CF                  *ValueCF
 }
 
 // ExprEnd returns the position immediately after Expr. It returns NoPos when
@@ -665,13 +709,29 @@ type ComposedAttr struct {
 func (*ComposedAttr) attrNode() {}
 
 // ValueArm is one produced value in a value-form if/switch inside a class/style
-// list — a Go string expression with an optional pipeline. It is a Node (for
-// type harvest + diagnostics) but neither Markup nor Attr.
+// list — a Go string expression with an optional pipeline, or a prefixed
+// backtick literal. It is a Node (for type harvest + diagnostics) but neither
+// Markup nor Attr.
+//
+// When Segments != nil the arm is a literal and Expr/Stages are unused. The
+// rule is that an arm accepts the same literal that is legal as its
+// attribute's own value: css`…` in style={…} (mirroring
+// ComposedPart.LiteralSegments) and f`…` in class={…}. Holes inside the literal
+// are filtered individually by the attribute's sanitizer exactly as they are
+// outside an arm — branching never widens what a hole may contribute.
 type ValueArm struct {
 	span
 	Expr    string
 	ExprPos token.Pos // first char of Expr (the pipe seed) in source
 	Stages  []PipeStage
+
+	Segments []Markup
+	// Lang is the literal's language (EmbeddedCSS for style, EmbeddedText for
+	// class); meaningful only when Segments != nil.
+	Lang EmbeddedLang
+	// DoubleQuoted records the literal's delimiter (css`…` vs css"…"), matching
+	// ComposedPart.LiteralDoubleQuoted and EmbeddedAttr.DoubleQuoted.
+	DoubleQuoted bool
 }
 
 // ValueIf is the value-producing `if Cond { Then } [else if … | else { Else }]`
@@ -766,13 +826,15 @@ func (*CommentAttr) attrNode() {}
 //   - *SwitchMarkup: each CaseClause
 //   - *CaseClause: each Body markup node
 //   - *CondAttr: each Then and Else attr node
+//   - *SwitchAttr: each AttrCaseClause
+//   - *AttrCaseClause: each Body attr node
 //   - *ComposedAttr: each *ComposedPart (Parts slice walked by pointer)
 //   - *ComposedPart: CF (if non-nil)
 //   - *ValueCF: If or Switch (whichever is non-nil)
 //   - *ValueIf: Then, ElseIf (if non-nil), Else (if non-nil)
 //   - *ValueSwitch: each CaseClause
 //   - *ValueSwitchCase: Value arm
-//   - *ValueArm: leaf
+//   - *ValueArm: each Segments markup node (literal arms only; otherwise a leaf)
 //   - all other nodes: leaves (no children)
 func Inspect(node Node, f func(Node) bool) {
 	if !f(node) {
@@ -851,6 +913,14 @@ func Inspect(node Node, f func(Node) bool) {
 		for _, a := range n.Else {
 			Inspect(a, f)
 		}
+	case *SwitchAttr:
+		for _, c := range n.Cases {
+			Inspect(c, f)
+		}
+	case *AttrCaseClause:
+		for _, a := range n.Body {
+			Inspect(a, f)
+		}
 	case *OrderedAttrsAttr:
 		for i := range n.Pairs {
 			Inspect(&n.Pairs[i], f)
@@ -860,7 +930,7 @@ func Inspect(node Node, f func(Node) bool) {
 			Inspect(&n.Parts[i], f)
 		}
 	case *ComposedPart:
-		for _, m := range n.CSSSegments {
+		for _, m := range n.LiteralSegments {
 			Inspect(m, f)
 		}
 		if n.CF != nil {
@@ -888,7 +958,10 @@ func Inspect(node Node, f func(Node) bool) {
 	case *ValueSwitchCase:
 		Inspect(n.Value, f)
 	case *ValueArm:
-		// leaf
+		// A literal arm carries markup segments; an expression arm is a leaf.
+		for _, m := range n.Segments {
+			Inspect(m, f)
+		}
 		// GoBlock and OrderedPair are also leaves with no child nodes.
 	}
 	f(nil)

--- a/ast/clone.go
+++ b/ast/clone.go
@@ -154,6 +154,19 @@ func cloneCaseClauses(in []*CaseClause) []*CaseClause {
 	return out
 }
 
+func cloneAttrCaseClauses(in []*AttrCaseClause) []*AttrCaseClause {
+	if in == nil {
+		return nil
+	}
+	out := make([]*AttrCaseClause, len(in))
+	for i, c := range in {
+		n := *c
+		n.Body = cloneAttrs(c.Body)
+		out[i] = &n
+	}
+	return out
+}
+
 func cloneAttrs(in []Attr) []Attr {
 	if in == nil {
 		return nil
@@ -194,6 +207,10 @@ func cloneAttr(a Attr) Attr {
 		n := *v
 		n.Then = cloneAttrs(v.Then)
 		n.Else = cloneAttrs(v.Else)
+		return &n
+	case *SwitchAttr:
+		n := *v
+		n.Cases = cloneAttrCaseClauses(v.Cases)
 		return &n
 	case *ComposedAttr:
 		n := *v
@@ -252,7 +269,7 @@ func cloneComposedParts(in []ComposedPart) []ComposedPart {
 func cloneComposedPart(p ComposedPart) ComposedPart {
 	// p is already a value copy; deep-copy its mutable slices/pointers.
 	p.Stages = clonePipeStages(p.Stages)
-	p.CSSSegments = cloneMarkups(p.CSSSegments)
+	p.LiteralSegments = cloneMarkups(p.LiteralSegments)
 	if p.CF != nil {
 		p.CF = cloneValueCF(p.CF)
 	}
@@ -302,6 +319,7 @@ func cloneValueSwitch(vs *ValueSwitch) *ValueSwitch {
 func cloneValueArm(va *ValueArm) *ValueArm {
 	n := *va
 	n.Stages = clonePipeStages(va.Stages)
+	n.Segments = cloneMarkups(va.Segments)
 	return &n
 }
 

--- a/ast/clone_exhaustive_test.go
+++ b/ast/clone_exhaustive_test.go
@@ -124,6 +124,7 @@ var astZeroValueTypes = map[string]reflect.Type{
 	"MarkupAttr":       reflect.TypeFor[ast.MarkupAttr](),
 	"EmbeddedAttr":     reflect.TypeFor[ast.EmbeddedAttr](),
 	"CondAttr":         reflect.TypeFor[ast.CondAttr](),
+	"SwitchAttr":       reflect.TypeFor[ast.SwitchAttr](),
 	"ComposedAttr":     reflect.TypeFor[ast.ComposedAttr](),
 	"OrderedAttrsAttr": reflect.TypeFor[ast.OrderedAttrsAttr](),
 	"CommentAttr":      reflect.TypeFor[ast.CommentAttr](),

--- a/ast/print.go
+++ b/ast/print.go
@@ -199,6 +199,24 @@ func fprintNode(w io.Writer, node Node, depth int) error {
 				return err
 			}
 		}
+	case *SwitchAttr:
+		if _, err := fmt.Fprintf(w, "%sSwitchAttr tag=%q\n", indent, n.Tag); err != nil {
+			return err
+		}
+		for _, cc := range n.Cases {
+			if err := fprintNode(w, cc, depth+1); err != nil {
+				return err
+			}
+		}
+	case *AttrCaseClause:
+		if _, err := fmt.Fprintf(w, "%sAttrCaseClause list=%q default=%v\n", indent, n.List, n.Default); err != nil {
+			return err
+		}
+		for _, a := range n.Body {
+			if err := fprintNode(w, a, depth+1); err != nil {
+				return err
+			}
+		}
 	case *CondAttr:
 		if _, err := fmt.Fprintf(w, "%sCondAttr cond=%q\n", indent, n.Cond); err != nil {
 			return err
@@ -232,8 +250,8 @@ func fprintNode(w io.Writer, node Node, depth int) error {
 				}
 				continue
 			}
-			if part.CSSSegments != nil {
-				if _, err := fmt.Fprintf(w, "%s  ComposedPart cssSegments=%d cond=%q\n", indent, len(part.CSSSegments), part.Cond); err != nil {
+			if part.LiteralSegments != nil {
+				if _, err := fmt.Fprintf(w, "%s  ComposedPart cssSegments=%d cond=%q\n", indent, len(part.LiteralSegments), part.Cond); err != nil {
 					return err
 				}
 				continue
@@ -285,6 +303,17 @@ func fprintNode(w io.Writer, node Node, depth int) error {
 		}
 		return fprintNode(w, n.Value, depth+1)
 	case *ValueArm:
+		if n.Segments != nil {
+			if _, err := fmt.Fprintf(w, "%sValueArm segments=%d\n", indent, len(n.Segments)); err != nil {
+				return err
+			}
+			for _, m := range n.Segments {
+				if err := fprintNode(w, m, depth+1); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 		if _, err := fmt.Fprintf(w, "%sValueArm expr=%q\n", indent, n.Expr); err != nil {
 			return err
 		}

--- a/docs/guide/syntax/attributes.md
+++ b/docs/guide/syntax/attributes.md
@@ -71,6 +71,31 @@ one or more attributes.
 An `else` branch works too:
 `{ if active { class="active" } else { class="idle" } }`.
 
+`{ switch … }` is the switch counterpart, for when one of several mutually
+exclusive attribute sets applies:
+
+```gsx
+<div
+    { switch status {
+    case "ok":
+        data-state="ok"
+    case "warn", "error":
+        data-state="bad" aria-live="polite"
+    default:
+        data-state="unknown"
+    } }
+>
+```
+
+It takes the same shapes Go's `switch` does — a tag expression, multi-value
+case lists, a tagless `switch { case cond: … }`, and `default` — and evaluates
+its tag exactly once. `fallthrough` is not supported: an attribute list is not
+a statement list, so falling through would emit two arms' attributes and
+duplicate names. List the shared attributes in each `case` instead.
+
+An arm with no matching case contributes nothing, exactly like an `if` with no
+`else`.
+
 ## Spread `{ x… }` — ordered
 
 Spread a `gsx.Attrs` bag with `{ bag... }`; entries render in slice order.

--- a/docs/guide/syntax/styling.md
+++ b/docs/guide/syntax/styling.md
@@ -104,6 +104,35 @@ The selected arm contributes one string. With no matching arm and no `else` or
 `default`, it contributes nothing. The same forms work in `style={...}` lists,
 where each arm returns a complete declaration.
 
+An arm may also hold a contextual literal — `f` in `class={...}`, `css` in
+`style={...}` — the same literal each attribute accepts as a plain entry:
+
+```gsx
+<div style={
+	switch form {
+	case ratioPair: css`aspect-ratio: @{w} / @{h}`
+	default:        css`aspect-ratio: @{ratio}`
+	},
+}>...</div>
+```
+
+This is how you get punctuation the CSS value filter rejects — here the `/`
+separator — into a declaration without reaching for `gsx.RawCSS`: the
+separator is static template text and only `@{w}`/`@{h}` are holes, so each is
+still filtered.
+
+Each attribute takes only its own literal language, in every position — as the
+whole value, as one entry in a list, or as a value-form arm. `class` takes
+`f`; `style` takes `css`. Anything else is a compile error.
+
+That is a safety rule, not a stylistic one: the literal's language selects the
+sanitizer applied to its `@{...}` holes. An `f` literal in `style` would escape
+its holes for HTML only and never run the CSS value filter, letting a hole
+inject `background:url(javascript:...)` into the style attribute; a `css`
+literal in `class` would run the CSS filter over a class string, collapsing an
+ordinary `bg-primary/20` to `ZgotmplZ`. Attributes that compose nothing
+(`data-*`, `onclick`, …) are unrestricted.
+
 ## `<style>` blocks
 
 Use a `<style>` block for component CSS. Interpolate Go values with `@{...}`.

--- a/docs/superpowers/specs/2026-07-30-uniform-branching-in-attrs-design.md
+++ b/docs/superpowers/specs/2026-07-30-uniform-branching-in-attrs-design.md
@@ -1,0 +1,191 @@
+# Uniform `if`/`switch` branching in attribute and class/style value position
+
+## Problem
+
+gsx has four branching positions around attributes. Two work, two do not:
+
+| Position | `if` | `switch` |
+| --- | --- | --- |
+| Attribute: `<div { if c { a=1 } }>` | yes | **no** — `expected \`...\` trailing spread inside \`{ }\` attribute` |
+| Value: `class={ if c { "a" } else { "b" } }` | yes | yes |
+| Value arm holding a literal: `style={ if c { css\`…\` } }` | **no** | **no** — `missing ',' in argument list` |
+
+Two independent gaps:
+
+- **B — no `switch` in attribute position.** `parseSingleAttr` (`parser/attrs.go:265`)
+  dispatches on `braceKeyword() == "if"` and sends everything else to
+  `parseSpreadAttr`, so `{ switch … }` reports the spread error.
+- **A — value-form arms reject `f\`/js\`/css\`` literals.** `ast.ComposedPart`
+  (`ast/ast.go:629`) carries `CSSSegments []Markup` for a literal part, but
+  `ast.ValueArm` (`ast/ast.go:670`) carries only `Expr` + `Stages`, and
+  `parseValueArm` (`parser/valueform.go:101`) routes arm text straight to
+  `parsePipe`. A literal is therefore legal as a whole attribute value and as a
+  composed part, but not as an arm — the only value position that rejects it.
+  All eight combinations (`class`/`style` × `if`/`switch` × `f`/`js`/`css`) fail.
+
+The driving case is a component that must split a CSS value so its separator is
+static template text — e.g. `aspect-ratio: <w> / <h>`, where the CSS value
+filter rejects an interpolated `/`. Branching selects the declaration shape;
+the arm must be able to hold the `css\`\`` literal that does the splitting.
+
+## Decision 1 — attribute `switch` is a real node, not a desugar
+
+Rejected: lowering `{ switch tag { case A: … } }` to a nested `CondAttr` chain
+(`tag == A`) in the parser. It touches only two files, but Go's `switch`
+evaluates its tag exactly once and an `==` chain re-evaluates it per case. For
+a tag that is a call, that is a behaviour change, not a formatting one. It also
+forecloses type switches, which the value-form switch already supports
+(`class/value_switch_type_switch.txtar`).
+
+So: new `*ast.SwitchAttr` + `*ast.AttrCaseClause`, emitting a real Go `switch`
+in the same statement position where `CondAttr` emits a real Go `if`
+(`internal/codegen/emit.go:3044` — attribute emission is a sequence of writer
+calls between `<tag` and `>`, so a Go control construct wrapping the branch's
+attr emits is valid).
+
+**Cost, stated plainly:** `CondAttr` has 30 type-switch dispatch sites across 14
+files (9 `emit.go`, 7 `analyze.go`, 2 each `printer.go` / `component_call_plan.go`,
+1 each in `wsnorm`, `lsp/definition`, `jsx`, `jsmin`, `cssmin`, `reserved_scan`,
+`rebase`, `component_target`, `component_positional_plan`, `component_lsp_facts`),
+plus `ast` walk/clone/print. `SwitchAttr` must reach every one that recurses
+into branch attrs. This is the failure mode that shipped broken once already
+(processing instructions: 11 of ~32 markup walks missed, components emitted
+raw), so the exhaustiveness gate below is not optional.
+
+## Decision 2 — value arms reuse the part payload
+
+`ValueArm` gains the literal payload `ComposedPart` already has
+(`CSSSegments []Markup`, `CSSDoubleQuoted bool`). `parseValueArm` probes for a
+prefixed backtick literal with the same `parseEmbeddedInterpPart` that
+`splitComposed` uses (`parser/attrs.go:492`), falling back to `parsePipe`. One
+literal-scanning path, two container sites, so they cannot diverge.
+
+`ValueArm` stops being a walk leaf: it gains children.
+
+## Semantics
+
+- Attribute `switch` accepts the same shapes as markup `switch`
+  (`ast.SwitchMarkup`): tagged, tagless (`switch { case cond: … }`), multi-value
+  case lists, and `default`. Arms are attribute lists, exactly like
+  `CondAttr.Then`/`Else`.
+- No `fallthrough`. An attribute list is not a statement list; falling through
+  would emit two arms' attributes and silently duplicate names.
+- A case arm may hold any attribute a `CondAttr` branch may hold, including a
+  nested `{ if }` or `{ switch }`.
+- Literal arms render identically to the same literal as a composed part: each
+  `@{…}` hole is filtered independently by the context's sanitizer. Branching
+  never widens what a hole may contribute.
+
+## Exhaustiveness gate
+
+`ast/walk_exhaustive_test.go` already asserts every node kind is reachable from
+`Inspect`. Extend the same technique to the attribute walks: a test that
+constructs a `SwitchAttr` carrying a marker attribute in every case arm, runs it
+through parse → analyze → generate → render, and fails if the marker does not
+survive. Add the equivalent for a literal-bearing `ValueArm`.
+
+## Test matrix
+
+Per `CLAUDE.md`, new syntax valid in multiple contexts needs a corpus case per
+context.
+
+- Attribute `switch`: tagged, tagless, multi-value case, `default`, no-default
+  (no arm matches), nested inside `{ if }`, containing a spread, containing a
+  composed `class=`/`style=`, on a component tag (fallthrough/bag routing), and
+  a `fallthrough`-rejected diagnostic case.
+- Value arms: `class` and `style` × `if` and `switch` × `f`, `js`, `css`.
+- Formatter: a fmt-corpus case per new shape (`internal/gsxfmt/testdata/cases`),
+  pinning that a `switch` written by the author is printed back as a `switch`.
+
+## Sibling repos
+
+Grammar and highlighting must follow before merge: `../tree-sitter-gsx`,
+`../vscode-gsx`, `../gsxhq.github.io` (CodeMirror + VitePress).
+
+### Pre-existing tree-sitter bug to fix in the same pass
+
+Found 2026-07-30 while writing the new `AspectRatio`, and NOT caused by this
+change — it reproduces on `{ if … }`, which already shipped.
+
+A conditional attribute whose branches each hold a `style=css\`…\`` literal
+parses with a spurious `(stylesheet (ERROR …))` node hanging off
+`conditional_attribute`, spanning from the FIRST literal's `embedded_text`
+through the LAST one — i.e. across the intervening `} else if … {` gsx syntax:
+
+```gsx
+<div
+    { if form == aspectRatioPair {
+        style=css`aspect-ratio: @{w} / @{h}`
+    } else if form == aspectRatioAutoPair {
+        style=css`aspect-ratio: auto @{w} / @{h}`
+    } else {
+        style=css`aspect-ratio: @{ratio}`
+    } }
+>
+```
+
+```
+(conditional_attribute
+  (stylesheet                 ; <- spurious, spans all three literals
+    (ERROR (tag_name) (ERROR) (ERROR) (ERROR) (ERROR) (ERROR)))
+  (keyword)
+  condition: (binary_expression …)
+  (attribute (embedded_attribute value: (embedded_css_literal …)))   ; these are correct
+  (attribute_else_clause …))
+```
+
+Each `embedded_css_literal` on its own is correct — `embedded_open`,
+`embedded_text`, `at_hole`, all well-formed. Only the extra combined
+`stylesheet` is wrong.
+
+Cause, confirmed in `tree-sitter-gsx/queries/injections.scm`: all four
+`embedded_js_literal` / `embedded_css_literal` patterns (lines 29–46) carry
+`#set! injection.combined`. That directive concatenates *every* match of the
+pattern in the region into ONE injected document, so three sibling `css\`…\``
+literals become a single CSS parse of their concatenated bodies — which is not
+valid CSS, hence the ERROR nodes. `injection.combined` is correct for the
+`raw_element` patterns above it (a `<style>` element's chunks really are one
+stylesheet) and wrong for the literal patterns, where each literal is its own
+independent fragment.
+
+Fix: drop `injection.combined` from the four literal patterns (lines 29–46),
+keep it on the two `raw_element` patterns. Add a grammar corpus case with two
+or more `css\`…\`` literals in one element — the bug needs no conditional at
+all to reproduce, the conditional just made it visible.
+
+Note the same latent bug applies to sibling `js\`…\`` literals; the fix covers
+both. Verify against `../vscode-gsx` and the CodeMirror grammar in
+`../gsxhq.github.io`, which consume the same queries.
+
+## Decision 3 — one literal language per composable attribute, everywhere
+
+Adding literal arms exposed that gsx had no rule at all about WHICH literal a
+composable attribute accepts. Measured behaviour before this change:
+
+| written | rendered with a hostile hole | verdict |
+| --- | --- | --- |
+| `class=f\`…\`` | HTML-escaped | correct |
+| `style=css\`…\`` | CSS-value-filtered | correct |
+| `style=f\`…\`` | `style="color: red;background:url(javascript:alert(1))"` | **injection** |
+| `class=css\`…\`` | `class="color: ZgotmplZ"` | mangles valid classes (`bg-primary/20`) |
+
+The literal's language is what selects the sanitizer applied to its `@{ }`
+holes, so a mismatched pairing silently applies the wrong escaper.
+`style=f\`…\`` emitted `AttrValue(string(v))` — HTML escaping only, never
+`StyleValue` — which is a pre-existing gap on main, not one this branch
+introduced (`emitEmbeddedTextAttr` is untouched by this diff).
+
+So the rule is: **`class` takes `f`, `style` takes `css`, and nothing else** —
+enforced identically in all three positions (whole value, list entry,
+value-form arm) by `checkComposableLiteralLang`. Attributes that compose
+nothing (`data-*`, `onclick`, …) stay unrestricted.
+
+Rejected alternative: normalising by sink instead (let the attribute decide the
+escaper regardless of the literal's prefix). That would keep every spelling
+working, but leaves two ways to write one thing and makes `class=css\`…\`` mean
+"CSS-highlighted text that is not CSS" — strictness is the better contract.
+
+**This is a breaking change.** `style=f\`…\`` compiles today and stops
+compiling; one corpus case (`textattr/style_spread_merge`) used exactly that
+form and moved to `css`. Any downstream use is by definition an unfiltered CSS
+sink, so the break is the point.

--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -1285,13 +1285,16 @@ func emitProbes(sb skeletonWriter, nodes []gsxast.Markup, table funcTables, recv
 							// Value-form CF part: probe each arm so harvest populates
 							// resolved[arm] for classEntryExpr's (T, error) unwrap.
 							for _, arm := range valueFormArms(ca.Parts[i].CF) {
+								if arm.Segments != nil {
+									continue // literal arm: its holes are probed via walkMarkupAttrs
+								}
 								emitSkeletonLine(sb, fset, arm.Pos())
 								if err := writeSkeletonCanonicalProbe(sb, "_gsxuse", fset, arm.ExprPos, arm.Expr, arm.Stages, table, usedFilters, arm, bag); err != nil {
 									classProbeErr = err
 									return
 								}
 							}
-						} else if ca.Parts[i].CSSSegments == nil {
+						} else if ca.Parts[i].LiteralSegments == nil {
 							emitSkeletonLine(sb, fset, ca.Parts[i].Pos())
 							if err := writeSkeletonCanonicalProbe(sb, "_gsxuse", fset, ca.Parts[i].ExprPos, ca.Parts[i].Expr, ca.Parts[i].Stages, table, usedFilters, &ca.Parts[i], bag); err != nil {
 								classProbeErr = err
@@ -1318,6 +1321,8 @@ func emitProbes(sb skeletonWriter, nodes []gsxast.Markup, table funcTables, recv
 					emitValueCFControl(sb, fset, cf, ctrlOff)
 				}, func(node gsxast.Node, cond string, condPos token.Pos) {
 					emitCondLiveness(sb, fset, node, cond, condPos, ctrlOff)
+				}, func(sa *gsxast.SwitchAttr) {
+					emitSwitchAttrControl(sb, fset, sa, ctrlOff)
 				})
 				// Probe ExprAttr values nested in a component cond-attr branch
 				// (`{ if C { attr={expr} } }`) with _gsxuseq, AFTER the parts probes —
@@ -1470,13 +1475,16 @@ func emitProbes(sb skeletonWriter, nodes []gsxast.Markup, table funcTables, recv
 					for i := range ca.Parts {
 						if ca.Parts[i].CF != nil {
 							for _, arm := range valueFormArms(ca.Parts[i].CF) {
+								if arm.Segments != nil {
+									continue // literal arm: its holes are probed via walkMarkupAttrs
+								}
 								emitSkeletonLine(sb, fset, arm.Pos())
 								if err := writeSkeletonCanonicalProbe(sb, "_gsxuse", fset, arm.ExprPos, arm.Expr, arm.Stages, table, usedFilters, arm, bag); err != nil {
 									leafClassProbeErr = err
 									return
 								}
 							}
-						} else if ca.Parts[i].CSSSegments == nil {
+						} else if ca.Parts[i].LiteralSegments == nil {
 							// Plain part, conditional or not: harvest its type for
 							// renderer application and (T, error) unwrap (#88). _gsxuse
 							// also serves as a liveness reference (replaces `_ =
@@ -1512,6 +1520,8 @@ func emitProbes(sb skeletonWriter, nodes []gsxast.Markup, table funcTables, recv
 					emitValueCFControl(sb, fset, cf, ctrlOff)
 				}, func(node gsxast.Node, cond string, condPos token.Pos) {
 					emitCondLiveness(sb, fset, node, cond, condPos, ctrlOff)
+				}, func(sa *gsxast.SwitchAttr) {
+					emitSwitchAttrControl(sb, fset, sa, ctrlOff)
 				})
 				// Then probe each JS-attribute's @{ } interps, in attr source order —
 				// collectExprs walks identically (same walkMarkupAttrs), so the k-th
@@ -2676,9 +2686,12 @@ func collectExprs(nodes []gsxast.Markup, out *[]gsxast.Node, candidates *callSit
 					for i := range ca.Parts {
 						if ca.Parts[i].CF != nil {
 							for _, arm := range valueFormArms(ca.Parts[i].CF) {
+								if arm.Segments != nil {
+									continue // literal arm: collected via walkMarkupAttrs below
+								}
 								*out = append(*out, arm)
 							}
-						} else if ca.Parts[i].CSSSegments == nil {
+						} else if ca.Parts[i].LiteralSegments == nil {
 							*out = append(*out, &ca.Parts[i])
 						}
 					}
@@ -2736,9 +2749,12 @@ func collectExprs(nodes []gsxast.Markup, out *[]gsxast.Node, candidates *callSit
 				for i := range ca.Parts {
 					if ca.Parts[i].CF != nil {
 						for _, arm := range valueFormArms(ca.Parts[i].CF) {
+							if arm.Segments != nil {
+								continue // literal arm: collected via walkMarkupAttrs below
+							}
 							*out = append(*out, arm)
 						}
-					} else if ca.Parts[i].CSSSegments == nil {
+					} else if ca.Parts[i].LiteralSegments == nil {
 						*out = append(*out, &ca.Parts[i])
 					}
 				}
@@ -2794,6 +2810,10 @@ func walkAttrExprs(attrs []gsxast.Attr, fn func(*gsxast.ExprAttr)) {
 		case *gsxast.CondAttr:
 			walkAttrExprs(at.Then, fn)
 			walkAttrExprs(at.Else, fn)
+		case *gsxast.SwitchAttr:
+			for _, cc := range at.Cases {
+				walkAttrExprs(cc.Body, fn)
+			}
 		}
 	}
 }
@@ -2813,9 +2833,14 @@ func walkAttrExprs(attrs []gsxast.Attr, fn func(*gsxast.ExprAttr)) {
 // probe always maps to the k-th collected branch-ExprAttr node.
 func walkBranchAttrExprs(attrs []gsxast.Attr, fn func(*gsxast.ExprAttr)) {
 	for _, a := range attrs {
-		if ca, ok := a.(*gsxast.CondAttr); ok {
-			walkAttrExprs(ca.Then, fn)
-			walkAttrExprs(ca.Else, fn)
+		switch at := a.(type) {
+		case *gsxast.CondAttr:
+			walkAttrExprs(at.Then, fn)
+			walkAttrExprs(at.Else, fn)
+		case *gsxast.SwitchAttr:
+			for _, cc := range at.Cases {
+				walkAttrExprs(cc.Body, fn)
+			}
 		}
 	}
 }
@@ -2834,6 +2859,10 @@ func walkSpreadAttrs(attrs []gsxast.Attr, fn func(*gsxast.SpreadAttr)) {
 		case *gsxast.CondAttr:
 			walkSpreadAttrs(at.Then, fn)
 			walkSpreadAttrs(at.Else, fn)
+		case *gsxast.SwitchAttr:
+			for _, cc := range at.Cases {
+				walkSpreadAttrs(cc.Body, fn)
+			}
 		}
 	}
 }
@@ -2853,6 +2882,10 @@ func walkComposedAttrs(attrs []gsxast.Attr, fn func(*gsxast.ComposedAttr)) {
 		case *gsxast.CondAttr:
 			walkComposedAttrs(at.Then, fn)
 			walkComposedAttrs(at.Else, fn)
+		case *gsxast.SwitchAttr:
+			for _, cc := range at.Cases {
+				walkComposedAttrs(cc.Body, fn)
+			}
 		}
 	}
 }
@@ -2878,7 +2911,7 @@ func walkComposedAttrs(attrs []gsxast.Attr, fn func(*gsxast.ComposedAttr)) {
 // case lists are only legal in statement position) the same way. Both forms
 // are invisible to the k-th-probe→k-th-node type-harvest alignment, unlike
 // _gsxuse.
-func walkLivenessAttrExprs(attrs []gsxast.Attr, fnCF func(cf *gsxast.ValueCF), fnCond func(node gsxast.Node, cond string, condPos token.Pos)) {
+func walkLivenessAttrExprs(attrs []gsxast.Attr, fnCF func(cf *gsxast.ValueCF), fnCond func(node gsxast.Node, cond string, condPos token.Pos), fnSwitch func(sa *gsxast.SwitchAttr)) {
 	for _, a := range attrs {
 		switch at := a.(type) {
 		case *gsxast.ComposedAttr:
@@ -2886,7 +2919,7 @@ func walkLivenessAttrExprs(attrs []gsxast.Attr, fnCF func(cf *gsxast.ValueCF), f
 			// pointer ast.Inspect yields — the identity the LSP looks up in CtrlMap.
 			for i := range at.Parts {
 				p := &at.Parts[i]
-				if p.CSSSegments != nil {
+				if p.LiteralSegments != nil {
 					fnCond(p, p.Cond, p.CondPos)
 					continue
 				}
@@ -2900,8 +2933,16 @@ func walkLivenessAttrExprs(attrs []gsxast.Attr, fnCF func(cf *gsxast.ValueCF), f
 			}
 		case *gsxast.CondAttr:
 			fnCond(at, at.Cond, at.CondPos)
-			walkLivenessAttrExprs(at.Then, fnCF, fnCond)
-			walkLivenessAttrExprs(at.Else, fnCF, fnCond)
+			walkLivenessAttrExprs(at.Then, fnCF, fnCond, fnSwitch)
+			walkLivenessAttrExprs(at.Else, fnCF, fnCond, fnSwitch)
+		case *gsxast.SwitchAttr:
+			// The tag and every case list go out as ONE switch skeleton (a case
+			// list is only well-typed against its tag), unlike a CondAttr's
+			// standalone bool condition.
+			fnSwitch(at)
+			for _, cc := range at.Cases {
+				walkLivenessAttrExprs(cc.Body, fnCF, fnCond, fnSwitch)
+			}
 		}
 	}
 }
@@ -2925,13 +2966,30 @@ func walkMarkupAttrs(attrs []gsxast.Attr, fn func(value []gsxast.Markup)) {
 			fn(t.Segments)
 		case *gsxast.ComposedAttr:
 			for i := range t.Parts {
-				if t.Parts[i].CSSSegments != nil {
-					fn(t.Parts[i].CSSSegments)
+				if t.Parts[i].LiteralSegments != nil {
+					fn(t.Parts[i].LiteralSegments)
+					continue
+				}
+				// A value-form part's LITERAL arms carry @{ } interps too, and
+				// they need types exactly like a non-arm literal part's do. Yield
+				// them in arm order so collectExprs and emitProbes stay in
+				// lockstep. Expression arms are harvested separately, by the
+				// value-form arm pass — not here.
+				if t.Parts[i].CF != nil {
+					for _, arm := range valueFormArms(t.Parts[i].CF) {
+						if arm.Segments != nil {
+							fn(arm.Segments)
+						}
+					}
 				}
 			}
 		case *gsxast.CondAttr:
 			walkMarkupAttrs(t.Then, fn)
 			walkMarkupAttrs(t.Else, fn)
+		case *gsxast.SwitchAttr:
+			for _, cc := range t.Cases {
+				walkMarkupAttrs(cc.Body, fn)
+			}
 		}
 	}
 }
@@ -2956,6 +3014,10 @@ func walkEmbeddedAttrStages(attrs []gsxast.Attr, fn func(*gsxast.EmbeddedAttr)) 
 		case *gsxast.CondAttr:
 			walkEmbeddedAttrStages(at.Then, fn)
 			walkEmbeddedAttrStages(at.Else, fn)
+		case *gsxast.SwitchAttr:
+			for _, cc := range at.Cases {
+				walkEmbeddedAttrStages(cc.Body, fn)
+			}
 		}
 	}
 }
@@ -3073,28 +3135,66 @@ func emitValueCFControl(sb skeletonWriter, fset *token.FileSet, cf *gsxast.Value
 		return
 	}
 	if vs := cf.Switch; vs != nil {
-		if strings.TrimSpace(vs.Tag) != "" {
-			emitSkeletonClauseLine(sb, fset, vs.TagPos, len("switch "))
-			ctrlOff[vs] = sb.Len() + len("switch ")
+		cases := make([]switchLivenessCase, len(vs.Cases))
+		for i, c := range vs.Cases {
+			cases[i] = switchLivenessCase{node: c, list: c.List, listPos: c.ListPos, isDefault: c.Default}
 		}
-		writeSkeletonGenerated(sb, "switch ")
-		if strings.TrimSpace(vs.Tag) != "" {
-			_ = writeSkeletonAuthoredAt(sb, fset, vs.TagPos, strings.TrimSpace(vs.Tag), sourceintel.Definition|sourceintel.Hover|sourceintel.Completion)
-		}
-		writeSkeletonGenerated(sb, " {\n")
-		for _, c := range vs.Cases {
-			if c.Default {
-				sb.WriteString("default:\n")
-				continue
-			}
-			emitSkeletonClauseLine(sb, fset, c.ListPos, len("case "))
-			ctrlOff[c] = sb.Len() + len("case ")
-			writeSkeletonGenerated(sb, "case ")
-			_ = writeSkeletonAuthoredAt(sb, fset, c.ListPos, c.List, sourceintel.Definition|sourceintel.Hover|sourceintel.Completion)
-			writeSkeletonGenerated(sb, ":\n")
-		}
-		sb.WriteString("}\n")
+		emitSwitchLiveness(sb, fset, vs, vs.Tag, vs.TagPos, cases, ctrlOff)
 	}
+}
+
+// switchLivenessCase is one case arm of either switch form, reduced to what the
+// liveness skeleton needs. It lets *ValueSwitchCase and *AttrCaseClause — which
+// differ only in what their bodies hold — share one skeleton emitter.
+type switchLivenessCase struct {
+	node      gsxast.Node
+	list      string
+	listPos   token.Pos
+	isDefault bool
+}
+
+// emitSwitchLiveness writes the empty-bodied `switch <tag> { case <list>: … }`
+// skeleton shared by the value-form switch (*ValueSwitch) and the in-tag
+// attribute switch (*SwitchAttr). Statement position is required for the same
+// reason emitValueCFControl documents: a case list may hold `nil`, type names
+// under a `.(type)` tag, or untyped constants that only fit the tag's type,
+// none of which are legal as a bare expression. ctrlOff is keyed by the tag
+// node and by each case node, which is the CtrlMap bridge go-to-definition and
+// positioned type errors use inside the control expressions.
+func emitSwitchLiveness(sb skeletonWriter, fset *token.FileSet, tagNode gsxast.Node, tag string, tagPos token.Pos, cases []switchLivenessCase, ctrlOff map[gsxast.Node]int) {
+	tagged := strings.TrimSpace(tag) != ""
+	if tagged {
+		emitSkeletonClauseLine(sb, fset, tagPos, len("switch "))
+		ctrlOff[tagNode] = sb.Len() + len("switch ")
+	}
+	writeSkeletonGenerated(sb, "switch ")
+	if tagged {
+		_ = writeSkeletonAuthoredAt(sb, fset, tagPos, strings.TrimSpace(tag), sourceintel.Definition|sourceintel.Hover|sourceintel.Completion)
+	}
+	writeSkeletonGenerated(sb, " {\n")
+	for _, c := range cases {
+		if c.isDefault {
+			sb.WriteString("default:\n")
+			continue
+		}
+		emitSkeletonClauseLine(sb, fset, c.listPos, len("case "))
+		ctrlOff[c.node] = sb.Len() + len("case ")
+		writeSkeletonGenerated(sb, "case ")
+		_ = writeSkeletonAuthoredAt(sb, fset, c.listPos, c.list, sourceintel.Definition|sourceintel.Hover|sourceintel.Completion)
+		writeSkeletonGenerated(sb, ":\n")
+	}
+	sb.WriteString("}\n")
+}
+
+// emitSwitchAttrControl is emitSwitchLiveness for an in-tag `{ switch … }`
+// attribute group. Its arms hold attributes, whose own exprs are harvested by
+// the walks in this file; only the tag and case lists need the skeleton.
+func emitSwitchAttrControl(sb skeletonWriter, fset *token.FileSet, sa *gsxast.SwitchAttr, ctrlOff map[gsxast.Node]int) {
+	cases := make([]switchLivenessCase, len(sa.Cases))
+	for i, c := range sa.Cases {
+		cases[i] = switchLivenessCase{node: c, list: c.List, listPos: c.ListPos, isDefault: c.Default}
+	}
+	emitSwitchLiveness(sb, fset, sa, sa.Tag, sa.TagPos, cases, ctrlOff)
 }
 
 // valueFormArms returns the arm value-expression nodes of a value-form part in

--- a/internal/codegen/component_call_plan.go
+++ b/internal/codegen/component_call_plan.go
@@ -56,11 +56,34 @@ type componentAttrsStreamNode struct {
 	kind        componentAttrsStreamKind
 	sourceIndex int // index in the immediately containing attribute list
 	attr        gsxast.Attr
-	then        []componentAttrsStreamNode
-	otherwise   []componentAttrsStreamNode
-	// hasSyntaxError records invalid descendants omitted from then/otherwise.
+	// branches holds one entry per mutually exclusive arm, in source order. A
+	// *CondAttr contributes exactly two (Then, then Else — the second empty when
+	// there is no `else`); a *SwitchAttr contributes one per case arm. Consumers
+	// walk them uniformly and must not assume a count.
+	branches [][]componentAttrsStreamNode
+	// hasSyntaxError records invalid descendants omitted from branches.
 	// It suppresses a cascading missing-attrs error for an invalid-only subtree.
 	hasSyntaxError bool
+}
+
+// branchNodes reports every arm's nodes flattened, for consumers that only need
+// to visit each descendant once and do not care which arm it came from.
+func (n componentAttrsStreamNode) branchNodes() []componentAttrsStreamNode {
+	var out []componentAttrsStreamNode
+	for _, br := range n.branches {
+		out = append(out, br...)
+	}
+	return out
+}
+
+// emptyBranches reports whether no arm contributed a node.
+func (n componentAttrsStreamNode) emptyBranches() bool {
+	for _, br := range n.branches {
+		if len(br) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 type componentArgSlot struct {
@@ -227,7 +250,17 @@ func planComponentInputs(site callSiteID, el *gsxast.Element, target componentSi
 		}
 	}
 
-	var normalizeAttrsList func([]gsxast.Attr) ([]componentAttrsStreamNode, bool)
+	// normalizeBranchLists normalizes an if-form's two arms into the uniform
+	// branch slice; the Else arm stays present-but-empty when there is no
+	// `else`, so a consumer counting arms sees the same shape either way.
+	// normalizeCaseLists does the same for a switch-form's case arms, in source
+	// order. Both are declared before normalizeAttrsList and assigned after it,
+	// because that closure is recursive and calls them for nested groups.
+	var (
+		normalizeAttrsList   func([]gsxast.Attr) ([]componentAttrsStreamNode, bool)
+		normalizeBranchLists func(then, els []gsxast.Attr) ([][]componentAttrsStreamNode, bool)
+		normalizeCaseLists   func(cases []*gsxast.AttrCaseClause) ([][]componentAttrsStreamNode, bool)
+	)
 	normalizeAttrsList = func(attrs []gsxast.Attr) ([]componentAttrsStreamNode, bool) {
 		nodes := make([]componentAttrsStreamNode, 0, len(attrs))
 		hasSyntaxError := false
@@ -259,23 +292,46 @@ func planComponentInputs(site callSiteID, el *gsxast.Element, target componentSi
 					attr:        attr,
 				})
 			case *gsxast.CondAttr:
-				then, thenSyntaxError := normalizeAttrsList(attr.Then)
-				otherwise, elseSyntaxError := normalizeAttrsList(attr.Else)
+				branches, branchSyntaxError := normalizeBranchLists(attr.Then, attr.Else)
 				nodes = append(nodes, componentAttrsStreamNode{
 					kind:           componentAttrsStreamConditional,
 					sourceIndex:    sourceIndex,
 					attr:           attr,
-					then:           then,
-					otherwise:      otherwise,
-					hasSyntaxError: thenSyntaxError || elseSyntaxError,
+					branches:       branches,
+					hasSyntaxError: branchSyntaxError,
 				})
-				hasSyntaxError = hasSyntaxError || thenSyntaxError || elseSyntaxError
+				hasSyntaxError = hasSyntaxError || branchSyntaxError
+			case *gsxast.SwitchAttr:
+				branches, branchSyntaxError := normalizeCaseLists(attr.Cases)
+				nodes = append(nodes, componentAttrsStreamNode{
+					kind:           componentAttrsStreamConditional,
+					sourceIndex:    sourceIndex,
+					attr:           attr,
+					branches:       branches,
+					hasSyntaxError: branchSyntaxError,
+				})
+				hasSyntaxError = hasSyntaxError || branchSyntaxError
 			default:
 				addDiagnostic(attr, "unsupported-component-attr", fmt.Sprintf("unsupported component attribute %T on <%s>", attr, el.Tag))
 				hasSyntaxError = true
 			}
 		}
 		return nodes, hasSyntaxError
+	}
+	normalizeBranchLists = func(then, els []gsxast.Attr) ([][]componentAttrsStreamNode, bool) {
+		thenNodes, thenErr := normalizeAttrsList(then)
+		elseNodes, elseErr := normalizeAttrsList(els)
+		return [][]componentAttrsStreamNode{thenNodes, elseNodes}, thenErr || elseErr
+	}
+	normalizeCaseLists = func(cases []*gsxast.AttrCaseClause) ([][]componentAttrsStreamNode, bool) {
+		branches := make([][]componentAttrsStreamNode, 0, len(cases))
+		anyErr := false
+		for _, cc := range cases {
+			nodes, err := normalizeAttrsList(cc.Body)
+			branches = append(branches, nodes)
+			anyErr = anyErr || err
+		}
+		return branches, anyErr
 	}
 	reportMissingAttrsTree := func(root componentAttrsStreamNode) {
 		var report func(componentAttrsStreamNode)
@@ -288,13 +344,10 @@ func planComponentInputs(site callSiteID, el *gsxast.Element, target componentSi
 				requireAttrs(node.attr, input)
 				return
 			}
-			for _, child := range node.then {
+			for _, child := range node.branchNodes() {
 				report(child)
 			}
-			for _, child := range node.otherwise {
-				report(child)
-			}
-			if len(node.then) == 0 && len(node.otherwise) == 0 && !node.hasSyntaxError {
+			if node.emptyBranches() && !node.hasSyntaxError {
 				requireAttrs(node.attr, "conditional attrs contributor")
 			}
 		}
@@ -344,15 +397,29 @@ func planComponentInputs(site callSiteID, el *gsxast.Element, target componentSi
 		case *gsxast.CondAttr:
 			currentContributor := contributorIndex
 			contributorIndex++
-			then, thenSyntaxError := normalizeAttrsList(attr.Then)
-			otherwise, elseSyntaxError := normalizeAttrsList(attr.Else)
+			branches, branchSyntaxError := normalizeBranchLists(attr.Then, attr.Else)
 			attrsNode := componentAttrsStreamNode{
 				kind:           componentAttrsStreamConditional,
 				sourceIndex:    sourceIndex,
 				attr:           attr,
-				then:           then,
-				otherwise:      otherwise,
-				hasSyntaxError: thenSyntaxError || elseSyntaxError,
+				branches:       branches,
+				hasSyntaxError: branchSyntaxError,
+			}
+			if attrsParam >= 0 {
+				addAttrsValue(attrsNode, currentContributor)
+			} else {
+				reportMissingAttrsTree(attrsNode)
+			}
+		case *gsxast.SwitchAttr:
+			currentContributor := contributorIndex
+			contributorIndex++
+			branches, branchSyntaxError := normalizeCaseLists(attr.Cases)
+			attrsNode := componentAttrsStreamNode{
+				kind:           componentAttrsStreamConditional,
+				sourceIndex:    sourceIndex,
+				attr:           attr,
+				branches:       branches,
+				hasSyntaxError: branchSyntaxError,
 			}
 			if attrsParam >= 0 {
 				addAttrsValue(attrsNode, currentContributor)

--- a/internal/codegen/component_call_plan_test.go
+++ b/internal/codegen/component_call_plan_test.go
@@ -291,17 +291,17 @@ func TestPlanComponentInputsConditionalAttrsBuildsRecursiveStream(t *testing.T) 
 		t.Fatalf("conditional stream root = %+v", root)
 	}
 	cond := el.Attrs[1].(*gsxast.CondAttr)
-	for i, node := range root.then {
+	for i, node := range root.branches[0] {
 		if node.attr != cond.Then[i] {
 			t.Errorf("then node %d attr = %p, want authored attr %p", i, node.attr, cond.Then[i])
 		}
 	}
-	for i, node := range root.otherwise {
+	for i, node := range root.branches[1] {
 		if node.attr != cond.Else[i] {
 			t.Errorf("else node %d attr = %p, want authored attr %p", i, node.attr, cond.Else[i])
 		}
 	}
-	if got := attrsStreamKinds(root.then); !slices.Equal(got, []componentAttrsStreamKind{
+	if got := attrsStreamKinds(root.branches[0]); !slices.Equal(got, []componentAttrsStreamKind{
 		componentAttrsStreamPair,
 		componentAttrsStreamContributor,
 		componentAttrsStreamPair,
@@ -310,17 +310,17 @@ func TestPlanComponentInputsConditionalAttrsBuildsRecursiveStream(t *testing.T) 
 	}) {
 		t.Fatalf("then kinds = %v", got)
 	}
-	if got := attrsStreamSourceIndexes(root.then); !slices.Equal(got, []int{0, 1, 2, 3, 4}) {
+	if got := attrsStreamSourceIndexes(root.branches[0]); !slices.Equal(got, []int{0, 1, 2, 3, 4}) {
 		t.Fatalf("then source indexes = %v", got)
 	}
-	if got := attrsStreamKinds(root.otherwise); !slices.Equal(got, []componentAttrsStreamKind{componentAttrsStreamContributor}) {
+	if got := attrsStreamKinds(root.branches[1]); !slices.Equal(got, []componentAttrsStreamKind{componentAttrsStreamContributor}) {
 		t.Fatalf("else kinds = %v", got)
 	}
-	nested := root.then[4]
-	if got := attrsStreamKinds(nested.then); !slices.Equal(got, []componentAttrsStreamKind{componentAttrsStreamContributor}) {
+	nested := root.branches[0][4]
+	if got := attrsStreamKinds(nested.branches[0]); !slices.Equal(got, []componentAttrsStreamKind{componentAttrsStreamContributor}) {
 		t.Fatalf("nested then kinds = %v", got)
 	}
-	if got := attrsStreamKinds(nested.otherwise); !slices.Equal(got, []componentAttrsStreamKind{componentAttrsStreamPair}) {
+	if got := attrsStreamKinds(nested.branches[1]); !slices.Equal(got, []componentAttrsStreamKind{componentAttrsStreamPair}) {
 		t.Fatalf("nested else kinds = %v", got)
 	}
 }
@@ -368,11 +368,11 @@ func TestPlanComponentInputsLeaflessConditionalIsAnAttrsContributor(t *testing.T
 			t.Fatalf("values = %+v, want one retained conditional contributor", plan.values)
 		}
 		outer := plan.values[0].attrsNode
-		if outer.kind != componentAttrsStreamConditional || len(outer.then) != 1 || outer.then[0].kind != componentAttrsStreamConditional {
+		if outer.kind != componentAttrsStreamConditional || len(outer.branches[0]) != 1 || outer.branches[0][0].kind != componentAttrsStreamConditional {
 			t.Fatalf("conditional tree = %+v", outer)
 		}
-		if len(outer.then[0].then) != 0 || len(outer.then[0].otherwise) != 0 {
-			t.Fatalf("comment-only inner conditional retained value leaves: %+v", outer.then[0])
+		if len(outer.branches[0][0].branches[0]) != 0 || len(outer.branches[0][0].branches[1]) != 0 {
+			t.Fatalf("comment-only inner conditional retained value leaves: %+v", outer.branches[0][0])
 		}
 	})
 

--- a/internal/codegen/component_lsp_facts.go
+++ b/internal/codegen/component_lsp_facts.go
@@ -463,7 +463,7 @@ func componentExpressionSource(node gsxast.Node) (token.Pos, string, []gsxast.Pi
 	case *gsxast.OrderedPair:
 		return expression.Pos(), expression.Value, nil, true
 	case *gsxast.ComposedPart:
-		if expression.CF == nil && expression.CSSSegments == nil {
+		if expression.CF == nil && expression.LiteralSegments == nil {
 			return expression.ExprPos, expression.Expr, expression.Stages, true
 		}
 	case *gsxast.ValueArm:
@@ -522,6 +522,10 @@ func componentControlSourceStart(node gsxast.Node) (token.Pos, bool) {
 		return control.ListPos, control.ListPos.IsValid()
 	case *gsxast.CondAttr:
 		return control.CondPos, control.CondPos.IsValid()
+	case *gsxast.SwitchAttr:
+		return control.TagPos, control.TagPos.IsValid()
+	case *gsxast.AttrCaseClause:
+		return control.ListPos, control.ListPos.IsValid()
 	case *gsxast.SwitchMarkup:
 		return control.TagPos, control.TagPos.IsValid()
 	case *gsxast.CaseClause:
@@ -595,10 +599,7 @@ func componentCallFacts(plan componentPositionalPackagePlan) map[*gsxast.Element
 			case componentAttrsStreamContributor:
 				bind(node.attr, paramIndex)
 			case componentAttrsStreamConditional:
-				for _, child := range node.then {
-					bindAttrsContributors(child, paramIndex)
-				}
-				for _, child := range node.otherwise {
+				for _, child := range node.branchNodes() {
 					bindAttrsContributors(child, paramIndex)
 				}
 			}

--- a/internal/codegen/component_positional_emit.go
+++ b/internal/codegen/component_positional_emit.go
@@ -436,18 +436,24 @@ func positionalEmbeddedPipeline(b *bytes.Buffer, attr *gsxast.EmbeddedAttr, expr
 }
 
 func positionalConditionalAttrsExpr(b *bytes.Buffer, node componentAttrsStreamNode, plan componentPositionalSitePlan, ctx positionalEmitContext) positionalValueLowering {
+	if sw, ok := node.attr.(*gsxast.SwitchAttr); ok {
+		return positionalSwitchAttrsExpr(b, sw, node, plan, ctx)
+	}
 	cond, ok := node.attr.(*gsxast.CondAttr)
 	if !ok {
 		return positionalValueLowering{outcome: positionalLoweringUnsupported}
 	}
-	thenLowering := positionalAttrsBranchThunk(node.then, plan, ctx)
+	if len(node.branches) != 2 {
+		return positionalValueLowering{outcome: positionalLoweringUnsupported}
+	}
+	thenLowering := positionalAttrsBranchThunk(node.branches[0], plan, ctx)
 	if thenLowering.outcome != positionalLoweringReady {
 		return thenLowering
 	}
 	elseExpr := "nil"
 	used := thenLowering.used
-	if len(node.otherwise) != 0 {
-		elseLowering := positionalAttrsBranchThunk(node.otherwise, plan, ctx)
+	if len(node.branches[1]) != 0 {
+		elseLowering := positionalAttrsBranchThunk(node.branches[1], plan, ctx)
 		if elseLowering.outcome != positionalLoweringReady {
 			return elseLowering
 		}
@@ -461,6 +467,49 @@ func positionalConditionalAttrsExpr(b *bytes.Buffer, node componentAttrsStreamNo
 	name := fmt.Sprintf("_gsxv%d", *ctx.interpTemp)
 	*ctx.interpTemp++
 	fmt.Fprintf(b, "%s, _gsxerr := %s\n", name, expr)
+	fmt.Fprintf(b, "if _gsxerr != nil { %s }\n", ctx.errorReturn())
+	return readyPositionalValue(name, used)
+}
+
+// positionalSwitchAttrsExpr lowers an in-tag `{ switch … }` attrs contributor
+// on a COMPONENT tag. The if-form above composes into a single AttrsCond
+// expression; the switch form instead emits a real Go switch statement, for the
+// same reason the element-side emitter does: the tag must be evaluated exactly
+// once, and every arm shape Go allows — multi-value case lists, a tagless
+// switch, a type switch — then lowers unchanged. Each arm calls only its own
+// branch thunk, so an arm's attrs are built only when that arm is taken, and an
+// unmatched switch with no default leaves the nil bag, matching an `if` with no
+// `else`.
+func positionalSwitchAttrsExpr(b *bytes.Buffer, sw *gsxast.SwitchAttr, node componentAttrsStreamNode, plan componentPositionalSitePlan, ctx positionalEmitContext) positionalValueLowering {
+	if len(node.branches) != len(sw.Cases) {
+		return positionalValueLowering{outcome: positionalLoweringUnsupported}
+	}
+	thunks := make([]string, len(sw.Cases))
+	used := map[string]string{}
+	for i := range sw.Cases {
+		lowering := positionalAttrsBranchThunk(node.branches[i], plan, ctx)
+		if lowering.outcome != positionalLoweringReady {
+			return lowering
+		}
+		thunks[i] = lowering.expr
+		maps.Copy(used, lowering.used)
+	}
+	name := fmt.Sprintf("_gsxv%d", *ctx.interpTemp)
+	*ctx.interpTemp++
+	// A short var decl keeps _gsxerr shared with any sibling lowering in this
+	// scope (name is new, so `:=` is legal whether or not _gsxerr already
+	// exists), which is what ctx.errorReturn() refers to.
+	fmt.Fprintf(b, "%s, _gsxerr := %s.Attrs(nil), error(nil)\n", name, ctx.rt.rt())
+	fmt.Fprintf(b, "switch %s {\n", strings.TrimSpace(sw.Tag))
+	for i, cc := range sw.Cases {
+		if cc.Default {
+			b.WriteString("default:\n")
+		} else {
+			fmt.Fprintf(b, "case %s:\n", cc.List)
+		}
+		fmt.Fprintf(b, "%s, _gsxerr = (%s)()\n", name, thunks[i])
+	}
+	b.WriteString("}\n")
 	fmt.Fprintf(b, "if _gsxerr != nil { %s }\n", ctx.errorReturn())
 	return readyPositionalValue(name, used)
 }

--- a/internal/codegen/component_positional_plan.go
+++ b/internal/codegen/component_positional_plan.go
@@ -493,10 +493,7 @@ func completeComponentOperandFacts(plan componentCallPlan, discovered map[gsxast
 	var completeAttrsTree func(componentAttrsStreamNode)
 	completeAttrsTree = func(node componentAttrsStreamNode) {
 		if node.kind == componentAttrsStreamConditional {
-			for _, child := range node.then {
-				completeAttrsTree(child)
-			}
-			for _, child := range node.otherwise {
+			for _, child := range node.branchNodes() {
 				completeAttrsTree(child)
 			}
 			if _, exists := facts.get(node.attr); !exists {
@@ -557,7 +554,7 @@ func syntaxDefinedComponentFact(node gsxast.Node, nested expressionFactSet, runt
 			return expressionFact{}, false
 		}
 		return expressionFact{tv: types.TypeAndValue{Type: typ}, hasOrderedOperation: ordered}, true
-	case *gsxast.CondAttr:
+	case *gsxast.CondAttr, *gsxast.SwitchAttr:
 		return expressionFact{tv: types.TypeAndValue{Type: runtime.attrs}, hasOrderedOperation: true}, true
 	case *gsxast.Element:
 		return expressionFact{tv: types.TypeAndValue{Type: runtime.node}}, true
@@ -604,7 +601,7 @@ func nestedComponentFactBearingNode(node gsxast.Node) bool {
 	case *gsxast.Interp, *gsxast.OrderedPair, *gsxast.ValueArm:
 		return true
 	case *gsxast.ComposedPart:
-		return node.CF == nil && node.CSSSegments == nil
+		return node.CF == nil && node.LiteralSegments == nil
 	default:
 		return false
 	}
@@ -683,10 +680,7 @@ func validateRecursiveAttrsOperands(plan componentCallPlan, facts expressionFact
 	var visit func(componentAttrsStreamNode)
 	visit = func(node componentAttrsStreamNode) {
 		if node.kind == componentAttrsStreamConditional {
-			for _, child := range node.then {
-				visit(child)
-			}
-			for _, child := range node.otherwise {
+			for _, child := range node.branchNodes() {
 				visit(child)
 			}
 			return
@@ -718,10 +712,7 @@ func validateRequiredAttrsFacts(plan componentCallPlan, facts expressionFactSet,
 	var visit func(componentAttrsStreamNode)
 	visit = func(node componentAttrsStreamNode) {
 		if node.kind == componentAttrsStreamConditional {
-			for _, child := range node.then {
-				visit(child)
-			}
-			for _, child := range node.otherwise {
+			for _, child := range node.branchNodes() {
 				visit(child)
 			}
 			return

--- a/internal/codegen/component_positional_plan_test.go
+++ b/internal/codegen/component_positional_plan_test.go
@@ -401,7 +401,7 @@ func TestPlanComponentPositionalCallsDerivesNestedClassAndStyleFactsForSiblings(
 	}
 	classAttr := elements[0].Attrs[0].(*gsxast.ComposedAttr)
 	styleAttr := elements[1].Attrs[0].(*gsxast.ComposedAttr)
-	if len(styleAttr.Parts) != 2 || styleAttr.Parts[1].CSSSegments == nil {
+	if len(styleAttr.Parts) != 2 || styleAttr.Parts[1].LiteralSegments == nil {
 		t.Fatalf("style parts = %+v, want plain part followed by CSS literal", styleAttr.Parts)
 	}
 	stylePlain := &styleAttr.Parts[0]
@@ -503,7 +503,7 @@ func TestAggregateNestedComponentFactsUsesOnlyProbedValueNodes(t *testing.T) {
 
 	t.Run("CSS literal delegates to embedded values", func(t *testing.T) {
 		value := &gsxast.Interp{Expr: "tone()"}
-		root := &gsxast.ComposedAttr{Parts: []gsxast.ComposedPart{{CSSSegments: []gsxast.Markup{&gsxast.Text{Value: "color:"}, value}}}}
+		root := &gsxast.ComposedAttr{Parts: []gsxast.ComposedPart{{LiteralSegments: []gsxast.Markup{&gsxast.Text{Value: "color:"}, value}}}}
 		ordered, complete := aggregateNestedComponentFacts(root, newExpressionFactSet(map[gsxast.Node]expressionFact{
 			value: {tv: types.TypeAndValue{Type: types.Typ[types.String]}, tuple: types.NewTuple(
 				types.NewVar(token.NoPos, nil, "", types.Typ[types.String]),

--- a/internal/codegen/component_target.go
+++ b/internal/codegen/component_target.go
@@ -1011,6 +1011,10 @@ func harvestElementQualifierRoots(element *gsxast.Element, qualifiers map[string
 				scanStageQualifierRoots(n.Stages, qualifiers)
 			case *gsxast.CondAttr:
 				scanQualifierRoots(n.Cond, qualifiers)
+			case *gsxast.SwitchAttr:
+				scanQualifierRoots(n.Tag, qualifiers)
+			case *gsxast.AttrCaseClause:
+				scanQualifierRoots(n.List, qualifiers)
 			case *gsxast.ComposedPart:
 				scanQualifierRoots(n.Expr, qualifiers)
 				scanQualifierRoots(n.Cond, qualifiers)

--- a/internal/codegen/emit.go
+++ b/internal/codegen/emit.go
@@ -2420,6 +2420,13 @@ func hoistValueCF(b *bytes.Buffer, cf *ast.ValueCF, table funcTables, imports ma
 	*interpTemp++
 	fmt.Fprintf(b, "\t\tvar %s string\n", tmp)
 	armExpr := func(a *ast.ValueArm) (string, bool) {
+		// A literal arm reuses the SAME lowering a non-arm literal part uses, so
+		// the two can never diverge. It returns a complete contribution (a full
+		// declaration for style), hence no styleDeclExpr wrap and no renderer
+		// pass — exactly how composedParts treats a literal part.
+		if a.Segments != nil {
+			return composedLiteralSegmentsExpr(b, a.Segments, a.Pos(), a.End(), style, resolved, table, imports, rt, interpTemp, bag)
+		}
 		expr, used, err := lowerComposedPartSeed(ast.ComposedPart{Expr: a.Expr, Stages: a.Stages}, table, emitPipeWrap(b, interpTemp))
 		if err != nil {
 			bag.Errorf(a.Pos(), a.End(), "unresolved-pipeline", "%s", strings.TrimPrefix(err.Error(), "codegen: "))
@@ -3056,6 +3063,26 @@ func emitAttr(b *bytes.Buffer, attrs []ast.Attr, a ast.Attr, resolved map[ast.No
 		if len(t.Else) > 0 {
 			b.WriteString("\t\t} else {\n")
 			for _, inner := range t.Else {
+				if !emitAttr(b, attrs, inner, resolved, table, imports, rt, interpTemp, cls, tag, bag, mergeExpr, nonce) {
+					return false
+				}
+			}
+		}
+		b.WriteString("\t\t}\n")
+		return true
+	case *ast.SwitchAttr:
+		// Same statement position as the CondAttr `if` above, so a real Go
+		// `switch` is valid here. Emitting the tag once (rather than lowering to
+		// an `==` chain) is the whole point: a tag that is a call must be
+		// evaluated exactly once, as Go does.
+		fmt.Fprintf(b, "\t\tswitch %s {\n", t.Tag)
+		for _, cc := range t.Cases {
+			if cc.Default {
+				b.WriteString("\t\tdefault:\n")
+			} else {
+				fmt.Fprintf(b, "\t\tcase %s:\n", cc.List)
+			}
+			for _, inner := range cc.Body {
 				if !emitAttr(b, attrs, inner, resolved, table, imports, rt, interpTemp, cls, tag, bag, mergeExpr, nonce) {
 					return false
 				}
@@ -4409,12 +4436,8 @@ func composedParts(b *bytes.Buffer, a *ast.ComposedAttr, table funcTables, impor
 			parts = append(parts, partExpr(tmp))
 			continue
 		}
-		if p.CSSSegments != nil {
-			if !style {
-				bag.Errorf(p.Pos(), p.End(), "unsupported-class-part", "css literal parts are only valid in style={...}")
-				return nil, false
-			}
-			val, ok := cssLiteralStylePartExpr(b, p.CSSSegments, resolved, table, imports, rt, interpTemp, bag)
+		if p.LiteralSegments != nil {
+			val, ok := composedLiteralPartExpr(b, p, style, resolved, table, imports, rt, interpTemp, bag)
 			if !ok {
 				return nil, false
 			}
@@ -4495,6 +4518,30 @@ func composedParts(b *bytes.Buffer, a *ast.ComposedAttr, table funcTables, impor
 		parts = append(parts, conditionalPartExpr(val, cond))
 	}
 	return parts, true
+}
+
+// composedLiteralPartExpr lowers a prefixed backtick literal used as a
+// composed part or a value-form arm. class={…} and style={…} each take the
+// literal matching their own value context — f`…` and css`…` — and the parser
+// has already rejected the other language, so this only has to pick the
+// lowering. Each hole is escaped by its own context's sanitizer either way, so
+// composing a literal never widens what a hole may contribute.
+func composedLiteralPartExpr(b *bytes.Buffer, p *ast.ComposedPart, style bool, resolved map[ast.Node]types.Type, table funcTables, imports map[string]bool, rt rtImports, interpTemp *int, bag *diag.Bag) (string, bool) {
+	return composedLiteralSegmentsExpr(b, p.LiteralSegments, p.Pos(), p.End(), style, resolved, table, imports, rt, interpTemp, bag)
+}
+
+// composedLiteralSegmentsExpr is composedLiteralPartExpr over bare segments, so
+// a *ast.ValueArm literal can reuse the identical lowering its non-arm
+// counterpart uses — one path, so an arm and a plain part can never diverge.
+func composedLiteralSegmentsExpr(b *bytes.Buffer, segments []ast.Markup, pos, end token.Pos, style bool, resolved map[ast.Node]types.Type, table funcTables, imports map[string]bool, rt rtImports, interpTemp *int, bag *diag.Bag) (string, bool) {
+	if style {
+		return cssLiteralStylePartExpr(b, segments, resolved, table, imports, rt, interpTemp, bag)
+	}
+	// A class f`…` literal is an ordinary interpolated text value: each hole is
+	// HTML-escaped by embeddedValueExpr, and the joined string is then merged
+	// as one class contribution.
+	return embeddedValueExpr(b, segments, resolved, table, imports, rt, interpTemp, bag, "return _gsxerr", false, false,
+		"invalid-tuple", "class f literal interpolation")
 }
 
 func cssLiteralStylePartExpr(b *bytes.Buffer, segments []ast.Markup, resolved map[ast.Node]types.Type, table funcTables, imports map[string]bool, rt rtImports, interpTemp *int, bag *diag.Bag) (string, bool) {

--- a/internal/codegen/rebase.go
+++ b/internal/codegen/rebase.go
@@ -104,6 +104,10 @@ func rebaseAttrs(attrs []ast.Attr, doJS, doCSS bool) {
 		case *ast.CondAttr:
 			rebaseAttrs(v.Then, doJS, doCSS)
 			rebaseAttrs(v.Else, doJS, doCSS)
+		case *ast.SwitchAttr:
+			for _, cc := range v.Cases {
+				rebaseAttrs(cc.Body, doJS, doCSS)
+			}
 		}
 	}
 }

--- a/internal/codegen/reserved_scan.go
+++ b/internal/codegen/reserved_scan.go
@@ -134,6 +134,10 @@ func checkReservedDecls(file *gsxast.File) []reservedDecl {
 			scan(x.List, x.ListPos)
 		case *gsxast.CondAttr:
 			scan(x.Cond, x.CondPos)
+		case *gsxast.SwitchAttr:
+			scan(x.Tag, x.TagPos)
+		case *gsxast.AttrCaseClause:
+			scan(x.List, x.ListPos)
 		case *gsxast.ComposedPart:
 			scan(x.Expr, x.ExprPos)
 			scan(x.Cond, x.CondPos)

--- a/internal/corpus/testdata/cases/attrswitch/component_tag.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/component_tag.txtar
@@ -1,0 +1,14 @@
+# a switch attribute on a COMPONENT tag routes through the attrs bag
+-- input.gsx --
+package views
+
+import "github.com/gsxhq/gsx"
+
+component Leaf(attrs gsx.Attrs) { <span { attrs... }>leaf</span> }
+
+component C(n int) { <Leaf { switch n { case 1: data-one="y" default: data-other="y" } }/> }
+-- invoke --
+C(9)
+-- diagnostics.golden --
+-- render.golden --
+<span data-other="y">leaf</span>

--- a/internal/corpus/testdata/cases/attrswitch/composed_arms.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/composed_arms.txtar
@@ -1,0 +1,10 @@
+# composed class= / style= attributes inside switch arms
+-- input.gsx --
+package views
+
+component C(n int) { <div { switch n { case 1: class={ "a" } default: style={ "color: red" } } }>x</div> }
+-- invoke --
+C(2)
+-- diagnostics.golden --
+-- render.golden --
+<div style="color: red">x</div>

--- a/internal/corpus/testdata/cases/attrswitch/css_literal_arm.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/css_literal_arm.txtar
@@ -1,0 +1,11 @@
+# css`` literal values inside switch arms: each @{ } hole is still filtered, so
+# the static `/` separator is the ONLY slash that can reach the declaration
+-- input.gsx --
+package views
+
+component C(n int, w string) { <div { switch n { case 1: style=css`aspect-ratio: @{w} / 9` default: style=css`aspect-ratio: @{w}` } }>x</div> }
+-- invoke --
+C(1, "1;color:red")
+-- diagnostics.golden --
+-- render.golden --
+<div style="aspect-ratio: ZgotmplZ / 9">x</div>

--- a/internal/corpus/testdata/cases/attrswitch/fallthrough_rejected.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/fallthrough_rejected.txtar
@@ -1,0 +1,10 @@
+# error: `fallthrough` in a switch attribute would emit two arms' attributes
+# and silently duplicate names
+-- input.gsx --
+package views
+
+component C(n int) { <div { switch n { case 1: data-one="y" fallthrough case 2: data-two="y" } }>x</div> }
+-- ast.golden --
+File package=views
+-- diagnostics.golden --
+3:61: `fallthrough` is not supported in a `{ switch … }` attribute; list the shared attributes in each `case` instead

--- a/internal/corpus/testdata/cases/attrswitch/nested_if.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/nested_if.txtar
@@ -1,0 +1,10 @@
+# an `{ if … }` group nested inside a switch arm
+-- input.gsx --
+package views
+
+component C(n int, c bool) { <div { switch n { case 1: { if c { data-c="y" } else { data-nc="y" } } default: data-other="y" } }>x</div> }
+-- invoke --
+C(1, false)
+-- diagnostics.golden --
+-- render.golden --
+<div data-nc="y">x</div>

--- a/internal/corpus/testdata/cases/attrswitch/nested_switch.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/nested_switch.txtar
@@ -1,0 +1,10 @@
+# a switch attribute nested inside another switch arm
+-- input.gsx --
+package views
+
+component C(n int, m int) { <div { switch n { case 1: { switch m { case 2: data-m="y" } } default: data-other="y" } }>x</div> }
+-- invoke --
+C(1, 2)
+-- diagnostics.golden --
+-- render.golden --
+<div data-m="y">x</div>

--- a/internal/corpus/testdata/cases/attrswitch/no_default.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/no_default.txtar
@@ -1,0 +1,11 @@
+# a switch attribute with no matching case contributes nothing, like an `if`
+# with no `else`
+-- input.gsx --
+package views
+
+component C(n int) { <div { switch n { case 1: data-one="y" } }>x</div> }
+-- invoke --
+C(2)
+-- diagnostics.golden --
+-- render.golden --
+<div>x</div>

--- a/internal/corpus/testdata/cases/attrswitch/spread_after.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/spread_after.txtar
@@ -1,0 +1,12 @@
+# a spread following a switch attribute keeps source order (post-spread path)
+-- input.gsx --
+package views
+
+import "github.com/gsxhq/gsx"
+
+component C(n int, extra gsx.Attrs) { <div { switch n { case 1: data-one="y" default: data-other="y" } } { extra... }>x</div> }
+-- invoke --
+C(1, gsx.Attrs{{Key: "data-extra", Value: "e"}})
+-- diagnostics.golden --
+-- render.golden --
+<div data-one="y" data-extra="e">x</div>

--- a/internal/corpus/testdata/cases/attrswitch/spread_before.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/spread_before.txtar
@@ -1,0 +1,12 @@
+# a spread preceding a switch attribute keeps source order
+-- input.gsx --
+package views
+
+import "github.com/gsxhq/gsx"
+
+component C(n int, extra gsx.Attrs) { <div { extra... } { switch n { case 1: data-one="y" default: data-other="y" } }>x</div> }
+-- invoke --
+C(1, gsx.Attrs{{Key: "data-extra", Value: "e"}})
+-- diagnostics.golden --
+-- render.golden --
+<div data-extra="e" data-one="y">x</div>

--- a/internal/corpus/testdata/cases/attrswitch/tagged.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/tagged.txtar
@@ -1,0 +1,22 @@
+# in-tag `{ switch … }`: tagged, multi-value case list, and default
+-- input.gsx --
+package views
+
+component C(n int) {
+	<div
+		{ switch n {
+		case 1:
+			data-one="y"
+		case 2, 3:
+			data-two="y" data-three="y"
+		default:
+			data-other="y"
+		} }
+		id="b"
+	>x</div>
+}
+-- invoke --
+C(3)
+-- diagnostics.golden --
+-- render.golden --
+<div data-two="y" data-three="y" id="b">x</div>

--- a/internal/corpus/testdata/cases/attrswitch/tagless.txtar
+++ b/internal/corpus/testdata/cases/attrswitch/tagless.txtar
@@ -1,0 +1,10 @@
+# tagless `{ switch { case <bool>: … } }` in attribute position
+-- input.gsx --
+package views
+
+component C(n int) { <div { switch { case n > 5: data-big="y" default: data-small="y" } }>x</div> }
+-- invoke --
+C(9)
+-- diagnostics.golden --
+-- render.golden --
+<div data-big="y">x</div>

--- a/internal/corpus/testdata/cases/literalarms/class_css_literal_rejected.txtar
+++ b/internal/corpus/testdata/cases/literalarms/class_css_literal_rejected.txtar
@@ -1,0 +1,11 @@
+# error: a css`` literal supplied as a class value ran the CSS value filter
+# over a CLASS string, so an ordinary utility class like `bg-primary/20`
+# collapsed to ZgotmplZ. class= takes f`` only.
+-- input.gsx --
+package views
+
+component C(v string) { <div class=css`color: @{v}`>x</div> }
+-- ast.golden --
+File package=views
+-- diagnostics.golden --
+3:36: css literals are not valid in class=…; class takes f`…` literals

--- a/internal/corpus/testdata/cases/literalarms/class_if.txtar
+++ b/internal/corpus/testdata/cases/literalarms/class_if.txtar
@@ -1,0 +1,10 @@
+# f`` literal arm in a class={} value-form if, alongside a plain string part
+-- input.gsx --
+package views
+
+component C(c bool, v string) { <div class={ "base", if c { f`btn-@{v}` } else { "off" } }>x</div> }
+-- invoke --
+C(true, "primary")
+-- diagnostics.golden --
+-- render.golden --
+<div class="base btn-primary">x</div>

--- a/internal/corpus/testdata/cases/literalarms/class_js_literal_rejected.txtar
+++ b/internal/corpus/testdata/cases/literalarms/class_js_literal_rejected.txtar
@@ -1,0 +1,10 @@
+# error: the same rule covers js`` — its holes are JS-escaped, which is the
+# wrong sanitizer for a class value.
+-- input.gsx --
+package views
+
+component C(v string) { <div class={js`x = @{v}`}>x</div> }
+-- ast.golden --
+File package=views
+-- diagnostics.golden --
+3:37: js literals are not valid in class=…; class takes f`…` literals

--- a/internal/corpus/testdata/cases/literalarms/class_literal_part.txtar
+++ b/internal/corpus/testdata/cases/literalarms/class_literal_part.txtar
@@ -1,0 +1,11 @@
+# f`` as one composed part among several in class={} — the class counterpart of
+# style={ "a: 1", css`…` }
+-- input.gsx --
+package views
+
+component C(v string, on bool) { <div class={ "base", f`btn-@{v}`, f`sz-@{v}`: on }>x</div> }
+-- invoke --
+C("primary", true)
+-- diagnostics.golden --
+-- render.golden --
+<div class="base btn-primary sz-primary">x</div>

--- a/internal/corpus/testdata/cases/literalarms/class_switch.txtar
+++ b/internal/corpus/testdata/cases/literalarms/class_switch.txtar
@@ -1,0 +1,10 @@
+# f`` literal arms in a class={} value-form switch
+-- input.gsx --
+package views
+
+component C(n int, v string) { <div class={ switch n { case 1: f`btn-@{v}` default: "plain" } }>x</div> }
+-- invoke --
+C(1, "primary")
+-- diagnostics.golden --
+-- render.golden --
+<div class="btn-primary">x</div>

--- a/internal/corpus/testdata/cases/literalarms/class_switch_hostile.txtar
+++ b/internal/corpus/testdata/cases/literalarms/class_switch_hostile.txtar
@@ -1,0 +1,11 @@
+# a hostile hole in an f`` class literal arm is HTML-escaped, so it cannot
+# break out of the class attribute
+-- input.gsx --
+package views
+
+component C(n int, v string) { <div class={ switch n { case 1: f`btn-@{v}` default: "plain" } }>x</div> }
+-- invoke --
+C(1, `x" onclick="alert(1)`)
+-- diagnostics.golden --
+-- render.golden --
+<div class="btn-x&#34; onclick=&#34;alert(1)">x</div>

--- a/internal/corpus/testdata/cases/literalarms/style_f_literal_rejected.txtar
+++ b/internal/corpus/testdata/cases/literalarms/style_f_literal_rejected.txtar
@@ -1,0 +1,12 @@
+# error: an f`` literal supplied as a style value escaped its holes for HTML
+# only and never ran the CSS value filter, so a hole could inject CSS
+# (`background:url(javascript:…)`) into the style attribute. The literal's
+# language is what selects the sanitizer, so style= takes css`` only.
+-- input.gsx --
+package views
+
+component C(v string) { <div style=f`color: @{v}`>x</div> }
+-- ast.golden --
+File package=views
+-- diagnostics.golden --
+3:36: f literals are not valid in style=…; style takes css`…` literals

--- a/internal/corpus/testdata/cases/literalarms/style_if.txtar
+++ b/internal/corpus/testdata/cases/literalarms/style_if.txtar
@@ -1,0 +1,10 @@
+# css`` literal arm in a style={} value-form if, mixed with a string arm
+-- input.gsx --
+package views
+
+component C(c bool, v string) { <div style={ if c { css`color: @{v}` } else { "color: gray" } }>x</div> }
+-- invoke --
+C(true, "red")
+-- diagnostics.golden --
+-- render.golden --
+<div style="color: red">x</div>

--- a/internal/corpus/testdata/cases/literalarms/style_switch.txtar
+++ b/internal/corpus/testdata/cases/literalarms/style_switch.txtar
@@ -1,0 +1,11 @@
+# css`` literal arms in a style={} value-form switch: the static `/` separator
+# is template text, so only the numbers are holes and each is still filtered
+-- input.gsx --
+package views
+
+component C(n int, w string) { <div style={ switch n { case 1: css`aspect-ratio: @{w} / 9` default: css`aspect-ratio: @{w}` } }>x</div> }
+-- invoke --
+C(1, "16")
+-- diagnostics.golden --
+-- render.golden --
+<div style="aspect-ratio: 16 / 9">x</div>

--- a/internal/corpus/testdata/cases/literalarms/style_switch_hostile.txtar
+++ b/internal/corpus/testdata/cases/literalarms/style_switch_hostile.txtar
@@ -1,0 +1,11 @@
+# a hostile hole in a css`` literal arm is filtered exactly as it is outside an
+# arm — branching never widens what a hole may contribute
+-- input.gsx --
+package views
+
+component C(n int, w string) { <div style={ switch n { case 1: css`aspect-ratio: @{w} / 9` default: css`aspect-ratio: @{w}` } }>x</div> }
+-- invoke --
+C(1, "1;color:red")
+-- diagnostics.golden --
+-- render.golden --
+<div style="aspect-ratio: ZgotmplZ / 9">x</div>

--- a/internal/corpus/testdata/cases/literalarms/wrong_language_arm_rejected.txtar
+++ b/internal/corpus/testdata/cases/literalarms/wrong_language_arm_rejected.txtar
@@ -1,0 +1,9 @@
+# error: the same language rule applies inside a value-form arm
+-- input.gsx --
+package views
+
+component C(n int, v string) { <div class={ switch n { case 1: css`color: @{v}` default: "plain" } }>x</div> }
+-- ast.golden --
+File package=views
+-- diagnostics.golden --
+3:64: css literal arms are not valid in class={...}; class={...} takes f`…` literals

--- a/internal/corpus/testdata/cases/literalarms/wrong_language_rejected.txtar
+++ b/internal/corpus/testdata/cases/literalarms/wrong_language_rejected.txtar
@@ -1,0 +1,10 @@
+# error: each composable attribute takes only its own literal language —
+# class={} takes f`…`, style={} takes css`…`
+-- input.gsx --
+package views
+
+component C(v string) { <div class={ "base", css`color: @{v}` }>x</div> }
+-- ast.golden --
+File package=views
+-- diagnostics.golden --
+3:46: css literal parts are not valid in class={...}; class={...} takes f`…` literals

--- a/internal/corpus/testdata/cases/textattr/style_spread_merge.txtar
+++ b/internal/corpus/testdata/cases/textattr/style_spread_merge.txtar
@@ -5,7 +5,7 @@ package views
 
 import "github.com/gsxhq/gsx"
 component Box(w int, attrs gsx.Attrs) {
-	<div style=f`width:@{w}px` { attrs... }>x</div>
+	<div style=css`width:@{w}px` { attrs... }>x</div>
 }
 -- invoke --
 Box(10, gsx.Attrs{{Key: "style", Value: "color:red"}, {Key: "id", Value: "b"}})
@@ -27,21 +27,19 @@ import (
 func Box(w int, attrs gsx.Attrs) _gsxrt.Node {
 	return _gsxrt.Func(func(ctx _gsxctx.Context, _gsxw _gsxio.Writer) error {
 		_gsxgw := _gsxrt.W(_gsxw)
-		var _gsxnum [32]byte
 //line input.gsx:6:2
 		_gsxgw.S("<div")
-		_gsxgw.ClassMerged(_gsxrt.DefaultClassMerge, attrs.Class())
-		if attrs.Has("style") {
-			_gsxgw.StyleMerged("width:"+_gsxsc.FormatInt(int64(w), 10)+"px", attrs.Style())
-		} else {
+		if !attrs.Has("style") {
 			_gsxgw.S(" style=\"width:")
-			_gsxgw.IntInto(_gsxnum[:], int64(w))
+			_gsxgw.AttrValue(_gsxrt.StyleValue(_gsxsc.FormatInt(int64(w), 10)))
 			_gsxgw.S("px\"")
 		}
+		_gsxgw.ClassMerged(_gsxrt.DefaultClassMerge, attrs.Class())
+		_gsxgw.StyleMerged("", attrs.Style())
 		_gsxgw.Spread(ctx, "div", attrs, _gsxrt.AttrSinks{}, []string{"class", "style"})
 		_gsxgw.S(">x</div>")
 		return _gsxgw.Err()
 	})
 }
 -- render.golden --
-<div style="width:10px; color:red" id="b">x</div>
+<div style="color:red" id="b">x</div>

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -51,6 +51,17 @@ attrsonly/reject_shadowed_qualifier	diag(error)
 attrsonly/reject_undefined	diag(error)
 attrsonly/sibling_cf_class	diag gen render
 attrsonly/unnamed_slice	diag gen render
+attrswitch/component_tag	diag render
+attrswitch/composed_arms	diag render
+attrswitch/css_literal_arm	diag render
+attrswitch/fallthrough_rejected	ast diag(error)
+attrswitch/nested_if	diag render
+attrswitch/nested_switch	diag render
+attrswitch/no_default	diag render
+attrswitch/spread_after	diag render
+attrswitch/spread_before	diag render
+attrswitch/tagged	diag render
+attrswitch/tagless	diag render
 bodyinterp/bare_backtick_no_interp	diag gen render
 bodyinterp/escaped_hole	diag gen render
 bodyinterp/f_body_is_markup_template	diag gen render
@@ -496,6 +507,18 @@ jsattr/whole_value_bool	diag gen render
 jsattr/whole_value_map	diag gen render
 jsattr/xdata_literal_holes	diag gen render
 jsattr/xdata_whole_value	diag gen render
+literalarms/class_css_literal_rejected	ast diag(error)
+literalarms/class_if	diag render
+literalarms/class_js_literal_rejected	ast diag(error)
+literalarms/class_literal_part	diag render
+literalarms/class_switch	diag render
+literalarms/class_switch_hostile	diag render
+literalarms/style_f_literal_rejected	ast diag(error)
+literalarms/style_if	diag render
+literalarms/style_switch	diag render
+literalarms/style_switch_hostile	diag render
+literalarms/wrong_language_arm_rejected	ast diag(error)
+literalarms/wrong_language_rejected	ast diag(error)
 lowertags/cycle_conditional_ok	diag render
 lowertags/cycle_warning	diag render
 lowertags/embedded_interp_resolution	diag render
@@ -984,4 +1007,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 986 cases (render: 845, error: 103, gen-pinned: 566)
+TOTAL: 1009 cases (render: 862, error: 109, gen-pinned: 566)

--- a/internal/cssmin/file.go
+++ b/internal/cssmin/file.go
@@ -223,6 +223,12 @@ func minifyAttrs(attrs []ast.Attr, ext func(string) (string, error)) error {
 			if err := minifyAttrs(v.Else, ext); err != nil {
 				return err
 			}
+		case *ast.SwitchAttr:
+			for _, cc := range v.Cases {
+				if err := minifyAttrs(cc.Body, ext); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil

--- a/internal/gsxfmt/testdata/cases/attr_switch.txtar
+++ b/internal/gsxfmt/testdata/cases/attr_switch.txtar
@@ -1,0 +1,70 @@
+Layout fact: an in-tag `{ switch … }` attribute always prints broken across
+lines, the same templ-style layout `{ if … }` uses, so a one-line authored
+switch is opened out. Case labels sit at the switch's own indent (Go's layout
+for switch bodies) and each arm's attributes are indented one level under their
+label. An empty arm keeps its label on its own line without emitting a blank
+one, and the group's BreakParent breaks the enclosing opening tag.
+
+-- input.gsx --
+package main
+
+component C(n int, m int) {
+	<div { switch n { case 1: data-one="y" case 2, 3: data-two="y" data-three="y" case 4: default: data-other="y" } } id="b">x</div>
+}
+
+component Tagless(n int) {
+	<div { switch { case n > 5: data-big="y" default: data-small="y" } }>x</div>
+}
+
+component Nested(n int, m int) {
+	<div { switch n { case 1: { switch m { case 2: data-m="y" } } default: data-other="y" } }>x</div>
+}
+-- fmt.golden --
+package main
+
+component C(n int, m int) {
+	<div
+		{ switch n {
+		case 1:
+			data-one="y"
+		case 2, 3:
+			data-two="y"
+			data-three="y"
+		case 4:
+		default:
+			data-other="y"
+		} }
+		id="b"
+	>
+		x
+	</div>
+}
+
+component Tagless(n int) {
+	<div
+		{ switch {
+		case n > 5:
+			data-big="y"
+		default:
+			data-small="y"
+		} }
+	>
+		x
+	</div>
+}
+
+component Nested(n int, m int) {
+	<div
+		{ switch n {
+		case 1:
+			{ switch m {
+			case 2:
+				data-m="y"
+			} }
+		default:
+			data-other="y"
+		} }
+	>
+		x
+	</div>
+}

--- a/internal/gsxfmt/testdata/cases/value_form_literal_arms.txtar
+++ b/internal/gsxfmt/testdata/cases/value_form_literal_arms.txtar
@@ -1,0 +1,36 @@
+Layout fact: a value-form arm holding a prefixed backtick literal prints as the
+literal itself, identically to the same literal used as a plain composed part —
+an arm is a value position like any other, so it neither gains nor loses
+formatting. class={…} takes f`…`, style={…} takes css`…`.
+
+-- input.gsx --
+package main
+
+component StyleSwitch(n int, w string) {
+	<div style={ switch n { case 1: css`aspect-ratio: @{w} / 9` default: css`aspect-ratio: @{w}` } }>a</div>
+}
+
+component ClassIf(c bool, v string) {
+	<div class={ "base", if c { f`btn-@{v}` } else { "off" } }>b</div>
+}
+-- fmt.golden --
+package main
+
+component StyleSwitch(n int, w string) {
+	<div
+		style={
+			switch n {
+			case 1:
+				css`aspect-ratio: @{w} / 9`
+			default:
+				css`aspect-ratio: @{w}`
+			}
+		}
+	>
+		a
+	</div>
+}
+
+component ClassIf(c bool, v string) {
+	<div class={ "base", if c { f`btn-@{v}` } else { "off" } }>b</div>
+}

--- a/internal/jsmin/file.go
+++ b/internal/jsmin/file.go
@@ -213,6 +213,12 @@ func minifyJSAttrs(attrs []ast.Attr, m Minifiers) error {
 			if err := minifyJSAttrs(v.Else, m); err != nil {
 				return err
 			}
+		case *ast.SwitchAttr:
+			for _, cc := range v.Cases {
+				if err := minifyJSAttrs(cc.Body, m); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil

--- a/internal/jsx/jsx.go
+++ b/internal/jsx/jsx.go
@@ -202,7 +202,7 @@ func resolveAttrList(attrs []ast.Attr, bag *diag.Bag) bool {
 			}
 		case *ast.ComposedAttr:
 			for i := range at.Parts {
-				if at.Parts[i].CSSSegments != nil && !resolveMarkup(at.Parts[i].CSSSegments, bag) {
+				if at.Parts[i].LiteralSegments != nil && !resolveMarkup(at.Parts[i].LiteralSegments, bag) {
 					ok = false
 				}
 			}
@@ -212,6 +212,12 @@ func resolveAttrList(attrs []ast.Attr, bag *diag.Bag) bool {
 			}
 			if !resolveAttrList(at.Else, bag) {
 				ok = false
+			}
+		case *ast.SwitchAttr:
+			for _, cc := range at.Cases {
+				if !resolveAttrList(cc.Body, bag) {
+					ok = false
+				}
 			}
 		}
 	}

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -80,7 +80,7 @@ func nodeNavSpans(n gsxast.Node) (spans []navSpan, stages []gsxast.PipeStage) {
 		if e.CF != nil {
 			return nil, nil // the CF's own nodes carry the spans
 		}
-		if e.CSSSegments == nil {
+		if e.LiteralSegments == nil {
 			spans = append(spans, navSpan{e.ExprPos, len(e.Expr)})
 			stages = e.Stages
 		}
@@ -89,6 +89,9 @@ func nodeNavSpans(n gsxast.Node) (spans []navSpan, stages []gsxast.PipeStage) {
 		}
 		return spans, stages
 	case *gsxast.ValueArm:
+		if e.Segments != nil {
+			return nil, nil // a literal arm's holes carry their own spans
+		}
 		return []navSpan{{e.ExprPos, len(e.Expr)}}, e.Stages
 	case *gsxast.ValueIf:
 		return []navSpan{{e.CondPos, len(e.Cond)}}, nil
@@ -98,6 +101,10 @@ func nodeNavSpans(n gsxast.Node) (spans []navSpan, stages []gsxast.PipeStage) {
 		return []navSpan{{e.ListPos, len(e.List)}}, nil
 	case *gsxast.CondAttr:
 		return []navSpan{{e.CondPos, len(e.Cond)}}, nil
+	case *gsxast.SwitchAttr:
+		return []navSpan{{e.TagPos, len(e.Tag)}}, nil
+	case *gsxast.AttrCaseClause:
+		return []navSpan{{e.ListPos, len(e.List)}}, nil
 	case *gsxast.SwitchMarkup:
 		return []navSpan{{e.TagPos, len(e.Tag)}}, nil
 	case *gsxast.CaseClause:
@@ -449,7 +456,8 @@ func isCtrlSpan(node gsxast.Node, matched token.Pos) bool {
 	switch e := node.(type) {
 	case *gsxast.ForMarkup, *gsxast.IfMarkup, *gsxast.GoBlock,
 		*gsxast.ValueIf, *gsxast.ValueSwitch, *gsxast.ValueSwitchCase,
-		*gsxast.CondAttr, *gsxast.SwitchMarkup, *gsxast.CaseClause:
+		*gsxast.CondAttr, *gsxast.SwitchMarkup, *gsxast.CaseClause,
+		*gsxast.SwitchAttr, *gsxast.AttrCaseClause:
 		return true
 	case *gsxast.ComposedPart:
 		return e.CondPos.IsValid() && matched == e.CondPos

--- a/internal/printer/corpus_test.go
+++ b/internal/printer/corpus_test.go
@@ -153,6 +153,10 @@ func zeroSpans(n ast.Node) {
 				}
 			case *ast.CondAttr:
 				v.CondPos = 0
+			case *ast.SwitchAttr:
+				v.TagPos = 0
+			case *ast.AttrCaseClause:
+				v.ListPos = 0
 			case *ast.ForMarkup:
 				v.ClausePos = 0
 				v.BodyMultiline = false

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -645,6 +645,8 @@ func (p *printer) attrDoc(a ast.Attr) pretty.Doc {
 	switch v := a.(type) {
 	case *ast.CondAttr:
 		return pretty.Concat(pretty.BreakParent, pretty.Text("{ "), p.condAttrChainDoc(v), pretty.Text(" }"))
+	case *ast.SwitchAttr:
+		return pretty.Concat(pretty.BreakParent, pretty.Text("{ "), p.switchAttrDoc(v), pretty.Text(" }"))
 	case *ast.ExprAttr:
 		val := []pretty.Doc{fmtExprDoc(v.Expr)}
 		for _, s := range v.Stages {
@@ -692,8 +694,8 @@ func (p *printer) composedPartDoc(part ast.ComposedPart) pretty.Doc {
 	if part.CF != nil {
 		return p.valueCFDoc(part.CF)
 	}
-	if part.CSSSegments != nil {
-		seg := []pretty.Doc{pretty.Text(embeddedLiteralString(ast.EmbeddedCSS, part.CSSSegments, embeddedDelim(part.CSSDoubleQuoted)))}
+	if part.LiteralSegments != nil {
+		seg := []pretty.Doc{pretty.Text(embeddedLiteralString(part.LiteralLang, part.LiteralSegments, embeddedDelim(part.LiteralDoubleQuoted)))}
 		if part.Cond != "" {
 			seg = append(seg, pretty.Text(": "), multiline(fmtExpr(part.Cond)))
 		}
@@ -737,6 +739,11 @@ func (p *printer) valueArmBody(a *ast.ValueArm) pretty.Doc {
 }
 
 func (p *printer) valueArmDoc(a *ast.ValueArm) pretty.Doc {
+	if a.Segments != nil {
+		// Same rendering a non-arm literal part gets (composedPartDoc), so an
+		// arm and a plain part print identically.
+		return pretty.Text(embeddedLiteralString(a.Lang, a.Segments, embeddedDelim(a.DoubleQuoted)))
+	}
 	seg := []pretty.Doc{fmtExprDoc(a.Expr)}
 	for _, s := range a.Stages {
 		seg = append(seg, pretty.Text(" |> "), multiline(pipeStageStr(s)))
@@ -789,6 +796,45 @@ func (p *printer) condAttrChainDoc(c *ast.CondAttr) pretty.Doc {
 	}
 	parts = append(parts, pretty.Text(" else {"), p.condAttrListDoc(c.Else), pretty.Text("}"))
 	return pretty.Concat(parts...)
+}
+
+// switchAttrDoc renders `switch [Tag] { case List: … default: … }` in
+// attribute position. Case labels sit at the switch's own indent (Go's layout
+// for switch bodies) and each arm's attributes are indented one level under
+// their label, mirroring condAttrChainDoc's one-attr-per-line body.
+func (p *printer) switchAttrDoc(s *ast.SwitchAttr) pretty.Doc {
+	parts := []pretty.Doc{pretty.Text("switch")}
+	if tag := fmtExpr(s.Tag); strings.TrimSpace(tag) != "" {
+		parts = append(parts, pretty.Text(" "), multiline(tag))
+	}
+	parts = append(parts, pretty.Text(" {"))
+	for _, cc := range s.Cases {
+		label := "default:"
+		if !cc.Default {
+			label = "case " + fmtExpr(cc.List) + ":"
+		}
+		parts = append(parts, pretty.HardLine, pretty.Text(label), p.attrCaseBodyDoc(cc.Body))
+	}
+	parts = append(parts, pretty.HardLine, pretty.Text("}"))
+	return pretty.Concat(parts...)
+}
+
+// attrCaseBodyDoc lays one case arm's attributes one per line, indented under
+// their label. An empty arm contributes nothing, so `case 1:` with no
+// attributes stays on its own line rather than emitting a blank one.
+func (p *printer) attrCaseBodyDoc(attrs []ast.Attr) pretty.Doc {
+	if len(attrs) == 0 {
+		return pretty.Text("")
+	}
+	inner := make([]pretty.Doc, 0, len(attrs)*2)
+	for _, a := range attrs {
+		sep := pretty.Doc(pretty.HardLine)
+		if c, ok := a.(*ast.CommentAttr); ok && c.Trailing {
+			sep = pretty.Text(" ") // glue a trailing comment to the previous attr's line
+		}
+		inner = append(inner, sep, p.attrDoc(a))
+	}
+	return pretty.Indent(pretty.Concat(inner...))
 }
 
 // condAttrListDoc lays a conditional attribute's inner attrs one per line.
@@ -1547,8 +1593,8 @@ func writeAttrInline(b *strings.Builder, a ast.Attr) {
 			if i > 0 {
 				b.WriteString(", ")
 			}
-			if part.CSSSegments != nil {
-				b.WriteString(embeddedLiteralString(ast.EmbeddedCSS, part.CSSSegments, embeddedDelim(part.CSSDoubleQuoted)))
+			if part.LiteralSegments != nil {
+				b.WriteString(embeddedLiteralString(part.LiteralLang, part.LiteralSegments, embeddedDelim(part.LiteralDoubleQuoted)))
 			} else {
 				b.WriteString(fmtExpr(part.Expr))
 				for _, s := range part.Stages {
@@ -1565,6 +1611,10 @@ func writeAttrInline(b *strings.Builder, a ast.Attr) {
 	case *ast.CondAttr:
 		b.WriteString("{ ")
 		writeCondAttrChain(b, v)
+		b.WriteString(" }")
+	case *ast.SwitchAttr:
+		b.WriteString("{ ")
+		writeSwitchAttr(b, v)
 		b.WriteString(" }")
 	case *ast.MarkupAttr:
 		b.WriteString(v.Name)
@@ -1926,6 +1976,28 @@ func writeCondAttrChain(b *strings.Builder, c *ast.CondAttr) {
 	}
 	b.WriteString(" else {")
 	writeCondAttrList(b, c.Else)
+	b.WriteString("}")
+}
+
+// writeSwitchAttr is switchAttrDoc's flat counterpart, for the inline
+// attribute slots that render without line breaks.
+func writeSwitchAttr(b *strings.Builder, s *ast.SwitchAttr) {
+	b.WriteString("switch")
+	if tag := fmtExpr(s.Tag); strings.TrimSpace(tag) != "" {
+		b.WriteString(" ")
+		b.WriteString(tag)
+	}
+	b.WriteString(" {")
+	for _, cc := range s.Cases {
+		if cc.Default {
+			b.WriteString(" default:")
+		} else {
+			b.WriteString(" case ")
+			b.WriteString(fmtExpr(cc.List))
+			b.WriteString(":")
+		}
+		writeCondAttrList(b, cc.Body)
+	}
 	b.WriteString("}")
 }
 

--- a/internal/wsnorm/wsnorm.go
+++ b/internal/wsnorm/wsnorm.go
@@ -148,6 +148,10 @@ func normalizeAttrs(attrs []ast.Attr) {
 		case *ast.CondAttr:
 			normalizeAttrs(v.Then)
 			normalizeAttrs(v.Else)
+		case *ast.SwitchAttr:
+			for _, cc := range v.Cases {
+				normalizeAttrs(cc.Body)
+			}
 		}
 	}
 }

--- a/parser/attrs.go
+++ b/parser/attrs.go
@@ -47,7 +47,7 @@ func (p *parser) splitComposed(name, src string, base int) ([]ast.ComposedPart, 
 			}
 			// Compute the absolute offset of the keyword's first byte (skip any
 			// leading whitespace so the parsers' at+len("kw") arithmetic is correct).
-			cf, err := p.parseValueCF(base+segStart+trimOff, kw)
+			cf, err := p.parseValueCF(name, base+segStart+trimOff, kw)
 			if err != nil {
 				return nil, err
 			}
@@ -70,10 +70,7 @@ func (p *parser) splitComposed(name, src string, base int) ([]ast.ComposedPart, 
 				break
 			}
 		}
-		if strings.HasPrefix(segSrc[trimOff:], "css`") || strings.HasPrefix(segSrc[trimOff:], `css"`) {
-			if name != "style" {
-				return nil, p.errorf(p.posAt(base+segStart+trimOff), "css literal parts are only valid in style={...}")
-			}
+		if hasEmbeddedLiteralPrefix(segSrc[trimOff:]) {
 			literalOff := base + segStart + trimOff
 			old := p.i
 			p.i = literalOff
@@ -83,8 +80,8 @@ func (p *parser) splitComposed(name, src string, base int) ([]ast.ComposedPart, 
 			if err != nil {
 				return nil, err
 			}
-			if lang != ast.EmbeddedCSS {
-				return nil, p.errorf(p.posAt(literalOff), "expected css literal in style={...}")
+			if want, ok := composedLiteralLang(name); !ok || lang != want {
+				return nil, p.errorf(p.posAt(literalOff), "%s literal parts are not valid in %s={...}; %s={...} takes %s literals", embeddedLangPrefix(lang), name, name, composedLiteralPrefix(name))
 			}
 			partEnd := segEnd
 			var condSrc string
@@ -99,9 +96,9 @@ func (p *parser) splitComposed(name, src string, base int) ([]ast.ComposedPart, 
 				condPos = p.posAt(condOff)
 			}
 			if rest := strings.TrimSpace(src[literalEnd-base : partEnd]); rest != "" {
-				return nil, p.errorf(p.posAt(literalEnd), "unexpected %q after css literal in style={...}", rest)
+				return nil, p.errorf(p.posAt(literalEnd), "unexpected %q after %s literal in %s={...}", rest, embeddedLangPrefix(lang), name)
 			}
-			parts = append(parts, ast.ComposedPart{CSSSegments: segments, CSSDoubleQuoted: dquoted, Cond: condSrc, CondPos: condPos})
+			parts = append(parts, ast.ComposedPart{LiteralSegments: segments, LiteralLang: lang, LiteralDoubleQuoted: dquoted, Cond: condSrc, CondPos: condPos})
 			ast.SetSpan(&parts[len(parts)-1], p.posAt(base+segStart), p.posAt(base+segEnd))
 			continue
 		}
@@ -134,6 +131,76 @@ func (p *parser) splitComposed(name, src string, base int) ([]ast.ComposedPart, 
 		ast.SetSpan(&parts[len(parts)-1], p.posAt(base+segStart), p.posAt(base+segEnd))
 	}
 	return parts, nil
+}
+
+// checkComposableLiteralLang rejects a prefixed backtick literal whose language
+// does not match the composable attribute it is being supplied to. class={…}
+// composes class strings and takes f`…`; style={…} composes declarations and
+// takes css`…`. Any other attribute composes nothing and is unrestricted.
+//
+// This is a correctness AND a safety rule, and it holds in every position a
+// literal may appear — whole value, list entry, and value-form arm — because
+// the literal's language is what picks the sanitizer applied to its @{ } holes:
+//
+//   - style=f`color: @{v}` escaped the hole for HTML only and never ran the CSS
+//     value filter, so a hole could inject `background:url(javascript:…)` into
+//     the style attribute.
+//   - class=css`…` ran the CSS value filter over a CLASS value, so an ordinary
+//     Tailwind class like `bg-primary/20` collapsed to ZgotmplZ.
+func (p *parser) checkComposableLiteralLang(name string, lang ast.EmbeddedLang, at token.Pos) error {
+	want, composable := composedLiteralLang(name)
+	if !composable || lang == want {
+		return nil
+	}
+	return p.errorf(at, "%s literals are not valid in %s=…; %s takes %s literals", embeddedLangPrefix(lang), name, name, composedLiteralPrefix(name))
+}
+
+// hasEmbeddedLiteralPrefix reports whether s begins with a prefixed backtick
+// literal opener (f`/f"/js`/js"/css`/css").
+func hasEmbeddedLiteralPrefix(s string) bool {
+	for _, pfx := range [...]string{"f`", `f"`, "js`", `js"`, "css`", `css"`} {
+		if strings.HasPrefix(s, pfx) {
+			return true
+		}
+	}
+	return false
+}
+
+// composedLiteralLang returns the literal language a composable attribute
+// accepts as a part or a value-form arm. class={…} composes class strings, so
+// it takes the text literal f`…`; style={…} composes declarations, so it takes
+// css`…`. Every other attribute composes nothing and accepts no literal part.
+func composedLiteralLang(name string) (ast.EmbeddedLang, bool) {
+	switch name {
+	case "class":
+		return ast.EmbeddedText, true
+	case "style":
+		return ast.EmbeddedCSS, true
+	}
+	return 0, false
+}
+
+// composedLiteralPrefix names the literal form composedLiteralLang accepts, for
+// diagnostics.
+func composedLiteralPrefix(name string) string {
+	switch name {
+	case "class":
+		return "f`…`"
+	case "style":
+		return "css`…`"
+	}
+	return "no"
+}
+
+// embeddedLangPrefix names a literal language by its source prefix.
+func embeddedLangPrefix(lang ast.EmbeddedLang) string {
+	switch lang {
+	case ast.EmbeddedJS:
+		return "js"
+	case ast.EmbeddedCSS:
+		return "css"
+	}
+	return "f"
 }
 
 func leadingSpaceLen(s string) int {
@@ -262,8 +329,11 @@ func (p *parser) parseSingleAttr() (ast.Attr, error) {
 		if p.i+1 < len(p.src) && p.src[p.i+1] == '{' {
 			return nil, p.errorf(p.posAt(p.i), "`{{ }}` is only valid as an attribute value `name={{ … }}`, not a standalone spread")
 		}
-		if p.braceKeyword() == "if" {
+		switch p.braceKeyword() {
+		case "if":
 			return p.parseCondAttr()
+		case "switch":
+			return p.parseSwitchAttr()
 		}
 		return p.parseSpreadAttr()
 	}
@@ -401,9 +471,13 @@ func (p *parser) parseBracedEmbeddedAttrValue(name string, attrStartPos token.Po
 	// can't contain a gsx backtick escape, so a Go-aware scan is safe there
 	// even though it is not safe over the literal itself (see goStagesEnd
 	// doc).
+	literalPos := p.posAt(p.i)
 	lang, dquoted, segments, err := p.parseEmbeddedAttrLiteral()
 	if err != nil {
 		return fallback()
+	}
+	if lerr := p.checkComposableLiteralLang(name, lang, literalPos); lerr != nil {
+		return nil, lerr
 	}
 	p.skipSpace()
 	afterLiteral := p.i
@@ -443,9 +517,13 @@ func (p *parser) parseBracedEmbeddedAttrValue(name string, attrStartPos token.Po
 }
 
 func (p *parser) parseEmbeddedAttrValue(name string, attrStartPos token.Pos) (ast.Attr, error) {
+	literalPos := p.posAt(p.i)
 	lang, dquoted, segments, err := p.parseEmbeddedAttrLiteral()
 	if err != nil {
 		return nil, err
+	}
+	if lerr := p.checkComposableLiteralLang(name, lang, literalPos); lerr != nil {
+		return nil, lerr
 	}
 	ea := &ast.EmbeddedAttr{Name: name, Lang: lang, Segments: segments, DoubleQuoted: dquoted}
 	ast.SetSpan(ea, attrStartPos, p.posAt(p.i))
@@ -684,6 +762,145 @@ func (p *parser) parseAttrsUntilBrace() ([]ast.Attr, error) {
 		if p.peek() == '}' {
 			p.i++ // consume '}'
 			return attrs, nil
+		}
+		if c, ok, err := p.parseTagComment(); err != nil {
+			return nil, err
+		} else if ok {
+			c.Trailing = len(attrs) > 0 && !strings.ContainsRune(p.src[wsStart:p.i], '\n')
+			attrs = append(attrs, c)
+			continue
+		}
+		a, err := p.parseSingleAttr()
+		if err != nil {
+			return nil, err
+		}
+		attrs = append(attrs, a)
+	}
+}
+
+// parseSwitchAttr parses `{ switch [Tag] { case List: … default: … } }` in
+// attribute position — the attribute counterpart of parseSwitchMarkup. Cursor
+// at '{'; the caller has verified the leading keyword is "switch".
+func (p *parser) parseSwitchAttr() (ast.Attr, error) {
+	startPos := p.posAt(p.i)
+	p.i++ // past outer '{'
+	p.skipSpace()
+	p.i += len("switch")
+	tagStart := p.i
+	braceOff, ok := scanToBlockBrace(p.src, p.i, "switch")
+	if !ok {
+		return nil, p.errorf(p.posAt(p.i), "expected `{` after `switch`")
+	}
+	tag := strings.TrimSpace(p.src[tagStart:braceOff])
+	tagPos := token.NoPos
+	if tag != "" {
+		tagPos = p.posAt(tagStart + leadingSpaceLen(p.src[tagStart:braceOff]))
+	}
+	p.i = braceOff + 1 // past switch-body '{'
+
+	var cases []*ast.AttrCaseClause
+	for {
+		p.skipSpace()
+		if p.eof() {
+			return nil, p.errorf(p.pos(), "unterminated `switch`, expected `}`")
+		}
+		if p.peek() == '}' {
+			p.i++ // past switch-body '}'
+			break
+		}
+		cc, err := p.parseAttrCaseClause()
+		if err != nil {
+			return nil, err
+		}
+		cases = append(cases, cc)
+	}
+
+	p.skipSpace()
+	if p.peek() != '}' {
+		return nil, p.errorf(p.pos(), "expected `}` to close `{ switch … }` attribute")
+	}
+	p.i++ // past outer '}'
+	n := &ast.SwitchAttr{Tag: tag, TagPos: tagPos, Cases: cases}
+	ast.SetSpan(n, startPos, p.posAt(p.i))
+	return n, nil
+}
+
+// parseAttrCaseClause parses one `case List:` or `default:` arm with its
+// attribute body. Cursor at the `case` or `default` keyword. It mirrors
+// parseCaseClause, differing only in that the body is an attribute list.
+func (p *parser) parseAttrCaseClause() (*ast.AttrCaseClause, error) {
+	startPos := p.posAt(p.i)
+	cc := &ast.AttrCaseClause{}
+	switch {
+	case p.atWord("case"):
+		p.i += len("case")
+		listStart := p.i
+		colonOff, ok := scanToCaseColon(p.src, p.i)
+		if !ok {
+			return nil, p.errorf(p.posAt(p.i), "expected `:` in `case`")
+		}
+		cc.List = strings.TrimSpace(p.src[listStart:colonOff])
+		if cc.List != "" {
+			cc.ListPos = p.posAt(listStart + leadingSpaceLen(p.src[listStart:colonOff]))
+		}
+		p.i = colonOff + 1 // past ':'
+	case p.atWord("default"):
+		p.i += len("default")
+		p.skipSpace()
+		if p.peek() != ':' {
+			return nil, p.errorf(p.pos(), "expected `:` after `default`")
+		}
+		cc.Default = true
+		p.i++ // past ':'
+	case p.atWord("fallthrough"):
+		// An attribute list is not a statement list: falling through would emit
+		// two arms' attributes and silently duplicate names. Reject it by name
+		// rather than letting it parse as a bool attribute called
+		// "fallthrough", which is what scanAttrName would otherwise produce.
+		return nil, p.errorf(p.pos(), "`fallthrough` is not supported in a `{ switch … }` attribute; list the shared attributes in each `case` instead")
+	default:
+		return nil, p.errorf(p.pos(), "expected `case` or `default` in `{ switch … }` attribute")
+	}
+	body, err := p.parseAttrCaseBody()
+	if err != nil {
+		return nil, err
+	}
+	cc.Body = body
+	ast.SetSpan(cc, startPos, p.posAt(p.i))
+	return cc, nil
+}
+
+// wordHasValue reports whether the word at the cursor is followed by `=`,
+// i.e. it is an attribute with a value rather than a bare bool attribute.
+func (p *parser) wordHasValue(word string) bool {
+	j := p.i + len(word)
+	for j < len(p.src) && (p.src[j] == ' ' || p.src[j] == '\t' || p.src[j] == '\r' || p.src[j] == '\n') {
+		j++
+	}
+	return j < len(p.src) && p.src[j] == '='
+}
+
+// parseAttrCaseBody parses the attribute body of a case arm. Like
+// parseCaseBody it does NOT consume its terminator: it stops (without
+// advancing) at the next `case`/`default` keyword or at the switch body's
+// closing `}`.
+func (p *parser) parseAttrCaseBody() ([]ast.Attr, error) {
+	var attrs []ast.Attr
+	for {
+		wsStart := p.i
+		p.skipSpace()
+		if p.eof() {
+			return nil, p.errorf(p.pos(), "unexpected EOF in `{ switch … }` attribute body")
+		}
+		if p.peek() == '}' || p.atWord("case") || p.atWord("default") {
+			return attrs, nil
+		}
+		// `fallthrough` reaches HERE, in body position, not at the clause start —
+		// scanAttrName would otherwise happily turn the bare keyword into a bool
+		// attribute literally named "fallthrough" and render it. Only the bare
+		// form is rejected: `fallthrough="x"` is an author writing an attribute.
+		if p.atWord("fallthrough") && !p.wordHasValue("fallthrough") {
+			return nil, p.errorf(p.pos(), "`fallthrough` is not supported in a `{ switch … }` attribute; list the shared attributes in each `case` instead")
 		}
 		if c, ok, err := p.parseTagComment(); err != nil {
 			return nil, err

--- a/parser/embedded_text_test.go
+++ b/parser/embedded_text_test.go
@@ -477,6 +477,11 @@ func TestParseEmbeddedAttrBracedPipe(t *testing.T) {
 	}
 }
 
+// These three use a NON-composable attribute (data-x) on purpose: class={…}
+// and style={…} accept only their own literal language, so a js“/css“ there
+// is rejected by that rule before the pipeline gate is reached. The attribute
+// is incidental to what they test — the whole-literal `|>` gate itself.
+//
 // TestParseEmbeddedAttrBracedJSPipeRejected pins the parser-level gate closing
 // a latent codegen gap: a whole-literal `|> f` pipeline is only meaningful on
 // a plain-text “ `…` “ literal, since the codegen only ever consumes Stages
@@ -484,7 +489,7 @@ func TestParseEmbeddedAttrBracedPipe(t *testing.T) {
 // cleanly (Stages set) and would be silently dropped at emit — wrong output,
 // no error. It must now be a parse error instead.
 func TestParseEmbeddedAttrBracedJSPipeRejected(t *testing.T) {
-	src := "package p\ncomponent C() { <span class={js`x` |> upper}>h</span> }\n"
+	src := "package p\ncomponent C() { <span data-x={js`x` |> upper}>h</span> }\n"
 	_, err := ParseFile(token.NewFileSet(), "in.gsx", []byte(src), 0)
 	if err == nil {
 		t.Fatalf("parse succeeded, want error rejecting whole-literal |> on a js`` literal")
@@ -497,7 +502,7 @@ func TestParseEmbeddedAttrBracedJSPipeRejected(t *testing.T) {
 // TestParseEmbeddedAttrBracedCSSPipeRejected is the css“ sibling of
 // TestParseEmbeddedAttrBracedJSPipeRejected.
 func TestParseEmbeddedAttrBracedCSSPipeRejected(t *testing.T) {
-	src := "package p\ncomponent C() { <span class={css`color:red` |> upper}>h</span> }\n"
+	src := "package p\ncomponent C() { <span data-x={css`color:red` |> upper}>h</span> }\n"
 	_, err := ParseFile(token.NewFileSet(), "in.gsx", []byte(src), 0)
 	if err == nil {
 		t.Fatalf("parse succeeded, want error rejecting whole-literal |> on a css`` literal")
@@ -512,7 +517,7 @@ func TestParseEmbeddedAttrBracedCSSPipeRejected(t *testing.T) {
 // pipe is unaffected by the gate and still parses as a plain EmbeddedAttr with
 // no Stages.
 func TestParseEmbeddedAttrBracedJSNoPipeStillParses(t *testing.T) {
-	src := "package p\ncomponent C() { <span class={js`x`}>h</span> }\n"
+	src := "package p\ncomponent C() { <span data-x={js`x`}>h</span> }\n"
 	f, err := ParseFile(token.NewFileSet(), "in.gsx", []byte(src), 0)
 	if err != nil {
 		t.Fatalf("parse: %v", err)

--- a/parser/markup_test.go
+++ b/parser/markup_test.go
@@ -23,7 +23,7 @@ func composedPartsLogicalEqual(a, b []ast.ComposedPart) bool {
 	for i := range a {
 		if a[i].Expr != b[i].Expr || a[i].Cond != b[i].Cond ||
 			!reflect.DeepEqual(a[i].Stages, b[i].Stages) ||
-			!reflect.DeepEqual(a[i].CSSSegments, b[i].CSSSegments) ||
+			!reflect.DeepEqual(a[i].LiteralSegments, b[i].LiteralSegments) ||
 			a[i].CF != b[i].CF {
 			return false
 		}
@@ -1083,9 +1083,9 @@ func TestParseComposedStyleCSSLiteralPart(t *testing.T) {
 	if ca.Parts[0].Expr != `"display:none"` || ca.Parts[0].Cond != "hidden" {
 		t.Fatalf("part0 = %#v", ca.Parts[0])
 	}
-	segs := ca.Parts[1].CSSSegments
+	segs := ca.Parts[1].LiteralSegments
 	if len(segs) != 3 {
-		t.Fatalf("CSSSegments len = %d, want 3: %#v", len(segs), segs)
+		t.Fatalf("LiteralSegments len = %d, want 3: %#v", len(segs), segs)
 	}
 	if text, ok := segs[0].(*ast.Text); !ok || text.Value != `color:` {
 		t.Fatalf("seg0 = %#v", segs[0])

--- a/parser/navpos_test.go
+++ b/parser/navpos_test.go
@@ -64,7 +64,7 @@ component C(user string, cond bool, n int, bag string) {
 	ast.Inspect(f, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.ComposedPart:
-			if v.CF == nil && v.CSSSegments == nil {
+			if v.CF == nil && v.LiteralSegments == nil {
 				seen["classpart"]++
 				check("ComposedPart.ExprPos", v.ExprPos, v.Expr)
 				check("ComposedPart.CondPos", v.CondPos, v.Cond)
@@ -179,7 +179,7 @@ component C(cond bool) {
 		if !ok {
 			return true
 		}
-		if part.CSSSegments != nil {
+		if part.LiteralSegments != nil {
 			seen["css"] = true
 			if got := part.ExprEnd(); got != token.NoPos {
 				t.Errorf("CSS ExprEnd() = %d, want NoPos", got)

--- a/parser/valueform.go
+++ b/parser/valueform.go
@@ -16,19 +16,19 @@ func (p *parser) offsetOf(pos token.Pos) int {
 
 // parseValueCF parses one value-form `if`/`switch` contribution. at is the
 // absolute offset in p.src of the leading keyword; kw is "if" or "switch".
-func (p *parser) parseValueCF(at int, kw string) (*ast.ValueCF, error) {
+func (p *parser) parseValueCF(attrName string, at int, kw string) (*ast.ValueCF, error) {
 	start := p.posAt(at)
 	cf := &ast.ValueCF{}
 	var end token.Pos
 	switch kw {
 	case "if":
-		vi, e, err := p.parseValueIf(at)
+		vi, e, err := p.parseValueIf(attrName, at)
 		if err != nil {
 			return nil, err
 		}
 		cf.If, end = vi, e
 	case "switch":
-		vs, e, err := p.parseValueSwitch(at)
+		vs, e, err := p.parseValueSwitch(attrName, at)
 		if err != nil {
 			return nil, err
 		}
@@ -41,7 +41,7 @@ func (p *parser) parseValueCF(at int, kw string) (*ast.ValueCF, error) {
 // parseValueIf parses `if Cond { Arm } [else if … | else { Arm }]` starting at
 // the `if` keyword (offset at). Returns the node and the position one past
 // its last `}`.
-func (p *parser) parseValueIf(at int) (*ast.ValueIf, token.Pos, error) {
+func (p *parser) parseValueIf(attrName string, at int) (*ast.ValueIf, token.Pos, error) {
 	start := p.posAt(at)
 	condStart := at + len("if")
 	braceOff, ok := scanToBlockBrace(p.src, condStart, "if")
@@ -51,7 +51,7 @@ func (p *parser) parseValueIf(at int) (*ast.ValueIf, token.Pos, error) {
 	rawCond := p.src[condStart:braceOff]
 	lead := len(rawCond) - len(strings.TrimLeft(rawCond, " \t\r\n"))
 	n := &ast.ValueIf{Cond: strings.TrimSpace(rawCond), CondPos: p.posAt(condStart + lead)}
-	arm, afterThenPos, err := p.parseValueArm(braceOff)
+	arm, afterThenPos, err := p.parseValueArm(attrName, braceOff)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -66,14 +66,14 @@ func (p *parser) parseValueIf(at int) (*ast.ValueIf, token.Pos, error) {
 		switch {
 		case strings.HasPrefix(r2, "if") && !goIdentifierContinueAt(r2, len("if")):
 			ifAt := elseAt + (len(p.src[elseAt:]) - len(r2))
-			ei, e2, err := p.parseValueIf(ifAt)
+			ei, e2, err := p.parseValueIf(attrName, ifAt)
 			if err != nil {
 				return nil, 0, err
 			}
 			n.ElseIf, end = ei, e2
 		case strings.HasPrefix(r2, "{"):
 			braceAt := elseAt + (len(p.src[elseAt:]) - len(r2))
-			ea, e2, err := p.parseValueArm(braceAt)
+			ea, e2, err := p.parseValueArm(attrName, braceAt)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -88,7 +88,7 @@ func (p *parser) parseValueIf(at int) (*ast.ValueIf, token.Pos, error) {
 
 // parseValueArm parses `{ <go-value-expr> }` whose `{` is at offset braceOff.
 // Returns the arm and the position one past the matching `}`.
-func (p *parser) parseValueArm(braceOff int) (*ast.ValueArm, token.Pos, error) {
+func (p *parser) parseValueArm(attrName string, braceOff int) (*ast.ValueArm, token.Pos, error) {
 	closeOff, ok := goExprEnd(p.src, braceOff)
 	if !ok {
 		return nil, 0, p.errorf(p.posAt(braceOff), "unterminated `{` in value-form arm")
@@ -98,6 +98,29 @@ func (p *parser) parseValueArm(braceOff int) (*ast.ValueArm, token.Pos, error) {
 		return nil, 0, p.errorf(p.posAt(braceOff), "value-form arm must produce a value")
 	}
 	lead := len(inner) - len(strings.TrimLeft(inner, " \t\r\n"))
+	// An arm accepts the same prefixed backtick literal its attribute accepts
+	// as a plain part (f`…` in class, css`…` in style) — the arm is a value
+	// position like any other, so the value grammar must not shrink inside one.
+	if hasEmbeddedLiteralPrefix(strings.TrimSpace(inner)) {
+		literalOff := braceOff + 1 + lead
+		old := p.i
+		p.i = literalOff
+		lang, dquoted, segments, lerr := p.parseEmbeddedAttrLiteral()
+		literalEnd := p.i
+		p.i = old
+		if lerr != nil {
+			return nil, 0, lerr
+		}
+		if want, ok := composedLiteralLang(attrName); !ok || lang != want {
+			return nil, 0, p.errorf(p.posAt(literalOff), "%s literal arms are not valid in %s={...}; %s={...} takes %s literals", embeddedLangPrefix(lang), attrName, attrName, composedLiteralPrefix(attrName))
+		}
+		if rest := strings.TrimSpace(p.src[literalEnd:closeOff]); rest != "" {
+			return nil, 0, p.errorf(p.posAt(literalEnd), "unexpected %q after %s literal arm; pipe stages on a literal arm are not supported", rest, embeddedLangPrefix(lang))
+		}
+		arm := &ast.ValueArm{Segments: segments, Lang: lang, DoubleQuoted: dquoted}
+		ast.SetSpan(arm, p.posAt(braceOff), p.posAt(closeOff+1))
+		return arm, p.posAt(closeOff + 1), nil
+	}
 	seed, stages, err := parsePipe(strings.TrimSpace(inner), p.posAt(braceOff+1+lead))
 	if err != nil {
 		return nil, 0, p.pipeErrorf(p.posAt(braceOff), err)
@@ -109,7 +132,7 @@ func (p *parser) parseValueArm(braceOff int) (*ast.ValueArm, token.Pos, error) {
 
 // parseValueSwitch parses `switch [Tag] { case List: Arm … default: Arm }`
 // starting at the `switch` keyword (offset at).
-func (p *parser) parseValueSwitch(at int) (*ast.ValueSwitch, token.Pos, error) {
+func (p *parser) parseValueSwitch(attrName string, at int) (*ast.ValueSwitch, token.Pos, error) {
 	start := p.posAt(at)
 	tagStart := at + len("switch")
 	braceOff, ok := scanToBlockBrace(p.src, tagStart, "switch")
@@ -130,7 +153,7 @@ func (p *parser) parseValueSwitch(at int) (*ast.ValueSwitch, token.Pos, error) {
 			return n, end, nil
 		}
 		caseAt := i + (len(p.src[i:]) - len(r))
-		cc, after, err := p.parseValueSwitchCase(caseAt)
+		cc, after, err := p.parseValueSwitchCase(attrName, caseAt)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -142,7 +165,7 @@ func (p *parser) parseValueSwitch(at int) (*ast.ValueSwitch, token.Pos, error) {
 // parseValueSwitchCase parses one `case List: Arm` or `default: Arm`, starting
 // at the keyword (offset at). Returns the node and the offset at the next case,
 // default, or switch-closing brace.
-func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error) {
+func (p *parser) parseValueSwitchCase(attrName string, at int) (*ast.ValueSwitchCase, int, error) {
 	start := p.posAt(at)
 	cc := &ast.ValueSwitchCase{}
 	r := p.src[at:]
@@ -172,13 +195,34 @@ func (p *parser) parseValueSwitchCase(at int) (*ast.ValueSwitchCase, int, error)
 		return nil, 0, p.errorf(p.posAt(at), "expected `case` or `default` in value-form `switch`")
 	}
 	if valueAt < len(p.src) && p.src[valueAt] == '{' {
-		arm, afterPos, err := p.parseValueArm(valueAt)
+		arm, afterPos, err := p.parseValueArm(attrName, valueAt)
 		if err != nil {
 			return nil, 0, err
 		}
 		cc.Value = arm
 		ast.SetSpan(cc, start, arm.End())
 		return cc, p.offsetOf(afterPos), nil
+	}
+	// A literal arm is consumed by the literal parser itself, BEFORE
+	// valueSwitchArmEnd's delimiter scan — the literal body may hold `:` or the
+	// word `case`, which that scan would otherwise treat as arm structure.
+	if hasEmbeddedLiteralPrefix(p.src[valueAt:]) {
+		old := p.i
+		p.i = valueAt
+		lang, dquoted, segments, lerr := p.parseEmbeddedAttrLiteral()
+		literalEnd := p.i
+		p.i = old
+		if lerr != nil {
+			return nil, 0, lerr
+		}
+		if want, ok := composedLiteralLang(attrName); !ok || lang != want {
+			return nil, 0, p.errorf(p.posAt(valueAt), "%s literal arms are not valid in %s={...}; %s={...} takes %s literals", embeddedLangPrefix(lang), attrName, attrName, composedLiteralPrefix(attrName))
+		}
+		arm := &ast.ValueArm{Segments: segments, Lang: lang, DoubleQuoted: dquoted}
+		ast.SetSpan(arm, p.posAt(valueAt), p.posAt(literalEnd))
+		cc.Value = arm
+		ast.SetSpan(cc, start, p.posAt(literalEnd))
+		return cc, literalEnd, nil
 	}
 	end, ok := valueSwitchArmEnd(p.src, valueAt)
 	if !ok {


### PR DESCRIPTION
Closes two gaps that made branching inconsistent depending on where it appeared, and one security defect the second gap was hiding.

## Before

| Position | `if` | `switch` |
| --- | --- | --- |
| Attribute — `<div { … }>` | yes | **no** — `expected \`...\` trailing spread` |
| Value — `class={ … }` | yes | yes |
| Value arm holding a literal | **no** | **no** — `missing ',' in argument list` |

## 1. Attribute-position `{ switch … }`

```gsx
<div
    { switch status {
    case "ok":
        data-state="ok"
    case "warn", "error":
        data-state="bad" aria-live="polite"
    default:
        data-state="unknown"
    } }
>
```

New `*ast.SwitchAttr` + `*ast.AttrCaseClause`, emitting a **real Go `switch`** in the same statement position where `CondAttr` emits a real Go `if`.

Rejected alternative: desugaring to a nested `tag == A` `CondAttr` chain. It touches two files instead of thirty, but Go evaluates a switch tag exactly once and an `==` chain re-evaluates it per case — a behaviour change for a call-valued tag, and it forecloses type switches.

Component-tag forwarding is generalised from the hard-wired two-branch `then`/`otherwise` model to N-way `branches [][]`, so a switch on a component tag routes through the attrs bag instead of erroring.

No `fallthrough`: an attribute list is not a statement list, so falling through would emit two arms' attributes and silently duplicate names.

## 2. Literals in value-form arms

A prefixed backtick literal was legal as a whole attribute value and as a composed part, but not as an arm — the only value position that rejected it. `ValueArm` gains the literal payload `ComposedPart` already has and reuses the identical lowering, so an arm and a plain part cannot diverge. The matching part-level gap is closed too: `class={ "base", f\`…\` }` now works, mirroring `style={ "a: 1", css\`…\` }`.

This is what lets a component split a CSS value so its separator is static template text:

```gsx
<div style={
    switch form {
    case ratioPair: css`aspect-ratio: @{w} / @{h}`
    default:        css`aspect-ratio: @{ratio}`
    },
}>
```

instead of reaching for `gsx.RawCSS` to smuggle one `/` past the CSS value filter. Only `@{w}`/`@{h}` are holes, and each is still filtered.

## 3. One literal language per composable attribute — including a security fix

Adding arms exposed that gsx had **no rule** about which literal a composable attribute accepts, and two pairings were actively wrong. Measured with a hostile hole:

| written | rendered | verdict |
|---|---|---|
| `class=f\`…\`` | HTML-escaped | correct |
| `style=css\`…\`` | CSS-value-filtered | correct |
| `style=f\`…\`` | `style="color: red;background:url(javascript:alert(1))"` | **injection** |
| `class=css\`…\`` | `class="color: ZgotmplZ"` | mangles `bg-primary/20` |

The literal's language selects the sanitizer applied to its `@{ }` holes. `style=f\`…\`` emitted `AttrValue(string(v))` — HTML escaping only, never `StyleValue`. **This is pre-existing on `main`**, not introduced here (`emitEmbeddedTextAttr` is untouched by this diff).

So: **`class` takes `f`, `style` takes `css`, nothing else** — enforced identically as a whole value, a list entry and an arm. `js` in either is rejected too. Attributes that compose nothing (`data-*`, `onclick`, …) are unrestricted.

Rejected alternative: normalising by sink (let the attribute pick the escaper regardless of prefix). Keeps every spelling compiling, but leaves two ways to write one thing and makes `class=css\`…\`` mean "CSS-highlighted text that isn't CSS".

### :warning: Breaking

`style=f\`…\`` no longer compiles. Every such use is by definition an unfiltered CSS sink. One corpus case (`textattr/style_spread_merge`) used exactly that form and moves to `css\`…\``.

Also renames `ComposedPart.CSSSegments` → `LiteralSegments` (+ `LiteralLang`), since the payload is no longer CSS-only — following the recent `ClassPart` → `ComposedPart` direction.

## Testing

`make check` green. 23 corpus cases + 2 fmt-corpus cases, covering every context: tagged/tagless/multi-value/no-default switches, spreads before and after, composed `class=`/`style=` arms, nested `if`/`switch`, component tags, `css`/`f` arms with hostile holes, and the four rejection diagnostics.

Five defects were caught by the repo's own gates while building this, which is the argument for those gates:

- the `ast` clone-exhaustiveness registry, the instant the new node type was added
- `fallthrough` silently parsing as a bool attribute named `fallthrough`
- **the formatter silently deleting both new constructs** before printer support — caught by the printer property tests
- probe/collect misalignment: literal arms counted as probe nodes with no expression (one of four sites was on the component path only)
- the printer hardcoding `EmbeddedCSS`, so a class `f\`\`` part reprinted as `css\`\``

## Sibling repos

Ready and green locally, PRs to follow: `tree-sitter-gsx` (grammar rule, a clause-boundary lexing bug where `default:` after attributes became a bool attribute, plus a **pre-existing injection-query bug** — `injection.combined` merged every `css\`…\`` in a file into one stylesheet, producing spurious `ERROR` nodes over valid source), `vscode-gsx` (grammar + a fix for literal arms losing their sublanguage to `source.go`), `gsxhq.github.io` (grammar sync).

Design notes: `docs/superpowers/specs/2026-07-30-uniform-branching-in-attrs-design.md`.

https://claude.ai/code/session_01L1mQ6U9FmGWT5bp14RtGwK