### PR TITLE
fix(codegen): anchor import diagnostics at the spec's authored column

### DIFF
--- a/internal/codegen/analyze.go
+++ b/internal/codegen/analyze.go
@@ -617,13 +617,15 @@ func buildSkeletonWithRecorder(file *gsxast.File, table funcTables, fset *token.
 		fmt.Fprintf(sb, "import %s %q\n", alias, usedFilters[alias])
 	}
 	for _, imp := range imports {
-		// Map go/types import errors back to the .gsx source. The skeleton spec
-		// starts at column 8 (after "import "), so compensate the //line column by
-		// that prefix; when the source column is < 8 (the common indented-import
-		// case) the compensated column would be < 1, so fall back to a line-only
-		// directive (column 1) rather than emit a misleading offset.
-		emitSkeletonLineImport(sb, fset, imp.pos)
+		// Map go/types import errors back to the .gsx source. The directive is
+		// emitted INLINE, after the "import " keyword and immediately before the
+		// spec (with no whitespace between), so it anchors exactly the position
+		// go/types reports an import error at: ImportSpec.Pos(), which is the alias
+		// when there is one, else the path literal. See the same emit in
+		// buildComponentTargetSkeleton for why the line form cannot work here and
+		// why the two sites must agree to the column.
 		writeSkeletonGenerated(sb, "import ")
+		emitSkeletonBlockLine(sb, fset, imp.pos)
 		if imp.name != "" {
 			if err := writeSkeletonAuthoredAt(sb, fset, imp.namePos, imp.name, sourceintel.Definition|sourceintel.Hover|sourceintel.Completion); err != nil {
 				return "", nil, nil, nil, nil, err
@@ -1755,23 +1757,6 @@ func emitSkeletonBlockLine(sb skeletonWriter, fset *token.FileSet, pos token.Pos
 	}
 	p := fset.Position(pos)
 	fmt.Fprintf(sb, "/*line %s:%d:%d*/", p.Filename, p.Line, p.Column)
-}
-
-// emitSkeletonLineImport emits a //line directive ahead of a hoisted user
-// import so go/types import errors (notably "imported and not used") resolve to
-// the .gsx source instead of the synthesized overlay .x.go. The skeleton spec
-// sits at column 8 (after the literal "import "), so the directive column is
-// compensated by that 7-char prefix; when the source column is ≤ 7 (the common
-// indented-import case) the compensated column would be < 1, so a line-only
-// directive (column 1) is emitted rather than a misleading offset.
-func emitSkeletonLineImport(sb skeletonWriter, fset *token.FileSet, pos token.Pos) {
-	if fset == nil || !pos.IsValid() {
-		return
-	}
-	const prefixLen = len("import ")
-	p := fset.Position(pos)
-	col := max(p.Column-prefixLen, 1)
-	fmt.Fprintf(sb, "//line %s:%d:%d\n", p.Filename, p.Line, col)
 }
 
 // probeExpr returns the Go expression to probe for an interpolation / expr-attr.

--- a/internal/codegen/component_target_skeleton.go
+++ b/internal/codegen/component_target_skeleton.go
@@ -352,11 +352,31 @@ func buildComponentTargetSkeleton(
 		fmt.Fprintf(&source, "import %s %q\n", alias, usedFilters[alias])
 	}
 	for _, spec := range imports {
-		emitSkeletonLineImport(&source, fset, spec.pos)
+		// Anchor the spec itself, INLINE, so go/types import errors carry the
+		// authored column. go/types reports them at ImportSpec.Pos() — the alias
+		// for `al "p"`, the `.` for a dot import — which is why the directive goes
+		// before the whole spec rather than before the path literal.
+		//
+		// The line form cannot do this: `//line` sets only the FIRST column of the
+		// next line, and the spec is preceded there by the 7-byte "import "
+		// keyword, so the directive column would have to be pre-decremented by 7 —
+		// unrepresentable for any import indented by less (a tab-indented spec sits
+		// at column 2, and clamping to 1 silently reports every such import at
+		// column 8).
+		//
+		// This must stay in lockstep with the same emit in buildSkeleton: an unused
+		// import errors in BOTH skeletons, and unmatchedTargetTypeErrors pairs them
+		// on the authored (file, line, column, softness). If the two disagree the
+		// pairing fails and the user sees the SAME error twice, at two columns.
+		//
+		// Emit no whitespace between `*/` and the spec — the directive anchors the
+		// byte immediately following it, so a single space shifts the column by one.
+		source.WriteString("import ")
+		emitSkeletonBlockLine(&source, fset, spec.pos)
 		if spec.name != "" {
-			fmt.Fprintf(&source, "import %s %q\n", spec.name, spec.path)
+			fmt.Fprintf(&source, "%s %q\n", spec.name, spec.path)
 		} else {
-			fmt.Fprintf(&source, "import %q\n", spec.path)
+			fmt.Fprintf(&source, "%q\n", spec.path)
 		}
 	}
 	source.WriteString("var _ _gsxrt.Node\nvar _ _gsxctx.Context\n")

--- a/internal/codegen/import_diag_test.go
+++ b/internal/codegen/import_diag_test.go
@@ -9,7 +9,8 @@ import (
 
 // TestUnusedImportDiagnosticMapsToSource verifies that a go/types
 // "imported and not used" error on a user import is reported against the .gsx
-// SOURCE file (with the correct line), not the synthesized overlay .x.go.
+// SOURCE file, at the exact line AND column of the offending import spec, not
+// the synthesized overlay .x.go.
 //
 // Before the fix, user imports were emitted into the skeleton without a //line
 // directive, so the type-checker positioned the error at the overlay .x.go path
@@ -17,12 +18,12 @@ import (
 // output) is laid out differently, so the rich renderer printed a blank source
 // line under the caret.
 //
-// Source layout (1-based lines):
+// Source layout (1-based lines and columns):
 //
 //	line 1: package main
 //	line 2: (blank)
 //	line 3: import (
-//	line 4: \t"context"     ← unused; error must land here
+//	line 4: \t"context"     ← unused; error must land here, at column 2
 //	line 5: )
 func TestUnusedImportDiagnosticMapsToSource(t *testing.T) {
 	t.Parallel()
@@ -52,8 +53,8 @@ func TestUnusedImportDiagnosticMapsToSource(t *testing.T) {
 		if !strings.HasSuffix(d.Start.Filename, "v.gsx") {
 			t.Errorf("unused-import diagnostic points at %q, want the .gsx source", d.Start.Filename)
 		}
-		if d.Start.Line != 4 {
-			t.Errorf("unused-import diagnostic on wrong line: got %d, want 4", d.Start.Line)
+		if d.Start.Line != 4 || d.Start.Column != 2 {
+			t.Errorf("unused-import diagnostic at %d:%d, want 4:2", d.Start.Line, d.Start.Column)
 		}
 	}
 	if !found {
@@ -61,15 +62,25 @@ func TestUnusedImportDiagnosticMapsToSource(t *testing.T) {
 	}
 }
 
-// TestUnusedImportDiagnosticPerImportLine verifies the .gsx line is resolved
-// per-import (via each spec's intra-chunk offset), not anchored at the import
-// block's start: here the unused import is the SECOND spec, on line 5, and the
-// aliased form is exercised too.
+// TestUnusedImportDiagnosticPerImportLine verifies each unused import resolves
+// to its OWN .gsx line and column — the line via the spec's intra-chunk offset,
+// the column via the inline `/*line*/` directive that anchors the spec itself.
 //
-//	line 3: import (
-//	line 4: \t"io"          ← used (referenced below)
-//	line 5: \tx "context"   ← unused alias; error must land here
-//	line 6: )
+// The fixture deliberately varies the indentation so a single wrong column
+// cannot satisfy every case. A line-form `//line` directive can only set the
+// next line's FIRST column, but the skeleton writes the spec after a 7-byte
+// "import " keyword; the old code compensated by subtracting 7 and clamping at
+// 1, which collapsed EVERY import indented by less than 7 columns onto column 8.
+// The expectations below are 2, 1, 3 and 8 — the first three all reported 8
+// before the fix, and the last one guards the shape the old code got right.
+//
+//	line  3: import (
+//	line  4: \t"io"            ← used (referenced below)
+//	line  5: \tx "context"     ← unused alias, tab-indented   → 5:2
+//	line  6: "strings"         ← unused, unindented           → 6:1
+//	line  7: \t\ty "bytes"     ← unused alias, two tabs       → 7:3
+//	line  8: )
+//	line 10: import "errors"   ← unused, single-line form     → 10:8
 func TestUnusedImportDiagnosticPerImportLine(t *testing.T) {
 	t.Parallel()
 	mod := tempModule(t, "gsximportline")
@@ -78,31 +89,48 @@ func TestUnusedImportDiagnosticPerImportLine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	src := "package main\n\nimport (\n\t\"io\"\n\tx \"context\"\n)\n\nvar _ io.Writer\n\ncomponent A() { <div>hi</div> }\n"
+	src := "package main\n\nimport (\n\t\"io\"\n\tx \"context\"\n\"strings\"\n\t\ty \"bytes\"\n)\n\nimport \"errors\"\n\nvar _ io.Writer\n\ncomponent A() { <div>hi</div> }\n"
 	if err := os.WriteFile(filepath.Join(viewsDir, "v.gsx"), []byte(src), 0o644); err != nil {
 		t.Fatal(err)
+	}
+
+	// path → expected 1-based .gsx position of the "imported and not used" error.
+	want := map[string][2]int{
+		"context": {5, 2},
+		"strings": {6, 1},
+		"bytes":   {7, 3},
+		"errors":  {10, 8},
 	}
 
 	out, err := GenerateDirs(mod, []string{viewsDir}, Options{}, nil)
 	if err != nil {
 		t.Fatalf("GenerateDirs: %v", err)
 	}
-	dr := out[viewsDir]
 
-	var found bool
-	for _, d := range dr.Diags {
+	got := map[string][2]int{}
+	for _, d := range out[viewsDir].Diags {
 		if d.Source != "types" || !strings.Contains(d.Message, "not used") {
 			continue
 		}
-		found = true
 		if !strings.HasSuffix(d.Start.Filename, "v.gsx") {
 			t.Errorf("diagnostic points at %q, want the .gsx source", d.Start.Filename)
+			continue
 		}
-		if d.Start.Line != 5 {
-			t.Errorf("aliased unused-import on wrong line: got %d, want 5", d.Start.Line)
+		for path := range want {
+			if strings.Contains(d.Message, `"`+path+`"`) {
+				got[path] = [2]int{d.Start.Line, d.Start.Column}
+			}
 		}
 	}
-	if !found {
-		t.Fatalf("no 'imported and not used' diagnostic found; got %+v", dr.Diags)
+
+	for path, wantPos := range want {
+		gotPos, ok := got[path]
+		if !ok {
+			t.Errorf("no 'imported and not used' diagnostic for %q; got %v", path, got)
+			continue
+		}
+		if gotPos != wantPos {
+			t.Errorf("unused import %q at %d:%d, want %d:%d", path, gotPos[0], gotPos[1], wantPos[0], wantPos[1])
+		}
 	}
 }

--- a/internal/corpus/testdata/cases/imports/unused_import_aliased_column.txtar
+++ b/internal/corpus/testdata/cases/imports/unused_import_aliased_column.txtar
@@ -1,0 +1,17 @@
+# Context: an unused ALIASED import reports at the spec's start — the alias
+# name, not the path literal. This case pins the distinction: the alias sits at
+# column 2 and the path literal at column 5, so anchoring the position directive
+# at the wrong one of the two is visible here and nowhere else. (A third wrong
+# answer, column 8, is what a directive that cannot anchor the spec produces.)
+-- input.gsx --
+package demo
+
+import (
+	zz "context"
+)
+
+component Uses() {
+	<b>hi</b>
+}
+-- diagnostics.golden --
+4:2: "context" imported as zz and not used

--- a/internal/corpus/testdata/cases/imports/unused_import_block_column.txtar
+++ b/internal/corpus/testdata/cases/imports/unused_import_block_column.txtar
@@ -1,0 +1,23 @@
+# Context: an unused import inside a parenthesized block reports at the SPEC's
+# own column. The indentation is load-bearing: the type-check skeleton writes
+# every hoisted import as `import <spec>`, so the spec sits at skeleton column 8.
+# A position directive that cannot anchor the spec itself collapses every
+# indented import onto column 8 — which is why the sibling case
+# unused_gsx_import.txtar (an unindented single-spec import, genuinely at
+# column 8) cannot discriminate and this one can. The unused spec is also the
+# SECOND in the block, so the line stays under test alongside the column.
+-- input.gsx --
+package demo
+
+import (
+	"io"
+	"context"
+)
+
+var _ io.Writer
+
+component Uses() {
+	<b>hi</b>
+}
+-- diagnostics.golden --
+5:2: "context" imported and not used

--- a/internal/corpus/testdata/cases/imports/unused_import_component_call_site.txtar
+++ b/internal/corpus/testdata/cases/imports/unused_import_component_call_site.txtar
@@ -1,0 +1,24 @@
+# Context: this case is the only one that exercises BOTH type-check skeletons.
+# The component tag `<Inner/>` gives the package a call site, which turns on the
+# target-discovery phase; that phase builds its own skeleton with its own copy of
+# the hoisted imports. Unpaired target-phase errors stay independently visible,
+# and the pairing key is the authored (file, line, column, softness) — so the two
+# skeletons must agree on the import's column to the byte. Pin ONE diagnostic:
+# if either skeleton anchors the import differently, correspondence breaks and
+# the same unused import is reported twice, at two different columns.
+-- input.gsx --
+package demo
+
+import (
+	"context"
+)
+
+component Inner() {
+	<b>hi</b>
+}
+
+component Outer() {
+	<Inner/>
+}
+-- diagnostics.golden --
+4:2: "context" imported and not used

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -472,6 +472,9 @@ imports/shadow_gsx_import	diag gen render
 imports/shadow_io	diag gen render
 imports/shadow_strconv	diag gen render
 imports/unused_gsx_import	diag(error)
+imports/unused_import_aliased_column	diag(error)
+imports/unused_import_block_column	diag(error)
+imports/unused_import_component_call_site	diag(error)
 interpolation/diag_element_in_attr_hole	diag render
 interpolation/field_access	diag render
 interpolation/interp_types	diag render
@@ -1008,4 +1011,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 1010 cases (render: 863, error: 109, gen-pinned: 566)
+TOTAL: 1013 cases (render: 863, error: 112, gen-pinned: 566)


### PR DESCRIPTION
`"pkg" imported and not used` reported a constant column 8 on .gsx files, whatever the import's real column — the vite overlay drew its caret six columns right of the offending path.

The skeleton writes each hoisted import as `import <spec>`, so the spec sits at skeleton column 8. A `//line` directive can only set the FIRST column of the next line, so emitSkeletonLineImport pre-subtracted len("import ") and clamped at 1. A tab-indented spec is at column 2, so max(2-7, 1) collapsed to 1 and mapped skeleton column 8 back to source column 8. The compensation only produced the right answer for imports at column >= 8 — in practice only an unindented single-spec `import "p"`.

Anchor the spec itself with an inline `/*line*/` directive instead. Block- form directives are honored anywhere in a line (go/scanner accepts them on `lit[1] == '*'` without the line-start test) and set the position of the byte immediately following, so the compensation term disappears rather than being re-derived. emitSkeletonBlockLine already did this for verbatim GoText; reuse it and drop the broken helper.

The directive precedes the whole spec because go/types reports import errors at ImportSpec.Pos() — the alias for `al "p"`, the `.` for a dot import, else the path literal.

Both import writers are fixed together, and that is load-bearing: an unused import errors in the shipping skeleton AND the target-discovery skeleton, and unmatchedTargetTypeErrors pairs the two phases on the authored (file, line, column, softness). Fixing one alone makes the columns diverge, the pairing fails, and the same error is reported twice at two columns.

Why this survived since 3b4d062a: that commit shipped the clamp knowingly ("falling back to col 1 for indented imports") and its tests pinned filename and line but never Column. The corpus golden imports/unused_gsx_import.txtar pins 3:8 for an unindented import — the one layout where the broken arithmetic is accidentally correct, so it could not discriminate. It is unchanged here, as it should be.

Coverage: import_diag_test.go now pins columns 1, 2, 3 and 8 (the last a regression guard for the shape the old code got right), plus three corpus cases — a tab-indented block, an aliased spec (distinguishing spec-start column 2 from path-start column 5), and one with a component call site, which is the only case that exercises the target-discovery skeleton and so catches a half-fix's duplicate diagnostic.

Not fixed here, same defect class on other surfaces: gen/poison.go emits `//line` before `var _ = GSX_GENERATION_FAILED__see_x`, so go build reports the identifier at column+8; the block form fixes the column but is not gofmt-clean, which that file deliberately is. emitSkeletonComponentNameLine anchors a whole signature with one directive, so params drift.

Claude-Session: https://claude.ai/code/session_01L1mQ6U9FmGWT5bp14RtGwK