### PR TITLE
gsx fmt: -stdin-filename mode + distinct exit codes for differs vs error

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -218,6 +218,7 @@ no path, the command formats `.`. Hidden directories, `.git`, `vendor`,
 | `-imports=goimports` | Remove unused imports and normalize import declarations. This is the default. |
 | `-imports=gofmt` | Format existing imports without removing, merging, or regrouping them. |
 | `-no-imports` | Alias for `-imports=gofmt`. |
+| `-stdin-filename=PATH` | Read the source from stdin and treat it as `PATH`. |
 
 The `goimports` mode cannot add a missing import; it organizes imports already
 present in the `.gsx` file. A CLI import mode overrides the
@@ -246,6 +247,20 @@ Author layout still wins: breaking the line right after an opening tag's `>`
 keeps that element block-formatted, even if its content would otherwise fit
 inline.
 
+### Formatting stdin
+
+`-stdin-filename` formats content that is not on disk. `PATH` names the file
+in `-l`/`-d` output and error messages and selects its `gsx.toml`,
+`.editorconfig`, and package for import analysis — nothing is read from it,
+and it need not exist. Path arguments and `-w` are rejected in this mode.
+
+A pre-commit hook uses it to check the **staged** blob rather than the working
+copy:
+
+```bash
+git show ":$f" | gsx fmt -l -stdin-filename "$f"
+```
+
 ### Check formatting in CI
 
 `-l` and `-d` exit `1` when any file differs, so either works as a CI check:
@@ -254,8 +269,14 @@ inline.
 gsx fmt -l .
 ```
 
-Parse, analysis, and write failures also exit `1`. Invalid flags, import-mode
-combinations, or paths exit `2`; otherwise formatting exits `0`.
+| Exit | Meaning |
+|------|---------|
+| `0` | Nothing failed; with `-l`/`-d`, nothing differs. |
+| `1` | With `-l`/`-d` only: at least one file differs and nothing failed. |
+| `2` | Something failed: a usage error (invalid flag, import-mode combination, or path) or a read, parse, analysis, or write failure on any file. |
+
+A failure wins over a difference, so a script can tell "run `-w`" from "this
+file is broken".
 
 ## `gsx info` {#info}
 

--- a/gen/fmt.go
+++ b/gen/fmt.go
@@ -28,6 +28,7 @@ import (
 //	-d         write a unified diff of the changes to stdout
 //	-imports   import handling: "goimports" (default) or "gofmt"
 //	-no-imports  alias for -imports gofmt
+//	-stdin-filename PATH  format standard input as if it were the file at PATH
 //
 // Import handling has two modes, resolved per directory (a CLI flag, when
 // given, overrides every directory's gsx.toml):
@@ -43,35 +44,57 @@ import (
 // for .gsx files, skipping the same junk dirs as discovery (.git, hidden dirs,
 // vendor, node_modules, testdata). No args formats "." recursively.
 //
+// With -stdin-filename PATH the source is read from stdin instead and treated
+// as the content of PATH: PATH names the file in -l/-d output and error
+// messages and anchors every per-file context (gsx.toml, .editorconfig, and
+// the package whose imports are analyzed), but nothing is read from it — the
+// analysis sees the stdin bytes in place of whatever is on disk at PATH. This
+// is how a pre-commit hook formats a STAGED blob rather than the working copy.
+// Path args and -w are usage errors in this mode.
+//
 // Exit codes:
 //
-//	0  success: all files parsed, and for default/-w no errors occurred
-//	1  a parse error on any file, OR (with -l or -d) any file differs
-//	2  a usage error: an unparseable flag, an invalid -imports value, or
-//	   -imports goimports combined with -no-imports
+//	0  success: nothing failed, and (with -l or -d) nothing differs
+//	1  (only with -l or -d) at least one file differs, and nothing failed
+//	2  something failed: a usage error (unparseable flag, invalid -imports
+//	   value, -imports goimports with -no-imports, a nonexistent path), or a
+//	   read/parse/write failure on any file, or a Go parse diagnostic
 //
-// The -l/-d non-zero-on-difference choice is deliberately CI-friendly: it lets
-// a build fail when sources are not canonically formatted (like `gofmt -l` used
-// as a check), unlike gofmt's own -l which always exits 0. Default and -w exit 0
-// on success regardless of how many files changed.
+// "differs" and "failed" are distinct so a script can tell "run -w" from
+// "this file is broken"; a failure wins over a difference. Exiting non-zero on
+// difference at all is deliberately CI-friendly (like `gofmt -l` used as a
+// gate), unlike gofmt's own -l which always exits 0. Default and -w exit 0 on
+// success regardless of how many files changed.
 //
 // All logic lives here (runFmt returns an int) so tests can drive it without
 // os.Exit.
-func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Formatter, opts codegen.Options, workDir string) int {
+func runFmt(stdin io.Reader, stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Formatter, opts codegen.Options, workDir string) int {
 	fs := flag.NewFlagSet("gsx fmt", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
-		write       bool
-		list        bool
-		diff        bool
-		noImports   bool
-		importsFlag string
+		write         bool
+		list          bool
+		diff          bool
+		noImports     bool
+		importsFlag   string
+		stdinFilename string
 	)
 	fs.BoolVar(&write, "w", false, "write result to (source) file instead of stdout")
 	fs.BoolVar(&list, "l", false, "list files whose formatting differs")
 	fs.BoolVar(&diff, "d", false, "display diffs instead of rewriting files")
 	fs.StringVar(&importsFlag, "imports", "", `import handling: "goimports" (default; remove unused + merge/dedup/group) or "gofmt" (format only)`)
 	fs.BoolVar(&noImports, "no-imports", false, `alias for -imports gofmt`)
+	fs.StringVar(&stdinFilename, "stdin-filename", "", "format standard input as if it were this .gsx `path` (nothing is read from the path); excludes path args and -w")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, "usage: gsx fmt [flags] [path ...]\n       gsx fmt [flags] -stdin-filename path < source\n\nFlags:\n")
+		fs.PrintDefaults()
+		fmt.Fprint(stderr, `
+Exit codes:
+  0  nothing failed and (with -l or -d) nothing differs
+  1  with -l or -d: at least one file differs, and nothing failed
+  2  a usage error, or a read/parse/write failure on any file
+`)
+	}
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
@@ -99,13 +122,46 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 		cliMode = gsxfmt.ImportsGofmt
 	}
 
-	// Anchor relative path arguments (and the default ".") at workDir so fmt never
-	// consults the process-global cwd.
-	paths := absPaths(workDir, fs.Args())
-	files, err := gsxFiles(paths)
-	if err != nil {
-		fmt.Fprintf(stderr, "gsx: %v\n", err)
-		return 2
+	// Sources are read through this indirection so stdin mode can substitute
+	// the piped bytes for the named file without touching the disk.
+	readSource := os.ReadFile
+	// overlay carries the stdin bytes (keyed by absolute path) into the
+	// unused-import analysis, which otherwise reads the package from disk.
+	var overlay map[string][]byte
+
+	var files []string
+	if stdinFilename != "" {
+		if len(fs.Args()) > 0 {
+			fmt.Fprintf(stderr, "gsx: -stdin-filename cannot be combined with path arguments\n")
+			return 2
+		}
+		if write {
+			fmt.Fprintf(stderr, "gsx: cannot use -w with standard input\n")
+			return 2
+		}
+		if !strings.HasSuffix(stdinFilename, ".gsx") {
+			fmt.Fprintf(stderr, "gsx: -stdin-filename: %q is not a .gsx path\n", stdinFilename)
+			return 2
+		}
+		src, err := io.ReadAll(stdin)
+		if err != nil {
+			fmt.Fprintf(stderr, "gsx: reading standard input: %v\n", err)
+			return 2
+		}
+		path := absPaths(workDir, []string{stdinFilename})[0]
+		files = []string{path}
+		overlay = map[string][]byte{path: src}
+		readSource = func(string) ([]byte, error) { return src, nil }
+	} else {
+		// Anchor relative path arguments (and the default ".") at workDir so fmt
+		// never consults the process-global cwd.
+		paths := absPaths(workDir, fs.Args())
+		var err error
+		files, err = gsxFiles(paths)
+		if err != nil {
+			fmt.Fprintf(stderr, "gsx: %v\n", err)
+			return 2
+		}
 	}
 
 	// Mode is resolved per directory (gsx.toml is discovered by walking up from
@@ -133,21 +189,23 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 	var unusedByPath map[string][]gsxfmt.ImportRef
 	var goDiags map[string][]diag.Diagnostic
 	if len(removalFiles) > 0 {
-		unusedByPath, goDiags = analyzeUnusedImports(removalFiles, opts)
+		unusedByPath, goDiags = analyzeUnusedImports(removalFiles, overlay, opts)
 	}
 
-	exit := 0
+	// failed and differs are tracked separately and folded into the exit code
+	// at the end (a failure wins): see the exit-code table above.
+	failed, differs := false, false
 	// The analyzer's Go parse errors are reported, but never stop formatting: the
 	// invalid Go passes through verbatim and the markup around it still canonicalizes.
-	if reportGoDiagnostics(stderr, files, goDiags) {
-		exit = 1
+	if reportGoDiagnostics(stderr, files, goDiags, readSource) {
+		failed = true
 	}
 	ec := newEditorConfigResolver()
 	for _, path := range files {
-		orig, err := os.ReadFile(path)
+		orig, err := readSource(path)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s: %v\n", path, err)
-			exit = 1
+			failed = true
 			continue
 		}
 		abs, _ := filepath.Abs(path)
@@ -164,7 +222,7 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 		})
 		if err != nil {
 			fmt.Fprintf(stderr, "%s: %v\n", path, err)
-			exit = 1
+			failed = true
 			continue
 		}
 		changed := !bytes.Equal(orig, formatted)
@@ -172,12 +230,12 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 		case list:
 			if changed {
 				fmt.Fprintln(stdout, path)
-				exit = 1
+				differs = true
 			}
 		case diff:
 			if changed {
 				fmt.Fprint(stdout, unifiedDiff(path, orig, formatted))
-				exit = 1
+				differs = true
 			}
 		case write:
 			if changed {
@@ -187,14 +245,20 @@ func runFmt(stdout, stderr io.Writer, args []string, cssFmt, jsFmt rawfmt.Format
 				}
 				if werr := os.WriteFile(path, formatted, mode); werr != nil {
 					fmt.Fprintf(stderr, "%s: %v\n", path, werr)
-					exit = 1
+					failed = true
 				}
 			}
 		default:
 			stdout.Write(formatted)
 		}
 	}
-	return exit
+	switch {
+	case failed:
+		return 2
+	case differs:
+		return 1
+	}
+	return 0
 }
 
 // Format returns the canonical, idempotent formatting of a single .gsx source
@@ -292,13 +356,18 @@ func importsModeFor(dir string) gsxfmt.ImportsMode {
 // carries the resolved codegen config so skeletons match what `generate` emits;
 // a zero/builtin opts still works (buildSkeleton tolerates unknown filters).
 //
+// overlay (absolute path → bytes) substitutes in-memory sources for files on
+// disk before analysis, so -stdin-filename analyzes the piped content rather
+// than the working copy. It goes through Module.SetOverride — the same buffer
+// mechanism the LSP uses — so it is scoped to that Module and never written.
+//
 // It also returns, per absolute .gsx path, the Go parse diagnostics the skeleton
 // surfaced. gsx copies user Go through as an opaque blob, so Go that is invalid
 // only in context (an `import` after a declaration, say) is caught nowhere else in
 // the fmt path; the skeleton's //line directives have already resolved each
 // position back to its .gsx origin. Only genuine parse failures become diagnostics;
 // a project that will not load yields none, so it can never make `gsx fmt` fail.
-func analyzeUnusedImports(files []string, opts codegen.Options) (map[string][]gsxfmt.ImportRef, map[string][]diag.Diagnostic) {
+func analyzeUnusedImports(files []string, overlay map[string][]byte, opts codegen.Options) (map[string][]gsxfmt.ImportRef, map[string][]diag.Diagnostic) {
 	out := map[string][]gsxfmt.ImportRef{}
 	diags := map[string][]diag.Diagnostic{}
 	dirSet := map[string]bool{}
@@ -317,6 +386,9 @@ func analyzeUnusedImports(files []string, opts codegen.Options) (map[string][]gs
 		m, err := codegen.Open(o)
 		if err != nil {
 			continue // not loadable → syntactic-only fallback (no removal, no diagnostics)
+		}
+		for path, src := range overlay {
+			m.SetOverride(path, src)
 		}
 		for _, dir := range g.dirs {
 			absDir, err := filepath.Abs(dir)
@@ -366,7 +438,9 @@ func analyzeUnusedImports(files []string, opts codegen.Options) (map[string][]gs
 //
 // Diagnostics for files outside the format set are dropped: the skeleton is
 // per-package, and `gsx fmt a.gsx` must not report on its untouched siblings.
-func reportGoDiagnostics(stderr io.Writer, files []string, byPath map[string][]diag.Diagnostic) bool {
+// readSource supplies the lines the rich renderer quotes, so stdin mode quotes
+// the bytes it analyzed rather than the working copy.
+func reportGoDiagnostics(stderr io.Writer, files []string, byPath map[string][]diag.Diagnostic, readSource func(string) ([]byte, error)) bool {
 	if len(byPath) == 0 {
 		return false
 	}
@@ -393,7 +467,7 @@ func reportGoDiagnostics(stderr io.Writer, files []string, byPath map[string][]d
 	})
 	if isTTY(stderr) {
 		diag.RenderRich(stderr, all, func(name string) ([]byte, bool) {
-			b, e := os.ReadFile(name)
+			b, e := readSource(name)
 			return b, e == nil
 		})
 	} else {

--- a/gen/fmt_stdin_test.go
+++ b/gen/fmt_stdin_test.go
@@ -1,0 +1,158 @@
+package gen
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gsxhq/gsx/internal/attrclass"
+	"github.com/gsxhq/gsx/internal/codegen"
+)
+
+// fmtCaptureStdin drives runFmt with the given stdin content.
+func fmtCaptureStdin(t *testing.T, stdin string, args []string) (int, string, string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	wd, _ := os.Getwd()
+	code := runFmt(strings.NewReader(stdin), &out, &errb, args, nil, nil, codegen.Options{Classifier: attrclass.Builtin()}, wd)
+	return code, out.String(), errb.String()
+}
+
+// TestFmtExitCodeFailureWinsOverDiffers pins the exit-code contract: with -l a
+// differing file alone is 1, but a parse failure anywhere in the same run is 2
+// even though another file also differs.
+func TestFmtExitCodeFailureWinsOverDiffers(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := writeFile(t, dir, "bad.gsx", "package views\n\ncomponent Broken( {\n")
+	dirty := writeFile(t, dir, "dirty.gsx", unformattedGsx)
+
+	if code, _, errb := fmtCapture(t, []string{"-l", dirty}); code != 1 {
+		t.Fatalf("-l dirty: exit = %d, want 1 (stderr=%q)", code, errb)
+	}
+	code, out, errb := fmtCapture(t, []string{"-l", bad, dirty})
+	if code != 2 {
+		t.Fatalf("-l bad+dirty: exit = %d, want 2 (stderr=%q)", code, errb)
+	}
+	if !strings.Contains(out, dirty) {
+		t.Errorf("-l still lists the differing file alongside the failure:\n%s", out)
+	}
+	if !strings.Contains(errb, "bad.gsx") {
+		t.Errorf("stderr missing the failing file: %q", errb)
+	}
+	// A nonexistent path is a failure too, not a "differs".
+	if code, _, _ := fmtCapture(t, []string{"-l", filepath.Join(dir, "missing.gsx")}); code != 2 {
+		t.Fatalf("-l missing: exit = %d, want 2", code)
+	}
+}
+
+// TestFmtStdin covers -stdin-filename: the piped bytes are what gets formatted
+// (the working copy at that path is never read, and is never written), the
+// name flows into -l/-d output and error messages, and the exit codes match
+// the file mode.
+func TestFmtStdin(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// The on-disk file is a DIFFERENT (already-canonical) source, so any output
+	// that reflects it proves the path was read.
+	const onDisk = "package views\n\ncomponent OnDisk() {\n\t<p>disk</p>\n}\n"
+	p := writeFile(t, dir, "hi.gsx", onDisk)
+	const canonical = "package views\n\ncomponent Hi(name string) {\n\t<p>{ name }</p>\n}\n"
+
+	t.Run("default writes formatted stdin to stdout", func(t *testing.T) {
+		code, out, errb := fmtCaptureStdin(t, unformattedGsx, []string{"-stdin-filename", p})
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0 (stderr=%q)", code, errb)
+		}
+		if out != canonical {
+			t.Errorf("stdout = %q, want %q", out, canonical)
+		}
+		if got, _ := os.ReadFile(p); string(got) != onDisk {
+			t.Errorf("stdin mode modified the file on disk")
+		}
+	})
+	t.Run("-l names the file and exits 1 when it differs", func(t *testing.T) {
+		code, out, _ := fmtCaptureStdin(t, unformattedGsx, []string{"-l", "-stdin-filename", p})
+		if code != 1 || out != p+"\n" {
+			t.Errorf("exit = %d, stdout = %q; want 1 and %q", code, out, p+"\n")
+		}
+		code, out, _ = fmtCaptureStdin(t, canonical, []string{"-l", "-stdin-filename", p})
+		if code != 0 || out != "" {
+			t.Errorf("canonical stdin: exit = %d, stdout = %q; want 0 and empty", code, out)
+		}
+	})
+	t.Run("-d diffs against the stdin bytes", func(t *testing.T) {
+		code, out, _ := fmtCaptureStdin(t, unformattedGsx, []string{"-d", "-stdin-filename", p})
+		if code != 1 {
+			t.Fatalf("exit = %d, want 1", code)
+		}
+		if !strings.Contains(out, "--- "+p+".orig") || !strings.Contains(out, "-component   Hi(name string) {\n") {
+			t.Errorf("diff does not name the file / show the stdin source:\n%s", out)
+		}
+		if strings.Contains(out, "OnDisk") {
+			t.Errorf("diff reflects the on-disk file, not stdin:\n%s", out)
+		}
+	})
+	t.Run("relative filename resolves against workDir", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := runFmt(strings.NewReader(unformattedGsx), &out, &errb, []string{"-l", "-stdin-filename", "hi.gsx"}, nil, nil, codegen.Options{Classifier: attrclass.Builtin()}, dir)
+		if code != 1 || out.String() != p+"\n" {
+			t.Errorf("exit = %d, stdout = %q; want 1 and %q", code, out.String(), p+"\n")
+		}
+	})
+	t.Run("nonexistent path is fine: nothing is read from it", func(t *testing.T) {
+		ghost := filepath.Join(dir, "new.gsx")
+		code, out, errb := fmtCaptureStdin(t, unformattedGsx, []string{"-stdin-filename", ghost})
+		if code != 0 || out != canonical {
+			t.Errorf("exit = %d, stdout = %q, stderr = %q; want 0 and canonical output", code, out, errb)
+		}
+	})
+	t.Run("parse error exits 2 and names the file", func(t *testing.T) {
+		code, _, errb := fmtCaptureStdin(t, "package views\n\ncomponent Broken( {\n", []string{"-stdin-filename", p})
+		if code != 2 || !strings.Contains(errb, "hi.gsx") {
+			t.Errorf("exit = %d, stderr = %q; want 2 naming hi.gsx", code, errb)
+		}
+	})
+	t.Run("usage errors", func(t *testing.T) {
+		for _, args := range [][]string{
+			{"-w", "-stdin-filename", p},
+			{"-stdin-filename", p, p},
+			{"-stdin-filename", filepath.Join(dir, "notgsx.go")},
+		} {
+			if code, _, errb := fmtCaptureStdin(t, unformattedGsx, args); code != 2 || errb == "" {
+				t.Errorf("%v: exit = %d, stderr = %q; want 2 with a message", args, code, errb)
+			}
+		}
+	})
+}
+
+// TestFmtStdinUnusedImportsSeeStdin proves stdin mode analyzes the PIPED
+// content for unused imports, not the working copy: the on-disk file uses
+// bytes and leaves strings unused; the stdin content is the reverse. Removal
+// must follow stdin. (One Module open — both directions share it.)
+func TestFmtStdinUnusedImportsSeeStdin(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping module-resolution test in -short mode")
+	}
+	dir := newModule(t, "fmtmod")
+	onDisk := "package fmtmod\n\nimport (\n\t\"bytes\"\n\t\"strings\"\n)\n\ncomponent Page() {\n\t<div>{bytes.ToUpper(nil)}</div>\n}\n"
+	piped := "package fmtmod\n\nimport (\n\t\"bytes\"\n\t\"strings\"\n)\n\ncomponent Page() {\n\t<div>{strings.ToUpper(\"x\")}</div>\n}\n"
+	page := writeFile(t, dir, "page.gsx", onDisk)
+
+	code, out, errb := fmtCaptureStdin(t, piped, []string{"-stdin-filename", page})
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, errb)
+	}
+	if strings.Contains(out, `"bytes"`) {
+		t.Errorf("bytes is unused in the stdin content and must be removed:\n%s", out)
+	}
+	if !strings.Contains(out, `"strings"`) {
+		t.Errorf("strings is used in the stdin content and must be kept:\n%s", out)
+	}
+	if got, _ := os.ReadFile(page); string(got) != onDisk {
+		t.Errorf("stdin mode modified the file on disk")
+	}
+}

--- a/gen/fmt_test.go
+++ b/gen/fmt_test.go
@@ -16,7 +16,7 @@ func fmtCapture(t *testing.T, args []string) (int, string, string) {
 	t.Helper()
 	var out, errb bytes.Buffer
 	wd, _ := os.Getwd()
-	code := runFmt(&out, &errb, args, nil, nil, codegen.Options{Classifier: attrclass.Builtin()}, wd)
+	code := runFmt(nil, &out, &errb, args, nil, nil, codegen.Options{Classifier: attrclass.Builtin()}, wd)
 	return code, out.String(), errb.String()
 }
 
@@ -145,7 +145,7 @@ func TestFmtWriteIdempotent(t *testing.T) {
 	}
 }
 
-// TestFmtParseError proves a parse-error file is reported to stderr and exits 1,
+// TestFmtParseError proves a parse-error file is reported to stderr and exits 2,
 // while other files in the same invocation still format.
 func TestFmtParseError(t *testing.T) {
 	t.Parallel()
@@ -159,8 +159,8 @@ func TestFmtParseError(t *testing.T) {
 		t.Fatal(err)
 	}
 	code, out, errb := fmtCapture(t, []string{bad, good})
-	if code != 1 {
-		t.Fatalf("exit = %d, want 1 (stderr=%q)", code, errb)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2 (stderr=%q)", code, errb)
 	}
 	if !strings.Contains(errb, "bad.gsx") {
 		t.Errorf("stderr missing bad file: %q", errb)
@@ -353,7 +353,7 @@ func TestFmtTwoDirsOneModule(t *testing.T) {
 	bPath := writeFile(t, filepath.Join(dir, "b"), "b.gsx", bSrc)
 
 	refs, _ := analyzeUnusedImports(
-		[]string{aPath, bPath},
+		[]string{aPath, bPath}, nil,
 		codegen.Options{Classifier: attrclass.Builtin()},
 	)
 
@@ -387,7 +387,7 @@ func TestFmtKeepsTypeArgAndAttrExprImports(t *testing.T) {
 	page := writeFile(t, filepath.Join(dir, "views"), "views.gsx", src)
 
 	refs, _ := analyzeUnusedImports(
-		[]string{page},
+		[]string{page}, nil,
 		codegen.Options{Classifier: attrclass.Builtin()},
 	)
 	abs, _ := filepath.Abs(page)
@@ -444,7 +444,7 @@ func TestFmtGoimportsMergesAndDedups(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out, errb bytes.Buffer
-	if code := runFmt(&out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+	if code := runFmt(nil, &out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
 		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
 	}
 	got := readFile(t, p)
@@ -471,7 +471,7 @@ func TestFmtImportsGofmtLeavesImportsAlone(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out, errb bytes.Buffer
-	if code := runFmt(&out, &errb, []string{"-w", "-imports", "gofmt", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+	if code := runFmt(nil, &out, &errb, []string{"-w", "-imports", "gofmt", p}, nil, nil, codegen.Options{}, dir); code != 0 {
 		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
 	}
 	got := readFile(t, p)
@@ -498,7 +498,7 @@ func TestFmtNoImportsIsGofmtAlias(t *testing.T) {
 			t.Fatal(err)
 		}
 		var out, errb bytes.Buffer
-		if code := runFmt(&out, &errb, append(args, p), nil, nil, codegen.Options{}, dir); code != 0 {
+		if code := runFmt(nil, &out, &errb, append(args, p), nil, nil, codegen.Options{}, dir); code != 0 {
 			t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
 		}
 		return readFile(t, p)
@@ -514,7 +514,7 @@ func TestFmtImportsFlagConflict(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	var out, errb bytes.Buffer
-	code := runFmt(&out, &errb, []string{"-imports", "goimports", "-no-imports", dir}, nil, nil, codegen.Options{}, dir)
+	code := runFmt(nil, &out, &errb, []string{"-imports", "goimports", "-no-imports", dir}, nil, nil, codegen.Options{}, dir)
 	if code != 2 {
 		t.Fatalf("exit = %d, want 2; stderr=%s", code, errb.String())
 	}
@@ -529,7 +529,7 @@ func TestFmtImportsFlagInvalid(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	var out, errb bytes.Buffer
-	code := runFmt(&out, &errb, []string{"-imports", "gofumpt", dir}, nil, nil, codegen.Options{}, dir)
+	code := runFmt(nil, &out, &errb, []string{"-imports", "gofumpt", dir}, nil, nil, codegen.Options{}, dir)
 	if code != 2 {
 		t.Fatalf("exit = %d, want 2", code)
 	}
@@ -557,7 +557,7 @@ func TestFmtConfigGofmtModeHonored(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out, errb bytes.Buffer
-	if code := runFmt(&out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
+	if code := runFmt(nil, &out, &errb, []string{"-w", p}, nil, nil, codegen.Options{}, dir); code != 0 {
 		t.Fatalf("runFmt=%d stderr=%s", code, errb.String())
 	}
 	if !strings.Contains(readFile(t, p), "\"bytes\"") {

--- a/gen/main.go
+++ b/gen/main.go
@@ -272,7 +272,7 @@ func runConfig(args []string, stdout, stderr io.Writer, cfg config) int {
 				FilterPkgs: merged.filterPkgs,
 			}
 		}
-		return runFmt(stdout, stderr, cmdArgs, cfg.cssFmt, cfg.jsFmt, fmtOpts, workDir)
+		return runFmt(os.Stdin, stdout, stderr, cmdArgs, cfg.cssFmt, cfg.jsFmt, fmtOpts, workDir)
 	case "init":
 		return runInit(cmdArgs, os.Stdin, stdout, stderr, workDir)
 	case "lsp":
@@ -611,7 +611,7 @@ Usage:
 Commands:
 	generate [paths...]   generate .x.go from .gsx files (default: .)
 	dev [flags]           warm generate + build-then-swap server + browser reload (dev loop)
-	fmt [paths...]        format .gsx files (canonical, idempotent)
+	fmt [paths...]        format .gsx files (canonical, idempotent; -stdin-filename reads stdin)
 	init [dir]            scaffold a gsx + Vite starter app (--template, --module)
 	clean --cache         remove the gsx cache directory
 	info                  list the resolved pipeline filters


### PR DESCRIPTION
Closes #189.

## 1. `-stdin-filename PATH`

Reads the source from stdin and treats it as the content of `PATH`. `PATH` names the file in `-l`/`-d` output and error messages and selects its `gsx.toml`, `.editorconfig`, and package for unused-import analysis — nothing is read from it, and it need not exist. Path args and `-w` are usage errors (exit 2).

The stdin bytes reach the unused-import analyzer through `Module.SetOverride` (the LSP's buffer mechanism), so a **staged** blob is analyzed as itself: `TestFmtStdinUnusedImportsSeeStdin` has the working copy use `bytes` and the piped content use `strings`, and removal follows the piped content (mutation-checked: dropping the override fails the test).

Pre-commit usage:
```sh
git show ":$f" | gsx fmt -l -stdin-filename "$f"
```

## 2. Exit codes

| exit | meaning |
|---|---|
| 0 | nothing failed; with `-l`/`-d`, nothing differs |
| 1 | `-l`/`-d` only: at least one file differs, nothing failed |
| 2 | usage error, or read/parse/write failure / Go diagnostic on any file |

A failure wins over a difference (`TestFmtExitCodeFailureWinsOverDiffers`). Previously parse errors and differences both exited 1. `gsx fmt -h` now prints the table; `docs/guide/cli.md` updated.

`make ci` exit 0 locally.

https://claude.ai/code/session_01FvxdtWbhziwpVy1YWwVehs
