### PR TITLE
perf(gen): batch watch-session refresh + incremental manifest derivation

### DIFF
--- a/gen/watch_batch_isolation_test.go
+++ b/gen/watch_batch_isolation_test.go
@@ -1,0 +1,76 @@
+package gen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWatchSession_BatchRefreshFailureIsolatesToBrokenDir pins the
+// partial-failure contract of the batched refresh in regenDirs: when one dir's
+// refresh fails (here its paired .x.go path is occupied by a directory, which
+// the manifest deliberately fails closed on), every healthy sibling in the
+// same module must still refresh, regenerate, and write — only the culprit dir
+// carries the error. The all-or-nothing batch alone would fan the one error
+// out to the whole module and leave healthy dirs' outputs stale on disk.
+func TestWatchSession_BatchRefreshFailureIsolatesToBrokenDir(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write := func(p, s string) {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(s), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module example.com/m\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+gsxModuleDir(t)+"\n")
+	write("a/a.gsx", "package a\ncomponent A() { <p>v1</p> }\n")
+	write("b/b.gsx", "package b\ncomponent B() { <p>v1</p> }\n")
+
+	aDir := filepath.Join(root, "a")
+	bDir := filepath.Join(root, "b")
+	s, startup, err := startWatchSessionForTest(watchConfig{paths: []string{root}})
+	if err != nil {
+		t.Fatalf("startWatchSessionForTest: %v", err)
+	}
+	for _, r := range startup {
+		if !r.OK {
+			t.Fatalf("startup regen not OK for %s: err=%v diags=%v", r.Dir, r.Err, r.Diags)
+		}
+	}
+
+	// Edit a's source, then break b: its paired output path becomes a
+	// directory, which pairedOutputPresent fails closed on during refresh.
+	write("a/a.gsx", "package a\ncomponent A() { <p>v2</p> }\n")
+	if err := os.Remove(filepath.Join(bDir, "b.x.go")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(bDir, "b.x.go"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	results := s.regenDirs([]string{aDir, bDir})
+	if len(results) != 2 {
+		t.Fatalf("regenDirs returned %d results, want 2", len(results))
+	}
+	aRes, bRes := results[0], results[1]
+	if !aRes.OK || aRes.Err != nil {
+		t.Fatalf("healthy dir a must regenerate despite b's broken refresh; got OK=%v err=%v", aRes.OK, aRes.Err)
+	}
+	if bRes.OK || bRes.Err == nil {
+		t.Fatalf("broken dir b must carry the refresh error; got OK=%v err=%v", bRes.OK, bRes.Err)
+	}
+	if !strings.Contains(bRes.Err.Error(), "b.x.go") {
+		t.Fatalf("b's error must blame b's own paired output, got: %v", bRes.Err)
+	}
+	generated, err := os.ReadFile(filepath.Join(aDir, "a.x.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(generated), "v2") {
+		t.Fatalf("a.x.go on disk is stale — the edit did not regenerate:\n%s", generated)
+	}
+}

--- a/gen/watch_perf_test.go
+++ b/gen/watch_perf_test.go
@@ -1,0 +1,85 @@
+package gen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/sourceview"
+)
+
+// TestWatchSession_ColdStartParseWorkIsLinear pins the parse-work complexity of
+// watch-session startup and warm regeneration. Cold startup over a module with
+// K package dirs and F total .gsx files must Inspect each file O(1) times —
+// not once per directory. The historical failure mode (74342b54 + whole-module
+// manifest reconstruction) re-Inspected all F files inside every per-dir
+// refresh, making startup and dep-surface reopen O(K × F): ~26s on a
+// 78-dir/1169-file module that generates in ~5s via the batch path.
+//
+// Deliberately NOT t.Parallel(): sourceview.InspectCalls is a process-wide
+// counter, and a non-parallel test has the package's only running slot, so the
+// deltas below are attributable to this session alone.
+func TestWatchSession_ColdStartParseWorkIsLinear(t *testing.T) {
+	root := t.TempDir()
+	write := func(p, s string) {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(s), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module example.com/m\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+gsxModuleDir(t)+"\n")
+
+	const dirs = 12
+	const filesPerDir = 3
+	const files = dirs * filesPerDir
+	for d := range dirs {
+		pkg := fmt.Sprintf("p%02d", d)
+		for f := range filesPerDir {
+			write(
+				filepath.Join(pkg, fmt.Sprintf("c%d.gsx", f)),
+				fmt.Sprintf("package %s\n\ncomponent C%d() {\n\t<p>x</p>\n}\n", pkg, f),
+			)
+		}
+	}
+
+	before := sourceview.InspectCalls()
+	s, startup, err := startWatchSessionForTest(watchConfig{paths: []string{root}})
+	if err != nil {
+		t.Fatalf("startWatchSessionForTest: %v", err)
+	}
+	for _, r := range startup {
+		if !r.OK {
+			t.Fatalf("startup regen not OK for %s: err=%v diags=%v", r.Dir, r.Err, r.Diags)
+		}
+	}
+	coldDelta := sourceview.InspectCalls() - before
+
+	// Each of the F files may legitimately be Inspected a small constant number
+	// of times during startup (manifest build plus bounded derivations). The
+	// quadratic regression Inspects each file once per package dir, i.e.
+	// ≥ dirs×files = 12F, far above this bound.
+	const coldBudget = 6 * files
+	if coldDelta > coldBudget {
+		t.Fatalf("cold startup performed %d Inspect calls over %d files in %d dirs; budget is %d (O(files)) — per-dir whole-module re-parse regression",
+			coldDelta, files, dirs, coldBudget)
+	}
+
+	// A warm single-dir regeneration must not re-parse the whole module either:
+	// its parse work is bounded by the refreshed dir's own files (plus a small
+	// constant), independent of module size.
+	before = sourceview.InspectCalls()
+	r := s.regenDir(filepath.Join(root, "p00"))
+	if !r.OK {
+		t.Fatalf("warm regenDir not OK: err=%v diags=%v", r.Err, r.Diags)
+	}
+	warmDelta := sourceview.InspectCalls() - before
+	const warmBudget = 6*filesPerDir + 6
+	if warmDelta > warmBudget {
+		t.Fatalf("warm single-dir regen performed %d Inspect calls; budget is %d (O(dir files)) — whole-module re-parse regression",
+			warmDelta, warmBudget)
+	}
+}

--- a/gen/watch_perf_test.go
+++ b/gen/watch_perf_test.go
@@ -19,67 +19,77 @@ import (
 //
 // Deliberately NOT t.Parallel(): sourceview.InspectCalls is a process-wide
 // counter, and a non-parallel test has the package's only running slot, so the
-// deltas below are attributable to this session alone.
+// deltas below are attributable to this session — except for goroutines leaked
+// by EARLIER tests in this binary (gen's LSP e2e harness runs in-process, and
+// its background analyzer calls Inspect). A leak is a one-shot burst, not a
+// steady stream, so a budget breach is retried once in a fresh module: a real
+// complexity regression breaches every window, foreign traffic at most one.
 func TestWatchSession_ColdStartParseWorkIsLinear(t *testing.T) {
-	root := t.TempDir()
-	write := func(p, s string) {
-		full := filepath.Join(root, p)
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(full, []byte(s), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	write("go.mod", "module example.com/m\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+gsxModuleDir(t)+"\n")
-
 	const dirs = 12
 	const filesPerDir = 3
 	const files = dirs * filesPerDir
-	for d := range dirs {
-		pkg := fmt.Sprintf("p%02d", d)
-		for f := range filesPerDir {
-			write(
-				filepath.Join(pkg, fmt.Sprintf("c%d.gsx", f)),
-				fmt.Sprintf("package %s\n\ncomponent C%d() {\n\t<p>x</p>\n}\n", pkg, f),
-			)
-		}
-	}
-
-	before := sourceview.InspectCalls()
-	s, startup, err := startWatchSessionForTest(watchConfig{paths: []string{root}})
-	if err != nil {
-		t.Fatalf("startWatchSessionForTest: %v", err)
-	}
-	for _, r := range startup {
-		if !r.OK {
-			t.Fatalf("startup regen not OK for %s: err=%v diags=%v", r.Dir, r.Err, r.Diags)
-		}
-	}
-	coldDelta := sourceview.InspectCalls() - before
-
 	// Each of the F files may legitimately be Inspected a small constant number
 	// of times during startup (manifest build plus bounded derivations). The
 	// quadratic regression Inspects each file once per package dir, i.e.
-	// ≥ dirs×files = 12F, far above this bound.
+	// ≥ dirs×files = 12F, far above this bound. Warm single-dir regen parse
+	// work is bounded by the dir's own files, independent of module size.
 	const coldBudget = 6 * files
-	if coldDelta > coldBudget {
-		t.Fatalf("cold startup performed %d Inspect calls over %d files in %d dirs; budget is %d (O(files)) — per-dir whole-module re-parse regression",
-			coldDelta, files, dirs, coldBudget)
+	const warmBudget = 6*filesPerDir + 6
+
+	measure := func() (coldDelta, warmDelta uint64) {
+		root := t.TempDir()
+		write := func(p, s string) {
+			full := filepath.Join(root, p)
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(full, []byte(s), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		write("go.mod", "module example.com/m\n\ngo 1.26.1\n\nrequire github.com/gsxhq/gsx v0.0.0\n\nreplace github.com/gsxhq/gsx => "+gsxModuleDir(t)+"\n")
+		for d := range dirs {
+			pkg := fmt.Sprintf("p%02d", d)
+			for f := range filesPerDir {
+				write(
+					filepath.Join(pkg, fmt.Sprintf("c%d.gsx", f)),
+					fmt.Sprintf("package %s\n\ncomponent C%d() {\n\t<p>x</p>\n}\n", pkg, f),
+				)
+			}
+		}
+
+		before := sourceview.InspectCalls()
+		s, startup, err := startWatchSessionForTest(watchConfig{paths: []string{root}})
+		if err != nil {
+			t.Fatalf("startWatchSessionForTest: %v", err)
+		}
+		for _, r := range startup {
+			if !r.OK {
+				t.Fatalf("startup regen not OK for %s: err=%v diags=%v", r.Dir, r.Err, r.Diags)
+			}
+		}
+		coldDelta = sourceview.InspectCalls() - before
+
+		before = sourceview.InspectCalls()
+		r := s.regenDir(filepath.Join(root, "p00"))
+		if !r.OK {
+			t.Fatalf("warm regenDir not OK: err=%v diags=%v", r.Err, r.Diags)
+		}
+		warmDelta = sourceview.InspectCalls() - before
+		return coldDelta, warmDelta
 	}
 
-	// A warm single-dir regeneration must not re-parse the whole module either:
-	// its parse work is bounded by the refreshed dir's own files (plus a small
-	// constant), independent of module size.
-	before = sourceview.InspectCalls()
-	r := s.regenDir(filepath.Join(root, "p00"))
-	if !r.OK {
-		t.Fatalf("warm regenDir not OK: err=%v diags=%v", r.Err, r.Diags)
+	cold, warm := measure()
+	if cold > coldBudget || warm > warmBudget {
+		cold2, warm2 := measure()
+		cold, warm = min(cold, cold2), min(warm, warm2)
 	}
-	warmDelta := sourceview.InspectCalls() - before
-	const warmBudget = 6*filesPerDir + 6
-	if warmDelta > warmBudget {
+	if cold > coldBudget {
+		t.Fatalf("cold startup performed %d Inspect calls over %d files in %d dirs; budget is %d (O(files)) — per-dir whole-module re-parse regression",
+			cold, files, dirs, coldBudget)
+	}
+	if warm > warmBudget {
 		t.Fatalf("warm single-dir regen performed %d Inspect calls; budget is %d (O(dir files)) — whole-module re-parse regression",
-			warmDelta, warmBudget)
+			warm, warmBudget)
 	}
 }

--- a/gen/watchsession.go
+++ b/gen/watchsession.go
@@ -451,13 +451,32 @@ func (s *watchSession) regenDirs(dirs []string) []cycleResult {
 		}
 		batchDirs[m] = append(batchDirs[m], dir)
 	}
-	refreshErr := make(map[*codegen.Module]error, len(batchOrder))
 	refreshMs := make(map[*codegen.Module]int64, len(batchOrder))
+	dirErr := map[string]error{}
+	dirErrMs := map[string]int64{}
 	for _, m := range batchOrder {
 		t := time.Now()
 		_, err := m.RefreshDiskSourcesAndInvalidate(batchDirs[m]...)
 		refreshMs[m] = time.Since(t).Milliseconds()
-		refreshErr[m] = err
+		if err == nil {
+			continue
+		}
+		// The batch refresh is all-or-nothing (atomic, no partial state), so
+		// one broken dir — an unreadable directory, a paired .x.go path
+		// occupied by a non-regular file — would otherwise block every
+		// healthy sibling in the module for the cycle. Re-scope per dir: the
+		// failure isolates to exactly the culprit dirs, and healthy dirs
+		// refresh and regenerate, restoring the per-dir form's partial-failure
+		// behavior (a module-wide failure such as a broken cold Build simply
+		// fails every per-dir attempt too, matching the old cold path).
+		refreshMs[m] = 0 // per-dir retries carry their own timing below
+		for _, dir := range batchDirs[m] {
+			dt := time.Now()
+			if _, derr := m.RefreshDiskSourcesAndInvalidate(dir); derr != nil {
+				dirErr[dir] = derr
+			}
+			dirErrMs[dir] = time.Since(dt).Milliseconds()
+		}
 	}
 	chargedRefresh := make(map[*codegen.Module]bool, len(batchOrder))
 	for i, dir := range dirs {
@@ -465,14 +484,16 @@ func (s *watchSession) regenDirs(dirs []string) []cycleResult {
 		if m == nil {
 			continue // moduleForDir already failed; results[i] is set
 		}
-		if err := refreshErr[m]; err != nil {
-			results[i] = cycleResult{Dir: dir, Err: err, DurMs: time.Since(starts[i]).Milliseconds()}
+		if err := dirErr[dir]; err != nil {
+			results[i] = cycleResult{Dir: dir, Err: err, DurMs: dirErrMs[dir]}
 			continue
 		}
 		results[i] = s.generateDir(m, dir)
-		// Charge each module's batch refresh to its first generated dir so
-		// aggregate durations (aggregateEvent sums per-dir DurMs) still cover
-		// the whole cycle's work.
+		// Fold this dir's share of refresh time into its result so aggregate
+		// durations (aggregateEvent sums per-dir DurMs) cover the whole
+		// cycle's work: the batch refresh is charged to the module's first
+		// generated dir, a fallback per-dir refresh to its own dir.
+		results[i].DurMs += dirErrMs[dir]
 		if !chargedRefresh[m] {
 			chargedRefresh[m] = true
 			results[i].DurMs += refreshMs[m]

--- a/gen/watchsession.go
+++ b/gen/watchsession.go
@@ -160,9 +160,7 @@ func (s *watchSession) initialGenerate() ([]cycleResult, error) {
 	// otherwise survive indefinitely. Must run before the per-dir regen loop,
 	// same ordering as the batch path.
 	startup := sweepOrphanStartup(s.cfg.paths, dirs)
-	for _, dir := range dirs {
-		startup = append(startup, s.regenDir(dir))
-	}
+	startup = append(startup, s.regenDirs(dirs)...)
 	return startup, nil
 }
 
@@ -200,9 +198,7 @@ func (s *watchSession) reopen() ([]cycleResult, error) {
 	// Walk-level orphan sweep — see the matching call in initialGenerate for
 	// why this can't be left to the per-dir sweep inside regenDir alone.
 	results := sweepOrphanStartup(s.cfg.paths, dirs)
-	for _, dir := range dirs {
-		results = append(results, s.regenDir(dir))
-	}
+	results = append(results, s.regenDirs(dirs)...)
 	return results, nil
 }
 
@@ -415,30 +411,88 @@ func sweepOrphanStartup(paths, kept []string) []cycleResult {
 	return results
 }
 
-// regenDir warm-regenerates one package dir using its module's warm Module. It
-// calls Module.Generate, maps the gsx-path-keyed output to .x.go files, and
-// writes them via the hash-gated writeFiles helper.
+// regenDirs warm-regenerates the given package dirs from current disk,
+// returning one cycleResult per dir in input order.
+//
+// Saved disk facts are refreshed — and stale cached analysis evicted — in ONE
+// atomic RefreshDiskSourcesAndInvalidate batch per owning module before any
+// generation. The refresh is the disk counterpart to SetOverride: it
+// re-enumerates the dirs' package/import/membership facts beneath any override
+// layer, and the eviction drops their reverse closures so generation
+// re-type-checks from the refreshed source. The warm Module otherwise reads a
+// frozen cold-load manifest, so without this a .gsx edit is invisible to
+// Generate. Batching keeps the "regenerate from current disk" contract while
+// paying the module-wide refresh bookkeeping once per cycle instead of once
+// per directory — the per-dir form made cold startup and dep-surface reopen
+// O(dirs × module files): ~26s on a 78-dir/1169-file module whose batch
+// generate takes ~5s. TestWatchSession_ColdStartParseWorkIsLinear pins this.
+//
+// A disk write that lands after the batch refresh but before a later dir's
+// Generate is not lost: observation is armed before every caller of this
+// helper snapshots membership, so the write's fsnotify event re-dirties the
+// dir and the next cycle regenerates it — the same guarantee the per-dir
+// refresh relied on for writes landing after ITS refresh.
+func (s *watchSession) regenDirs(dirs []string) []cycleResult {
+	results := make([]cycleResult, len(dirs))
+	starts := make([]time.Time, len(dirs))
+	modules := make([]*codegen.Module, len(dirs))
+	batchDirs := map[*codegen.Module][]string{}
+	var batchOrder []*codegen.Module
+	for i, dir := range dirs {
+		starts[i] = time.Now()
+		m, err := s.moduleForDir(dir)
+		if err != nil {
+			results[i] = cycleResult{Dir: dir, Err: err, DurMs: time.Since(starts[i]).Milliseconds()}
+			continue
+		}
+		modules[i] = m
+		if _, seen := batchDirs[m]; !seen {
+			batchOrder = append(batchOrder, m)
+		}
+		batchDirs[m] = append(batchDirs[m], dir)
+	}
+	refreshErr := make(map[*codegen.Module]error, len(batchOrder))
+	refreshMs := make(map[*codegen.Module]int64, len(batchOrder))
+	for _, m := range batchOrder {
+		t := time.Now()
+		_, err := m.RefreshDiskSourcesAndInvalidate(batchDirs[m]...)
+		refreshMs[m] = time.Since(t).Milliseconds()
+		refreshErr[m] = err
+	}
+	chargedRefresh := make(map[*codegen.Module]bool, len(batchOrder))
+	for i, dir := range dirs {
+		m := modules[i]
+		if m == nil {
+			continue // moduleForDir already failed; results[i] is set
+		}
+		if err := refreshErr[m]; err != nil {
+			results[i] = cycleResult{Dir: dir, Err: err, DurMs: time.Since(starts[i]).Milliseconds()}
+			continue
+		}
+		results[i] = s.generateDir(m, dir)
+		// Charge each module's batch refresh to its first generated dir so
+		// aggregate durations (aggregateEvent sums per-dir DurMs) still cover
+		// the whole cycle's work.
+		if !chargedRefresh[m] {
+			chargedRefresh[m] = true
+			results[i].DurMs += refreshMs[m]
+		}
+	}
+	return results
+}
+
+// regenDir warm-regenerates one package dir from current disk; it is the
+// single-dir form of regenDirs and shares its refresh/generate contract.
 func (s *watchSession) regenDir(dir string) cycleResult {
+	return s.regenDirs([]string{dir})[0]
+}
+
+// generateDir runs the post-refresh half of one dir's regeneration: orphan
+// sweep, Module.Generate, poison-on-error, and the hash-gated write. Callers
+// must have refreshed and invalidated dir's saved disk facts first (see
+// regenDirs).
+func (s *watchSession) generateDir(m *codegen.Module, dir string) cycleResult {
 	start := time.Now()
-	m, err := s.moduleForDir(dir)
-	if err != nil {
-		return cycleResult{Dir: dir, Err: err, DurMs: time.Since(start).Milliseconds()}
-	}
-	// Refresh authoritative saved disk facts for dir before warm invalidation,
-	// then evict dir's stale cached analysis. The warm Module reads source from a
-	// frozen cold-load manifest, not live disk, so without this a .gsx edit is
-	// invisible to Generate. RefreshDiskSources is the disk counterpart to
-	// SetOverride (it re-enumerates dir's package/import/membership facts and
-	// updates the saved layer beneath any override); Invalidate then drops dir's
-	// reverse closure so it re-type-checks from the refreshed source. This is the
-	// same refresh-before-invalidation sequence regenPending applies to the
-	// changed dir, and it restores the "regenDir regenerates dir from current
-	// disk" contract every direct caller (initial generate, reopen, warm
-	// dependents) relies on.
-	if err := m.RefreshDiskSources(dir); err != nil {
-		return cycleResult{Dir: dir, Err: err, DurMs: time.Since(start).Milliseconds()}
-	}
-	m.Invalidate(dir)
 	// Dir-scoped orphan sweep: a .gsx sibling deletion in dir is independent
 	// of what this cycle regenerates for the .gsx files still present, so it
 	// runs unconditionally (mirrors writeDirOutcome in gen/cache.go).
@@ -549,8 +603,14 @@ func (s *watchSession) regenPending(pending map[string]bool, depDirty bool) ([]c
 			continue
 		}
 	}
+	// The affected reverse closure can be large (a shared component dirties
+	// every dependent); regenerate it as one batch so the refresh bookkeeping
+	// is paid per cycle, not per dir. Sorted for deterministic emit order.
+	affectedDirs := make([]string, 0, len(affected))
 	for dir := range affected {
-		results = append(results, s.regenDir(dir))
+		affectedDirs = append(affectedDirs, dir)
 	}
+	sort.Strings(affectedDirs)
+	results = append(results, s.regenDirs(affectedDirs)...)
 	return results, nil
 }

--- a/internal/sourceview/derive_test.go
+++ b/internal/sourceview/derive_test.go
@@ -1,0 +1,156 @@
+package sourceview
+
+import (
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+// manifestView flattens every derived projection of a Manifest into a
+// comparable value so a derived manifest can be checked for equality against a
+// from-scratch Build of the same disk state.
+func manifestView(t *testing.T, m *Manifest) map[string]any {
+	t.Helper()
+	sources := map[string]string{}
+	for _, path := range m.SourcePaths() {
+		source, ok := m.Source(path)
+		if !ok {
+			t.Fatalf("SourcePaths lists %s but Source misses it", path)
+		}
+		sources[path] = string(source)
+	}
+	overlay := map[string]string{}
+	for path, source := range m.Overlay() {
+		overlay[path] = string(source)
+	}
+	return map[string]any{
+		"sources":     sources,
+		"facts":       m.Facts(),
+		"gsxDirs":     m.GSXDirs(),
+		"packageDirs": m.PackageDirs(),
+		"paired":      m.PairedOutputs(),
+		"overlay":     overlay,
+	}
+}
+
+// TestRefreshDirsMatchesFreshBuild pins the incremental-derivation contract:
+// after arbitrary disk edits, RefreshDirs over the touched dirs must produce a
+// manifest indistinguishable from a from-scratch Build of the same disk state
+// — reused facts included. A stale reused fact (wrong package name, dropped
+// import edge) shows up as a projection mismatch here.
+func TestRefreshDirsMatchesFreshBuild(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n")
+	writeTestFile(t, root, "a/a1.gsx", "package a\ncomponent A1() { <p/> }\n")
+	writeTestFile(t, root, "a/a2.gsx", "package a\ncomponent A2() { <p/> }\n")
+	writeTestFile(t, root, "b/b1.gsx", "package b\n\nimport \"example.com/app/a\"\n\ncomponent B1() { <a.A1/> }\n")
+	writeTestFile(t, root, "b/helper.go", "package b\nfunc helper() {}\n")
+
+	build := func() *Manifest {
+		m, err := Build(BuildOptions{ModuleRoot: root, ModulePath: "example.com/app"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m
+	}
+	base := build()
+
+	// Edit one file, add one, remove nothing; refresh both dirs.
+	writeTestFile(t, root, "a/a1.gsx", "package a\n\nimport \"strings\"\n\ncomponent A1() { <p>{strings.ToUpper(\"x\")}</p> }\n")
+	writeTestFile(t, root, "b/b2.gsx", "package b\ncomponent B2() { <p/> }\n")
+	refreshed, err := base.RefreshDirs([]string{filepath.Join(root, "a"), filepath.Join(root, "b")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := manifestView(t, refreshed), manifestView(t, build()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("refreshed manifest diverges from fresh Build:\n got: %#v\nwant: %#v", got, want)
+	}
+
+	// The changed file's fact must reflect the new bytes, not the reused old
+	// ones: the strings import is a new edge.
+	fact, ok := refreshed.Fact(filepath.Join(root, "a", "a1.gsx"))
+	if !ok || !slices.Contains(fact.Imports(), "strings") {
+		t.Fatalf("refreshed manifest misses the edited file's new import edge; fact=%+v ok=%v", fact, ok)
+	}
+
+	// Refreshing an untouched dir must not re-parse the module: every fact is
+	// reusable, so the Inspect count stays bounded by the refreshed dir's own
+	// file count (re-reads are byte-identical).
+	before := InspectCalls()
+	again, err := refreshed.RefreshDirs([]string{filepath.Join(root, "a")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delta := InspectCalls() - before; delta > 0 {
+		t.Fatalf("byte-identical refresh re-parsed %d files; want 0 (fact reuse)", delta)
+	}
+	if got, want := manifestView(t, again), manifestView(t, refreshed); !reflect.DeepEqual(got, want) {
+		t.Fatalf("no-op refresh changed the manifest:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestWithFileSnapshotsEmptyReturnsReceiver pins the zero-derivation fast
+// path: deriving with no snapshots is the identity, and manifests are
+// immutable, so the receiver itself is the correct result.
+func TestWithFileSnapshotsEmptyReturnsReceiver(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n")
+	writeTestFile(t, root, "a/a.gsx", "package a\ncomponent A() { <p/> }\n")
+	m, err := Build(BuildOptions{ModuleRoot: root, ModulePath: "example.com/app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	same, err := m.WithFileSnapshots(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if same != m {
+		t.Fatalf("WithFileSnapshots(nil) allocated a new manifest; want the receiver")
+	}
+	same, err = m.WithFileSnapshots(map[string]FileSnapshot{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if same != m {
+		t.Fatalf("WithFileSnapshots(empty) allocated a new manifest; want the receiver")
+	}
+}
+
+// TestDerivedManifestsShareWithoutAliasing pins the immutability contract the
+// slice sharing relies on: mutating what accessors return must never leak into
+// any manifest, parent or derived.
+func TestDerivedManifestsShareWithoutAliasing(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/app\n\ngo 1.26.1\n")
+	path := writeTestFile(t, root, "a/a.gsx", "package a\ncomponent A() { <p/> }\n")
+	writeTestFile(t, root, "a/h.go", "package a\nfunc h() {}\n")
+	parent, err := Build(BuildOptions{ModuleRoot: root, ModulePath: "example.com/app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	derived, err := parent.RefreshDirs([]string{filepath.Join(root, "a")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range []*Manifest{parent, derived} {
+		source, ok := m.Source(path)
+		if !ok {
+			t.Fatal("source missing")
+		}
+		for i := range source {
+			source[i] = 'X'
+		}
+		for _, v := range m.Overlay() {
+			for i := range v {
+				v[i] = 'X'
+			}
+		}
+	}
+	for _, m := range []*Manifest{parent, derived} {
+		source, _ := m.Source(path)
+		if string(source) != "package a\ncomponent A() { <p/> }\n" {
+			t.Fatalf("caller mutation leaked into manifest source: %q", source)
+		}
+	}
+}

--- a/internal/sourceview/manifest.go
+++ b/internal/sourceview/manifest.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 
 	gsxast "github.com/gsxhq/gsx/ast"
@@ -310,15 +311,24 @@ func Build(options BuildOptions) (*Manifest, error) {
 			helperGoFiles[path] = cloneFileSnapshot(snapshot)
 		}
 	}
-	return newManifest(root, physicalRoot, options.ModulePath, sources, pairedPresent, nil, trackedFiles, helperGoFiles)
+	return newManifest(nil, root, physicalRoot, options.ModulePath, sources, pairedPresent, nil, trackedFiles, helperGoFiles)
 }
 
-func newManifest(moduleRoot, physicalRoot, modulePath string, sources map[string][]byte, pairedPresent map[string]bool, preferredSentinels map[string]string, trackedFiles, helperGoFiles map[string]FileSnapshot) (*Manifest, error) {
+// newManifest takes ownership of the sources, trackedFiles, and helperGoFiles
+// maps and of every byte slice they hold; callers must not retain or mutate
+// them afterwards. All stored slices are immutable — the accessor surface
+// clones on the way out, and derivations share slices instead of copying.
+//
+// prev, when non-nil, is the manifest this construction derives from: any path
+// whose source bytes are unchanged from prev reuses prev's FileFact instead of
+// re-running Inspect, so derivation parse work is proportional to the changed
+// file set rather than the module.
+func newManifest(prev *Manifest, moduleRoot, physicalRoot, modulePath string, sources map[string][]byte, pairedPresent map[string]bool, preferredSentinels map[string]string, trackedFiles, helperGoFiles map[string]FileSnapshot) (*Manifest, error) {
 	manifest := &Manifest{
 		moduleRoot:    moduleRoot,
 		physicalRoot:  physicalRoot,
 		modulePath:    modulePath,
-		sources:       make(map[string][]byte, len(sources)),
+		sources:       sources,
 		facts:         make(map[string]FileFact, len(sources)),
 		gsxDirs:       make(map[string]bool),
 		packageDirs:   make(map[string]string),
@@ -326,14 +336,23 @@ func newManifest(moduleRoot, physicalRoot, modulePath string, sources map[string
 		pairedPresent: make(map[string]bool, len(sources)),
 		overlay:       make(map[string][]byte),
 		sentinelByDir: make(map[string]string),
-		trackedFiles:  cloneFileSnapshots(trackedFiles),
-		helperGoFiles: cloneFileSnapshots(helperGoFiles),
+		trackedFiles:  trackedFiles,
+		helperGoFiles: helperGoFiles,
+	}
+	if manifest.sources == nil {
+		manifest.sources = map[string][]byte{}
+	}
+	if manifest.trackedFiles == nil {
+		manifest.trackedFiles = map[string]FileSnapshot{}
+	}
+	if manifest.helperGoFiles == nil {
+		manifest.helperGoFiles = map[string]FileSnapshot{}
 	}
 	for path, snapshot := range manifest.trackedFiles {
 		if strings.HasSuffix(path, ".go") {
 			switch snapshot.state {
 			case FilePresent:
-				manifest.overlay[path] = bytes.Clone(snapshot.source)
+				manifest.overlay[path] = snapshot.source
 			case FileAbsent:
 				manifest.overlay[path] = []byte(absentGoReplacement)
 			}
@@ -345,8 +364,7 @@ func newManifest(moduleRoot, physicalRoot, modulePath string, sources map[string
 			manifest.overlay[paired] = []byte(pairedReplacement)
 		}
 	}
-	for path, source := range sources {
-		manifest.sources[path] = bytes.Clone(source)
+	for path := range manifest.sources {
 		manifest.sourcePaths = append(manifest.sourcePaths, path)
 	}
 	sort.Strings(manifest.sourcePaths)
@@ -355,7 +373,17 @@ func newManifest(moduleRoot, physicalRoot, modulePath string, sources map[string
 	loadRoots := make(map[string]bool)
 	for _, path := range manifest.sourcePaths {
 		source := manifest.sources[path]
-		fact := Inspect(path, source, true)
+		fact, reused := FileFact{}, false
+		if prev != nil {
+			if prevFact, ok := prev.facts[path]; ok {
+				if prevSource, ok := prev.sources[path]; ok && sameSourceBytes(prevSource, source) {
+					fact, reused = prevFact, true
+				}
+			}
+		}
+		if !reused {
+			fact = Inspect(path, source, true)
+		}
 		manifest.facts[path] = fact
 		dir := filepath.Dir(path)
 		manifest.gsxDirs[dir] = true
@@ -447,11 +475,18 @@ func (manifest *Manifest) WithFileSnapshots(snapshots map[string]FileSnapshot) (
 	if manifest == nil {
 		return nil, fmt.Errorf("sourceview: nil saved manifest")
 	}
-	sources := cloneSources(manifest.sources)
+	// Zero snapshots derive the identical view; manifests are immutable, so the
+	// receiver itself is that view.
+	if len(snapshots) == 0 {
+		return manifest, nil
+	}
+	// Shallow map clones: the byte slices they reference are immutable and
+	// shared with the receiver (see newManifest's ownership contract).
+	sources := maps.Clone(manifest.sources)
 	pairedPresent := maps.Clone(manifest.pairedPresent)
 	preferredSentinels := maps.Clone(manifest.sentinelByDir)
-	trackedFiles := cloneFileSnapshots(manifest.trackedFiles)
-	helperGoFiles := cloneFileSnapshots(manifest.helperGoFiles)
+	trackedFiles := maps.Clone(manifest.trackedFiles)
+	helperGoFiles := maps.Clone(manifest.helperGoFiles)
 	for path, snapshot := range snapshots {
 		absPath, err := filepath.Abs(path)
 		if err != nil {
@@ -502,7 +537,7 @@ func (manifest *Manifest) WithFileSnapshots(snapshots map[string]FileSnapshot) (
 			return nil, fmt.Errorf("sourceview: invalid saved file state %d for %s", snapshot.state, absPath)
 		}
 	}
-	return newManifest(manifest.moduleRoot, manifest.physicalRoot, manifest.modulePath, sources, pairedPresent, preferredSentinels, trackedFiles, helperGoFiles)
+	return newManifest(manifest, manifest.moduleRoot, manifest.physicalRoot, manifest.modulePath, sources, pairedPresent, preferredSentinels, trackedFiles, helperGoFiles)
 }
 
 // RefreshDirs replaces the saved GSX membership, bytes, paired-output state,
@@ -529,11 +564,12 @@ func (manifest *Manifest) RefreshDirs(dirs []string) (*Manifest, error) {
 		}
 		dirSet[absDir] = true
 	}
-	sources := cloneSources(manifest.sources)
+	// Shallow map clones — shared immutable byte slices; see newManifest.
+	sources := maps.Clone(manifest.sources)
 	pairedPresent := maps.Clone(manifest.pairedPresent)
 	preferredSentinels := maps.Clone(manifest.sentinelByDir)
-	trackedFiles := cloneFileSnapshots(manifest.trackedFiles)
-	helperGoFiles := cloneFileSnapshots(manifest.helperGoFiles)
+	trackedFiles := maps.Clone(manifest.trackedFiles)
+	helperGoFiles := maps.Clone(manifest.helperGoFiles)
 	for path := range sources {
 		if !dirSet[filepath.Dir(path)] {
 			continue
@@ -609,15 +645,20 @@ func (manifest *Manifest) RefreshDirs(dirs []string) (*Manifest, error) {
 			pairedPresent[paired] = present
 		}
 	}
-	return newManifest(manifest.moduleRoot, manifest.physicalRoot, manifest.modulePath, sources, pairedPresent, preferredSentinels, trackedFiles, helperGoFiles)
+	return newManifest(manifest, manifest.moduleRoot, manifest.physicalRoot, manifest.modulePath, sources, pairedPresent, preferredSentinels, trackedFiles, helperGoFiles)
 }
 
-func cloneSources(sources map[string][]byte) map[string][]byte {
-	out := make(map[string][]byte, len(sources))
-	for path, source := range sources {
-		out[path] = bytes.Clone(source)
+// sameSourceBytes reports whether two immutable source slices hold identical
+// bytes, preferring O(1) backing-array identity before falling back to a
+// content compare (a re-read of an unchanged file yields a fresh slice).
+func sameSourceBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
 	}
-	return out
+	if len(a) == 0 || &a[0] == &b[0] {
+		return true
+	}
+	return bytes.Equal(a, b)
 }
 
 func cloneFileSnapshot(snapshot FileSnapshot) FileSnapshot {
@@ -625,17 +666,19 @@ func cloneFileSnapshot(snapshot FileSnapshot) FileSnapshot {
 	return snapshot
 }
 
-func cloneFileSnapshots(snapshots map[string]FileSnapshot) map[string]FileSnapshot {
-	out := make(map[string]FileSnapshot, len(snapshots))
-	for path, snapshot := range snapshots {
-		out[path] = cloneFileSnapshot(snapshot)
-	}
-	return out
-}
+// inspectCalls counts Inspect invocations process-wide. Tests use it to pin
+// the parse-work complexity of manifest construction and derivation: cold
+// watch-session startup must perform O(module files) Inspects, not
+// O(dirs × module files). See TestWatchSession_ColdStartParseWorkIsLinear.
+var inspectCalls atomic.Uint64
+
+// InspectCalls returns the process-wide count of Inspect invocations.
+func InspectCalls() uint64 { return inspectCalls.Load() }
 
 // Inspect extracts the dependency-surface fact for source. A malformed file
 // retains any recoverable package clause but publishes no guessed import edge.
 func Inspect(path string, source []byte, present bool) FileFact {
+	inspectCalls.Add(1)
 	fact := FileFact{present: present}
 	if !present {
 		return fact


### PR DESCRIPTION
## Problem

`gsx dev` on gsxui (1,169 `.gsx` / 78 package dirs) showed ~26–30s "generating" at cold startup and again on **every authored `.go` save** — even with a warm on-disk cache (which the watch session never consults, by design). The honest batch generate of the same module takes ~5s.

Root cause: a watch cycle refreshed saved disk facts **once per regenerated directory**, and every `RefreshDiskSources` rebuilt whole-module `sourceview` manifests — re-`Inspect`ing (fully re-parsing) and re-cloning every `.gsx` in the module up to three times per dir. Cold startup and dep-surface reopen were `O(dirs × module files)`: ~900 parses for a 36-file/12-dir module, ~25× the file count.

## Fix

Two independent halves, together linear by construction:

- **sourceview: incremental manifest derivation.** `newManifest` takes the parent manifest and reuses each unchanged file's `FileFact` instead of re-running `Inspect` (backing-array identity, then `bytes.Equal` — `Inspect` is pure in `(path, source, present)`). Derivations share immutable source bytes via shallow map clones; the accessor surface already clones at every exit. `WithFileSnapshots` with zero snapshots returns the receiver (manifests are immutable, the identity derivation *is* the view).
- **gen: batched atomic refresh.** `regenDirs(dirs)` refreshes+invalidates each owning module's whole dir batch with ONE `RefreshDiskSourcesAndInvalidate`, then generates per dir; `regenDir` is its single-dir form, so warm cycles keep the exact refresh-then-generate contract. `initialGenerate`, `reopen`, and `regenPending`'s dependent closure hand over whole batches (closure sorted → deterministic emit order). On a batch refresh error the module falls back to per-dir refresh so one broken dir (e.g. its `.x.go` path occupied by a directory) can't block healthy siblings — pinned by `TestWatchSession_BatchRefreshFailureIsolatesToBrokenDir`.

## Measured (gsxui module, warm machine)

| Path | Before | After |
|---|---|---|
| Cold `gsx dev` startup → server up | 21.4s | ~3s |
| One-line `.go` edit → reopen generate | 25.6s | 4.6s |

Generated output is byte-identical (`1169 up to date`; a deleted `.x.go` is restored identically on cold start).

## Gates

- `TestWatchSession_ColdStartParseWorkIsLinear` pins the complexity via a process-wide `Inspect` counter (cold startup `O(files)`, warm single-dir regen `O(dir files)`), hardened against one-shot foreign counter traffic by re-measuring once on breach.
- `TestRefreshDirsMatchesFreshBuild` pins derivation differentially against a from-scratch `Build`, including staleness (new import edge detected) and zero-parse no-op refresh; `TestDerivedManifestsShareWithoutAliasing` pins the immutability contract the slice sharing relies on.
- Independent adversarial review (4 lenses, live probe programs) — one confirmed defect (batch error blast radius), fixed above; probes also confirmed fact-reuse staleness resistance, no aliasing leaks, pointer-identity consumers sound, and strictly stronger lock discipline than the old two-step refresh.
- `make ci` exit 0, `make lint` exit 0.

https://claude.ai/code/session_01L1mQ6U9FmGWT5bp14RtGwK