### PR TITLE
feat(lsp): auto-import unimported component packages in tag position

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -709,7 +709,43 @@ In-process LSP over JSON-RPC on stdio (`internal/lsp`, wired at `gen/main.go`
   ways, tier + prefix cap) in internal/lsp + internal/codegen; e2e (unimported
   `strings.▮` → ToUpper with an import edit that reparses cleanly, bare
   package-name item, imported-package precedence) in gen.
-  **Follow-ups:** snippet placeholders;
+  **Auto-import in TAG position** — DONE. `<ui.▮` on a package the file has not
+  imported now completes, and `source.organizeImports` / **Add import** now fire
+  on `<ui.Button/>`. Both were structurally impossible before, for two separate
+  reasons. (1) `MissingImports` was derived only from the SHIPPING skeleton, but
+  a component tag's identity expression exists as Go syntax only in the
+  target-DISCOVERY skeleton; an unresolved qualifier makes discovery reject the
+  call site, so the element is never stamped `IsComponent` and lowers as a leaf
+  carrying no selector — and on the rejecting branch analyze rebuilds from an
+  EMPTY gsx file set, leaving nothing to walk. `missingFromTargetMarkers`
+  (add_imports.go) now applies the SAME exact `info.Uses` miss test to discovery's
+  own marker table and info, and `mergeMissingImports` folds it in (shipping
+  answer wins a collision, so Pos stays on the occurrence whose diagnostic the
+  user is reading). (2) `componentTagItems` only ever consulted imported
+  qualifiers; it now returns `(items, resolved)` and `tagCompletion` falls through
+  to `unimportedTagItems` when — and only when — the qualifier resolves to
+  nothing. Gating on `resolved` rather than on an empty item list is what keeps an
+  imported-but-componentless package, and an in-scope binding with no method
+  components, from being second-guessed with an auto-import list. Only
+  TAG-CALLABLE symbols are offered: `codegen.ExportedSymbol`/`lsp.ImportSymbol`
+  gained a `TagCallable` flag, computed inside the analysis lock from real type
+  objects, and the predicate behind it (callable-universe shape + every parameter
+  named) plus the `gsx.Node` identity lookup moved into `internal/tagcallable` as
+  `IsCandidate`/`NodeInterface` so the imported and unimported tag surfaces cannot
+  drift. A markup cursor also cannot locate its import chunk in the LIVE buffer
+  the way a Go-expression cursor can — `<ui.` does not parse, while `{ fmt. }`
+  does (Go is an opaque blob to gsx) — so `prepareImportEditIn` parses the
+  REPAIRED buffer while addressing the original document; that is exact because
+  `completionPatches` never modifies a byte before the cursor and `apply` refuses
+  any edit reaching the cursor. Tests: unit (tag-qualifier MissingImports with Pos
+  pinned to the shipped diagnostic, resolved-qualifier negative, sibling-package
+  resolve + TagCallable classification in internal/codegen; handler-level
+  unimported/imported tag cursors with the applied-edit round trip, and the
+  `resolved` flag matrix in internal/lsp).
+  **Follow-ups:** unimported package NAMES at a bare tag cursor (`<u▮` does not
+  offer `ui.` — Option 2's tag counterpart, deferred: it needs a tag-callable
+  probe per candidate package to avoid offering ~1000 componentless names);
+  snippet placeholders;
   body-local value bindings as method-component qualifiers (declared in a
   `{{ }}` block, a v1 gap); `Component.Doc` — component-tag completion/hover
   still show only the rendered signature (`renderComponentSig`), never a doc

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -81,9 +81,11 @@ supports tree-sitter.
 | Code actions | Organize imports and choose missing imports. |
 | Completion | Go identifiers and members, pipe filters, component tags and attributes, HTML tags/attributes/values, and `hx-*` attributes when htmx is enabled. |
 
-Completion returns plain text edits, not snippets, and does not add imports
-yet; use the missing-import quick fix for that. References do not include
-external packages. See [Status](./status.md) for the current limits.
+Completion returns plain text edits, not snippets. Completing a symbol on a
+package you have not imported — `ui.Button` in a Go expression, or `<ui.Button`
+as a tag — adds the import along with the name. A tag cursor offers only the
+package's component-shaped declarations. References do not include external
+packages. See [Status](./status.md) for the current limits.
 
 ## Organize imports {#organize-imports-on-save}
 
@@ -99,7 +101,8 @@ Enable formatting and import organization on save in VS Code:
 ```
 
 The organize-imports action removes unused imports, sorts them, and adds a
-missing import when there is one unambiguous match. When several packages match,
+missing import when there is one unambiguous match — including the package half
+of a component tag, so `<ui.Button/>` imports `ui`. When several packages match,
 use the **Add import** quick fix to choose one. Run `go get` first when the
 package is not in your module.
 

--- a/gen/lsp.go
+++ b/gen/lsp.go
@@ -1084,7 +1084,7 @@ func (a lspAnalyzer) ExportedSymbols(dir, importPath string) []lsp.ImportSymbol 
 	}
 	out := make([]lsp.ImportSymbol, len(syms))
 	for i, sym := range syms {
-		out[i] = lsp.ImportSymbol{Name: sym.Name, Kind: importSymbolKind(sym.Kind), Detail: sym.Detail}
+		out[i] = lsp.ImportSymbol{Name: sym.Name, Kind: importSymbolKind(sym.Kind), Detail: sym.Detail, TagCallable: sym.TagCallable}
 	}
 	return out
 }

--- a/gen/lsp_completion_e2e_test.go
+++ b/gen/lsp_completion_e2e_test.go
@@ -2207,6 +2207,52 @@ func TestAutoImportCompletionE2E(t *testing.T) {
 		}
 	})
 
+	// TAG position: `<ui.▮` on a sibling package the file never imported. Two
+	// things are exercised here that no Go-expression case can reach — the tag
+	// surface offers only TAG-CALLABLE symbols (Button, not Plain), and the buffer
+	// is genuinely unterminated, so the import chunk has to be located in the
+	// REPAIRED parse while the edit addresses the live document.
+	t.Run("unimported component tag qualifier", func(t *testing.T) {
+		extra := map[string]string{"ui/ui.go": "package ui\n\nimport \"github.com/gsxhq/gsx\"\n\n" +
+			"func Button(label string) gsx.Node { return nil }\n\n" +
+			"func Plain(s string) string { return s }\n"}
+		source := "package page\n\ncomponent Home() {\n\t<div><ui.</div>\n}\n"
+		cursor := strings.Index(source, "<ui.") + len("<ui.")
+		items := runHTMLCompletionE2E(t, extra, source, cursor)
+		labels := map[string]bool{}
+		var button *lsp.CompletionItem
+		for i := range items {
+			labels[items[i].Label] = true
+			if items[i].Label == "Button" {
+				button = &items[i]
+			}
+		}
+		if button == nil {
+			t.Fatalf("unimported `<ui.` did not offer Button; labels=%v", labels)
+		}
+		if labels["Plain"] {
+			t.Errorf("`<ui.` offered Plain; a tag cursor must offer tag-callable symbols only (labels=%v)", labels)
+		}
+		if button.Kind != 7 { // ciKindClass
+			t.Errorf("Button kind = %d, want Class(7)", button.Kind)
+		}
+		if len(button.AdditionalTextEdits) != 1 {
+			t.Fatalf("Button AdditionalTextEdits = %d, want 1 (the import)", len(button.AdditionalTextEdits))
+		}
+		got := applyLSPEdits(source, append([]lsp.TextEdit{*button.TextEdit}, button.AdditionalTextEdits...))
+		if !strings.Contains(got, "import \"example.com/app/ui\"") {
+			t.Errorf("applied doc missing the ui import:\n%s", got)
+		}
+		if !strings.Contains(got, "<div><ui.Button</div>") {
+			t.Errorf("applied doc did not insert the tag name in place:\n%s", got)
+		}
+		// The source was mid-typing and stays mid-typing, so no reparse assertion:
+		// what must survive is the untouched prefix around the inserted import.
+		if !strings.HasPrefix(got, "package page\n") {
+			t.Errorf("applied doc corrupted the head:\n%s", got)
+		}
+	})
+
 	// Option 2: bare `{ fm }` offers the package name `fmt` at the bottom tier
 	// with an import edit.
 	t.Run("unimported package name", func(t *testing.T) {

--- a/internal/codegen/add_imports.go
+++ b/internal/codegen/add_imports.go
@@ -94,6 +94,110 @@ func missingFromSkeletons(byGsx map[string]fileSkeleton, gsxFset *token.FileSet,
 	return out
 }
 
+// missingFromTargetMarkers finds every undefined qualifier used as the PACKAGE
+// half of a component tag — `<ui.Button/>` where the file never imported `ui`.
+//
+// missingFromSkeletons cannot see these. A component tag's identity expression
+// (`ui.Button`) exists as real Go syntax only in the target-DISCOVERY skeleton,
+// under its own marker binding (`var _gsxtargetN = ui.Button`) and its own
+// type-check. An unresolved qualifier makes discovery REJECT the call site, so
+// the element is never stamped IsComponent and the shipping skeleton — the only
+// input missingFromSkeletons reads — lowers it as a plain leaf element carrying
+// no selector at all. Worse, a rejected site fails the package, and analyze then
+// builds the shipping skeleton from an EMPTY gsx file set, so that pass has
+// nothing left to walk. Without this function an unimported component package is
+// invisible to organizeImports and to the add-import quickfix, even though the
+// user is staring at the `undefined: ui` those same markers produced.
+//
+// The test is the same exact one missingFromSkeletons applies, against
+// discovery's own types.Info: a selector root is always a reference occurrence,
+// so an identifier with no entry in info.Uses resolved to nothing. A qualifier
+// that IS resolved (an imported package, a local shadowing it) is not reported,
+// and neither is a bare `<Foo/>` tag (no selector, hence no qualifier to
+// import) nor a chained `<a.b.C/>` root (not a bare identifier).
+//
+// Pos anchors at the element's TagPos — exactly where componentTargetDiagnostic
+// and the checker's own `undefined: ui` land — so the quickfix the user reaches
+// for from that diagnostic resolves the same qualifier the diagnostic named.
+// Entries are deduped by (Name, Symbol) per file for the same reason
+// missingFromSkeletons dedupes: the caller adds one import either way.
+//
+// Pure: walks the marker table discovery already built and the info it already
+// produced. No IO, no lock, no packages.Load.
+func missingFromTargetMarkers(registry *componentTargetMarkerRegistry, gsxFset *token.FileSet, info *types.Info) map[string][]MissingImport {
+	if registry == nil || info == nil || gsxFset == nil {
+		return nil
+	}
+	out := map[string][]MissingImport{}
+	seen := map[string]bool{} // gsxPath+"\x00"+name+"."+symbol
+	for _, marker := range registry.ordered {
+		if marker.expr == nil || marker.element == nil {
+			continue // syntax-invalid target: no expression was type-checked
+		}
+		shape, ok := componentTargetShapeOf(marker.expr)
+		if !ok || shape.selector == nil {
+			continue
+		}
+		qualifier, isIdent := shape.selector.X.(*goast.Ident)
+		if !isIdent {
+			continue
+		}
+		if _, used := info.Uses[qualifier]; used {
+			continue // an imported package, a local, a receiver...
+		}
+		if !marker.element.TagPos.IsValid() {
+			// Defensive: every candidate element comes from a real parse, so this
+			// never fires. Reporting it anyway would key the entry under an empty
+			// filename, which no caller could ever look up.
+			continue
+		}
+		pos := gsxFset.Position(marker.element.TagPos)
+		key := pos.Filename + "\x00" + qualifier.Name + "." + shape.selector.Sel.Name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out[pos.Filename] = append(out[pos.Filename], MissingImport{
+			Name:   qualifier.Name,
+			Symbol: shape.selector.Sel.Name,
+			Pos:    pos,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mergeMissingImports folds extra into base, keeping base's entry whenever the
+// same file already reports the same (Name, Symbol) — base is the shipping
+// skeleton's answer, whose Pos matches the diagnostic the user sees for a
+// Go-expression use. Neither map is mutated; the result is a fresh map.
+func mergeMissingImports(base, extra map[string][]MissingImport) map[string][]MissingImport {
+	if len(extra) == 0 {
+		return base
+	}
+	out := make(map[string][]MissingImport, len(base)+len(extra))
+	seen := map[string]bool{}
+	for path, mis := range base {
+		out[path] = append([]MissingImport(nil), mis...)
+		for _, mi := range mis {
+			seen[path+"\x00"+mi.Name+"."+mi.Symbol] = true
+		}
+	}
+	for path, mis := range extra {
+		for _, mi := range mis {
+			key := path + "\x00" + mi.Name + "." + mi.Symbol
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out[path] = append(out[path], mi)
+		}
+	}
+	return out
+}
+
 // inHarvestProbe reports whether pos falls inside one of spans (each a
 // harvestProbeSpans result for the same file/fset — see that function's doc).
 func inHarvestProbe(spans []posSpan, pos token.Pos) bool {

--- a/internal/codegen/add_imports_test.go
+++ b/internal/codegen/add_imports_test.go
@@ -520,3 +520,101 @@ func TestMissingImportsDifferentSymbolsSamePackage(t *testing.T) {
 		t.Fatalf("missing = %v, want %v", got, want)
 	}
 }
+
+// TestMissingImportsComponentTagQualifier: a qualifier used ONLY as the package
+// half of a component tag — `<ui.Button/>` — is reported, so organizeImports and
+// the add-import quickfix can act on the very `undefined: ui` the user is
+// looking at.
+//
+// This is the case the shipping skeleton structurally cannot see (see
+// missingFromTargetMarkers): an unresolved qualifier makes target discovery
+// reject the call site, the element is never stamped IsComponent, and the
+// element lowers as a plain leaf carrying no selector at all. Pos is asserted
+// against the REAL shipped diagnostic rather than a hardcoded column, the same
+// contract TestMissingImportsPosMatchesDiagnostic pins for Go-expression uses.
+func TestMissingImportsComponentTagQualifier(t *testing.T) {
+	m, dir := newMissingModule(t, "package u\n\ncomponent Wrap() {\n\t<ui.Button/>\n}\n")
+	pr, err := m.Package(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mis := pr.MissingImports[filepath.Join(dir, "a.gsx")]
+	if len(mis) != 1 || mis[0].Name != "ui" || mis[0].Symbol != "Button" {
+		t.Fatalf("MissingImports = %+v, want exactly one {ui Button}", mis)
+	}
+	var want *diagPos
+	for i := range pr.Diags {
+		if d := &pr.Diags[i]; strings.Contains(d.Message, "undefined: ui") {
+			want = &diagPos{line: d.Start.Line, col: d.Start.Column}
+			break
+		}
+	}
+	if want == nil {
+		t.Fatalf("no shipped diagnostic contains %q; Diags = %+v", "undefined: ui", pr.Diags)
+	}
+	if mis[0].Pos.Line != want.line || mis[0].Pos.Column != want.col {
+		t.Fatalf("MissingImport.Pos = %d:%d, want the shipped diagnostic's %d:%d",
+			mis[0].Pos.Line, mis[0].Pos.Column, want.line, want.col)
+	}
+}
+
+// TestMissingImportsComponentTagIgnoresResolvedQualifier: `<strings.Nope/>` on
+// an IMPORTED `strings` is a bad symbol, not a missing import. The qualifier
+// resolves, so nothing is reported — otherwise organizeImports would keep
+// re-adding an import the file already has.
+func TestMissingImportsComponentTagIgnoresResolvedQualifier(t *testing.T) {
+	src := "package u\n\nimport \"strings\"\n\ncomponent Wrap() {\n\t<strings.Nope/>\n}\n"
+	m, dir := newMissingModule(t, src)
+	if got := missingNames(t, m, dir); len(got) != 0 {
+		t.Fatalf("missing = %v, want none (strings is imported; only its symbol is wrong)", got)
+	}
+}
+
+// TestComponentTagQualifierResolvesToModulePackage is the end-to-end shape a
+// gsx project actually hits: a sibling package in the SAME module, never
+// imported by the .gsx file, used as `<ui.Button/>`. It pins the whole chain the
+// organize-imports code action walks — MissingImports names the qualifier,
+// ResolveImportCandidates maps it to the sibling's import path — plus the
+// TagCallable classification the `<ui.▮` completion surface filters on.
+//
+// The sibling is deliberately plain Go with no `component` keyword: a package
+// like that declares nothing in ComponentDecls, so TagCallable is the only thing
+// that can tell Button (a tag) from Count (not one).
+func TestComponentTagQualifierResolvesToModulePackage(t *testing.T) {
+	sibling := "package ui\n\nimport \"github.com/gsxhq/gsx\"\n\n" +
+		"// Button is tag-callable: one gsx.Node result, every parameter named.\n" +
+		"func Button(label string) gsx.Node { return nil }\n\n" +
+		"// Unnamed is the callable-universe shape but could never receive a markup\n" +
+		"// attribute, so completion must not offer it.\n" +
+		"func Unnamed(string) gsx.Node { return nil }\n\n" +
+		"// Count has the wrong result type.\n" +
+		"func Count() int { return 0 }\n\n" +
+		"// Size is not callable at all.\n" +
+		"const Size = 3\n"
+	m, dir := newMissingModuleFiles(t,
+		"", "package u\n\ncomponent Wrap() {\n\t<ui.Button label=\"go\"/>\n}\n",
+		map[string]string{"ui/ui.go": sibling})
+
+	if got := missingNames(t, m, dir); len(got) != 1 || got[0] != "ui.Button" {
+		t.Fatalf("missing = %v, want [ui.Button]", got)
+	}
+	cands := m.ResolveImportCandidates(dir, "ui", "Button")
+	if len(cands) != 1 || cands[0] != "example.com/u/ui" {
+		t.Fatalf("ResolveImportCandidates(ui, Button) = %v, want [example.com/u/ui]", cands)
+	}
+
+	tagCallable := map[string]bool{}
+	for _, sym := range m.PackageExportedSymbols("example.com/u/ui") {
+		tagCallable[sym.Name] = sym.TagCallable
+	}
+	want := map[string]bool{"Button": true, "Unnamed": false, "Count": false, "Size": false}
+	for name, wantCallable := range want {
+		got, present := tagCallable[name]
+		if !present {
+			t.Fatalf("PackageExportedSymbols did not report %q; got %v", name, tagCallable)
+		}
+		if got != wantCallable {
+			t.Errorf("%s TagCallable = %v, want %v", name, got, wantCallable)
+		}
+	}
+}

--- a/internal/codegen/component_target_package.go
+++ b/internal/codegen/component_target_package.go
@@ -25,6 +25,12 @@ type componentTargetPackageResult struct {
 	facts           map[callSiteID]componentTargetFact
 	expressionFacts map[gsxast.Node]expressionFact
 	diagnostics     []diag.Diagnostic
+	// missingImports are the undefined qualifiers used as the package half of a
+	// component tag, per .gsx path — see missingFromTargetMarkers for why the
+	// shipping skeleton cannot report them. Published even when diagnostics
+	// reject the package, since an unresolved qualifier is BOTH the rejection's
+	// cause and the fact the add-import code action needs.
+	missingImports map[string][]MissingImport
 }
 
 type componentTargetExpressionHarvest struct {
@@ -203,6 +209,11 @@ func discoverComponentTargets(
 	module.recordTargetImports(dir, importPaths)
 
 	pkg, info, typeErrs := checkComponentTargetPackage(pkgPath, pkgName, goFiles, fset, importer, componentTargetCheckConfig{typeEnvironment: typeEnvironment})
+	// Computed from the markers and the info this check just produced, BEFORE
+	// any rejection path can discard them: an unimported component package is
+	// exactly the case that rejects the site, so waiting until after would mean
+	// only ever reporting the qualifiers that did not need reporting.
+	missingImports := missingFromTargetMarkers(markers, fset, info)
 	facts, unrelated, err := harvestComponentTargetFacts(goFiles, fset, info, typeErrs, markers)
 	if err != nil {
 		return componentTargetPackageResult{}, nil, err
@@ -240,6 +251,7 @@ func discoverComponentTargets(
 		facts:           facts,
 		expressionFacts: expressionFacts,
 		diagnostics:     bag.Sorted(),
+		missingImports:  missingImports,
 	}, unrelated, nil
 }
 

--- a/internal/codegen/export_symbols.go
+++ b/internal/codegen/export_symbols.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gsxhq/gsx/internal/codegen/stdpath"
+	"github.com/gsxhq/gsx/internal/tagcallable"
 )
 
 // SymbolKind is a coarse classification of an exported package-level symbol,
@@ -27,10 +28,19 @@ const (
 // ExportedSymbol is one exported top-level declaration of a package, described
 // by value (name, coarse kind, formatted type/signature) so the caller never
 // touches a graph *types.Object outside the analysis lock.
+//
+// TagCallable reports whether this declaration could be written as a gsx TAG
+// (`<pkg.Name/>`) — tagcallable.IsCandidate, the same completion-grade
+// predicate internal/lsp applies when scanning an ALREADY-imported package's
+// scope. It is carried on every symbol rather than served by a separate
+// enumeration so both the Go-expression member surface (`pkg.▮`, which wants
+// every export) and the tag surface (`<pkg.▮`, which wants only these) read one
+// answer computed once, inside the analysis lock, from real type objects.
 type ExportedSymbol struct {
-	Name   string
-	Kind   SymbolKind
-	Detail string
+	Name        string
+	Kind        SymbolKind
+	Detail      string
+	TagCallable bool
 }
 
 // PackageName is one importable package: its declared name (the qualifier a
@@ -75,6 +85,10 @@ func (m *Module) PackageExportedSymbols(importPath string) []ExportedSymbol {
 	}
 	scope := pkg.Scope()
 	qf := func(p *types.Package) string { return p.Name() }
+	// nil when pkg does not import the gsx runtime at all — then no declaration
+	// of pkg can be tag-callable, and IsCandidate rejects every object against a
+	// nil node. Resolved once per package, not once per symbol.
+	node := tagcallable.NodeInterface(pkg)
 	var out []ExportedSymbol
 	for _, name := range scope.Names() {
 		obj := scope.Lookup(name)
@@ -82,9 +96,10 @@ func (m *Module) PackageExportedSymbols(importPath string) []ExportedSymbol {
 			continue
 		}
 		out = append(out, ExportedSymbol{
-			Name:   name,
-			Kind:   classifyExportedSymbol(obj),
-			Detail: exportedSymbolDetail(obj, qf),
+			Name:        name,
+			Kind:        classifyExportedSymbol(obj),
+			Detail:      exportedSymbolDetail(obj, qf),
+			TagCallable: node != nil && tagcallable.IsCandidate(obj, node),
 		})
 	}
 	slices.SortFunc(out, func(a, b ExportedSymbol) int { return strings.Compare(a.Name, b.Name) })

--- a/internal/codegen/module_importer.go
+++ b/internal/codegen/module_importer.go
@@ -1164,6 +1164,11 @@ func (m *Module) analyze(dir string, mi *moduleImporter, purpose analysisPurpose
 	var positionalPlan componentPositionalPackagePlan
 	var targetErrs []types.Error
 	var targetDiagnostics []diag.Diagnostic
+	// Undefined qualifiers used as the package half of a component tag. Only
+	// discovery's own type-check can see them (missingFromTargetMarkers), and
+	// they must survive BOTH branches below — the rejecting one empties gsxFiles,
+	// so the shipping skeleton it goes on to build has nothing left to walk.
+	var targetMissingImports map[string][]MissingImport
 	if callSites != nil && (callSites.hasCandidates() || len(componentPlan.families) != 0) {
 		targetBag := diag.NewBag(fset)
 		targetResult, unrelatedTargetErrs, targetErr := discoverComponentTargets(
@@ -1175,6 +1180,7 @@ func (m *Module) analyze(dir string, mi *moduleImporter, purpose analysisPurpose
 		if targetErr != nil {
 			return nil, targetErr
 		}
+		targetMissingImports = targetResult.missingImports
 		if len(targetResult.diagnostics) != 0 {
 			targetErrs = append(targetErrs, unrelatedTargetErrs...)
 			targetDiagnostics = append(targetDiagnostics, targetResult.diagnostics...)
@@ -1690,7 +1696,14 @@ func (m *Module) analyze(dir string, mi *moduleImporter, purpose analysisPurpose
 	// copy of a child-prop expression using spansByFile, the same per-file spans
 	// the type-error loop's quietSpans, above, is built from. See
 	// missingFromSkeletons' doc.
-	missingImports := missingFromSkeletons(skelByGsx, fset, info, spansByFile)
+	//
+	// Folded together with target discovery's own findings: a qualifier used
+	// ONLY as a component tag's package half never reaches a shipping skeleton
+	// (see missingFromTargetMarkers), so without this merge `<ui.Button/>` on an
+	// unimported `ui` would report `undefined: ui` and then offer no way to fix
+	// it. The shipping answer wins any (file, name, symbol) collision, keeping
+	// Pos on the occurrence whose diagnostic the user is most likely reading.
+	missingImports := mergeMissingImports(missingFromSkeletons(skelByGsx, fset, info, spansByFile), targetMissingImports)
 	if localComponentProvenance != nil {
 		componentDecls = make(map[ComponentDeclKey][]sourceintel.VersionedSpan)
 		for key, provenance := range localComponentProvenance {

--- a/internal/lsp/autoimport.go
+++ b/internal/lsp/autoimport.go
@@ -48,10 +48,16 @@ func (k SymbolKind) ciKind() int {
 // auto-import completion candidate. Kind/Detail feed the item's icon and
 // signature; the import path is supplied separately by the resolving caller
 // (one package's symbols share one path).
+//
+// TagCallable is the LSP mirror of codegen.ExportedSymbol.TagCallable: the
+// symbol could be written as a gsx tag (`<pkg.Name/>`). A Go-expression cursor
+// (`pkg.▮`) ignores it and offers everything; a TAG cursor (`<pkg.▮`) offers
+// only the symbols carrying it.
 type ImportSymbol struct {
-	Name   string
-	Kind   SymbolKind
-	Detail string
+	Name        string
+	Kind        SymbolKind
+	Detail      string
+	TagCallable bool
 }
 
 // ImportablePackage is one package a file could import: its declared name (the
@@ -155,12 +161,31 @@ type importEditPrep struct {
 // parse, or there is no place to put imports), so the loop can be skipped
 // entirely.
 func prepareImportEdit(text string, enc encoding) (importEditPrep, bool) {
+	return prepareImportEditIn(text, text, enc)
+}
+
+// prepareImportEditIn is prepareImportEdit for a cursor whose LIVE buffer does
+// not parse: parseSrc is the repaired buffer (repairResult.src), text is the
+// original document the resulting TextEdit ranges must address.
+//
+// A markup cursor needs this and a Go-expression cursor does not. gsx treats Go
+// as an opaque blob, so `{ fmt.▮ }` is still a well-formed gsx document and the
+// live buffer parses as-is; `<ui.▮` is an unterminated element and does not
+// parse at all — which is precisely the buffer state the user is in WHILE
+// typing the tag that needs the import.
+//
+// Substituting the repaired bytes is exact, not approximate: completionPatches
+// only ever INSERTS at the cursor and never modifies a byte before it, so the
+// two buffers are byte-identical over [0, cursor) — and apply refuses any edit
+// reaching at or past cursorStart, so every range this prep can produce lies
+// wholly inside that identical prefix. Nothing downstream re-reads parseSrc.
+func prepareImportEditIn(parseSrc, text string, enc encoding) (importEditPrep, bool) {
 	fset := token.NewFileSet()
-	file, err := gsxparser.ParseFile(fset, "buffer.gsx", text, 0)
+	file, err := gsxparser.ParseFile(fset, "buffer.gsx", parseSrc, 0)
 	if file == nil || err != nil {
 		return importEditPrep{}, false
 	}
-	chunkStart, oldSrc, ok := importChunkRegion(file, fset, text)
+	chunkStart, oldSrc, ok := importChunkRegion(file, fset, parseSrc)
 	if !ok {
 		return importEditPrep{}, false
 	}
@@ -325,6 +350,60 @@ func (s *Server) unimportedQualifierItems(dir, path, text, qualifier string, sta
 				continue
 			}
 			item := newCompletionItem(text, start, end, s.enc, sym.Name, sym.Name, sym.Kind.ciKind(), tierImported, sym.Detail, nil)
+			item.AdditionalTextEdits = []TextEdit{edit}
+			s.applyImportPathLabel(&item, sym.Detail, importPath)
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+// unimportedTagItems is the TAG-position counterpart of
+// unimportedQualifierItems: `<ui.▮` where `ui` names no import and no in-scope
+// binding resolves to the candidate package(s), and each package's TAG-CALLABLE
+// exported symbols become items whose accept inserts both the tag name and the
+// import.
+//
+// Two differences from the Go-expression member surface, both load-bearing:
+//
+//   - Only ImportSymbol.TagCallable symbols are offered. `<ui.` is not a Go
+//     selector — a const, a struct type, or a func returning int can never be a
+//     tag, and offering them would make the list mostly noise. The predicate is
+//     codegen's (tagcallable.IsCandidate), applied inside the analysis lock over
+//     real type objects, so an unimported package's tag list matches exactly what
+//     componentValueNameItems offers once the import exists.
+//   - Items are ciKindClass, matching componentNameItems — an editor that
+//     auto-appends "()" to a Function-kind item would produce `<ui.Button()`,
+//     which is not valid markup. The TIER stays unimportedQualifierItems'
+//     tierImported, below every context-native component.
+//
+// A qualifier that maps to several packages yields one item per surviving symbol
+// per path, each labelled with its own path — same honesty rule as Option 1. A
+// candidate whose import edit cannot be synthesized is skipped rather than
+// offered without its import.
+//
+// parseSrc is the repaired buffer the import edit is located in — see
+// prepareImportEditIn for why a markup cursor cannot use the live text.
+func (s *Server) unimportedTagItems(dir, parseSrc, text, qualifier string, start, end int) []CompletionItem {
+	paths := s.analyzer.ResolveImport(dir, qualifier, "")
+	if len(paths) == 0 {
+		return nil
+	}
+	prep, ok := prepareImportEditIn(parseSrc, text, s.enc)
+	if !ok {
+		return nil
+	}
+	var items []CompletionItem
+	for _, importPath := range paths {
+		edit, ok := prep.apply(importPath, start)
+		if !ok {
+			continue
+		}
+		for _, sym := range s.analyzer.ExportedSymbols(dir, importPath) {
+			if !sym.TagCallable || isReservedGsxInternal(sym.Name) {
+				continue
+			}
+			item := newCompletionItem(text, start, end, s.enc, sym.Name, sym.Name, ciKindClass, tierImported, sym.Detail, nil)
 			item.AdditionalTextEdits = []TextEdit{edit}
 			s.applyImportPathLabel(&item, sym.Detail, importPath)
 			items = append(items, item)

--- a/internal/lsp/completion_gsx.go
+++ b/internal/lsp/completion_gsx.go
@@ -122,16 +122,31 @@ func (s *Server) pipeFilterPackage(dir, path string, src []byte) *Package {
 // componentDeclPackage comes back nil (analysis is a shell): only the COMPONENT
 // half depends on the package. A qualified `<pkg.▮` cursor is component-only —
 // HTML tags have no qualifier — so htmlTagItems is skipped there.
+//
+// A qualifier that resolves to NOTHING — neither an in-scope binding nor an
+// import — falls through to unimportedTagItems, which offers the tag-callable
+// symbols of whatever package(s) that name could import, each item carrying the
+// import edit. That fallback is gated on componentTagItems' `resolved` flag, not
+// on its item list being empty: an imported package that happens to declare no
+// components, and an in-scope var whose type declares no method components, both
+// legitimately produce zero items and must NOT be second-guessed with an
+// auto-import list (the same precedence rule undefinedQualifier enforces for a
+// Go-expression cursor).
 func (s *Server) tagCompletion(cc completionContext, path, text string, off int, r repairResult) CompletionList {
 	start, end := completionTokenSpan(text, off, false)
 	capitalizedPrefix := startsWithUpper(text[start:end])
+	dir := filepath.Dir(path)
 
 	var items []CompletionItem
-	if pkg := s.componentDeclPackage(filepath.Dir(path), path, r.src); pkg != nil {
-		items = componentTagItems(pkg, cc.qualifier, capitalizedPrefix, path, off, text, start, end, s.enc)
+	resolved := false
+	if pkg := s.componentDeclPackage(dir, path, r.src); pkg != nil {
+		items, resolved = componentTagItems(pkg, cc.qualifier, capitalizedPrefix, path, off, text, start, end, s.enc)
 	}
-	if cc.qualifier == "" {
+	switch {
+	case cc.qualifier == "":
 		items = append(items, htmlTagItems(capitalizedPrefix, text, start, end, s.enc)...)
+	case !resolved:
+		items = append(items, s.unimportedTagItems(dir, string(r.src), text, cc.qualifier, start, end)...)
 	}
 	if len(items) == 0 {
 		return emptyCompletion()
@@ -215,45 +230,58 @@ func (s *Server) componentDeclPackage(dir, path string, src []byte) *Package {
 // caller / htmlTagItems, not here. The parameter is retained so the signature
 // documents the merge contract and the tests pin that components stay tierContext
 // either way.
-func componentTagItems(pkg *Package, qualifier string, capitalizedPrefix bool, path string, off int, text string, start, end int, enc encoding) []CompletionItem {
+//
+// resolved reports whether a NON-EMPTY qualifier named something already
+// visible from this cursor — an in-scope binding, or an import. It is always
+// true for an empty qualifier (there is nothing to resolve). false means the
+// name is undefined here, which is the caller's cue to offer unimported
+// packages; it is deliberately independent of whether any items came back, so a
+// resolvable-but-componentless qualifier is never mistaken for a missing import.
+func componentTagItems(pkg *Package, qualifier string, capitalizedPrefix bool, path string, off int, text string, start, end int, enc encoding) ([]CompletionItem, bool) {
 	if pkg == nil || pkg.Types == nil {
-		return nil
+		return nil, false
 	}
 	if qualifier != "" {
-		// Go-scoping precedence: a value binding named qualifier shadows a
+		// Go-scoping precedence: an in-scope binding named qualifier shadows a
 		// same-named import, so try receiver/param/var resolution first. resolved
-		// == true means qualifier IS an in-scope value binding — stop here even
-		// when its type declares no method components (the binding still shadows
-		// any import, per Go).
+		// == true means qualifier IS such a binding — stop here even when it
+		// yields no items (the binding still shadows any import, per Go, and it is
+		// certainly not a missing import).
 		if items, resolved := receiverVarComponentItems(pkg, qualifier, path, off, text, start, end, enc); resolved {
-			return items
+			return items, true
 		}
 		impPath, ok := importQualifierCandidates(pkg)[qualifier]
 		if !ok {
-			return nil
+			return nil, false
 		}
 		items := componentNameItems(pkg, impPath, text, start, end, enc)
 		if target := importedPackageAt(pkg, impPath); target != nil {
 			items = append(items, componentValueNameItems(target, offeredNames(items), true, text, start, end, enc)...)
 		}
-		return items
+		return items, true
 	}
 	items := componentNameItems(pkg, pkg.Types.Path(), text, start, end, enc)
 	items = append(items, componentValueNameItems(pkg.Types, offeredNames(items), false, text, start, end, enc)...)
 	items = append(items, importQualifierItems(pkg, text, start, end, enc)...)
-	return items
+	return items, true
 }
 
 // receiverVarComponentItems resolves a qualified tag cursor `<qualifier.▮`
-// against the in-scope VALUE bindings visible from the enclosing component,
-// and offers the method components declared on the binding's type. It returns
-// (items, resolved): resolved reports whether qualifier named an in-scope value
-// binding (a *types.Var — receiver, parameter, or package-scope var). When
-// resolved is true the caller must NOT fall through to import-qualifier
-// resolution, even if items is empty: a value binding shadows a same-named
-// import (Go scoping), so `<qualifier.▮` can only mean that binding's methods.
-// When resolved is false (qualifier is an import PkgName, or resolves to
-// nothing) the caller proceeds to the import-qualifier path.
+// against the in-scope bindings visible from the enclosing component, and offers
+// the method components declared on a value binding's type. It returns
+// (items, resolved): resolved reports whether qualifier named an in-scope
+// binding OTHER than an import — a *types.Var (receiver, parameter, or
+// package-scope var), or any other declared object such as a func, type, or
+// const. When resolved is true the caller must NOT fall through to
+// import-qualifier resolution or to auto-import, even if items is empty: such a
+// binding shadows a same-named import (Go scoping), so `<qualifier.▮` can only
+// mean that binding — and a binding that carries no method components has none
+// to offer, not a missing import to add.
+//
+// When resolved is false — qualifier is an import PkgName, or resolves to
+// nothing at all — the caller proceeds to the import-qualifier path, and from
+// there to unimported-package resolution. A PkgName deliberately reports false
+// so the import path (which knows the resolved package) owns it.
 //
 // The scope is the enclosing component's generated-func scope, located WITHOUT
 // relying on authored-offset↔skeleton-offset alignment (which does not hold —
@@ -279,9 +307,14 @@ func receiverVarComponentItems(pkg *Package, qualifier, path string, off int, te
 		return nil, false
 	}
 	_, obj := scope.LookupParent(qualifier, token.NoPos)
-	v, ok := obj.(*types.Var)
-	if !ok {
-		return nil, false
+	v, isVar := obj.(*types.Var)
+	if !isVar {
+		if _, isPkgName := obj.(*types.PkgName); obj == nil || isPkgName {
+			return nil, false // undefined, or an import the qualifier path owns
+		}
+		// A func / type / const / builtin named qualifier: it shadows any
+		// same-named import per Go scoping, and carries no method components.
+		return nil, true
 	}
 	typeName, pkgPath, ok := namedTypeOf(v.Type())
 	if !ok {
@@ -437,38 +470,29 @@ func componentValueNameItems(target *types.Package, skip map[string]bool, export
 }
 
 // tagCallableValueNames returns target's package-scope identifiers — sorted,
-// minus skip — that satisfy codegen's callable-universe tag shape: a
-// types.Func or function-valued types.Var whose signature has one result
-// assignable to gsx.Node (single-sourced from internal/tagcallable — see its
-// package doc) AND every parameter named.
-//
-// The named-parameter half is NOT part of the shared tagcallable predicate:
-// it is a deliberate, conservative choice specific to offering completion
-// candidates, not a copy of some single codegen acceptance function. codegen
-// itself only requires named parameters at the point it plans how markup
-// attributes bind to a resolved call target — component_signature.go's
-// analyzeComponentSignature (the "component-parameter-name" check), reached
-// from component_positional_plan.go's operand planning
-// (planComponentPositionalCalls) — which runs on one already-authored,
-// already-resolved call site, never on a package-scope scan like this one.
-// An unnamed parameter could never receive a markup attribute that way, so
-// completion excludes it up front rather than offering a candidate codegen
-// would reject at the call site; but nothing stops a future codegen change
-// from accepting unnamed parameters through some other binding path this
-// scan does not know about, without this file needing to track it — hence
-// "deliberate choice", not "mirrored rule".
+// minus skip — that tagcallable.IsCandidate accepts: the callable-universe tag
+// shape (one result assignable to gsx.Node) plus every parameter named. Both
+// halves, and the gsx.Node lookup they are checked against, are single-sourced
+// in internal/tagcallable so this scan and codegen's unimported-package scan
+// (Module.PackageExportedSymbols' TagCallable flag, which feeds `<pkg.▮` for a
+// package this file does not import yet) can never drift apart. See that
+// package's doc for why the named-parameter rule belongs to the completion
+// layer.
 //
 // exportedOnly gates on obj.Exported() — required when target is a DIFFERENT
 // package than the one completion is running in (Go visibility), and false
 // for target's own package (every package-scope identifier, exported or
 // not, is a legal same-package tag).
 //
-// gsxNodeInterface resolving to nil (target does not import gsx.Node at all,
-// directly or — for the tests' synthetic packages — because it has no
+// tagcallable.NodeInterface resolving to nil (target does not import gsx.Node
+// at all, directly or — for the tests' synthetic packages — because it has no
 // imports set up) is a silent, fail-soft "no value candidates", not an error:
 // most packages never define a component-shaped value.
 func tagCallableValueNames(target *types.Package, skip map[string]bool, exportedOnly bool) []string {
-	iface := gsxNodeInterface(target)
+	if target == nil {
+		return nil
+	}
+	iface := tagcallable.NodeInterface(target)
 	if iface == nil {
 		return nil
 	}
@@ -482,85 +506,13 @@ func tagCallableValueNames(target *types.Package, skip map[string]bool, exported
 		if exportedOnly && !obj.Exported() {
 			continue
 		}
-		var sig *types.Signature
-		switch o := obj.(type) {
-		case *types.Func:
-			sig, _ = o.Type().(*types.Signature)
-		case *types.Var:
-			sig = tagcallable.Signature(o.Type())
-		default:
-			continue
-		}
-		if sig == nil || !isTagCallableSignature(sig, iface) {
+		if !tagcallable.IsCandidate(obj, iface) {
 			continue
 		}
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	return names
-}
-
-// isTagCallableSignature reports whether sig matches codegen's
-// callable-universe shape — tagcallable.IsResult, single-sourced with
-// codegen's component_identity.go — AND every parameter is named. See
-// tagCallableValueNames' doc for why the named-parameter half stays a
-// completion-local, deliberately conservative addition rather than part of
-// the shared predicate.
-func isTagCallableSignature(sig *types.Signature, node *types.Interface) bool {
-	if !tagcallable.IsResult(sig, node) {
-		return false
-	}
-	for param := range sig.Params().Variables() {
-		if param.Name() == "" {
-			return false
-		}
-	}
-	return true
-}
-
-// gsxNodeInterface locates the gsx.Node interface type within target's OWN
-// direct imports. target must import "github.com/gsxhq/gsx" itself for any
-// of its declarations to type-check against gsx.Node in the first place, so
-// this never needs to search transitively or reach into a different
-// package's import graph (in particular, the LSP's own analyzed root
-// package's imports are irrelevant — target is scanned as an independent
-// package, per the go/types identity rule that every *types.Package in one
-// checked build shares one canonical object per imported package). Returns
-// nil (fail-soft) when target does not import gsx at all.
-//
-// This duplicates a lookup codegen also performs — component_signature.go's
-// runtimeContractFromAnalysisPackage is the authority there, and its
-// runtimeContract.node is exactly this same gsx.Node identity — but that
-// helper is not reachable from here without either a layering violation
-// (internal/lsp importing internal/codegen) or pulling in invariants this
-// scan does not need: runtimeContractFromAnalysisPackage resolves Node,
-// Attr, AND Attrs together for one fixed "the analysis package" and errors
-// if any is missing or inconsistent, whereas this needs only Node, resolved
-// against an arbitrary imported target package that is never itself "the
-// analysis package". Folding the two would mean either exporting a
-// narrower, Node-only codegen entry point (not part of this pass; a
-// follow-up if the duplication proves troublesome) or accepting the
-// unrelated Attr/Attrs requirement here. Kept local for now, with codegen's
-// runtimeContract as the documented authority for the identity this mirrors.
-func gsxNodeInterface(target *types.Package) *types.Interface {
-	if target == nil {
-		return nil
-	}
-	for _, imp := range target.Imports() {
-		if imp.Path() != "github.com/gsxhq/gsx" {
-			continue
-		}
-		tn, ok := imp.Scope().Lookup("Node").(*types.TypeName)
-		if !ok {
-			return nil
-		}
-		iface, ok := types.Unalias(tn.Type()).Underlying().(*types.Interface)
-		if !ok {
-			return nil
-		}
-		return iface
-	}
-	return nil
 }
 
 // componentNameItems returns one item per plain (non-receiver) component

--- a/internal/lsp/completion_gsx_recv_test.go
+++ b/internal/lsp/completion_gsx_recv_test.go
@@ -119,7 +119,7 @@ func (f *Form) _submit() { _ = f }
 func TestReceiverVarTagResolvesMethodComponents(t *testing.T) {
 	pkg, src := methodComponentFixture(t)
 	off := strings.Index(src, "<p.Row") + len("<p.")
-	items := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8)
 	got := map[string]int{}
 	for _, it := range items {
 		got[it.Label] = it.Kind
@@ -154,7 +154,7 @@ func TestReceiverVarTagResolvesMethodComponents(t *testing.T) {
 func TestParamVarTagResolvesMethodComponents(t *testing.T) {
 	pkg, src := methodComponentFixture(t)
 	off := strings.Index(src, "<p.Row") + len("<p.")
-	items := componentTagItems(pkg, "f", false, "page.gsx", off, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "f", false, "page.gsx", off, "", 0, 0, encUTF8)
 	if len(items) != 1 || items[0].Label != "Submit" {
 		t.Fatalf("items = %+v, want exactly [Submit] for the *Form param `f`", items)
 	}
@@ -168,7 +168,7 @@ func TestParamVarTagResolvesMethodComponents(t *testing.T) {
 func TestReceiverVarUnknownQualifierEmpty(t *testing.T) {
 	pkg, src := methodComponentFixture(t)
 	off := strings.Index(src, "<p.Row") + len("<p.")
-	if items := componentTagItems(pkg, "zzz", false, "page.gsx", off, "", 0, 0, encUTF8); len(items) != 0 {
+	if items, _ := componentTagItems(pkg, "zzz", false, "page.gsx", off, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("items = %+v, want empty for an unresolvable qualifier", items)
 	}
 }
@@ -187,7 +187,7 @@ func TestReceiverVarShadowsImport(t *testing.T) {
 	pkg.ComponentDecls[ComponentDeclKey{PackagePath: "example.com/app/pkgp", ComponentKey: ".Button"}] = nil
 
 	off := strings.Index(src, "<p.Row") + len("<p.")
-	items := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8)
 	for _, it := range items {
 		if it.Label == "Button" {
 			t.Fatalf("import component Button leaked past the shadowing receiver var: %+v", items)
@@ -213,7 +213,7 @@ func TestReceiverVarBindingWithoutMethodsStopsFallback(t *testing.T) {
 	pkg.ComponentDecls[ComponentDeclKey{PackagePath: "example.com/app/pkgp", ComponentKey: ".Button"}] = nil
 
 	off := strings.Index(src, "<p.Row") + len("<p.")
-	if items := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8); len(items) != 0 {
+	if items, _ := componentTagItems(pkg, "p", false, "page.gsx", off, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("items = %+v, want empty (receiver var shadows import even with no methods)", items)
 	}
 }
@@ -233,7 +233,7 @@ var _ = myui.ToUpper
 	}
 	// No Files/GSXFset/SigTypes: enclosingComponentAt finds nothing, the package
 	// scope has no `myui` var, so resolution declines and the import path runs.
-	items := componentTagItems(pkg, "myui", false, "page.gsx", 10, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "myui", false, "page.gsx", 10, "", 0, 0, encUTF8)
 	if len(items) != 1 || items[0].Label != "Button" {
 		t.Fatalf("items = %+v, want [Button] via import fallback", items)
 	}

--- a/internal/lsp/completion_gsx_test.go
+++ b/internal/lsp/completion_gsx_test.go
@@ -270,7 +270,7 @@ func componentTagFixturePackage() *Package {
 // qualifiers (sorted) — deterministic despite ComponentDecls being a map.
 func TestComponentTagItemsBareCursor(t *testing.T) {
 	pkg := componentTagFixturePackage()
-	items := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
 	if len(items) != 2 {
 		t.Fatalf("len(items) = %d, want 2: %+v", len(items), items)
 	}
@@ -297,7 +297,7 @@ func TestComponentTagItemsBareCursor(t *testing.T) {
 // package's plain component ("Button"), dot-free.
 func TestComponentTagItemsQualified(t *testing.T) {
 	pkg := componentTagFixturePackage()
-	items := componentTagItems(pkg, "ui", false, "", 0, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "ui", false, "", 0, "", 0, 0, encUTF8)
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d, want 1: %+v", len(items), items)
 	}
@@ -313,7 +313,7 @@ func TestComponentTagItemsQualified(t *testing.T) {
 // matching no import's Name() yields an empty list, not a panic.
 func TestComponentTagItemsQualifiedUnknownImport(t *testing.T) {
 	pkg := componentTagFixturePackage()
-	if items := componentTagItems(pkg, "nope", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
+	if items, _ := componentTagItems(pkg, "nope", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("items = %+v, want empty for an unresolvable qualifier", items)
 	}
 }
@@ -325,7 +325,7 @@ func TestComponentTagItemsNilTypesFailsSoft(t *testing.T) {
 	pkg := &Package{ComponentDecls: map[ComponentDeclKey][]sourceintel.VersionedSpan{
 		{PackagePath: "example.com/app/page", ComponentKey: ".Card"}: nil,
 	}}
-	if items := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
+	if items, _ := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("items = %+v, want empty when pkg.Types is nil", items)
 	}
 }
@@ -352,17 +352,17 @@ var _ = myui.ToUpper
 		{PackagePath: "strings", ComponentKey: ".Button"}: nil,
 	}
 
-	items := componentTagItems(pkg, "myui", false, "", 0, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "myui", false, "", 0, "", 0, 0, encUTF8)
 	if len(items) != 1 || items[0].Label != "Button" {
 		t.Fatalf("qualifier=%q items = %+v, want exactly [Button]", "myui", items)
 	}
 
 	// The declared name ("strings") must NOT resolve — only the alias does.
-	if items := componentTagItems(pkg, "strings", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
+	if items, _ := componentTagItems(pkg, "strings", false, "", 0, "", 0, 0, encUTF8); len(items) != 0 {
 		t.Fatalf("qualifier=%q items = %+v, want empty (declared name is not the local name)", "strings", items)
 	}
 
-	bareItems := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
+	bareItems, _ := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
 	var qualItem *CompletionItem
 	for i := range bareItems {
 		if bareItems[i].Kind == ciKindModule {
@@ -456,7 +456,7 @@ func buildIconValueComponentFixture() *Package {
 // ciKindClass), BadParam/WrongResult/unexp are not.
 func TestComponentValueNameItemsQualified(t *testing.T) {
 	pkg := buildIconValueComponentFixture()
-	items := componentTagItems(pkg, "icon", false, "", 0, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "icon", false, "", 0, "", 0, 0, encUTF8)
 	got := map[string]CompletionItem{}
 	for _, it := range items {
 		got[it.Label] = it
@@ -485,7 +485,7 @@ func TestComponentValueNameItemsQualified(t *testing.T) {
 // though it has zero ComponentDecls entries.
 func TestComponentValueNameItemsBareCursorLocal(t *testing.T) {
 	pkg := buildIconValueComponentFixture()
-	items := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "", false, "", 0, "", 0, 0, encUTF8)
 	var local, qual *CompletionItem
 	for i := range items {
 		switch items[i].Label {
@@ -518,7 +518,7 @@ func TestComponentValueNameItemsDedup(t *testing.T) {
 	pkg.ComponentDecls = map[ComponentDeclKey][]sourceintel.VersionedSpan{
 		{PackagePath: "github.com/tespkg/one-learning/ds/icon", ComponentKey: ".X"}: nil,
 	}
-	items := componentTagItems(pkg, "icon", false, "", 0, "", 0, 0, encUTF8)
+	items, _ := componentTagItems(pkg, "icon", false, "", 0, "", 0, 0, encUTF8)
 	count := 0
 	for _, it := range items {
 		if it.Label == "X" {
@@ -539,6 +539,18 @@ type tagCompletionAnalyzer struct {
 	ephPkg   *Package
 	ephErr   error
 	analyzed *Package // returned by Analyze, populates s.pkgs[dir] via didOpen
+	// resolve/symbols back the unimported-qualifier fallback (`<ui.▮` where the
+	// file never imported ui); both stay nil for every test that must NOT reach
+	// it, so a regression that fires the fallback on a resolved qualifier shows
+	// up as items appearing where the fixture supplies none.
+	resolve map[string][]string
+	symbols map[string][]ImportSymbol
+}
+
+func (a tagCompletionAnalyzer) ResolveImport(_, name, _ string) []string { return a.resolve[name] }
+
+func (a tagCompletionAnalyzer) ExportedSymbols(_, path string) []ImportSymbol {
+	return a.symbols[path]
 }
 
 func (a tagCompletionAnalyzer) AnalyzeEphemeral(string, string, []byte) (*Package, error) {
@@ -1164,4 +1176,158 @@ func TestElementAtTagOffsetNoMatch(t *testing.T) {
 	if got := elementAtTagOffset(nil, "page.gsx", 0); got != nil {
 		t.Fatalf("got = %+v, want nil for a nil package", got)
 	}
+}
+
+// unimportedTagFixture is componentTagFixturePackage's counterpart for the
+// auto-import path: the analyzed package imports NOTHING, so a `<ui.▮` cursor
+// finds no qualifier to resolve and falls through to unimportedTagItems.
+func unimportedTagFixture() *Package {
+	main := types.NewPackage("example.com/app/page", "page")
+	main.MarkComplete()
+	return &Package{Types: main}
+}
+
+// uiImportSymbols is one unimported package's exported surface: a tag-callable
+// component and three symbols that are not tags. Only Button may be offered at
+// a `<ui.▮` cursor.
+func uiImportSymbols() map[string][]ImportSymbol {
+	return map[string][]ImportSymbol{
+		"example.com/app/ui": {
+			{Name: "Button", Kind: SymbolFunc, Detail: "func ui.Button(label string) gsx.Node", TagCallable: true},
+			{Name: "Format", Kind: SymbolFunc, Detail: "func ui.Format(s string) string"},
+			{Name: "Theme", Kind: SymbolTypeStruct, Detail: "type ui.Theme struct{...}"},
+			{Name: "Size", Kind: SymbolConst, Detail: "const ui.Size untyped int = 3"},
+		},
+	}
+}
+
+// TestTagCompletionUnimportedQualifier drives the real handler at `<ui.▮` in a
+// file that never imported ui: the package's TAG-CALLABLE symbol is offered,
+// carrying the import as an AdditionalTextEdit, and its non-tag symbols are
+// not. This is the wiring test — componentTagItems finds nothing, reports the
+// qualifier unresolved, and tagCompletion falls through to unimportedTagItems.
+func TestTagCompletionUnimportedQualifier(t *testing.T) {
+	uri := "file:///m/a.gsx"
+	text := "package p\n\nimport \"github.com/gsxhq/gsx\"\n\nvar _ gsx.Node\n\ncomponent C() {\n\t<div><ui.</div>\n}\n"
+	off := strings.Index(text, "<ui.") + len("<ui.")
+	pos := positionForByteOffset(text, off, encUTF16)
+
+	a := tagCompletionAnalyzer{
+		ephPkg:  unimportedTagFixture(),
+		resolve: map[string][]string{"ui": {"example.com/app/ui"}},
+		symbols: uiImportSymbols(),
+	}
+	out := drive(t, a, initFrame()+didOpenFrame(uri, text)+
+		completionFrame(2, uri, pos)+exitFrame())
+	items := decodeCompletionItems(t, out, 2)
+
+	button := itemByLabel(items, "Button")
+	if button == nil {
+		t.Fatalf("`<ui.` completion missing Button; labels=%v", labelSet(items))
+	}
+	if button.Kind != ciKindClass {
+		t.Errorf("Button.Kind = %d, want ciKindClass (%d) — a Function-kind item makes editors append \"()\"", button.Kind, ciKindClass)
+	}
+	if len(button.AdditionalTextEdits) != 1 {
+		t.Fatalf("Button.AdditionalTextEdits = %+v, want exactly the import edit", button.AdditionalTextEdits)
+	}
+	if got := button.AdditionalTextEdits[0].NewText; !strings.Contains(got, "example.com/app/ui") {
+		t.Errorf("Button import edit = %q, want it to add example.com/app/ui", got)
+	}
+	for _, name := range []string{"Format", "Theme", "Size"} {
+		if itemByLabel(items, name) != nil {
+			t.Errorf("`<ui.` offered %q, want tag-callable symbols only", name)
+		}
+	}
+	// The import edit was located in the REPAIRED buffer but must address the
+	// ORIGINAL document (prepareImportEditIn). Applying both edits to the live
+	// text is the only assertion that catches an off-by-N in that mapping.
+	got := applyTextEdits(text, append([]TextEdit{*button.TextEdit}, button.AdditionalTextEdits...), encUTF16)
+	if !strings.Contains(got, "\"example.com/app/ui\"") {
+		t.Errorf("applied document did not gain the import:\n%s", got)
+	}
+	if !strings.Contains(got, "<ui.Button") {
+		t.Errorf("applied document did not gain the tag name:\n%s", got)
+	}
+	if strings.Contains(got, "packag\n") || !strings.HasPrefix(got, "package p\n") {
+		t.Errorf("applied document corrupted the head:\n%s", got)
+	}
+}
+
+// TestTagCompletionImportedQualifierSkipsAutoImport is the precedence guard: a
+// qualifier that already names an IMPORT resolves, so the auto-import fallback
+// must not run even though the fixture's resolve/symbols maps could answer it.
+// Otherwise `<ui.▮` on an imported ui would offer a duplicate Button carrying a
+// redundant import edit.
+func TestTagCompletionImportedQualifierSkipsAutoImport(t *testing.T) {
+	uri := "file:///m/a.gsx"
+	text := "package p\n\nimport \"example.com/app/ui\"\n\ncomponent C() {\n\t<div><ui.</div>\n}\n"
+	off := strings.Index(text, "<ui.") + len("<ui.")
+	pos := positionForByteOffset(text, off, encUTF16)
+
+	a := tagCompletionAnalyzer{
+		ephPkg:  componentTagFixturePackage(), // already imports example.com/app/ui
+		resolve: map[string][]string{"ui": {"example.com/app/ui"}},
+		symbols: uiImportSymbols(),
+	}
+	out := drive(t, a, initFrame()+didOpenFrame(uri, text)+
+		completionFrame(2, uri, pos)+exitFrame())
+	items := decodeCompletionItems(t, out, 2)
+
+	if len(items) != 1 || items[0].Label != "Button" {
+		t.Fatalf("`<ui.` on an imported ui = %v, want exactly the declared component [Button]", labelSet(items))
+	}
+	if len(items[0].AdditionalTextEdits) != 0 {
+		t.Errorf("Button.AdditionalTextEdits = %+v, want none (ui is already imported)", items[0].AdditionalTextEdits)
+	}
+}
+
+// TestComponentTagItemsResolvedFlag pins the flag tagCompletion gates the
+// auto-import fallback on. It is deliberately independent of whether items came
+// back: an import that declares no components, and an in-scope binding that
+// carries no method components, both resolve to something and must never be
+// second-guessed with an auto-import list.
+func TestComponentTagItemsResolvedFlag(t *testing.T) {
+	t.Run("bare cursor always resolved", func(t *testing.T) {
+		if _, resolved := componentTagItems(componentTagFixturePackage(), "", false, "", 0, "", 0, 0, encUTF8); !resolved {
+			t.Error("resolved = false for an empty qualifier, want true (nothing to resolve)")
+		}
+	})
+	t.Run("imported qualifier with components", func(t *testing.T) {
+		if _, resolved := componentTagItems(componentTagFixturePackage(), "ui", false, "", 0, "", 0, 0, encUTF8); !resolved {
+			t.Error("resolved = false for an imported qualifier, want true")
+		}
+	})
+	t.Run("unknown qualifier", func(t *testing.T) {
+		if _, resolved := componentTagItems(componentTagFixturePackage(), "nope", false, "", 0, "", 0, 0, encUTF8); resolved {
+			t.Error("resolved = true for a qualifier naming nothing, want false")
+		}
+	})
+	t.Run("imported qualifier with NO components", func(t *testing.T) {
+		// The noise guard: `strings` is imported and declares no components, so it
+		// yields zero items — but it is resolved, so no auto-import list may follow.
+		src := "package p\n\nimport \"strings\"\n\nvar _ = strings.ToUpper\n"
+		pkg, _ := buildSyntheticPackage(t, src)
+		items, resolved := componentTagItems(pkg, "strings", false, "page.gsx", 0, "", 0, 0, encUTF8)
+		if len(items) != 0 {
+			t.Fatalf("items = %+v, want none (strings declares no components)", items)
+		}
+		if !resolved {
+			t.Error("resolved = false for an imported componentless package, want true")
+		}
+	})
+	t.Run("in-scope non-value binding shadows imports", func(t *testing.T) {
+		// A package-scope func named `helper` shadows any same-named import per Go
+		// scoping. It carries no method components, so items is empty — but it is
+		// resolved, and `<helper.` is not a missing import.
+		src := "package p\n\nfunc helper() {}\n"
+		pkg, _ := buildSyntheticPackage(t, src)
+		items, resolved := componentTagItems(pkg, "helper", false, "page.gsx", 0, "", 0, 0, encUTF8)
+		if len(items) != 0 {
+			t.Fatalf("items = %+v, want none", items)
+		}
+		if !resolved {
+			t.Error("resolved = false for an in-scope func binding, want true")
+		}
+	})
 }

--- a/internal/tagcallable/tagcallable.go
+++ b/internal/tagcallable/tagcallable.go
@@ -14,13 +14,103 @@
 // import internal/codegen, so this leaf package is the only legal place for
 // the shared rule to live.
 //
-// This package intentionally does NOT decide the "every parameter must be
-// named" restriction some callers additionally apply — that is not part of
-// the callable-universe shape itself (see each consumer's own doc for where
-// and why it layers that on).
+// The package exposes TWO layers, deliberately kept apart:
+//
+//   - Signature/IsResult are the callable-universe shape itself, and nothing
+//     more. They do NOT decide the "every parameter must be named"
+//     restriction: a call site codegen resolves is held only to the shape.
+//   - IsCandidate is the COMPLETION-grade predicate layered on top — the
+//     shape plus every parameter named — used when scanning a whole package
+//     scope for names to OFFER in tag position. An unnamed parameter could
+//     never receive a markup attribute (component_signature.go's
+//     "component-parameter-name" check rejects it at the point a resolved
+//     call site is planned), so a package-scope scan excludes it up front
+//     rather than offering a candidate codegen would later reject. That is a
+//     deliberate, conservative completion choice, not a mirror of some single
+//     codegen acceptance function — but it must be identical across every
+//     completion surface that offers tags, which is why it lives here rather
+//     than in one of them.
+//
+// NodeInterface resolves the gsx.Node identity a scan needs, from the scanned
+// package's OWN direct imports.
 package tagcallable
 
 import "go/types"
+
+// gsxRuntimeImportPath is the import path of the gsx runtime package, whose Node
+// interface every tag-callable result must be assignable to.
+const gsxRuntimeImportPath = "github.com/gsxhq/gsx"
+
+// NodeInterface locates the gsx.Node interface type within pkg's OWN direct
+// imports. pkg must import the gsx runtime itself for any of its declarations
+// to type-check against gsx.Node in the first place, so this never needs to
+// search transitively or reach into a different package's import graph (in particular
+// the import graph of whichever package is doing the ASKING is irrelevant: pkg
+// is scanned as an independent package, per the go/types identity rule that
+// every *types.Package in one checked build shares one canonical object per
+// imported package).
+//
+// Returns nil (fail-soft, never an error) when pkg is nil, does not import gsx
+// at all, or its gsx does not declare a Node interface: most packages never
+// define a component-shaped value, and a scan that finds no gsx.Node simply has
+// no candidates to offer.
+//
+// codegen's component_signature.go runtimeContractFromAnalysisPackage is the
+// authority for this same identity when it resolves Node, Attr, and Attrs
+// TOGETHER for one fixed "the analysis package", erroring if any is missing or
+// inconsistent. This narrower lookup answers the different question a scan asks
+// — Node alone, for an arbitrary target package that is never itself the
+// analysis package — and both now read the identity the same way.
+func NodeInterface(pkg *types.Package) *types.Interface {
+	if pkg == nil {
+		return nil
+	}
+	for _, imp := range pkg.Imports() {
+		if imp.Path() != gsxRuntimeImportPath {
+			continue
+		}
+		tn, ok := imp.Scope().Lookup("Node").(*types.TypeName)
+		if !ok {
+			return nil
+		}
+		iface, ok := types.Unalias(tn.Type()).Underlying().(*types.Interface)
+		if !ok {
+			return nil
+		}
+		return iface
+	}
+	return nil
+}
+
+// IsCandidate reports whether the package-scope object obj may be OFFERED as a
+// tag name completing against node: a *types.Func, or a *types.Var whose type
+// unwraps to a callable signature, whose signature satisfies IsResult AND names
+// every parameter. See the package doc for why the named-parameter rule is part
+// of this predicate but not of IsResult.
+//
+// Visibility (obj.Exported()) is NOT decided here: a same-package scan legally
+// offers unexported names while a cross-package one may not, and only the
+// caller knows which it is doing.
+func IsCandidate(obj types.Object, node types.Type) bool {
+	var sig *types.Signature
+	switch o := obj.(type) {
+	case *types.Func:
+		sig, _ = o.Type().(*types.Signature)
+	case *types.Var:
+		sig = Signature(o.Type())
+	default:
+		return false
+	}
+	if !IsResult(sig, node) {
+		return false
+	}
+	for param := range sig.Params().Variables() {
+		if param.Name() == "" {
+			return false
+		}
+	}
+	return true
+}
 
 // Signature returns typ's callable *types.Signature — unwrapping a defined
 // (named) function type's underlying type — or nil when typ is not callable


### PR DESCRIPTION
`<ui.Button/>` on a package the file has not imported now completes, and
`source.organizeImports` / the **Add import** quickfix now fire on it.

Motivating repro (verified end-to-end against the real project, then confirmed
by @jackielii): a `.gsx` file using `<ui.Button>` from a sibling package in the
same module showed `undefined: ui`, offered **zero** code actions, and offered
**zero** completions at `<ui.`.

## Two unrelated root causes

**1. `MissingImports` never saw tag position.** It was derived only from the
SHIPPING skeleton, but a component tag's identity expression (`ui.Button`)
exists as Go syntax only in the target-DISCOVERY skeleton
(`var _gsxtargetN = ui.Button`). An unresolved qualifier makes discovery reject
the call site, so the element is never stamped `IsComponent` and lowers as a
plain leaf carrying no selector — and on that branch `analyze` rebuilds from an
**empty** gsx file set, so the shipping pass has nothing left to walk.

`missingFromTargetMarkers` now applies the *same exact* `info.Uses`-miss test to
discovery's own marker table and info, computed before any rejection path can
discard it. `mergeMissingImports` folds it in, the shipping answer winning a
collision so `Pos` stays on the occurrence whose diagnostic the user is reading.

**2. `componentTagItems` only knew imported qualifiers.** It now returns
`(items, resolved)`, and `tagCompletion` falls through to `unimportedTagItems`
when — and only when — the qualifier resolves to nothing.

Gating on `resolved` rather than on an empty item list is the load-bearing part:
an imported-but-componentless package (`<vite.`) and an in-scope binding with no
method components both legitimately yield zero items and must **not** be
second-guessed with an auto-import list.

## Two supporting pieces

- **Only tag-callable symbols are offered**, so `<strings.` stays empty instead
  of flooding with 50 items. `codegen.ExportedSymbol` / `lsp.ImportSymbol` gained
  a `TagCallable` flag computed inside the analysis lock from real type objects,
  and the predicate behind it (callable-universe shape + every parameter named)
  plus the `gsx.Node` identity lookup moved into `internal/tagcallable` as
  `IsCandidate`/`NodeInterface` — so the imported and unimported tag surfaces
  cannot drift apart. A package that does not import gsx short-circuits to nil
  and costs zero `AssignableTo` calls.
- **A markup cursor cannot use the live buffer** the way a Go-expression cursor
  can: `<ui.` does not parse, while `{ fmt. }` does (Go is an opaque blob to
  gsx) — and that is precisely the buffer state *while typing* the tag that
  needs the import. `prepareImportEditIn` parses the REPAIRED buffer while
  addressing the original document. That is exact, not approximate:
  `completionPatches` never modifies a byte before the cursor, and `apply`
  already refuses any edit reaching at or past it.

## Checked

- **No format-on-save flip-flop**: with the import present the package carries a
  non-unused-import type error, so it is not reported unused — the added import
  is not removed on the next organize.
- `<vite.` (imported, componentless) and `<strings.` (resolvable, no tag-callable
  exports) both still return zero completion items.

## Tests

- `internal/codegen`: tag-qualifier `MissingImports` with `Pos` pinned to the
  *shipped* diagnostic; resolved-qualifier negative; sibling-package resolve +
  `TagCallable` classification (`Button` yes; unnamed-param, wrong-result, and
  non-callable exports no). All three vacuity-checked — verified failing with the
  fix disabled.
- `internal/lsp`: handler-level unimported and imported tag cursors (the latter
  proving the fallback does *not* fire), including an applied-edit round trip
  that catches an off-by-N in the repaired→original mapping; plus the `resolved`
  flag matrix.
- `gen`: e2e subtest driving a genuinely **unterminated** `<ui.` through the
  JSON-RPC server against a real sibling package.

Docs: `docs/guide/editor.md` had a stale "does not add imports yet" line (wrong
since auto-import shipped), now corrected; ROADMAP updated with the design and
the one deferred follow-up (unimported package *names* at a bare `<u▮` cursor,
which needs a per-candidate tag-callable probe to avoid offering ~1000
componentless names).

`make ci` green on the final tree.

https://claude.ai/code/session_01L1mQ6U9FmGWT5bp14RtGwK
