### PR TITLE
docs: v0.1.0 — first tagged release, versioning policy and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+Tagged releases of `github.com/gsxhq/gsx`. Before 1.0, a minor bump may change
+syntax or APIs; a patch bump does not. See
+[Releases and versioning](docs/guide/status.md#releases-and-versioning).
+
+## v0.1.0 — 2026-09-03
+
+First tagged release. Everything the [Status](docs/guide/status.md) page lists as
+shipped is in this tag:
+
+- **Language** — verbatim component signatures with declared `children` and
+  `attrs` roles, control flow, `|>` pipelines with `(T, error)` auto-unwrap,
+  attribute forwarding and ordered `{{ }}` bags, named slots, element literals,
+  `js`/`css`/`f` tagged literals, bare `//` comments, processing instructions.
+- **Rendering** — standard-library-only runtime; contextual HTML, URL, CSS and
+  JavaScript escaping ported from `html/template`; name-driven boolean
+  attributes with `gsx.Toggle`; `Attrs.Bool`; CSP nonce injection; renderers
+  registry.
+- **Toolchain** — `gsx init`, `generate` (with `--watch`), `fmt`, `info`,
+  `clean`, `version`; the `gsx dev` loop with the Vite plugin
+  (`@gsxhq/vite-plugin-gsx` 0.11) and `github.com/gsxhq/vite` (v0.3).
+- **Editor** — `gsx lsp`: diagnostics, definition, references, hover, symbols,
+  formatting, code actions, completion with auto-import; VS Code extension and
+  tree-sitter grammar in sibling repos.
+
+Requires Go 1.26.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 A JSX-like templating language for Go, compiled to plain Go that streams HTML.
 
-> **Status — alpha.** gsx is used in production today, while language and API
-> compatibility may change before 1.0. See [Status](docs/guide/status.md) and
+> **Status — alpha, tagged.** gsx is used in production today and ships tagged
+> releases from `v0.1.0`; language and API compatibility may change before 1.0.
+> See [Status](docs/guide/status.md), the [changelog](CHANGELOG.md), and the
 > [Roadmap](docs/ROADMAP.md).
 
 ## What is gsx

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,6 +6,10 @@ Living high-level status. Update as subsystems land. Detailed design lives in
 Module: `github.com/gsxhq/gsx` · runtime is **standard-library only**; the
 generator/CLI may use `golang.org/x/tools`.
 
+**Releases:** tagged from `v0.1.0` (`2026-09-03`); one tag covers runtime + CLI.
+Pre-1.0 minor bumps may break, patch bumps do not. Notes in `CHANGELOG.md`,
+policy in `docs/guide/status.md#releases-and-versioning`.
+
 **Status key:** [x] done · [~] partial / in progress · [ ] not started.
 
 ## Current component contract
@@ -37,7 +41,7 @@ generator/CLI may use `golang.org/x/tools`.
 | Pipeline `\|>` end-to-end | [x] seed-first forward-application lowering + `std` filters + user filter packages (`gen.WithFilters` + `gen.WithFilter` aliases, multi-pkg last-wins) + `ctx` injection + `(T,error)` implicit auto-unwrap **at any stage** (halts the chain on error). Works in interp / attr / class / style / spread / child-prop values / `{{ }}` pairs / cond-attr branches (all pipeline-legal contexts). Initialism-aware naming pending. |
 | CLI (`gsx`) / `gen.Main` | [~] `generate` (incl. `--watch`/`--format=ndjson`) · `fmt` · `info` · `init` · `lsp` · `clean --cache` · `version` · `help` ship, with `--json` + structured diagnostics. `vet`/`render`/`explain`/numeric codes pending. `WithClassMerger` + `class_merger` TOML knob shipped. |
 | Language server (`gsx lsp`) | [~] diagnostics (debounced) + authored-source go-to-definition, hover, document symbols, workspace symbols + module-wide symbol graph (references/definition for every authored Go symbol) + formatting ship; completion deferred, and so is intelligence sourced FROM external/non-project packages' own files (they are not indexed), while go-to-definition from a `.gsx` cursor INTO them works. Read intelligence excludes exact paired generated `.x.go` outputs while preserving legitimate unpaired authored `.x.go`. |
-| Developer experience (Vite + `init`) | [x] `gsx init` scaffold + `@gsxhq/vite-plugin-gsx` (npm v0.5.0) + `github.com/gsxhq/vite` (v0.2.0) + browser dev panel + front-door auto-restart. |
+| Developer experience (Vite + `init`) | [x] `gsx init` scaffold + `@gsxhq/vite-plugin-gsx` (npm 0.11.1) + `github.com/gsxhq/vite` (v0.3.2) + browser dev panel + front-door auto-restart. |
 
 ## Done
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -351,5 +351,7 @@ single uncached generation run.
 
 ## Stability {#status}
 
-The CLI is alpha. This page lists the commands that are available now; see
-[Status](./status.md) for the broader shipped surface.
+The CLI is alpha and ships in tagged releases with the runtime (one module, one
+tag; see [Releases and versioning](./status.md#releases-and-versioning)). This
+page lists the commands that are available now; see [Status](./status.md) for
+the broader shipped surface.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,9 @@ cd hello-gsx
 ```
 
 If another program named `gsx` is installed, run `gsx version` before
-scaffolding to check which binary your shell found.
+scaffolding to check which binary your shell found. `@latest` is the newest
+tagged release; to pin one, use its tag instead (see
+[Releases and versioning](./status.md#releases-and-versioning)).
 
 `--yes` also adds gsx as a Go tool, tidies the module, and installs the Vite
 dependencies.

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -27,11 +27,32 @@ The [language server](./editor.md) provides diagnostics, navigation, references,
 symbols, formatting, code actions, completion, completion documentation, and
 auto-imports.
 
+## Releases and versioning
+
+gsx ships tagged releases, starting at `v0.1.0`. Tags follow semantic
+versioning as Go modules read it: before 1.0 a **minor** bump (`v0.2.0`) may
+change syntax or APIs and may require source migrations, and a **patch** bump
+(`v0.1.1`) does not. Each release is listed in the
+[changelog](https://github.com/gsxhq/gsx/blob/main/CHANGELOG.md).
+
+Pin the runtime and the CLI to the same tag:
+
+```sh
+go get github.com/gsxhq/gsx@v0.1.0
+go get -tool github.com/gsxhq/gsx/cmd/gsx@v0.1.0
+```
+
+`@latest` resolves to the newest tag, which is what `gsx init` pins. To follow
+unreleased work use `@main`. The runtime and the CLI live in one module, so one
+tag covers both; `gsx version` prints the tag the binary was built from.
+
+Releases require the Go version in `go.mod` (currently 1.26).
+
 ## Durable boundaries
 
 - Generation produces `.x.go` files that are compiled with the application.
 - Find-references is project-scoped and excludes external package references.
-- Pre-1.0 releases may require source migrations.
+- Pre-1.0 minor releases may require source migrations.
 
 ## Roadmap
 


### PR DESCRIPTION
## Why

gsx has no tags. Dependents (saas-template, one-learning) pin pseudo-versions, and `gsx init`'s `go get -tool …@latest` floats to whatever main is. The library is in a good state to cut **v0.1.0** so dependents can use a tagged version.

## What

- **Status page** gains *Releases and versioning*: semver as Go modules read it (pre-1.0 minor may break, patch does not), how to pin runtime + CLI to one tag, what `@latest` / `@main` resolve to, Go version requirement.
- **`CHANGELOG.md`** with the v0.1.0 notes (shipped surface summary).
- README status line, Getting started and the CLI stability note link to the policy.
- ROADMAP: releases line; the DX row's companion versions were stale (plugin 0.11.1, vite v0.3.2).

## Release steps after merge

```sh
git checkout main && git pull --ff-only
git tag -a v0.1.0 -m 'gsx v0.1.0'
git push origin v0.1.0
gh release create v0.1.0 --title 'v0.1.0' --notes-file CHANGELOG.md   # optional GitHub release
```

Then `go get github.com/gsxhq/gsx@v0.1.0` in dependents; `gsx init` picks it up via `@latest` automatically.

https://claude.ai/code/session_01KstNrJwNSFjAbdDSzSMd5w
