### PR TITLE
fix(fmt): re-indent multi-line control-flow header fragments

### DIFF
--- a/internal/gsxfmt/testdata/cases/cf_header_multiline_indent.txtar
+++ b/internal/gsxfmt/testdata/cases/cf_header_multiline_indent.txtar
@@ -1,0 +1,57 @@
+A multi-line Go fragment in a control-flow header (a for clause's range
+operand, a switch case list) must re-indent its continuation lines to the
+header's own depth. gofmt renders the fragment relative to column 0; joining
+lines with HardLine (the multiline helper) lets the engine add the current
+indent, keeping gofmt's relative tabs on top. Wrapping the fragment in a bare
+Text instead leaks the column-0 lines verbatim (the gsxui gallery.gsx bug).
+
+-- input.gsx --
+package pages
+
+func releaseList() gsx.Node {
+	return (
+		<div class="p-4">
+			{ for _, tag := range []string{
+				"v1.2.0-beta.5", "v1.2.0-beta.4", "v1.2.0-beta.3",
+				"v1.2.0-beta.2", "v1.2.0-beta.1", "v1.1.9",
+			} {
+				<div class="text-sm">{ tag }</div>
+			} }
+			{ switch len([]string{
+				"a", "b",
+			}) {
+			case len([]int{
+				1, 2,
+			}):
+				<span>two</span>
+			default:
+				<span>other</span>
+			} }
+		</div>
+	)
+}
+-- fmt.golden --
+package pages
+
+func releaseList() gsx.Node {
+	return (
+		<div class="p-4">
+			{ for _, tag := range []string{
+				"v1.2.0-beta.5", "v1.2.0-beta.4", "v1.2.0-beta.3",
+				"v1.2.0-beta.2", "v1.2.0-beta.1", "v1.1.9",
+			} {
+				<div class="text-sm">{ tag }</div>
+			} }
+			{ switch len([]string{
+				"a", "b",
+			}) {
+			case len([]int{
+				1, 2,
+			}):
+				<span>two</span>
+			default:
+				<span>other</span>
+			} }
+		</div>
+	)
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -761,7 +761,7 @@ func (p *printer) valueSwitchDoc(s *ast.ValueSwitch) pretty.Doc {
 	for _, c := range s.Cases {
 		label := pretty.Text("default:")
 		if !c.Default {
-			label = pretty.Concat(pretty.Text("case "), pretty.Text(fmtCaseList(c.List)), pretty.Text(":"))
+			label = pretty.Concat(pretty.Text("case "), multiline(fmtCaseList(c.List)), pretty.Text(":"))
 		}
 		cases = append(cases,
 			pretty.Line, label,
@@ -809,11 +809,11 @@ func (p *printer) switchAttrDoc(s *ast.SwitchAttr) pretty.Doc {
 	}
 	parts = append(parts, pretty.Text(" {"))
 	for _, cc := range s.Cases {
-		label := "default:"
+		label := pretty.Text("default:")
 		if !cc.Default {
-			label = "case " + fmtExpr(cc.List) + ":"
+			label = pretty.Concat(pretty.Text("case "), multiline(fmtExpr(cc.List)), pretty.Text(":"))
 		}
-		parts = append(parts, pretty.HardLine, pretty.Text(label), p.attrCaseBodyDoc(cc.Body))
+		parts = append(parts, pretty.HardLine, label, p.attrCaseBodyDoc(cc.Body))
 	}
 	parts = append(parts, pretty.HardLine, pretty.Text("}"))
 	return pretty.Concat(parts...)
@@ -1298,7 +1298,7 @@ func (p *printer) ifChain(i *ast.IfMarkup) pretty.Doc {
 
 func (p *printer) forMarkup(f *ast.ForMarkup) pretty.Doc {
 	return pretty.Group(pretty.Concat(
-		pretty.Text("{ for "), pretty.Text(fmtClause(f.Clause)), pretty.Text(" {"), p.cfBody(f.Body, f.BodyMultiline), pretty.Text("} }")))
+		pretty.Text("{ for "), multiline(fmtClause(f.Clause)), pretty.Text(" {"), p.cfBody(f.Body, f.BodyMultiline), pretty.Text("} }")))
 }
 
 // cfBody renders a control-flow body between an already-emitted `{` and a
@@ -1372,7 +1372,7 @@ func (p *printer) switchMarkup(s *ast.SwitchMarkup) pretty.Doc {
 		for _, c := range s.Cases {
 			label := pretty.Text("default:")
 			if !c.Default {
-				label = pretty.Concat(pretty.Text("case "), pretty.Text(fmtCaseList(c.List)), pretty.Text(":"))
+				label = pretty.Concat(pretty.Text("case "), multiline(fmtCaseList(c.List)), pretty.Text(":"))
 			}
 			inlineCases = append(inlineCases, pretty.Concat(label, p.caseBody(c.Body, c.BodyMultiline)))
 		}
@@ -1386,7 +1386,7 @@ func (p *printer) switchMarkup(s *ast.SwitchMarkup) pretty.Doc {
 	for _, c := range s.Cases {
 		label := pretty.Text("default:")
 		if !c.Default {
-			label = pretty.Concat(pretty.Text("case "), pretty.Text(fmtCaseList(c.List)), pretty.Text(":"))
+			label = pretty.Concat(pretty.Text("case "), multiline(fmtCaseList(c.List)), pretty.Text(":"))
 		}
 		caseParts = append(caseParts, pretty.HardLine, pretty.Concat(label, p.caseBody(c.Body, c.BodyMultiline)))
 	}


### PR DESCRIPTION
Found dogfooding on gsxui `site/stylepreview/maia/gallery.gsx`: a multi-line `[]string{…}` range operand in a `{ for … }` header came out with its continuation lines at column 0, and `gsx fmt` was not idempotent on its own output.

**Root cause:** multi-line Go fragments in control-flow headers were wrapped in bare `pretty.Text`, so gofmt's column-0-relative continuation lines passed through verbatim. Switch tags and if conditions already routed through the `multiline` helper (split at newlines, HardLine-joined so the engine re-indents to the current depth, preserving gofmt's relative tabs); the **for clause** and **case lists** did not.

**Fix:** route the for clause (`forMarkup`), the case lists in the value-switch and both markup-switch forms, and the attr-switch case label through `multiline`. The flat inline-attr writers are untouched — they are the by-contract no-line-breaks path.

**Tests:** new fmt-corpus case `cf_header_multiline_indent.txtar` pins a multi-line range operand and multi-line case-list expressions (reproduced both the indent corruption and the idempotence failure before the fix). Printer round-trip property suite, `internal/gsxfmt`, and the semantic corpus pass; verified on the original gsxui file.

https://claude.ai/code/session_019RcKsiztZMtku64MYGqfka