### PR TITLE
fix(fmt): braced comment groups round-trip — split per comment, never emit a mid-line //

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@
 package ast
 
 import (
+	"fmt"
 	"go/token"
 	"strings"
 )
@@ -111,6 +112,13 @@ func SetSpan(n Node, start, end token.Pos) {
 		v.span = s
 	case *ValueCF:
 		v.span = s
+	case *CommentAttr:
+		v.span = s
+	default:
+		// Every span-embedding node must be listed: a silent fallthrough
+		// drops the node's positions (CommentAttr was missing here since it
+		// shipped — every comment attribute silently carried NoPos).
+		panic(fmt.Sprintf("ast.SetSpan: unhandled node type %T", n))
 	}
 }
 
@@ -319,6 +327,9 @@ func (*MarkerRegion) markupNode() {}
 // `{/* text */}` / `{// text }`, or a bare line-start `// text` (Bare=true).
 // Unlike HTMLComment it is NOT rendered — codegen drops it, the formatter
 // preserves it and never converts between the braced and bare spellings.
+// A braced group holding several comments parses to one Comment per comment;
+// an empty group is a single empty block comment whose canonical braced
+// output is `{}`.
 type Comment struct {
 	span
 	Text  string
@@ -797,14 +808,17 @@ type OrderedAttrsAttr struct {
 func (*OrderedAttrsAttr) attrNode() {}
 
 // CommentAttr is a source-only comment in an element's attribute list: bare
-// `// text` / `/* text */`, or a braced comment-only `{/* */}` / `{// }`. It is
-// never rendered (codegen ignores it); the formatter preserves it. Braced forms
-// canonicalize to bare on output, so no "braced" flag is retained.
+// `// text` / `/* text */`, or a braced comment-only `{ … }` group. It is
+// never rendered (codegen ignores it); the formatter preserves it. Braced
+// forms canonicalize to bare on output, so no "braced" flag is retained; a
+// group holding several comments parses to one CommentAttr per comment, and an
+// empty group ({} / { } / { ; }) is a single empty block comment whose
+// canonical output is `/**/` — the one bare spelling with nothing in it.
 type CommentAttr struct {
 	span
 	Text     string // inner text, delimiters and wrapping braces stripped, trimmed
 	Block    bool   // true = /* */, false = //
-	Trailing bool   // true = same source line as the previous attribute
+	Trailing bool   // true = same source line as the previous attribute/comment
 }
 
 func (*CommentAttr) attrNode() {}

--- a/docs/guide/syntax/comments.md
+++ b/docs/guide/syntax/comments.md
@@ -25,7 +25,7 @@ An HTML comment is rendered verbatim, including `<` and `&` in its text.
 
 ## Comments inside a tag
 
-Use Go-style line or block comments to annotate an element's attributes. Braced comment forms are also accepted there. These comments remain in the `.gsx` source but do not render.
+Use Go-style line or block comments to annotate an element's attributes. Braced comment forms are also accepted there, and one braced group may hold several comments. These comments remain in the `.gsx` source but do not render.
 
 <!--@include: ./_generated/comments/020-attribute-comments.md-->
 

--- a/docs/superpowers/specs/2026-07-03-preserve-source-comments-through-fmt-design.md
+++ b/docs/superpowers/specs/2026-07-03-preserve-source-comments-through-fmt-design.md
@@ -164,3 +164,16 @@ Rewrite `docs/guide/syntax/comments.md`:
   YAGNI until asked). Comments inside an attribute *value* Go expression
   (`id={ x /* keep */ }`) already survive via `go/format` and are untouched.
 - Blank-line preservation between attributes.
+
+## Addendum (2026-08-10): comment groups split per comment
+
+A braced comment-only `{ … }` may hold any number of comments — its boundary is
+"no real Go token inside the braces". The single-node collapse described above
+corrupted multi-comment groups (`{ /* a */ // b }` became one block comment
+whose text contained `*/`, and the reconstructed output failed to reparse), so
+the parser now emits one `CommentAttr`/`Comment` per interior comment
+(`parser/markup.go` commentParts), and an empty group (`{}` / `{ }` / `{ ; }`)
+is a single empty block comment — canonical output `/**/` in attribute
+position, `{}` in child position. Canonicalize-to-bare is unchanged, applied
+per comment; a line comment's forced break now lives inside the printer's
+`attrDoc` so the inline-atom flat path can never emit `//` mid-line.

--- a/internal/corpus/testdata/cases/comments/comment_group_empty.txtar
+++ b/internal/corpus/testdata/cases/comments/comment_group_empty.txtar
@@ -1,0 +1,20 @@
+# An empty comment brace — {} or { } or only whitespace/semicolons inside — is
+# a comment group with nothing in it (commentParts accepts it), in both attribute
+# and child position. It renders nothing and must survive the formatter as a
+# parseable comment (attr canonical form /**/, child canonical form {}).
+-- input.gsx --
+package views
+
+component C() {
+	<input type="checkbox" {} { } value="x"/>
+	<div>
+		{}
+		{ }
+		<span>ok</span>
+	</div>
+}
+-- invoke --
+C()
+-- diagnostics.golden --
+-- render.golden --
+<input type="checkbox" value="x"><div><span>ok</span></div>

--- a/internal/corpus/testdata/cases/comments/comment_group_multi.txtar
+++ b/internal/corpus/testdata/cases/comments/comment_group_multi.txtar
@@ -1,0 +1,26 @@
+# A braced comment group may hold SEVERAL comments (any mix of /* */ and //,
+# per commentParts' boundary: no real Go token inside the braces). Each interior
+# comment is its own AST node — the group is not collapsed to a single text.
+# All are source-only: the rendered HTML carries none of them.
+-- input.gsx --
+package views
+
+component C(name string) {
+	<input
+		type="checkbox"
+		{ /* block a */ /* block b */ }
+		{ /* head note */ // tail note
+		}
+		id={name}
+	/>
+	<div>
+		{ /* child a */ // child b
+		}
+		<span>ok</span>
+	</div>
+}
+-- invoke --
+C("agree")
+-- diagnostics.golden --
+-- render.golden --
+<input type="checkbox" id="agree"><div><span>ok</span></div>

--- a/internal/corpus/testdata/coverage.golden
+++ b/internal/corpus/testdata/coverage.golden
@@ -132,6 +132,8 @@ comments/bare_contexts	diag render
 comments/bare_midline_text	diag render
 comments/bare_preserve_exempt	diag render
 comments/bare_touches_text_err	diag(error)
+comments/comment_group_empty	diag render
+comments/comment_group_multi	diag render
 comments/cond_attr_comment	diag render
 comments/content_comment	diag render
 comments/parse_snapshot	ast diag
@@ -1011,4 +1013,4 @@ xpkg/imported_signature_roles	diag gen render
 xpkg/interleaved_imports_error	diag(error)
 xpkg/multi_gsx_package	diag render
 xpkg/real_gsxshared_file	diag render
-TOTAL: 1013 cases (render: 863, error: 112, gen-pinned: 566)
+TOTAL: 1015 cases (render: 865, error: 112, gen-pinned: 566)

--- a/internal/gsxfmt/testdata/cases/comment_groups.txtar
+++ b/internal/gsxfmt/testdata/cases/comment_groups.txtar
@@ -1,0 +1,72 @@
+A braced comment-only group may hold zero, one, or several comments. Attribute
+position canonicalizes every comment to bare form — one bare comment per
+interior comment, an empty group ({} / { } / { ; }) to /**/ (the one bare
+spelling with nothing in it, inline-safe), and a line comment always ends its
+output line (the tag header breaks; it can never swallow following
+attributes). Child position stays braced — one brace pair per comment, an
+empty group prints {}, and a line comment keeps the closing } on the next
+line. Comment text is preserved exactly: no stray delimiters from group
+splitting (the old collapse emitted "/* a */ // b */").
+-- input.gsx --
+package ui
+
+component EmptyAttr() {
+	<input {} type="text"/>
+	<input { } type="text"/>
+	<input { ; } type="text"/>
+}
+
+component MultiAttr() {
+	<input { /* a */ /* b */ } type="text"/>
+	<input
+		{ /* head */ // tail
+		}
+		type="text"
+	/>
+}
+
+component LineAttrInlineTag() {
+	<input {// note
+	} type="text"/>
+}
+
+component Children() {
+	<div>
+		{}
+		{ /* a */ // b
+		}
+		{ /* a */ /* b */ }
+		<span>ok</span>
+	</div>
+}
+-- fmt.golden --
+package ui
+
+component EmptyAttr() {
+	<input /**/ type="text"/>
+	<input /**/ type="text"/>
+	<input /**/ type="text"/>
+}
+
+component MultiAttr() {
+	<input /* a */ /* b */ type="text"/>
+	<input
+		/* head */ // tail
+		type="text"
+	/>
+}
+
+component LineAttrInlineTag() {
+	<input
+		// note
+		type="text"
+	/>
+}
+
+component Children() {
+	<div>
+		{}{/* a */}{// b
+		}{/* a */}{/* b */}
+		<span>ok</span>
+	</div>
+}

--- a/internal/printer/corpus_test.go
+++ b/internal/printer/corpus_test.go
@@ -104,6 +104,15 @@ func TestCorpusIdempotence(t *testing.T) {
 func zeroSpans(n ast.Node) {
 	ast.Inspect(n, func(m ast.Node) bool {
 		if m != nil {
+			if _, ok := m.(ast.GoText); ok {
+				// GoText is the one VALUE leaf Inspect yields (GoWithElements
+				// holds its parts by value): SetSpan through an interface copy
+				// can never reach the stored part, and now panics instead of
+				// silently no-opping. Skipping keeps the long-standing
+				// behavior explicit — GoText spans never differ here because
+				// normalizedAST canonicalizes Go fragments on both sides.
+				return true
+			}
 			ast.SetSpan(m, 0, 0)
 			// Position fields outside the embedded span (set by the parser for
 			// codegen //line columns and the LSP) must also be zeroed so the

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -545,12 +545,9 @@ func (p *printer) element(e *ast.Element) pretty.Doc {
 			if c.Trailing {
 				sep = pretty.Text(" ") // glue to the previous attr's line
 			}
+			// A `//` line comment's forced break lives inside attrDoc itself
+			// (so atomDoc's Flat sees it too); block comments may stay inline.
 			attrs = append(attrs, sep, p.attrDoc(a))
-			if !c.Block {
-				// A `//` line comment cannot share a flat line with what follows;
-				// force the opening-tag group to break. Block comments may stay inline.
-				attrs = append(attrs, pretty.BreakParent)
-			}
 			continue
 		}
 		attrs = append(attrs, pretty.Line, p.attrDoc(a))
@@ -647,6 +644,25 @@ func (p *printer) attrDoc(a ast.Attr) pretty.Doc {
 		return pretty.Concat(pretty.BreakParent, pretty.Text("{ "), p.condAttrChainDoc(v), pretty.Text(" }"))
 	case *ast.SwitchAttr:
 		return pretty.Concat(pretty.BreakParent, pretty.Text("{ "), p.switchAttrDoc(v), pretty.Text(" }"))
+	case *ast.CommentAttr:
+		if v.Block {
+			if v.Text == "" {
+				// Empty comment group ({} in source): /**/ is the only bare
+				// spelling with nothing in it. Inline-safe, so no forced break.
+				return pretty.Text("/**/")
+			}
+			return pretty.Text("/* " + v.Text + " */")
+		}
+		// A `//` line comment swallows everything after it on its output line,
+		// so the doc itself carries the forced break (same convention as
+		// CondAttr/SwitchAttr above). This is what disqualifies atomDoc's
+		// pretty.Flat, which sees only this doc — a break added by the caller's
+		// layout loop would be invisible there and the atom would render the
+		// comment inline, eating the following attributes on reparse.
+		if v.Text == "" {
+			return pretty.Concat(pretty.Text("//"), pretty.BreakParent)
+		}
+		return pretty.Concat(pretty.Text("// "), pretty.Text(v.Text), pretty.BreakParent)
 	case *ast.ExprAttr:
 		val := []pretty.Doc{fmtExprDoc(v.Expr)}
 		for _, s := range v.Stages {
@@ -906,7 +922,15 @@ func (p *printer) markup(n ast.Markup) pretty.Doc {
 		// line form is safe on one line here — the printer controls layout, so
 		// nothing after `}` is on the comment's line to be swallowed.
 		if v.Block {
+			if v.Text == "" {
+				// Empty comment group: `{}` is the minimal braced spelling and
+				// reparses to exactly this node.
+				return pretty.Text("{}")
+			}
 			return pretty.Concat(pretty.Text("{/* "), pretty.Text(v.Text), pretty.Text(" */}"))
+		}
+		if v.Text == "" {
+			return pretty.Concat(pretty.Text("{//"), pretty.HardLine, pretty.Text("}"))
 		}
 		return pretty.Concat(pretty.Text("{// "), pretty.Text(v.Text), pretty.HardLine, pretty.Text("}"))
 	case *ast.Text:
@@ -1553,11 +1577,16 @@ func writeAttrInline(b *strings.Builder, a ast.Attr) {
 		b.WriteString(v.Value)
 		b.WriteString(`"`)
 	case *ast.CommentAttr:
-		if v.Block {
+		switch {
+		case v.Block && v.Text == "":
+			b.WriteString("/**/")
+		case v.Block:
 			b.WriteString("/* ")
 			b.WriteString(v.Text)
 			b.WriteString(" */")
-		} else {
+		case v.Text == "":
+			b.WriteString("//")
+		default:
 			b.WriteString("// ")
 			b.WriteString(v.Text)
 		}

--- a/parser/attrs.go
+++ b/parser/attrs.go
@@ -766,8 +766,10 @@ func (p *parser) parseAttrsUntilBrace() ([]ast.Attr, error) {
 		if c, ok, err := p.parseTagComment(); err != nil {
 			return nil, err
 		} else if ok {
-			c.Trailing = len(attrs) > 0 && !strings.ContainsRune(p.src[wsStart:p.i], '\n')
-			attrs = append(attrs, c)
+			c[0].Trailing = len(attrs) > 0 && !strings.ContainsRune(p.src[wsStart:p.i], '\n')
+			for _, n := range c {
+				attrs = append(attrs, n)
+			}
 			continue
 		}
 		a, err := p.parseSingleAttr()
@@ -905,8 +907,10 @@ func (p *parser) parseAttrCaseBody() ([]ast.Attr, error) {
 		if c, ok, err := p.parseTagComment(); err != nil {
 			return nil, err
 		} else if ok {
-			c.Trailing = len(attrs) > 0 && !strings.ContainsRune(p.src[wsStart:p.i], '\n')
-			attrs = append(attrs, c)
+			c[0].Trailing = len(attrs) > 0 && !strings.ContainsRune(p.src[wsStart:p.i], '\n')
+			for _, n := range c {
+				attrs = append(attrs, n)
+			}
 			continue
 		}
 		a, err := p.parseSingleAttr()

--- a/parser/comment_group_test.go
+++ b/parser/comment_group_test.go
@@ -1,0 +1,211 @@
+package parser
+
+import (
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/ast"
+)
+
+// commentAttrs collects the CommentAttr nodes from an attribute list in order.
+func commentAttrs(attrs []ast.Attr) []*ast.CommentAttr {
+	var out []*ast.CommentAttr
+	for _, a := range attrs {
+		if c, ok := a.(*ast.CommentAttr); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// childComments collects the Comment nodes from a children list in order.
+func childComments(nodes []ast.Markup) []*ast.Comment {
+	var out []*ast.Comment
+	for _, n := range nodes {
+		if c, ok := n.(*ast.Comment); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// A braced comment group in attribute position holds a SEQUENCE of comments
+// (commentParts' boundary: no real Go token inside the braces). The parser
+// emits one CommentAttr per interior comment — collapsing them into one node
+// loses the delimiters and corrupts the text on output ("a */ // b"). An
+// empty group is a single empty block comment (canonical output /**/).
+func TestAttrCommentGroupSplitsPerComment(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string // attribute-position bytes between type="checkbox" and value="x"
+		want []ast.CommentAttr
+	}{
+		{
+			name: "two block comments",
+			src:  "{ /* a */ /* b */ }",
+			want: []ast.CommentAttr{
+				{Text: "a", Block: true, Trailing: false},
+				{Text: "b", Block: true, Trailing: true}, // same source line as part before it
+			},
+		},
+		{
+			name: "block then line",
+			src:  "{ /* a */ // b\n\t\t}",
+			want: []ast.CommentAttr{
+				{Text: "a", Block: true, Trailing: false},
+				{Text: "b", Block: false, Trailing: true},
+			},
+		},
+		{
+			name: "line then block on next line",
+			src:  "{ // a\n\t\t/* b */ }",
+			want: []ast.CommentAttr{
+				{Text: "a", Block: false, Trailing: false},
+				{Text: "b", Block: true, Trailing: false}, // next source line: not trailing
+			},
+		},
+		{
+			name: "empty group",
+			src:  "{}",
+			want: []ast.CommentAttr{
+				{Text: "", Block: true, Trailing: false},
+			},
+		},
+		{
+			name: "whitespace-only group",
+			src:  "{ }",
+			want: []ast.CommentAttr{
+				{Text: "", Block: true, Trailing: false},
+			},
+		},
+		{
+			name: "semicolons tolerated, contribute nothing",
+			src:  "{ ; }",
+			want: []ast.CommentAttr{
+				{Text: "", Block: true, Trailing: false},
+			},
+		},
+		{
+			name: "single block comment unchanged",
+			src:  "{/* braced note */}",
+			want: []ast.CommentAttr{
+				{Text: "braced note", Block: true, Trailing: false},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "package p\n\ncomponent C() {\n\t<input\n\t\ttype=\"checkbox\"\n\t\t" + tc.src + "\n\t\tvalue=\"x\"\n\t/>\n}\n"
+			f := parseStringT(t, src)
+			el := f.Decls[0].(*ast.Component).Body[0].(*ast.Element)
+			got := commentAttrs(el.Attrs)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d CommentAttr nodes, want %d: %+v", len(got), len(tc.want), got)
+			}
+			for i, w := range tc.want {
+				g := got[i]
+				if g.Text != w.Text || g.Block != w.Block || g.Trailing != w.Trailing {
+					t.Errorf("node %d = {Text:%q Block:%t Trailing:%t}, want {Text:%q Block:%t Trailing:%t}",
+						i, g.Text, g.Block, g.Trailing, w.Text, w.Block, w.Trailing)
+				}
+			}
+		})
+	}
+}
+
+// Group-node spans partition the group: the first node's span opens at `{`,
+// the last closes past `}`, and interior extents are exact SOURCE byte offsets
+// even when a comment carries CRLF line endings (go/scanner strips '\r' from
+// comment literals, so extents must not be derived from len(lit)).
+func TestAttrCommentGroupSpansAreSourceExact(t *testing.T) {
+	group := "{ /* a */ /* b\r\nc */ /* d */ }"
+	prefix := "package p\n\ncomponent C() {\n\t<input\n\t\ttype=\"checkbox\"\n\t\t"
+	src := prefix + group + "\n\t\tvalue=\"x\"\n\t/>\n}\n"
+	fset := token.NewFileSet()
+	f, err := ParseFile(fset, "test.gsx", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	el := f.Decls[0].(*ast.Component).Body[0].(*ast.Element)
+	got := commentAttrs(el.Attrs)
+	if len(got) != 3 {
+		t.Fatalf("got %d CommentAttr nodes, want 3", len(got))
+	}
+	off := func(p token.Pos) int { return fset.Position(p).Offset }
+	groupOff := len(prefix)
+	// First node opens at `{`; last node closes just past `}`.
+	if o := off(got[0].Pos()); o != groupOff {
+		t.Errorf("first node starts at offset %d, want %d (the `{`)", o, groupOff)
+	}
+	if o := off(got[2].End()); o != groupOff+len(group) {
+		t.Errorf("last node ends at offset %d, want %d (past the `}`)", o, groupOff+len(group))
+	}
+	// The middle node's extent is the exact source token, CRs included.
+	bStart := groupOff + strings.Index(group, "/* b")
+	bEnd := groupOff + strings.Index(group, "c */") + len("c */")
+	if o := off(got[1].Pos()); o != bStart {
+		t.Errorf("middle node starts at offset %d, want %d", o, bStart)
+	}
+	if o := off(got[1].End()); o != bEnd {
+		t.Errorf("middle node ends at offset %d, want %d (exact source extent past `*/`)", o, bEnd)
+	}
+	// go/scanner strips '\r' from comment literals, so the TEXT is CRLF-
+	// normalized (as gofmt does) even though the SPAN covers the raw source.
+	if got[1].Text != "b\nc" {
+		t.Errorf("middle node text = %q, want %q", got[1].Text, "b\nc")
+	}
+}
+
+// Same splitting in child position: one *ast.Comment per interior comment,
+// all Bare=false (braced). An empty group is a single empty block comment
+// (canonical output {}).
+func TestChildCommentGroupSplitsPerComment(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string // child-position bytes
+		want []ast.Comment
+	}{
+		{
+			name: "block then line",
+			src:  "{ /* a */ // b\n\t\t}",
+			want: []ast.Comment{
+				{Text: "a", Block: true},
+				{Text: "b", Block: false},
+			},
+		},
+		{
+			name: "two blocks",
+			src:  "{ /* a */ /* b */ }",
+			want: []ast.Comment{
+				{Text: "a", Block: true},
+				{Text: "b", Block: true},
+			},
+		},
+		{
+			name: "empty group",
+			src:  "{}",
+			want: []ast.Comment{
+				{Text: "", Block: true},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "package p\n\ncomponent C() {\n\t<div>\n\t\t" + tc.src + "\n\t\t<span>ok</span>\n\t</div>\n}\n"
+			f := parseStringT(t, src)
+			el := f.Decls[0].(*ast.Component).Body[0].(*ast.Element)
+			got := childComments(el.Children)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d Comment nodes, want %d: %+v", len(got), len(tc.want), got)
+			}
+			for i, w := range tc.want {
+				g := got[i]
+				if g.Text != w.Text || g.Block != w.Block || g.Bare {
+					t.Errorf("node %d = {Text:%q Block:%t Bare:%t}, want {Text:%q Block:%t Bare:false}",
+						i, g.Text, g.Block, g.Bare, w.Text, w.Block)
+				}
+			}
+		})
+	}
+}

--- a/parser/markup.go
+++ b/parser/markup.go
@@ -114,11 +114,14 @@ func (p *parser) parseText() *ast.Text {
 }
 
 // parseTagComment recognizes a tag-interior comment at the cursor: bare `//` or
-// `/* */`, or a comment-only `{ … }`. Returns (node, true, nil) when one is
-// consumed, (nil, false, nil) when the cursor is not at a comment, or
-// (nil, false, err) for an unterminated block comment. Trailing is left false;
-// the caller sets it from the preceding whitespace.
-func (p *parser) parseTagComment() (*ast.CommentAttr, bool, error) {
+// `/* */`, or a comment-only `{ … }` group. Returns (nodes, true, nil) when one
+// is consumed — a braced group yields one CommentAttr per interior comment, so
+// the slice is non-empty whenever ok is true — (nil, false, nil) when the
+// cursor is not at a comment, or (nil, false, err) for an unterminated block
+// comment. Trailing is left false on the first node; the caller sets it from
+// the preceding whitespace. Later nodes' Trailing comes from the group's own
+// interior layout (same source line as the part before = trailing).
+func (p *parser) parseTagComment() ([]*ast.CommentAttr, bool, error) {
 	start := p.i
 	if p.at("/*") {
 		p.i += 2 // past '/*'
@@ -128,7 +131,7 @@ func (p *parser) parseTagComment() (*ast.CommentAttr, bool, error) {
 				p.i += 2 // past '*/'
 				n := &ast.CommentAttr{Text: text, Block: true}
 				ast.SetSpan(n, p.posAt(start), p.posAt(p.i))
-				return n, true, nil
+				return []*ast.CommentAttr{n}, true, nil
 			}
 			p.i++
 		}
@@ -143,64 +146,117 @@ func (p *parser) parseTagComment() (*ast.CommentAttr, bool, error) {
 		// leave '\n' in place so skipSpace() sees it
 		n := &ast.CommentAttr{Text: text, Block: false}
 		ast.SetSpan(n, p.posAt(start), p.posAt(p.i))
-		return n, true, nil
+		return []*ast.CommentAttr{n}, true, nil
 	}
 	if p.peek() == '{' {
 		end, ok := goExprEnd(p.src, p.i)
 		if !ok {
 			return nil, false, nil
 		}
-		inner := p.src[p.i+1 : end]
-		if !commentOnly(inner) {
+		parts, ok := commentParts(p.src[p.i+1 : end])
+		if !ok {
 			return nil, false, nil
 		}
-		text, block := splitBracedComment(inner)
+		innerBase := p.i + 1
+		groupStart, groupEnd := p.posAt(start), p.posAt(end+1)
 		p.i = end + 1 // past '}'
-		n := &ast.CommentAttr{Text: text, Block: block}
-		ast.SetSpan(n, p.posAt(start), p.posAt(p.i))
-		return n, true, nil
+		if len(parts) == 0 {
+			// Empty group ({} / { } / { ; }): a single empty block comment —
+			// /**/ is the one bare spelling with nothing in it.
+			n := &ast.CommentAttr{Text: "", Block: true}
+			ast.SetSpan(n, groupStart, groupEnd)
+			return []*ast.CommentAttr{n}, true, nil
+		}
+		nodes := make([]*ast.CommentAttr, len(parts))
+		for i, part := range parts {
+			n := &ast.CommentAttr{
+				Text:     part.text,
+				Block:    part.block,
+				Trailing: i > 0 && part.line == parts[i-1].line,
+			}
+			// The braces belong to the group, not to any one comment: the
+			// first span starts at `{` and the last ends past `}`, so the
+			// nodes together still cover the group's full source extent.
+			s, e := p.posAt(innerBase+part.off), p.posAt(innerBase+part.end)
+			if i == 0 {
+				s = groupStart
+			}
+			if i == len(parts)-1 {
+				e = groupEnd
+			}
+			ast.SetSpan(n, s, e)
+			nodes[i] = n
+		}
+		return nodes, true, nil
 	}
 	return nil, false, nil
 }
 
-// splitBracedComment extracts the inner text and kind of a comment-only `{ … }`
-// body (as verified by commentOnly). Braced comments in attribute position
-// canonicalize to the bare form, so the wrapping braces and delimiters are
-// stripped.
-func splitBracedComment(inner string) (text string, block bool) {
-	trimmed := strings.TrimSpace(inner)
-	if after, ok := strings.CutPrefix(trimmed, "/*"); ok {
-		return strings.TrimSpace(strings.TrimSuffix(after, "*/")), true
-	}
-	after, _ := strings.CutPrefix(trimmed, "//")
-	return strings.TrimSpace(after), false
+// commentPart is one comment inside a comment-only `{ … }` group, located
+// relative to the group's interior.
+type commentPart struct {
+	text  string
+	block bool // true = /* */, false = //
+	off   int  // byte offset of the comment token within the interior
+	end   int  // byte offset just past the comment token
+	line  int  // 1-based line within the interior
 }
 
-// commentOnly reports whether src contains only Go comments (no real expression tokens).
-// A {/* … */} or {// … \n} whose body passes this check can be silently dropped.
-func commentOnly(src string) bool {
+// commentParts scans the interior of a braced group and returns its comments
+// in source order. ok=false when the interior holds any real Go token — then
+// the brace is not a comment group but an expression (or an error) for other
+// parse paths. Semicolons, explicit or auto-inserted, are lexical noise (as
+// they always were here) and contribute no part; a group with no parts at all
+// ({}, { }, { ; }) is still a comment group, just an empty one.
+func commentParts(src string) (parts []commentPart, ok bool) {
 	fset := token.NewFileSet()
 	file := fset.AddFile("", fset.Base(), len(src))
 	var s scanner.Scanner
 	s.Init(file, []byte(src), nil, scanner.ScanComments)
 	for {
-		_, tok, _ := s.Scan()
+		pos, tok, lit := s.Scan()
 		switch tok {
 		case token.EOF:
-			return true
-		case token.COMMENT, token.SEMICOLON:
-			// allowed — comments and auto-inserted semicolons are fine
+			return parts, true
+		case token.COMMENT:
+			off := file.Offset(pos)
+			part := commentPart{
+				block: strings.HasPrefix(lit, "/*"),
+				off:   off,
+				line:  file.Line(pos),
+			}
+			// The token's end is measured in the SOURCE, not via len(lit):
+			// go/scanner strips '\r' from comment literals, so a CRLF-bearing
+			// comment's lit under-counts the source extent by one byte per CR.
+			if part.block {
+				part.text = strings.TrimSpace(lit[2 : len(lit)-2])
+				part.end = off + strings.Index(src[off:], "*/") + len("*/")
+			} else {
+				part.text = strings.TrimSpace(lit[2:])
+				part.end = off + len(src[off:])
+				if nl := strings.IndexByte(src[off:], '\n'); nl >= 0 {
+					part.end = off + nl
+				}
+				for part.end > off && src[part.end-1] == '\r' {
+					part.end--
+				}
+			}
+			parts = append(parts, part)
+		case token.SEMICOLON:
+			// allowed — explicit or auto-inserted semicolons are fine
 		default:
-			return false
+			return nil, false
 		}
 	}
 }
 
-// parseBracedComment builds a *ast.Comment when the `{…}` at the current cursor
-// is comment-only, advancing past the closing `}`. Otherwise it returns
-// (nil, false, nil) without moving the cursor. Unterminated `{` is not an error
-// here — parseInterp handles that.
-func (p *parser) parseBracedComment() (*ast.Comment, bool, error) {
+// parseBracedComment builds *ast.Comment nodes when the `{…}` at the current
+// cursor is comment-only, advancing past the closing `}` — one node per
+// interior comment (the slice is non-empty whenever ok is true; an empty group
+// is a single empty block comment, canonical output `{}`). Otherwise it
+// returns (nil, false, nil) without moving the cursor. Unterminated `{` is not
+// an error here — parseInterp handles that.
+func (p *parser) parseBracedComment() ([]*ast.Comment, bool, error) {
 	if p.peek() != '{' {
 		return nil, false, nil
 	}
@@ -209,15 +265,34 @@ func (p *parser) parseBracedComment() (*ast.Comment, bool, error) {
 	if !ok {
 		return nil, false, nil
 	}
-	inner := p.src[p.i+1 : end]
-	if !commentOnly(inner) {
+	parts, ok := commentParts(p.src[p.i+1 : end])
+	if !ok {
 		return nil, false, nil
 	}
-	text, block := splitBracedComment(inner)
+	innerBase := p.i + 1
+	groupStart, groupEnd := p.posAt(start), p.posAt(end+1)
 	p.i = end + 1
-	n := &ast.Comment{Text: text, Block: block}
-	ast.SetSpan(n, p.posAt(start), p.posAt(p.i))
-	return n, true, nil
+	if len(parts) == 0 {
+		n := &ast.Comment{Text: "", Block: true}
+		ast.SetSpan(n, groupStart, groupEnd)
+		return []*ast.Comment{n}, true, nil
+	}
+	nodes := make([]*ast.Comment, len(parts))
+	for i, part := range parts {
+		n := &ast.Comment{Text: part.text, Block: part.block}
+		// Brace ownership as in parseTagComment: first span opens at `{`,
+		// last closes past `}`.
+		s, e := p.posAt(innerBase+part.off), p.posAt(innerBase+part.end)
+		if i == 0 {
+			s = groupStart
+		}
+		if i == len(parts)-1 {
+			e = groupEnd
+		}
+		ast.SetSpan(n, s, e)
+		nodes[i] = n
+	}
+	return nodes, true, nil
 }
 
 // parseGoBlock parses `{{ stmt }}`. Cursor must be at the first '{' of `{{`.
@@ -326,14 +401,12 @@ func (p *parser) parseMarkupUntilCloseWS(what string, preserveWS bool) ([]ast.Ma
 			nodes = append(nodes, el)
 		case p.peek() == '{':
 			leadingBreak := newlineBefore(p.src, p.i)
-			node, skipped, err := p.parseBraceNode()
+			bnodes, err := p.parseBraceNode()
 			if err != nil {
 				return nil, err
 			}
-			if !skipped {
-				stampLeadingBreak(node, leadingBreak)
-				nodes = append(nodes, node)
-			}
+			stampLeadingBreak(bnodes[0], leadingBreak)
+			nodes = append(nodes, bnodes...)
 		case p.atBareContentComment():
 			nodes = append(nodes, p.parseBareComment())
 		default:
@@ -604,14 +677,12 @@ func (p *parser) parseCaseBody() ([]ast.Markup, error) {
 			nodes = append(nodes, el)
 		case p.peek() == '{':
 			leadingBreak := newlineBefore(p.src, p.i)
-			node, skipped, err := p.parseBraceNode()
+			bnodes, err := p.parseBraceNode()
 			if err != nil {
 				return nil, err
 			}
-			if !skipped {
-				stampLeadingBreak(node, leadingBreak)
-				nodes = append(nodes, node)
-			}
+			stampLeadingBreak(bnodes[0], leadingBreak)
+			nodes = append(nodes, bnodes...)
 		case p.atBareContentComment():
 			nodes = append(nodes, p.parseBareComment())
 		default:
@@ -731,38 +802,57 @@ func caseBodyLabelStart(src string, i int) bool {
 }
 
 // parseBraceNode dispatches a `{`-leading construct in a child/markup context.
-// Cursor must be at '{'. It returns (node, false, nil) for a GoBlock, control
-// flow, or interpolation; (nil, true, nil) when a comment-only `{ }` was
-// skipped; or (nil, false, err) on error. Control-flow cases are wired in
-// Tasks 3–5.
-func (p *parser) parseBraceNode() (ast.Markup, bool, error) {
+// Cursor must be at '{'. It returns (nodes, nil) — a single node for a
+// GoBlock, control flow, or interpolation; one node per interior comment for
+// a comment-only `{ … }` group — or (nil, err) on error. The slice is never
+// empty on success.
+func (p *parser) parseBraceNode() ([]ast.Markup, error) {
 	if p.at("{{") {
 		gb, err := p.parseGoBlock()
-		return gb, false, err
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Markup{gb}, nil
 	}
-	if c, ok, err := p.parseBracedComment(); err != nil {
-		return nil, false, err
+	if cs, ok, err := p.parseBracedComment(); err != nil {
+		return nil, err
 	} else if ok {
-		return c, false, nil
+		nodes := make([]ast.Markup, len(cs))
+		for i, c := range cs {
+			nodes[i] = c
+		}
+		return nodes, nil
 	}
 	switch p.braceKeyword() {
 	case "if":
 		n, err := p.parseIfMarkup()
-		return n, false, err
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Markup{n}, nil
 	case "for":
 		n, err := p.parseForMarkup()
-		return n, false, err
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Markup{n}, nil
 	case "switch":
 		n, err := p.parseSwitchMarkup()
-		return n, false, err
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Markup{n}, nil
 	}
 	if in, ok, err := p.tryParseBodyEmbeddedInterp(); err != nil {
-		return nil, false, err
+		return nil, err
 	} else if ok {
-		return in, false, nil
+		return []ast.Markup{in}, nil
 	}
 	in, err := p.parseInterp()
-	return in, false, err
+	if err != nil {
+		return nil, err
+	}
+	return []ast.Markup{in}, nil
 }
 
 // tryParseBodyEmbeddedInterp recognizes a lone f`…` literal — optionally
@@ -890,8 +980,10 @@ func (p *parser) parseAttrsUntil(stop func() bool) (attrs []ast.Attr, multiline 
 		if c, ok, cerr := p.parseTagComment(); cerr != nil {
 			return nil, false, cerr
 		} else if ok {
-			c.Trailing = len(attrs) > 0 && !strings.ContainsRune(p.src[wsStart:p.i], '\n')
-			attrs = append(attrs, c)
+			c[0].Trailing = len(attrs) > 0 && !strings.ContainsRune(p.src[wsStart:p.i], '\n')
+			for _, n := range c {
+				attrs = append(attrs, n)
+			}
 			continue
 		}
 		a, aerr := p.parseSingleAttr()
@@ -1334,15 +1426,12 @@ func (p *parser) parseChildrenTerm(term childTerm) ([]ast.Markup, token.Pos, err
 		}
 		if p.peek() == '{' {
 			leadingBreak := newlineBefore(p.src, p.i)
-			node, skipped, err := p.parseBraceNode()
+			bnodes, err := p.parseBraceNode()
 			if err != nil {
 				return nil, token.NoPos, err
 			}
-			if skipped {
-				continue
-			}
-			stampLeadingBreak(node, leadingBreak)
-			nodes = append(nodes, node)
+			stampLeadingBreak(bnodes[0], leadingBreak)
+			nodes = append(nodes, bnodes...)
 			continue
 		}
 		if p.atBareContentComment() {

--- a/parser/markup_test.go
+++ b/parser/markup_test.go
@@ -484,7 +484,7 @@ func TestUnterminatedTagBlockComment(t *testing.T) {
 
 func TestParseIfSimple(t *testing.T) {
 	p := testParser(`{ if ok { <b>yes</b> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +505,7 @@ func TestParseIfSimple(t *testing.T) {
 
 func TestParseIfElse(t *testing.T) {
 	p := testParser(`{ if a { <b>1</b> } else { <i>2</i> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -517,7 +517,7 @@ func TestParseIfElse(t *testing.T) {
 
 func TestParseIfElseIfChain(t *testing.T) {
 	p := testParser(`{ if a { <x/> } else if b { <y/> } else { <z/> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -542,7 +542,7 @@ func TestParseIfElseIfChain(t *testing.T) {
 
 func TestParseIfWithInterpAndText(t *testing.T) {
 	p := testParser(`{ if it.Active { <strong>{it.Name}</strong> } else { {it.Name} } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -565,16 +565,30 @@ func TestParseIfWithInterpAndText(t *testing.T) {
 
 var _ = ast.Text{}
 
+// parseSingleBraceNode runs parseBraceNode and asserts the construct produced
+// exactly one node (every non-comment-group brace construct does).
+func parseSingleBraceNode(p *parser) (ast.Markup, error) {
+	nodes, err := p.parseBraceNode()
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes) != 1 {
+		panic("parseSingleBraceNode: construct produced more than one node")
+	}
+	return nodes[0], nil
+}
+
 func TestParseGoBlock(t *testing.T) {
 	// {{ … }} at child level becomes a GoBlock with trimmed Code; trailing text remains.
 	p := testParser("{{ x := f() }}rest<")
-	node, skipped, err := p.parseBraceNode()
+	bnodes, err := p.parseBraceNode()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if skipped {
-		t.Fatal("GoBlock should not be skipped")
+	if len(bnodes) != 1 {
+		t.Fatalf("got %d nodes, want 1", len(bnodes))
 	}
+	node := bnodes[0]
 	gb, ok := node.(*ast.GoBlock)
 	if !ok {
 		t.Fatalf("got %T, want *ast.GoBlock", node)
@@ -590,7 +604,7 @@ func TestParseGoBlock(t *testing.T) {
 func TestParseGoBlockNestedBraces(t *testing.T) {
 	// Inner Go braces (composite literal, if-block) must not end the {{ }} early.
 	p := testParser("{{ if err != nil { return err }; m := map[string]int{} }}")
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -629,7 +643,7 @@ component C() {
 
 func TestParseForRange(t *testing.T) {
 	p := testParser(`{ for i, it := range items { <li>{it.Name}</li> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +662,7 @@ func TestParseForRange(t *testing.T) {
 
 func TestParseForCStyle(t *testing.T) {
 	p := testParser(`{ for i := 0; i < n; i++ { <x/> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -660,7 +674,7 @@ func TestParseForCStyle(t *testing.T) {
 
 func TestParseForWithGoBlockInside(t *testing.T) {
 	p := testParser(`{ for i := range xs { {{ v := g(i) }}<a>{v}</a> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -686,7 +700,7 @@ func TestParseSwitch(t *testing.T) {
 			<span>info</span>
 		} }`
 	p := testParser(src)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -717,7 +731,7 @@ func TestParseSwitchTagless(t *testing.T) {
 			<a/>
 		} }`
 	p := testParser(src)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -737,7 +751,7 @@ func TestSwitchCaseBodyTextDoesNotSwallowLabel(t *testing.T) {
 	parseSwitch := func(t *testing.T, src string) *ast.SwitchMarkup {
 		t.Helper()
 		p := testParser(src)
-		node, _, err := p.parseBraceNode()
+		node, err := parseSingleBraceNode(p)
 		if err != nil {
 			t.Fatalf("parse error: %v\nsrc:\n%s", err, src)
 		}
@@ -920,7 +934,7 @@ func TestCaseBodyLabelScanIsLinearNotQuadratic(t *testing.T) {
 	parseOnce := func(src string) time.Duration {
 		p := testParser(src)
 		start := time.Now()
-		if _, _, err := p.parseBraceNode(); err != nil {
+		if _, err := p.parseBraceNode(); err != nil {
 			t.Fatalf("parse error: %v", err)
 		}
 		return time.Since(start)
@@ -973,7 +987,7 @@ func BenchmarkCaseBodyLabelScanPathological(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		p := testParser(s)
-		if _, _, err := p.parseBraceNode(); err != nil {
+		if _, err := p.parseBraceNode(); err != nil {
 			b.Fatalf("parse error: %v", err)
 		}
 	}
@@ -1159,7 +1173,7 @@ func TestParseForRangeSliceLiteral(t *testing.T) {
 	// I2: ranging over a bare composite literal — the literal's '{' must NOT be
 	// taken as the body brace.
 	p := testParser(`{ for _, v := range []int{1, 2} { <a>{v}</a> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
@@ -1177,7 +1191,7 @@ func TestParseForRangeSliceLiteral(t *testing.T) {
 
 func TestParseForRangeMapLiteral(t *testing.T) {
 	p := testParser(`{ for k := range map[string]int{"a": 1} { <i>{k}</i> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
@@ -1190,7 +1204,7 @@ func TestParseForRangeMapLiteral(t *testing.T) {
 func TestParseIfParenComposite(t *testing.T) {
 	// Paren-wrapped composite in an if condition still resolves to the body brace.
 	p := testParser(`{ if (struct{ Ok bool }{Ok: true}).Ok { <y/> } }`)
-	node, _, err := p.parseBraceNode()
+	node, err := parseSingleBraceNode(p)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}


### PR DESCRIPTION
## What broke

`gsx fmt` could emit output that does not parse, in two ways:

1. **Group collapse.** A comment-only `{ … }` group collapsed into ONE node: `splitBracedComment` kept the first comment's kind and the raw interior as text. `{ /* a */ // b␤}` printed as `/* a */ // b */` (attr — text corrupted with a stray `*/`) or `{/* a */ // b */}` (child — **does not reparse**).
2. **Mid-line `//`.** `{}` collapsed to an empty LINE comment, and the line-comment forced break lived only in `element()`'s layout loop — invisible to `atomDoc`'s `pretty.Flat`. `<input {} type="text"/>` formatted to `<input //  type="text"/>`, whose `//` swallows the rest of the line on reparse.

## The fix

- **Parser** (`commentParts`, a real `go/scanner` pass): one `CommentAttr`/`Comment` node per interior comment, exact source-byte extents (CRLF-safe), `Trailing` from the group's own line layout; empty group (`{}`/`{ }`/`{ ; }`) = a single empty block comment.
- **Printer**: `attrDoc` owns the `CommentAttr` case; line comments carry `BreakParent` inside the doc (CondAttr/SwitchAttr convention), so the atom/Flat path can never render `//` mid-line. Canonicals: attr = bare per comment, `/**/` for empty; child = braced per comment, `{}` for empty.
- **`ast.SetSpan` hole**: `*CommentAttr` was missing from the type switch — every comment attribute has carried `NoPos` since the feature shipped. Added the case + a panicking default, which immediately caught a second silent no-op (printer test helper calling `SetSpan` on value-typed `GoText` leaves; now skipped explicitly).

## Proof

- `TestCorpusInputsProperty` (reparse safety + faithfulness + idempotence) failed on the two new corpus cases before the fix; green now.
- Adversarial workflow: **2,400-sample round-trip fuzz** clean on this branch, and the same harness pointed at a main-built binary reproduces both bug classes at sample 0-2 (vacuity-validated); **7-context probe matrix** (cond/switch attr bodies, component tags, markup-attr slots, cf bodies, fragments, `<pre>`, PI regions) — main emitted unparseable or corrupted output in all 7, branch round-trips everywhere.
- `make ci` exit 0 (verified from make's own exit code).

## Deliberate canonicals to sanity-check in review

- `{/*  */}` (whitespace-only comment) now canonicalizes to `{}` (trim-to-empty = empty group). Main printed `{/*  */}`.
- `<input {}/>` → `<input /**//>` — `/**/` abuts `/>`; lexes unambiguously, cosmetic only.
- A comment starting on a multi-line block comment's LAST line is not glued (Trailing compares token START lines); layout nit, never unsafe.

## Surfaced, out of scope

- gsx accepts `{ ; }` as a comment group (semicolon tolerance inherited from `commentOnly`); tree-sitter-gsx does not — pre-existing divergence, worth deciding once.
- Interior NBSP in comment/text gains an ASCII space from the fill word-splitter — identical on main (wsnorm-is-ASCII territory).
- `gen`'s `TestDevStopsPostingAfterWebExit` was failing on main AND branch from a scaffold server leaked 5 days ago squatting port 7811 (killed). The dev tests' hard-coded ports remain leak-sensitive.

https://claude.ai/code/session_01L1mQ6U9FmGWT5bp14RtGwK